### PR TITLE
Fix various spelling errors

### DIFF
--- a/doc/NEWS
+++ b/doc/NEWS
@@ -662,7 +662,7 @@ some cleanup to be less confusing.
 The user experience was improved. The ".kdb" or ".config" directory now
 will be created if they do not exist.
 
-The debian packages are now splitted to have full advantage of the
+The debian packages are now split to have full advantage of the
 new plugin system.  The core packages (libelektra, libelektra-dev and
 libelektra-bin) do not depend on libxml anymore.  New is the package
 libelektra-full, which contains a single dynamic library containing all

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -11,7 +11,7 @@
 
 include (LibAddMacros)
 
-#dont call add_headers in a loop
+#don't call add_headers in a loop
 add_headers (HDR_FILES)
 
 macro (do_example source)

--- a/src/bindings/cpp/include/keyset.hpp
+++ b/src/bindings/cpp/include/keyset.hpp
@@ -420,7 +420,7 @@ inline KeySet::~KeySet ()
 }
 
 /**
- * If you dont want destruction of keyset at
+ * If you don't want destruction of keyset at
  * the end you can release the pointer.
  * */
 inline ckdb::KeySet * KeySet::release()

--- a/src/bindings/cpp/tests/testcpp_ks.cpp
+++ b/src/bindings/cpp/tests/testcpp_ks.cpp
@@ -687,7 +687,7 @@ void rcall(KeySet ks)
 	succeed_if (ks.lookup("user/xxx"), "could not find key");
 	succeed_if (!ks.lookup("user/yyy"), "could not find key");
 
-	// dont destroy ks
+	// don't destroy ks
 	ks.release();
 }
 

--- a/src/include/kdbprivate.h
+++ b/src/include/kdbprivate.h
@@ -353,7 +353,7 @@ struct _Plugin
  *
  * A trie is a data structure which can handle the longest prefix matching very
  * fast. This is exactly what needs to be done when using kdbGet() and kdbSet()
- * in a hierachy where backends are mounted - you need the backend mounted
+ * in a hierarchy where backends are mounted - you need the backend mounted
  * closest to the parentKey.
  */
 struct _Trie
@@ -379,7 +379,7 @@ struct _Split
 	Backend **handles;	/*!< The KDB for the keyset */
 	Key **parents;		/*!< The parentkey for the keyset.
 				Is either the mountpoint of the backend
-				or "user", "system" for the splitted root backends */
+				or "user", "system" for the split root backends */
 	int *syncbits;		/*!< Bits for various options:
 				Bit 0: Is there any key in there which need to be synced?
 				Bit 1: Do we need relative checks? (cascading backend?)*/
@@ -393,7 +393,7 @@ struct _Split
 
 ssize_t keySetRaw(Key *key, const void *newBinary, size_t dataSize);
 
-/*Methods for splitted keysets */
+/*Methods for split keysets */
 Split * elektraSplitNew(void);
 void elektraSplitDel(Split *keysets);
 void elektraSplitResize(Split *ret);

--- a/src/libelektra/backend.c
+++ b/src/libelektra/backend.c
@@ -103,7 +103,7 @@ system/elektra/mountpoints/<name>
  * configuration like needed.
  *
  * @note The given KeySet will be deleted within the function,
- * dont use it afterwards.
+ * don't use it afterwards.
  *
  * @param elektraConfig the configuration to work with.
  *        It is used to build up this backend.

