### PR TITLE
swig-python: add support for python 2.7/legacy

### DIFF
--- a/src/bindings/swig/CMakeLists.txt
+++ b/src/bindings/swig/CMakeLists.txt
@@ -1,5 +1,12 @@
 if (BUILD_SWIG_PYTHON)
-	add_subdirectory (python)
+	find_package (PythonInterp 2.7 REQUIRED)
+	find_package (PythonLibs 2.7 REQUIRED)
+
+	if (PYTHONLIBS_VERSION_STRING MATCHES "^3\\.[0-9]+")
+		add_subdirectory (python)
+	else ()
+		add_subdirectory (python-legacy)
+	endif ()
 endif (BUILD_SWIG_PYTHON)
 
 if (BUILD_SWIG_LUA)

--- a/src/bindings/swig/python-legacy/CMakeLists.txt
+++ b/src/bindings/swig/python-legacy/CMakeLists.txt
@@ -1,0 +1,46 @@
+include (${SWIG_USE_FILE})
+include(LibAddMacros)
+
+find_package (PythonInterp 2.7 REQUIRED)
+find_package (PythonLibs 2.7 REQUIRED)
+
+if (PYTHONLIBS_VERSION_STRING MATCHES "^3\\.[0-9]+")
+	message (SEND_ERROR "python-legacy is for python 2.7 only")
+endif ()
+
+add_headers (HDR_FILES)
+add_cppheaders (HDR_FILES)
+
+include_directories (${PYTHON_INCLUDE_PATH})
+include_directories (${CMAKE_CURRENT_SOURCE_DIR})
+
+set (CMAKE_SWIG_OUTDIR ${CMAKE_CURRENT_BINARY_DIR})
+set (CMAKE_SWIG_FLAGS "-O")
+
+set_source_files_properties (kdb.i PROPERTIES CPLUSPLUS ON)
+set_source_files_properties (kdb.i PROPERTIES SWIG_FLAGS "-extranative")
+swig_add_module (swig-python-legacy python kdb.i)
+swig_link_libraries (swig-python-legacy elektra ${PYTHON_LIBRARIES})
+set_target_properties (_swig-python-legacy PROPERTIES OUTPUT_NAME _kdb)
+
+set (PYTHON_GET_MODULES_DIR_COMMAND "from distutils.sysconfig import get_python_lib; print(get_python_lib(True, prefix='${CMAKE_INSTALL_PREFIX}'))")
+execute_process (
+	COMMAND ${PYTHON_EXECUTABLE} -c "${PYTHON_GET_MODULES_DIR_COMMAND}"
+	OUTPUT_VARIABLE PYTHON_SITE_PACKAGES
+	OUTPUT_STRIP_TRAILING_WHITESPACE
+)
+
+install (
+	FILES ${CMAKE_CURRENT_BINARY_DIR}/kdb.py
+	DESTINATION ${PYTHON_SITE_PACKAGES}
+)
+
+install (
+	TARGETS _swig-python-legacy
+	LIBRARY DESTINATION ${PYTHON_SITE_PACKAGES}
+)
+
+include_directories (${CMAKE_CURRENT_SOURCE_DIR})
+include_directories (${CMAKE_SOURCE_DIR}/src/swig/)
+
+add_subdirectory (tests)

--- a/src/bindings/swig/python-legacy/kdb.i
+++ b/src/bindings/swig/python-legacy/kdb.i
@@ -1,0 +1,55 @@
+%module kdb
+
+/* python2 compat */
+%pythonbegin %{
+  from __future__ import print_function
+%}
+
+%include "../python/kdb.i"
+
+/*
+ * python2 doesn't have a binary datatype
+ * so we overwrite the __init__ to handle KEY_VALUE/BINARY
+ */
+%pythoncode %{
+  Key.__oldinit__ = Key.__init__
+
+  def __Key_new_init__(self, *args):
+    passed  = []
+    skipped = []
+
+    if len(args):
+      iargs = iter(args)
+      passed.append(next(iargs))
+      for arg in iargs:
+        if arg == KEY_VALUE:
+          skipped.append(arg)
+          skipped.append(next(iargs))
+        elif arg == KEY_BINARY:
+          skipped.append(arg)
+        else:
+          passed.append(arg)
+
+    self.__oldinit__(*passed)
+
+    if len(skipped):
+      iskipped = iter(skipped)
+      for arg in iskipped:
+        if arg == KEY_VALUE:
+          if self.isBinary():
+            self.binary = next(iskipped)
+          else:
+            self.string = next(iskipped)
+        elif arg == KEY_BINARY:
+          self.setMeta("binary", "")
+
+  Key.__init__ = __Key_new_init__
+%}
+
+/* more "binary datatype missing"-stuff */
+%pythoncode %{
+  del Key.set
+  Key.value  = property(Key.get, None, None, "Key value")
+  Key.string = property(Key._getString, Key._setString, None, "Key string value")
+  Key.binary = property(Key._getBinary, Key._setBinary, None, "Key binary value")
+%}

--- a/src/bindings/swig/python-legacy/tests/CMakeLists.txt
+++ b/src/bindings/swig/python-legacy/tests/CMakeLists.txt
@@ -1,0 +1,15 @@
+set(PYTHON_MODULEPATH "${CMAKE_CURRENT_BINARY_DIR}/..")
+
+macro (do_python_test source)
+	get_filename_component (name ${source} NAME)
+	add_test (
+		NAME ${name}
+		COMMAND ${PYTHON_EXECUTABLE} -B ${source}
+		)
+	set_tests_properties (${name} PROPERTIES ENVIRONMENT "PYTHONPATH=${PYTHON_MODULEPATH}")
+endmacro (do_python_test)
+
+file (GLOB TESTS *.py)
+foreach (file ${TESTS})
+	do_python_test (${file})
+endforeach (file ${TESTS})

--- a/src/bindings/swig/python-legacy/tests/test_kdb.py
+++ b/src/bindings/swig/python-legacy/tests/test_kdb.py
@@ -1,0 +1,63 @@
+import kdb, unittest
+
+class Constants(unittest.TestCase):
+	def setUp(self):
+		pass
+
+	def test_kdbconfig_h(self):
+		self.assertIsInstance(kdb.DB_SYSTEM, str)
+		self.assertIsInstance(kdb.DB_USER,   str)
+		self.assertIsInstance(kdb.DB_HOME,   str)
+		self.assertIsInstance(kdb.DEBUG,     ( int, long ))
+		self.assertIsInstance(kdb.VERBOSE,   ( int, long ))
+
+	def test_kdb_h(self):
+		self.assertIsInstance(kdb.VERSION,       str)
+		self.assertIsInstance(kdb.VERSION_MAJOR, ( int, long ))
+		self.assertIsInstance(kdb.VERSION_MINOR, ( int, long ))
+		self.assertIsInstance(kdb.VERSION_MICRO, ( int, long ))
+		self.assertIsNone(kdb.KS_END)
+
+class KDB(unittest.TestCase):
+	def setUp(self):
+		pass
+
+	'''
+	disabled until elektra libraries can be loaded by
+	the build system (and static build is gone)
+
+	def test_ctor(self):
+		self.assertIsInstance(kdb.KDB(), kdb.KDB)
+		error = kdb.Key()
+		self.assertIsInstance(kdb.KDB(error), kdb.KDB)
+
+	def test_get(self):
+		with kdb.KDB() as db:
+			ks = kdb.KeySet()
+			db.get(ks, "system/elektra")
+
+			key = ks["system/elektra/version/constants/KDB_VERSION"]
+			self.assertEqual(key.value, kdb.VERSION)
+
+	def test_set(self):
+		with kdb.KDB() as db:
+			ks = kdb.KeySet(100)
+			db.get(ks, "user/MyApp")
+
+			try:
+				key = ks["user/MyApp/mykey"]
+			except KeyError:
+				key = kdb.Key("user/MyApp/mykey")
+				ks.append(key)
+			key.string = "new_value"
+
+			db.set(ks, "user/MyApp")
+
+		with kdb.KDB() as db:
+			ks = kdb.KeySet(100)
+			db.get(ks, "user/MyApp")
+			self.assertEqual(ks["user/MyApp/mykey"].value, "new_value")
+	'''
+
+if __name__ == '__main__':
+	unittest.main()