--- a/src/libelektra/internal.c
+++ b/src/libelektra/internal.c
@@ -229,7 +229,7 @@ int elektraRealloc (void ** buffer, size_t size)
  * @code
 if ((buffer = elektraMalloc (length)) == 0) {
 	// here comes the failure handler
-	// no allocation happened here, so dont use buffer
+	// no allocation happened here, so don't use buffer
 #if DEBUG
 	fprintf (stderr, "Allocation error");
 #endif

--- a/src/libelektra/kdb.c
+++ b/src/libelektra/kdb.c
@@ -111,7 +111,7 @@
  * These libraries for backends will be loaded and with it the
  * @p KDB datastructure will be initialized.
  *
- * You must always call this method before retrieving or commiting any
+ * You must always call this method before retrieving or committing any
  * keys to the database. In the end of the program,
  * after using the key database, you must not forget to kdbClose().
  * You can use the atexit () handler for it.
@@ -487,7 +487,7 @@ int kdbGet(KDB *handle, KeySet *ks, Key *parentKey)
 	// Check if a update is needed at all
 	switch(elektraGetCheckUpdateNeeded(split, parentKey))
 	{
-	case 0: // We dont need an update so lets do nothing
+	case 0: // We don't need an update so let's do nothing
 		keySetName (parentKey, keyName(initialParent));
 		keyDel (initialParent);
 		elektraSplitDel (split);

--- a/src/libelektra/kdbenum.c
+++ b/src/libelektra/kdbenum.c
@@ -104,7 +104,7 @@ enum option_t
 	KDB_O_SYNC=1<<9,
 /** This option has no effect.
       KeySets are always sorted.
-      @deprecated dont use */
+      @deprecated don't use */
 	KDB_O_SORT=1<<10,
 /** Do not call kdbGet() for every key
       containing other keys (keyIsDir()). */

--- a/src/libelektra/keyset.c
+++ b/src/libelektra/keyset.c
@@ -774,7 +774,7 @@ ssize_t ksAppendKey(KeySet *ks, Key *toAppend)
  * @return the size of the KeySet after transfer
  * @return -1 on NULL pointers
  * @param ks the KeySet that will receive the keys
- * @param toAppend the KeySet that provides the keys that will be transfered
+ * @param toAppend the KeySet that provides the keys that will be transferred
  * @see ksAppendKey()
  * 
  */
@@ -1721,7 +1721,7 @@ if ((myKey = ksLookupByName (myConfig, "/myapp/current/specific/key", 0)) == NUL
  * 	Currently no options supported.
  * @return pointer to the Key found, 0 otherwise
  * @return 0 on NULL pointers
- * @see keyCompare() for very powerfull Key lookups in KeySets
+ * @see keyCompare() for very powerful Key lookups in KeySets
  * @see ksCurrent(), ksRewind(), ksNext()
  */
 Key *ksLookupByName(KeySet *ks, const char *name, option_t options)
@@ -1800,7 +1800,7 @@ while (key=ksLookupByString(ks,"my value",0))
  * 	  Lookup ignoring case.
  * @return the Key found, 0 otherwise
  * @see ksLookupByBinary()
- * @see keyCompare() for very powerfull Key lookups in KeySets
+ * @see keyCompare() for very powerful Key lookups in KeySets
  * @see ksCurrent(), ksRewind(), ksNext()
  */
 Key *ksLookupByString(KeySet *ks, const char *value, option_t options)
@@ -1860,7 +1860,7 @@ Key *ksLookupByString(KeySet *ks, const char *value, option_t options)
  * @return the Key found, NULL otherwise
  * @return 0 on NULL pointer
  * @see ksLookupByString()
- * @see keyCompare() for very powerfull Key lookups in KeySets
+ * @see keyCompare() for very powerful Key lookups in KeySets
  * @see ksCurrent(), ksRewind(), ksNext()
  */
 Key *ksLookupByBinary(KeySet *ks, const void *value, size_t size,

--- a/src/libelektra/keytest.c
+++ b/src/libelektra/keytest.c
@@ -586,7 +586,7 @@ kdbGetByName(handle, ks, "user/sw/MyApp", 0);
 // we are interested only in key type and access permissions
 interests=(KEY_TYPE | KEY_MODE);
 
-ksRewind(ks);   // put cursor in the begining
+ksRewind(ks);   // put cursor in the beginning
 while ((curren=ksNext(ks))) {
 	match=keyCompare(current,base);
 	

--- a/src/libelektra/plugin.c
+++ b/src/libelektra/plugin.c
@@ -158,7 +158,7 @@ int elektraProcessPlugin(Key *cur, int *pluginNumber, char **pluginName, char **
 			return 2;
 		}
 	} else {
-		*pluginName = elektraMalloc (fullsize-2); /* dont alloc for #n */
+		*pluginName = elektraMalloc (fullsize-2); /* don't alloc for #n */
 		strncpy (*pluginName, &fullname[2],fullsize-2);
 
 		return 1;

--- a/src/libelektra/split.c
+++ b/src/libelektra/split.c
@@ -77,7 +77,7 @@ Split * elektraSplitNew(void)
 /**
  * Delete a split object.
  *
- * Will free all allocated resources of a splitted keyset.
+ * Will free all allocated resources of a split keyset.
  *
  * @param keysets the split object to work with
  * @ingroup split
@@ -191,7 +191,7 @@ ssize_t elektraSplitSearchBackend(Split *split, Backend *backend, Key *parent)
  *          keys below parentKey
  * @return 0 if parentKey == 0 or there are keys below
  *          or same than parentKey which do not fit
- *          in any of splitted keysets
+ *          in any of split keysets
  * @param split the split object to work with
  * @param parentKey the key which relation is searched for
  * @ingroup split
@@ -289,7 +289,7 @@ int elektraSplitBuildup (Split *split, KDB *kdb, Key *parentKey)
  */
 int elektraSplitDivide (Split *split, KDB *handle, KeySet *ks)
 {
-	ssize_t curFound = 0; /* If key could be appended to any of the existing splitted keysets */
+	ssize_t curFound = 0; /* If key could be appended to any of the existing split keysets */
 	int needsSync = 0;
 	Key *curKey = 0;
 	Backend *curHandle = 0;
@@ -331,7 +331,7 @@ int elektraSplitDivide (Split *split, KDB *handle, KeySet *ks)
  */
 int elektraSplitAppoint (Split *split, KDB *handle, KeySet *ks)
 {
-	ssize_t curFound = 0; /* If key could be appended to any of the existing splitted keysets */
+	ssize_t curFound = 0; /* If key could be appended to any of the existing split keysets */
 	Key *curKey = 0;
 	Backend *curHandle = 0;
 	ssize_t defFound = elektraSplitAppend (split, 0, 0, 0);
@@ -511,7 +511,7 @@ int elektraSplitMerge (Split *split, KeySet *dest)
  *
  * @return 0 if kdbSet() is not needed
  * @return 1 if kdbSet() is needed
- * @pre user/system was splitted before.
+ * @pre user/system was split before.
  * @param split the split object to work with
  * @ingroup split
  *
@@ -590,7 +590,7 @@ int elektraSplitPrepare (Split *split)
 
 		if ((split->syncbits[i] & 1) == 0)
 		{
-			/* We dont need i anymore */
+			/* We don't need i anymore */
 			for (size_t j = i+1; j<size; ++j)
 			{
 				if ((split->syncbits[j] & 1) == 1)
@@ -599,7 +599,7 @@ int elektraSplitPrepare (Split *split)
 					Key *tmpParent = 0;
 					int tmpSyncbits = 0;
 
-					/* Ohh, we have found an important j... lets swap j and i */
+					/* Ohh, we have found an important j... let's swap j and i */
 					ksDel (split->keysets[i]);
 					split->keysets[i] = ksDup(split->keysets[j]);
 
@@ -618,7 +618,7 @@ int elektraSplitPrepare (Split *split)
 				}
 			}
 
-			/* We are finished, search did not find anything which needed sync, so lets remove the rest */
+			/* We are finished, search did not find anything which needed sync, so let's remove the rest */
 			for (size_t j = i; j<size; ++j)
 			{
 				if ((split->syncbits[j] & 1) == 0)

--- a/src/libelektra/trie.c
+++ b/src/libelektra/trie.c
@@ -160,7 +160,7 @@ Trie* elektraTrieInsert(Trie *trie, const char *name, Backend *value)
 			/* insert the name given as a parameter into the new trie entry */
 			trie->children[idx]=elektraTrieInsert(NULL, name+(p-trie->text[idx]), value);
 
-			/* insert the splitted try into the new trie entry */
+			/* insert the split try into the new trie entry */
 
 			idx2 = (unsigned char) newname[0];
 			trie->children[idx]->text[idx2]=newname;

--- a/src/libloader/doc.c
+++ b/src/libloader/doc.c
@@ -57,7 +57,7 @@ int elektraModulesInit (KeySet *modules, Key *error)
  * system/elektra/modules/name
  * You might want to use an struct and store it there as binary key.
  *
- * If anything goes wrong dont append anything to modules. Instead
+ * If anything goes wrong don't append anything to modules. Instead
  * report the error to the error key and return with 0.
  *
  * @pre the name is not null, empty and has at least one character

--- a/src/libtools/include/backends.hpp
+++ b/src/libtools/include/backends.hpp
@@ -1,7 +1,7 @@
 /**
  * \file
  *
- * \brief Allows to list all available backends
+ * \brief Allows one to list all available backends
  *
  * \copyright BSD License (see doc/COPYING or http://www.libelektra.org)
  *
@@ -33,7 +33,7 @@ struct BackendInfo
 };
 
 /**
- * @brief Allows to list backends
+ * @brief Allows one to list backends
  */
 class Backends
 {

--- a/src/libtools/include/modules.hpp
+++ b/src/libtools/include/modules.hpp
@@ -1,7 +1,7 @@
 /**
  * \file
  *
- * \brief Allows to load plugins
+ * \brief Allows one to load plugins
  *
  * \copyright BSD License (see doc/COPYING or http://www.libelektra.org)
  *
@@ -22,7 +22,7 @@ namespace tools
 {
 
 /**
- * @brief Allows to load plugins
+ * @brief Allows one to load plugins
  */
 class Modules
 {

--- a/src/libtools/include/toolexcept.hpp
+++ b/src/libtools/include/toolexcept.hpp
@@ -144,7 +144,7 @@ struct ConflictViolation: public PluginCheckException
 	{
 		return  "Conflict Violation!\n"
 			"You tried to add a plugin which conflicts with another.\n"
-			"Please dont add a plugin which conflicts.";
+			"Please don't add a plugin which conflicts.";
 	}
 };
 

--- a/src/plugins/doc/doc.c
+++ b/src/plugins/doc/doc.c
@@ -485,7 +485,7 @@ int docError(Plugin *handle ELEKTRA_UNUSED, KeySet *returned ELEKTRA_UNUSED, Key
  * You need to use a macro so that both dynamic and static loading
  * of the plugin works.
  *
- * The first paramter is the name of the plugin.
+ * The first parameter is the name of the plugin.
  * Then every plugin should have:
  * @c ELEKTRA_PLUGIN_OPEN,
  * @c ELEKTRA_PLUGIN_CLOSE,

--- a/src/plugins/resolver/filename.c
+++ b/src/plugins/resolver/filename.c
@@ -36,7 +36,7 @@ int elektraResolverCheckFile(const char* filename)
 	keyDel(check);
 	free(buffer);
 
-	/* Be strict, dont allow any .., even if it would be allowed sometimes */
+	/* Be strict, don't allow any .., even if it would be allowed sometimes */
 	if(strstr (filename, "..") != 0) return -1;
 
 

--- a/src/plugins/resolver/testmod_resolver.c
+++ b/src/plugins/resolver/testmod_resolver.c
@@ -261,20 +261,20 @@ void test_tempname()
 
 void test_checkfile()
 {
-	succeed_if (elektraResolverCheckFile("valid") == 1, "valid file not recogniced");
-	succeed_if (elektraResolverCheckFile("/valid") == 0, "valid absolute file not recogniced");
-	succeed_if (elektraResolverCheckFile("/absolute/valid") == 0, "valid absolute file not recogniced");
-	succeed_if (elektraResolverCheckFile("../valid") == -1, "invalid file not recogniced");
-	succeed_if (elektraResolverCheckFile("valid/..") == -1, "invalid file not recogniced");
-	succeed_if (elektraResolverCheckFile("/../valid") == -1, "invalid absolute file not recogniced");
-	succeed_if (elektraResolverCheckFile("/valid/..") == -1, "invalid absolute file not recogniced");
+	succeed_if (elektraResolverCheckFile("valid") == 1, "valid file not recognised");
+	succeed_if (elektraResolverCheckFile("/valid") == 0, "valid absolute file not recognised");
+	succeed_if (elektraResolverCheckFile("/absolute/valid") == 0, "valid absolute file not recognised");
+	succeed_if (elektraResolverCheckFile("../valid") == -1, "invalid file not recognised");
+	succeed_if (elektraResolverCheckFile("valid/..") == -1, "invalid file not recognised");
+	succeed_if (elektraResolverCheckFile("/../valid") == -1, "invalid absolute file not recognised");
+	succeed_if (elektraResolverCheckFile("/valid/..") == -1, "invalid absolute file not recognised");
 	succeed_if (elektraResolverCheckFile("very..strict") == -1, "resolver is currently very strict");
 	succeed_if (elektraResolverCheckFile("very/..strict") == -1, "resolver is currently very strict");
 	succeed_if (elektraResolverCheckFile("very../strict") == -1, "resolver is currently very strict");
 	succeed_if (elektraResolverCheckFile("very/../strict") == -1, "resolver is currently very strict");
-	succeed_if (elektraResolverCheckFile("/") == -1, "invalid absolute file not recogniced");
-	succeed_if (elektraResolverCheckFile(".") == -1, "invalid file not recogniced");
-	succeed_if (elektraResolverCheckFile("..") == -1, "invalid file not recogniced");
+	succeed_if (elektraResolverCheckFile("/") == -1, "invalid absolute file not recognised");
+	succeed_if (elektraResolverCheckFile(".") == -1, "invalid file not recognised");
+	succeed_if (elektraResolverCheckFile("..") == -1, "invalid file not recognised");
 }
 
 

--- a/src/plugins/struct/checker.cpp
+++ b/src/plugins/struct/checker.cpp
@@ -16,7 +16,7 @@ void ListChecker::buildup (Factory &f, std::string const& templateParameter)
 	CheckerPtr c = f.get(templateParameter);
 	if (!c.get()) throw "Could not create structure of template Parameter";
 
-	// recursive handling code would belong here, but we dont have config
+	// recursive handling code would belong here, but we don't have config
 	// at the moment in ListChecker...
 	c->buildup(f, "");
 

--- a/src/plugins/struct/struct.cpp
+++ b/src/plugins/struct/struct.cpp
@@ -40,7 +40,7 @@ inline static int elektraStructOpenDelegator(ckdb::Plugin *handle, kdb::KeySet& 
 	if (config.lookup("/module"))
 	{
 		// suppress warnings if it is just a module
-		// dont buildup the struct then
+		// don't buildup the struct then
 		return 0;
 	}
 

--- a/src/plugins/type/type.cpp
+++ b/src/plugins/type/type.cpp
@@ -40,7 +40,7 @@ inline static int elektraTypeOpenDelegator(ckdb::Plugin *handle, kdb::KeySet& co
 	if (config.lookup("/module"))
 	{
 		// suppress warnings if it is just a module
-		// dont buildup the struct then
+		// don't buildup the struct then
 		return 0;
 	}
 

--- a/src/plugins/xmltool/kscompare.c
+++ b/src/plugins/xmltool/kscompare.c
@@ -8,14 +8,14 @@
  *
  * This method behavior is the following:
  * - A key (by full name) that is present on @p ks1 and @p ks2, and has
- *   something different, will be transfered from @p ks2 to @p ks1, and
+ *   something different, will be transferred from @p ks2 to @p ks1, and
  *   @p ks1's (old) version deleted.
- * - Keys present in @p ks1, but not in @p ks2 will be transfered from @p ks1
+ * - Keys present in @p ks1, but not in @p ks2 will be transferred from @p ks1
  *   to @p removed.
  * - Keys that are keyCompare() equal in @p ks1 and @p ks2 will be
  *   keyDel()eted from @p ks2.
  * - Keys present in @p ks2 but not in @p ks1 will
- *   be transfered to @p ks1.
+ *   be transferred to @p ks1.
  *
  * In the end, @p ks1 will have all the keys that matter, and @p ks2
  * will be empty.

--- a/src/plugins/yajl/yajl_gen_close.c
+++ b/src/plugins/yajl/yajl_gen_close.c
@@ -51,7 +51,7 @@ static void elektraGenCloseLast(yajl_gen g, const Key *key)
  * _/#
  * _/___empty_map
  * (lookahead says it is not a map)
- * -> dont do anything
+ * -> don't do anything
  *
  * (C3)
  * #

--- a/src/tools/kdb/file.hpp
+++ b/src/tools/kdb/file.hpp
@@ -30,7 +30,7 @@ public:
 
 	virtual std::string getLongHelpText()
 	{
-		return "While elektra allows to store configuration in binary\n"
+		return "While elektra allows one to store configuration in binary\n"
 		       "key databases, there are typically stored in configuration\n"
 		       "files.\n"
 		       "For administrative users and people used to configuration\n"

--- a/src/tools/kdb/main.cpp
+++ b/src/tools/kdb/main.cpp
@@ -164,7 +164,7 @@ int main(int argc, char**argv)
 	}
 	catch (...)
 	{
-		std::cerr << "Unkown error" << std::endl;
+		std::cerr << "Unknown error" << std::endl;
 		displayHelp(argv[0], f.getCommands());
 		return 7;
 	}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -25,7 +25,7 @@
 
 include (LibAddMacros)
 
-#dont call add_headers in a loop
+#don't call add_headers in a loop
 add_headers (HDR_FILES)
 
 macro (do_test source)

--- a/tests/test_key.c
+++ b/tests/test_key.c
@@ -821,10 +821,10 @@ void test_keyName()
 	succeed_if (strcmp (keyName(key), "user") == 0, "Name Problem: Double Dot as basename");
 
 	keySetName(key,"user/..");
-	succeed_if (strcmp (keyName(key), "user") == 0, "Name Problem: Can't go higher then user in hierachy");
+	succeed_if (strcmp (keyName(key), "user") == 0, "Name Problem: Can't go higher then user in hierarchy");
 
 	keySetName(key,"user/hidden/../..");
-	succeed_if (strcmp (keyName(key), "user") == 0, "Name Problem: Can't go higher then user in hierachy");
+	succeed_if (strcmp (keyName(key), "user") == 0, "Name Problem: Can't go higher then user in hierarchy");
 
 	succeed_if (keySetName(key, "user///sw/../sw//././MyApp")==sizeof("user/sw/MyApp"), "could not set keySet example");
 	succeed_if (strcmp (keyName(key), "user/sw/MyApp") == 0, "Example of keySet does not work");

--- a/tests/test_ks.c
+++ b/tests/test_ks.c
@@ -2380,7 +2380,7 @@ void test_ksDoubleAppendKey()
 	keyDel (k); // has no effect
 
 	ksDel (ks);
-	// dont free key here!!
+	// don't free key here!!
 }
 
 void test_ksAppendKey()

--- a/tests/test_split.c
+++ b/tests/test_split.c
@@ -1,5 +1,5 @@
 /*************************************************************************** 
- *           test_split.c  - Test suite for splitted keyset data structure
+ *           test_split.c  - Test suite for split keyset data structure
  *                  -------------------
  *  begin                : Fri 21 Mar 2008
  *  copyright            : (C) 2008 by Markus Raab

--- a/tests/test_splitget.c
+++ b/tests/test_splitget.c
@@ -1,5 +1,5 @@
 /*************************************************************************** 
- *           test_splitset.c  - Test suite for splitted keyset data structure
+ *           test_splitset.c  - Test suite for split keyset data structure
  *                  -------------------
  *  begin                : Tue Jun 29 2010
  *  copyright            : (C) 2010 by Markus Raab

--- a/tests/test_splitset.c
+++ b/tests/test_splitset.c
@@ -1,5 +1,5 @@
 /*************************************************************************** 
- *           test_splitset.c  - Test suite for splitted keyset data structure
+ *           test_splitset.c  - Test suite for split keyset data structure
  *                  -------------------
  *  begin                : Tue Jun 29 2010
  *  copyright            : (C) 2010 by Markus Raab
@@ -185,7 +185,7 @@ void test_mount()
 	succeed_if (split->handles, "did not alloc handles array");
 	succeed_if (split->syncbits[0] == 1, "system part need to by synced");
 	succeed_if (split->syncbits[1] == 1, "user part need to by synced");
-	succeed_if (split->size == 3, "not splitted according user, system");
+	succeed_if (split->size == 3, "not split according user, system");
 	succeed_if (ksGetSize(split->keysets[0]) == 2, "size of keyset not correct");
 	succeed_if (ksGetSize(split->keysets[1]) == 2, "size of keyset not correct");
 	compare_keyset(split->keysets[1], split1);
@@ -204,7 +204,7 @@ void test_mount()
 	succeed_if (split->syncbits[1] == 0, "user part does not need to by synced");
 	succeed_if (ksGetSize(split->keysets[0]) == 2, "size of keyset not correct");
 	succeed_if (ksGetSize(split->keysets[1]) == 2, "size of keyset not correct");
-	succeed_if (split->size == 3, "not splitted according user, system");
+	succeed_if (split->size == 3, "not split according user, system");
 	elektraSplitDel (split);
 
 	split = elektraSplitNew();
@@ -217,7 +217,7 @@ void test_mount()
 	succeed_if (split->syncbits[1] == 1, "user part need to by synced");
 	succeed_if (ksGetSize(split->keysets[0]) == 2, "size of keyset not correct");
 	succeed_if (ksGetSize(split->keysets[1]) == 2, "size of keyset not correct");
-	succeed_if (split->size == 3, "not splitted according user, system");
+	succeed_if (split->size == 3, "not split according user, system");
 	elektraSplitDel (split);
 
 	split = elektraSplitNew();
@@ -230,7 +230,7 @@ void test_mount()
 	succeed_if (split->syncbits[1] == 1, "user part need to by synced");
 	succeed_if (ksGetSize(split->keysets[0]) == 2, "size of keyset not correct");
 	succeed_if (ksGetSize(split->keysets[1]) == 2, "size of keyset not correct");
-	succeed_if (split->size == 3, "not splitted according user, system");
+	succeed_if (split->size == 3, "not split according user, system");
 	elektraSplitDel (split);
 
 
@@ -277,7 +277,7 @@ void test_easyparent()
 
 	succeed_if (split->keysets, "did not alloc keysets array");
 	succeed_if (split->handles, "did not alloc handles array");
-	succeed_if (split->size == 2, "not splitted according user, system");
+	succeed_if (split->size == 2, "not split according user, system");
 	succeed_if (split->syncbits[0] & 1, "system part need to by synced");
 	succeed_if (split->syncbits[1] & 1, "user part need to be synced");
 	compare_keyset(split->keysets[0], split1);
@@ -294,7 +294,7 @@ void test_easyparent()
 
 	succeed_if (split->keysets, "did not alloc keysets array");
 	succeed_if (split->handles, "did not alloc handles array");
-	succeed_if (split->size == 2, "not splitted according user, system");
+	succeed_if (split->size == 2, "not split according user, system");
 	succeed_if (split->syncbits[0] & 1, "system part need to by synced");
 	succeed_if (split->syncbits[1] & 1, "user part need to be synced");
 	compare_keyset(split->keysets[0], split1);
@@ -347,7 +347,7 @@ void test_optimize()
 
 	succeed_if (split->keysets, "did not alloc keysets array");
 	succeed_if (split->handles, "did not alloc handles array");
-	succeed_if (split->size == 3, "not splitted according user, system");
+	succeed_if (split->size == 3, "not split according user, system");
 	succeed_if (split->syncbits[0] == 1, "system part not optimized");
 	succeed_if (split->syncbits[1] == 0, "user part need to by synced");
 	compare_keyset(split->keysets[0], split1);
@@ -364,7 +364,7 @@ void test_optimize()
 
 	succeed_if (split->keysets, "did not alloc keysets array");
 	succeed_if (split->handles, "did not alloc handles array");
-	succeed_if (split->size == 3, "not splitted according user, system");
+	succeed_if (split->size == 3, "not split according user, system");
 	succeed_if (split->syncbits[0] == 0, "system part not optimized");
 	succeed_if (split->syncbits[1] == 0, "user part not optimized");
 	compare_keyset(split->keysets[0], split1);
@@ -387,7 +387,7 @@ void test_optimize()
 
 	succeed_if (split->keysets, "did not alloc keysets array");
 	succeed_if (split->handles, "did not alloc handles array");
-	succeed_if (split->size == 3, "not splitted according user, system");
+	succeed_if (split->size == 3, "not split according user, system");
 	succeed_if (split->syncbits[0] == 1, "optimized too much");
 	succeed_if (split->syncbits[1] == 1, "optimized too much");
 	compare_keyset(split->keysets[0], split1);
@@ -455,7 +455,7 @@ void test_three()
 
 	succeed_if (split->keysets, "did not alloc keysets array");
 	succeed_if (split->handles, "did not alloc handles array");
-	succeed_if (split->size == 5, "not splitted according three");
+	succeed_if (split->size == 5, "not split according three");
 	succeed_if (split->syncbits[0] == 1, "system part need to by synced");
 	succeed_if (split->syncbits[1] == 1, "user part need to by synced");
 	succeed_if (split->syncbits[2] == 1, "user part need to by synced");
@@ -476,7 +476,7 @@ void test_three()
 	/* Prepare should not change anything here (everything needs sync) */
 	succeed_if (split->keysets, "did not alloc keysets array");
 	succeed_if (split->handles, "did not alloc handles array");
-	succeed_if (split->size == 4, "not splitted according three");
+	succeed_if (split->size == 4, "not split according three");
 	succeed_if (split->syncbits[0] == 1, "system part need to by synced");
 	succeed_if (split->syncbits[1] == 1, "user part need to by synced");
 	succeed_if (split->syncbits[2] == 1, "user part need to by synced");
@@ -569,7 +569,7 @@ void test_userremove()
 	elektraSplitDel (split);
 
 
-	/* But it should even need sync when we dont have any unsynced keys! */
+	/* But it should even need sync when we don't have any unsynced keys! */
 	clear_sync(ks);
 	split = elektraSplitNew();
 
@@ -696,7 +696,7 @@ void test_systemremove()
 	elektraSplitDel (split);
 
 
-	/* But it should even need sync when we dont have any unsynced keys! */
+	/* But it should even need sync when we don't have any unsynced keys! */
 	clear_sync(ks);
 	split = elektraSplitNew();
 


### PR DESCRIPTION
- allows to -> allows one to
- altough -> although
- begining -> beginning
- commiting -> committing
- dont -> don't
- hierachy -> hierarchy
- lets -> let's
- paramter -> parameter
- powerfull -> powerful
- recogniced -> recognised
- splitted -> split
- transfered -> transferred
- unkown -> unknown