--- a/src/bindings/swig/python-legacy/tests/test_key.py
+++ b/src/bindings/swig/python-legacy/tests/test_key.py
@@ -1,0 +1,137 @@
+import kdb, unittest
+
+class Key(unittest.TestCase):
+	def setUp(self):
+		self.key = kdb.Key("user/key",
+			kdb.KEY_NAME,    "user/foo/bar",
+			kdb.KEY_VALUE,   "value",
+			kdb.KEY_OWNER,   "myowner",
+			kdb.KEY_COMMENT, "mycomment",
+			kdb.KEY_UID,     "123",
+			kdb.KEY_GID,     456,
+			kdb.KEY_MODE,    0o644,
+			kdb.KEY_ATIME,   123,
+			kdb.KEY_MTIME,   "456",
+			kdb.KEY_CTIME,   789,
+			kdb.KEY_DIR,
+			kdb.KEY_META,    "by", "manuel",
+			kdb.KEY_NULL
+			)
+
+		self.bkey = kdb.Key("system/bkey",
+			kdb.KEY_BINARY,
+			kdb.KEY_VALUE,   "bvalue\0\0",
+			kdb.KEY_END,
+			kdb.KEY_OWNER,   "lost"
+			)
+
+	def test_ctor(self):
+		self.assertIsInstance(self.key, kdb.Key)
+		self.assertIsInstance(self.bkey, kdb.Key)
+
+		k = kdb.Key()
+		self.assertIsInstance(k, kdb.Key)
+		self.assertFalse(k.isValid())
+
+		k = kdb.Key("wrongname")
+		self.assertIsInstance(k, kdb.Key)
+		self.assertFalse(k.isValid())
+
+		k = kdb.Key("/wrongname")
+		self.assertIsInstance(k, kdb.Key)
+		self.assertFalse(k.isValid())
+
+		k = kdb.Key("user/foo")
+		self.assertIsInstance(k, kdb.Key)
+		self.assertTrue(k.isValid())
+
+		k = kdb.Key(self.key)
+		self.assertIsInstance(k, kdb.Key)
+		self.assertTrue(k.isValid())
+
+	def test_operator(self):
+		self.assertNotEqual(self.key, self.bkey)
+		self.assertEqual(kdb.Key(self.key), self.key)
+		self.assertEqual(self.key, kdb.Key("user/foo/bar", kdb.KEY_OWNER, "myowner"))
+		self.assertEqual(kdb.Key(), kdb.Key())
+		self.assertNotEqual(kdb.Key("user/key1"), kdb.Key("user/key2"))
+
+		self.assertTrue(kdb.Key("user/key1") == kdb.Key("user/key1"))
+		self.assertTrue(kdb.Key("user/key1") != kdb.Key("user/key2"))
+		self.assertTrue(kdb.Key("user/key1") <  kdb.Key("user/key2"))
+		self.assertTrue(kdb.Key("user/key1") <= kdb.Key("user/key2"))
+		self.assertTrue(kdb.Key("user/key2") >  kdb.Key("user/key1"))
+		self.assertTrue(kdb.Key("user/key2") >= kdb.Key("user/key1"))
+
+		self.assertTrue(bool(self.key))
+		self.assertTrue(bool(self.bkey))
+
+		self.assertEqual(str(self.key),  "user/foo/bar")
+		self.assertEqual(str(self.bkey), "system/bkey")
+
+	def test_properties(self):
+		self.assertEqual(self.key.name,      "user/foo/bar")
+		self.assertEqual(self.key.value,     "value")
+		self.assertEqual(self.key.basename,  "bar")
+		self.assertEqual(self.key.dirname,   "user/foo")
+		self.assertEqual(self.key.fullname,  "user:myowner/foo/bar")
+
+		self.assertEqual(self.bkey.name,     "system/bkey")
+		self.assertEqual(self.bkey.value,    "bvalue\0\0")
+		self.assertEqual(self.bkey.basename, "bkey")
+		self.assertEqual(self.bkey.dirname,  "system")
+		self.assertEqual(self.bkey.fullname, "system/bkey")
+
+		k = kdb.Key("user/key1", kdb.KEY_VALUE, "value")
+		self.assertFalse(k.isBinary())
+		self.assertIsNone(k.getMeta("binary"))
+
+		k.name     = "system/key2"
+		k.basename = "key3"
+		k.binary   = "bvalue\0\0"
+		self.assertEqual(k.name,  "system/key3")
+		self.assertEqual(k.value, "bvalue\0\0")
+		self.assertTrue(k.isBinary())
+		self.assertIsInstance(self.bkey.getMeta("binary"), kdb.Key)
+
+		k = kdb.Key("user/key2")
+		with self.assertRaises(kdb.KeyInvalidName):
+			k.name = "foo"
+
+	def test_functions(self):
+		self.assertTrue(self.key.isUser())
+		self.assertTrue(self.bkey.isSystem())
+		self.assertTrue(self.key.isString())
+		self.assertTrue(self.bkey.isBinary())
+		self.assertTrue(kdb.Key("user/foo").isBelow(self.key))
+
+		k = kdb.Key("user/key1", kdb.KEY_VALUE, "value")
+		self.assertEqual(k.get(), "value")
+
+	def test_meta(self):
+		self.assertIsInstance(self.key.getMeta("owner"), kdb.Key)
+		self.assertEqual(self.key.getMeta("owner").value,   "myowner")
+		self.assertEqual(self.key.getMeta("owner").name,    "owner")
+		self.assertEqual(self.key.getMeta("comment").value, "mycomment")
+		self.assertEqual(self.key.getMeta("uid").value,     "123")
+		self.assertEqual(self.key.getMeta("gid").value,     "456")
+		self.assertEqual(self.key.getMeta("mode").value,    "755")
+		self.assertEqual(self.key.getMeta("atime").value,   "123")
+		self.assertEqual(self.key.getMeta("mtime").value,   "456")
+		self.assertEqual(self.key.getMeta("ctime").value,   "789")
+		self.assertEqual(self.key.getMeta("by").value,      "manuel")
+
+		self.assertFalse(self.key.hasMeta("doesnt_exist"))
+		self.assertIsNone(self.key.getMeta("doesnt_exist"))
+		self.assertTrue(bool(self.bkey.getMeta("binary")))
+		self.assertIsNone(self.bkey.getMeta("owner"))
+
+		k = kdb.Key("user/key1")
+		k.setMeta("foo", "bar")
+		self.assertEqual(k.getMeta("foo").value, "bar")
+
+		self.assertEqual(sum(1 for _ in self.key.getMeta()),  9)
+		self.assertEqual(sum(1 for _ in self.bkey.getMeta()), 1)
+
+if __name__ == '__main__':
+	unittest.main()

--- a/src/bindings/swig/python-legacy/tests/test_keyset.py
+++ b/src/bindings/swig/python-legacy/tests/test_keyset.py
@@ -1,0 +1,105 @@
+import kdb, unittest
+
+class KeySet(unittest.TestCase):
+	def setUp(self):
+		self.ks = kdb.KeySet(100,
+			kdb.Key("system/key1"),
+			kdb.Key("system/key2"),
+			kdb.Key("user/key3"),
+			kdb.Key("user/key4"),
+			kdb.KS_END,
+			kdb.Key("user/lost")
+			)
+
+	def test_ctor(self):
+		self.assertIsInstance(self.ks, kdb.KeySet)
+
+		ks = kdb.KeySet(0)
+		self.assertIsInstance(ks, kdb.KeySet)
+
+		ks = kdb.KeySet(self.ks)
+		self.assertIsInstance(ks, kdb.KeySet)
+
+	def test_operator(self):
+		self.assertEqual(len(self.ks),       4)
+		self.assertEqual(len(kdb.KeySet(0)), 0)
+
+		self.assertTrue(kdb.Key("user/key3") in self.ks)
+		self.assertFalse(kdb.Key("user/foo") in self.ks)
+
+		self.assertEqual(self.ks[0],  kdb.Key("system/key1"))
+		self.assertEqual(self.ks[-1], kdb.Key("user/key4"))
+		with self.assertRaises(IndexError):
+			self.assertIsNone(self.ks[100])
+		with self.assertRaises(IndexError):
+			self.assertIsNone(self.ks[-100])
+
+		self.assertEqual(self.ks[1:3], [ self.ks[1], self.ks[2] ])
+
+		self.assertEqual(self.ks["user/key3"], kdb.Key("user/key3"))
+		with self.assertRaises(KeyError):
+			self.assertIsNone(self.ks["user/doesnt_exist"])
+
+		self.assertEqual(self.ks[kdb.Key("system/key2")], kdb.Key("system/key2"))
+		with self.assertRaises(KeyError):
+			self.ks[kdb.Key("user/doesnt_exist")]
+
+	def test_functions(self):
+		self.assertEqual(self.ks.lookup("user/key3"), kdb.Key("user/key3"))
+		self.assertEqual(self.ks.lookup(kdb.Key("system/key2")), kdb.Key("system/key2"))
+		self.assertEqual(self.ks.lookup(0),  kdb.Key("system/key1"))
+		self.assertEqual(self.ks.lookup(-1), kdb.Key("user/key4"))
+
+		ks = kdb.KeySet(0)
+		ks.append(kdb.Key("user/foo"))
+		ks.append(kdb.Key("user/bar"))
+		self.assertEqual(len(ks), 2)
+
+		' test clear '
+		ks = kdb.KeySet(0)
+		ks.append(kdb.Key("user/test1"))
+		ks.append(kdb.Key("user/test2"))
+		ks.append(kdb.Key("user/test3"))
+		ks.clear()
+		self.assertEqual(len(ks), 0);
+
+		' test pop '
+		ks = kdb.KeySet(0)
+		ks.append(kdb.Key("user/test1"))
+		ks.append(kdb.Key("user/test2"))
+		ks.append(kdb.Key("user/test3"))
+		self.assertEqual(ks.pop(), kdb.Key("user/test3"))
+		self.assertEqual(len(ks), 2)
+		
+		' test cut '
+		ks = kdb.KeySet(0)
+		ks.append(kdb.Key("user/level11"))
+		ks.append(kdb.Key("user/level13"))
+		ks.append(kdb.Key("user/level13/level21"))
+		ks.append(kdb.Key("user/level13/level22/level31"))
+		ks.append(kdb.Key("user/level13/level23"))
+		ks.append(kdb.Key("user/level15"))
+		
+		cutresult = ks.cut(kdb.Key("user/level13"))
+		
+		self.assertEqual(len(cutresult), 4)
+		self.assertTrue(kdb.Key("user/level13") in cutresult)
+		self.assertTrue(kdb.Key("user/level13/level21") in cutresult)
+		self.assertTrue(kdb.Key("user/level13/level22/level31") in cutresult)
+		self.assertTrue(kdb.Key("user/level13/level23") in cutresult)
+	
+		self.assertEqual(len(ks), 2)
+		self.assertTrue(kdb.Key("user/level11") in ks)
+		self.assertTrue(kdb.Key("user/level15") in ks)
+			
+		cutresult = ks.cut(kdb.Key("user/does/not/exist"))
+		self.assertEqual(len(cutresult), 0)
+		self.assertEqual(len(ks), 2)
+
+	def test_iterator(self):
+		self.assertEqual(sum(1 for _ in self.ks),           4)
+		self.assertEqual(sum(1 for _ in reversed(self.ks)), 4)
+		self.assertEqual(sum(1 for _ in kdb.KeySet(0)),     0)
+
+if __name__ == '__main__':
+	unittest.main()


### PR DESCRIPTION
In principle this is a big hack as it modifies the python class at runtime. Since it's python legacy I hope it won't stay that long.

I was not able to let cmake compile both python + python-legacy in one step. I fear that's not possible at all as both modules use the FindPythonLibs cmake module which will only run once.

So the best way to force compilation of python-legacy is to run cmake with some extra defines. I think you'll need to define:
- PYTHON_EXECUTABLE:FILEPATH=/usr/bin/python2.7
- PYTHON_INCLUDE_DIR:PATH=/usr/include/python2.7
- PYTHON_LIBRARY:FILEPATH=/usr/lib64/libpython2.7.so (or /usr/lib/libpython2.7.so)
