### PR TITLE
Implemented a new ini plugin

### DIFF
--- a/src/plugins/ini/CMakeLists.txt
+++ b/src/plugins/ini/CMakeLists.txt
@@ -1,0 +1,22 @@
+include (LibAddMacros)
+
+
+set (SOURCES ini.h ini.c lib/inih.h lib/inih.c)
+add_sources (elektra-full ${SOURCES})
+add_headers (SOURCES)
+add_definitions( -DINI_ALLOW_MULTILINE=0 )
+set (PLUGIN_NAME elektra-ini)
+add_library (${PLUGIN_NAME} MODULE ${SOURCES})
+target_link_libraries (${PLUGIN_NAME} elektra)
+
+add_includes (elektra-full ${CMAKE_CURRENT_BINARY_DIR})
+include_directories (${CMAKE_CURRENT_BINARY_DIR})
+
+generate_readme (ini)
+
+install (TARGETS ${PLUGIN_NAME}
+	DESTINATION lib${LIB_SUFFIX}/${TARGET_PLUGIN_FOLDER})
+
+install(DIRECTORY ini DESTINATION ${TARGET_TEST_DATA_FOLDER})
+
+add_plugintest (ini)

--- a/src/plugins/ini/README.md
+++ b/src/plugins/ini/README.md
@@ -1,0 +1,7 @@
+- infos = Information about ini plugin is in keys below
+- infos/author = Felix Berlakovich <elektra@berlakovich.net>
+- infos/licence = BSD
+- infos/needs =
+- infos/provides = storage
+- infos/placements = getstorage setstorage
+- infos/description = ini file backend

--- a/src/plugins/ini/contract.h
+++ b/src/plugins/ini/contract.h
@@ -1,0 +1,31 @@
+/*
+ * contract.h
+ *
+ *  Created on: 10 May 2014
+ *      Author: felixl
+ */
+
+#ifndef CONTRACT_H_
+#define CONTRACT_H_
+
+// @formatter:off
+
+ksNew (30,
+		keyNew ("system/elektra/modules/ini",
+				KEY_VALUE, "Ini plugin waits for your orders", KEY_END),
+		keyNew ("system/elektra/modules/ini/exports", KEY_END),
+		keyNew ("system/elektra/modules/ini/exports/get",
+				KEY_FUNC, elektraIniGet,
+				KEY_END),
+		keyNew ("system/elektra/modules/ini/exports/set",
+				KEY_FUNC, elektraIniSet,
+				KEY_END),
+#include "README.c"
+		keyNew ("system/elektra/modules/ini/infos/version",
+				KEY_VALUE, PLUGINVERSION,
+				KEY_END),
+		KS_END);
+
+// @formatter:on
+
+#endif /* CONTRACT_H_ */

--- a/src/plugins/ini/ini.c
+++ b/src/plugins/ini/ini.c
@@ -1,0 +1,217 @@
+/**
+ * \file
+ *
+ * \brief A plugin for reading and writing ini files
+ *
+ * \copyright BSD License (see doc/COPYING or http://www.libelektra.org)
+ *
+ */
+
+#ifndef HAVE_KDBCONFIG
+# include "kdbconfig.h"
+#endif
+
+#include <errno.h>
+#include <string.h>
+#include <stdlib.h>
+#include <kdberrors.h>
+#include "lib/inih.h"
+#include "ini.h"
+
+#define ELEKTRA_SET_GENERAL_ERROR_IF(id, parentKey, message, condition) \
+	do { \
+		if (condition) \
+		{ \
+			ELEKTRA_SET_ERROR(id, parentKey, message); \
+			errno = errnosave; \
+			return -1; \
+		} \
+	} while (0)
+
+#define ELEKTRA_SET_ERRNO_ERROR_IF(id, parentKey, condition) \
+	ELEKTRA_SET_GENERAL_ERROR_IF(id, parentKey, strerror(errno), condition)
+
+
+typedef struct {
+	const Key *parentKey;
+	KeySet *result;
+	char *collectedComment;
+} Configuration;
+
+static void writeCommentToMeta (Configuration *config, Key *key)
+{
+	if (config->collectedComment)
+	{
+		keySetMeta (key, "comment", config->collectedComment);
+		free (config->collectedComment);
+		config->collectedComment = 0;
+	}
+}
+
+static int iniKeyToElektraKey (void *vconfig, const char *section, const char *name, const char *value)
+{
+
+	Configuration *config = (Configuration *)vconfig;
+
+	Key *appendKey = keyDup (config->parentKey);
+
+	if (section)
+	{
+		keyAddBaseName(appendKey, section);
+	}
+
+	keyAddBaseName (appendKey, name);
+	writeCommentToMeta (config, appendKey);
+	keySetString (appendKey, value);
+	ksAppendKey (config->result, appendKey);
+
+	return 1;
+}
+
+static int iniSectionToElektraKey (void *vconfig, const char *section)
+{
+	Configuration *config = (Configuration *)vconfig;
+
+	Key *appendKey = keyDup (config->parentKey);
+
+	keyAddBaseName(appendKey, section);
+	writeCommentToMeta (config, appendKey);
+	keySetDir(appendKey);
+	ksAppendKey(config->result, appendKey);
+
+	return 1;
+}
+
+static int iniCommentToMeta (void *vconfig, const char *comment)
+{
+	Configuration *config = (Configuration *)vconfig;
+
+	size_t commentSize = strlen (comment) + 1;
+
+	if (!config->collectedComment)
+	{
+		config->collectedComment = malloc (commentSize);
+
+		if (!config->collectedComment) return 0;
+
+		strncpy (config->collectedComment, comment, commentSize);
+	}
+	else
+	{
+		size_t newCommentSize = strlen (config->collectedComment) + commentSize + 1;
+		config->collectedComment = realloc (config->collectedComment, newCommentSize);
+
+		if (!config->collectedComment) return 0;
+
+		strcat (config->collectedComment, "\n");
+		strncat (config->collectedComment, comment, newCommentSize);
+	}
+
+	return 1;
+}
+
+int elektraIniGet(Plugin *handle ELEKTRA_UNUSED, KeySet *returned, Key *parentKey)
+{
+	/* get all keys */
+
+	int errnosave = errno;
+
+	if (!strcmp (keyName (parentKey), "system/elektra/modules/ini"))
+	{
+		KeySet *info =
+#include "contract.h"
+
+		ksAppend (returned, info);
+		ksDel (info);
+		return 1;
+	}
+
+	FILE *fh = fopen (keyString (parentKey), "r");
+	ELEKTRA_SET_ERRNO_ERROR_IF(9, parentKey, !fh);
+
+	KeySet *append = ksNew (ksGetSize (returned) * 2, KS_END);
+
+	Configuration config;
+	config.parentKey = parentKey;
+	config.result = append;
+	config.collectedComment = 0;
+
+	int ret = ini_parse_file(fh,iniKeyToElektraKey, iniSectionToElektraKey, iniCommentToMeta, &config);
+
+	fclose (fh);
+	ELEKTRA_SET_GENERAL_ERROR_IF(87, parentKey, "Unable to parse the ini file", ret < 0);
+
+	ksClear(returned);
+	ksAppend(returned, config.result);
+	ksDel(config.result);
+	errno = errnosave;
+	return 1; /* success */
+}
+
+// TODO: # and ; comments get mixed up, patch inih to differentiate and
+// create comment keys instead of writing meta data. Writing the meta
+// data can be done by keytometa then
+void writeComments(Key* current, FILE* fh)
+{
+	const Key* commentMeta = keyGetMeta (current, "comment");
+	if (commentMeta)
+	{
+		size_t commentSize = keyGetValueSize (commentMeta);
+		char* comments = malloc (commentSize);
+		keyGetString (commentMeta, comments, commentSize);
+		char* savePtr;
+		char* currentComment = strtok_r (comments, "\n", &savePtr);
+		while (currentComment)
+		{
+			fprintf (fh, ";%s\n", currentComment);
+			currentComment = strtok_r (0, "\n", &savePtr);
+		}
+
+		free (comments);
+	}
+}
+
+int elektraIniSet(Plugin *handle ELEKTRA_UNUSED, KeySet *returned, Key *parentKey)
+{
+	/* set all keys */
+	int errnosave = errno;
+
+	FILE *fh = fopen(keyString(parentKey), "w");
+
+	ELEKTRA_SET_ERRNO_ERROR_IF(9, parentKey, !fh);
+
+	ksRewind (returned);
+	Key *current;
+	while ((current = ksNext (returned)))
+	{
+		writeComments (current, fh);
+		size_t baseNameSize = keyGetBaseNameSize(current);
+		char *name = malloc (baseNameSize);
+		keyGetBaseName(current, name, baseNameSize);
+
+		if (keyIsDir(current))
+		{
+			fprintf (fh, "[%s]\n", name);
+		}
+		else
+		{
+			fprintf (fh, "%s = %s\n", name, keyString(current));
+		}
+
+		free (name);
+	}
+
+	fclose (fh);
+
+	errno = errnosave;
+	return 1; /* success */
+}
+
+Plugin *ELEKTRA_PLUGIN_EXPORT(ini)
+{
+	return elektraPluginExport("ini",
+		ELEKTRA_PLUGIN_GET,	&elektraIniGet,
+		ELEKTRA_PLUGIN_SET,	&elektraIniSet,
+		ELEKTRA_PLUGIN_END);
+}
+

--- a/src/plugins/ini/ini.h
+++ b/src/plugins/ini/ini.h
@@ -1,0 +1,37 @@
+/***************************************************************************
+                     ini.c  -  Skeleton of a plugin
+                             -------------------
+    begin                : Fri May 21 2010
+    copyright            : (C) 2010 by Markus Raab
+    email                : elektra@markus-raab.org
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the BSD License (revised).                      *
+ *                                                                         *
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This is the skeleton of the methods you'll have to implement in order *
+ *   to provide a valid plugin.                                            *
+ *   Simple fill the empty functions with your code and you are            *
+ *   ready to go.                                                          *
+ *                                                                         *
+ ***************************************************************************/
+
+
+#ifndef ELEKTRA_PLUGIN_INI_H
+#define ELEKTRA_PLUGIN_INI_H
+
+#include <kdbplugin.h>
+
+
+int elektraIniGet(Plugin *handle, KeySet *ks, Key *parentKey);
+int elektraIniSet(Plugin *handle, KeySet *ks, Key *parentKey);
+
+Plugin *ELEKTRA_PLUGIN_EXPORT(ini);
+
+#endif

--- a/src/plugins/ini/ini/commentini
+++ b/src/plugins/ini/ini/commentini
@@ -1,0 +1,9 @@
+;nosection comment1
+;nosection comment2
+nosectionkey = nosectionvalue
+;section comment1
+;section comment2
+[section1]
+;key comment1
+;key comment2
+key1 = value1

--- a/src/plugins/ini/ini/plainini
+++ b/src/plugins/ini/ini/plainini
@@ -1,0 +1,7 @@
+nosectionkey = nosectionvalue
+[section1]
+key1 = value1
+key2 = value2
+[section2]
+emptykey = 
+key3 = value3

--- a/src/plugins/ini/lib/inih.c
+++ b/src/plugins/ini/lib/inih.c
@@ -1,0 +1,191 @@
+/* inih -- simple .INI file parser
+
+inih is released under the New BSD license (see LICENSE.txt). Go to the project
+home page for more info:
+
+http://code.google.com/p/inih/
+
+*/
+
+#include <stdio.h>
+#include <ctype.h>
+#include <string.h>
+
+#include "inih.h"
+
+#if !INI_USE_STACK
+#include <stdlib.h>
+#endif
+
+#define MAX_SECTION 50
+#define MAX_NAME 50
+
+/* Strip whitespace chars off end of given string, in place. Return s. */
+static char* rstrip(char* s)
+{
+    char* p = s + strlen(s);
+    while (p > s && isspace((unsigned char)(*--p)))
+        *p = '\0';
+    return s;
+}
+
+/* Return pointer to first non-whitespace char in given string. */
+static char* lskip(const char* s)
+{
+    while (*s && isspace((unsigned char)(*s)))
+        s++;
+    return (char*)s;
+}
+
+/* Return pointer to first char c or ';' comment in given string, or pointer to
+   null at end of string if neither found. ';' must be prefixed by a whitespace
+   character to register as a comment. */
+static char* find_char_or_comment(const char* s, char c)
+{
+    int was_whitespace = 0;
+    while (*s && *s != c && !(was_whitespace && *s == ';')) {
+        was_whitespace = isspace((unsigned char)(*s));
+        s++;
+    }
+    return (char*)s;
+}
+
+/* Version of strncpy that ensures dest (size bytes) is null-terminated. */
+static char* strncpy0(char* dest, const char* src, size_t size)
+{
+    strncpy(dest, src, size);
+    dest[size - 1] = '\0';
+    return dest;
+}
+
+/* See documentation in header file. */
+int ini_parse_file(FILE* file,
+                   int (*handler)(void*, const char*, const char*,
+                                  const char*),
+                   int (*sectionHandler)(void*, const char*),
+                   int (*commentHandler)(void*, const char*),
+                   void* user)
+{
+    /* Uses a fair bit of stack (use heap instead if you need to) */
+#if INI_USE_STACK
+    char line[INI_MAX_LINE];
+#else
+    char* line;
+#endif
+    char section[MAX_SECTION] = "";
+    char prev_name[MAX_NAME] = "";
+
+    char* start;
+    char* end;
+    char* name;
+    char* value;
+    int lineno = 0;
+    int error = 0;
+
+#if !INI_USE_STACK
+    line = (char*)malloc(INI_MAX_LINE);
+    if (!line) {
+        return -2;
+    }
+#endif
+
+    /* Scan through file line by line */
+    while (fgets(line, INI_MAX_LINE, file) != NULL) {
+        lineno++;
+
+        start = line;
+#if INI_ALLOW_BOM
+        if (lineno == 1 && (unsigned char)start[0] == 0xEF &&
+                           (unsigned char)start[1] == 0xBB &&
+                           (unsigned char)start[2] == 0xBF) {
+            start += 3;
+        }
+#endif
+        start = lskip(rstrip(start));
+
+        if (*start == ';' || *start == '#') {
+        	start += 1;
+        	if (!commentHandler(user, start) && !error)
+        		error = lineno;
+            /* Per Python ConfigParser, allow '#' comments at start of line */
+        }
+#if INI_ALLOW_MULTILINE
+        else if (*prev_name && *start && start > line) {
+            /* Non-black line with leading whitespace, treat as continuation
+               of previous name's value (as per Python ConfigParser). */
+            if (!handler(user, section, prev_name, start) && !error)
+                error = lineno;
+        }
+#endif
+        else if (*start == '[') {
+            /* A "[section]" line */
+            end = find_char_or_comment(start + 1, ']');
+            if (*end == ']') {
+                *end = '\0';
+                strncpy0(section, start + 1, sizeof(section));
+                *prev_name = '\0';
+                if(!sectionHandler(user, section) && !error)
+                	error = lineno;
+            }
+            else if (!error) {
+                /* No ']' found on section line */
+                error = lineno;
+            }
+        }
+        else if (*start && *start != ';') {
+            /* Not a comment, must be a name[=:]value pair */
+            end = find_char_or_comment(start, '=');
+            if (*end != '=') {
+                end = find_char_or_comment(start, ':');
+            }
+            if (*end == '=' || *end == ':') {
+                *end = '\0';
+                name = rstrip(start);
+                value = lskip(end + 1);
+                end = find_char_or_comment(value, '\0');
+                if (*end == ';')
+                    *end = '\0';
+                rstrip(value);
+
+                /* Valid name[=:]value pair found, call handler */
+                strncpy0(prev_name, name, sizeof(prev_name));
+                if (!handler(user, section, name, value) && !error)
+                    error = lineno;
+            }
+            else if (!error) {
+                /* No '=' or ':' found on name[=:]value line */
+                error = lineno;
+            }
+        }
+
+#if INI_STOP_ON_FIRST_ERROR
+        if (error)
+            break;
+#endif
+    }
+
+#if !INI_USE_STACK
+    free(line);
+#endif
+
+    return error;
+}
+
+/* See documentation in header file. */
+int ini_parse(const char* filename,
+			int (*handler)(void*, const char*, const char*,
+						   const char*),
+			int (*sectionHandler)(void*, const char*),
+			int (*commentHandler)(void*, const char*),
+			void* user)
+{
+    FILE* file;
+    int error;
+
+    file = fopen(filename, "r");
+    if (!file)
+        return -1;
+    error = ini_parse_file(file, handler, sectionHandler, commentHandler, user);
+    fclose(file);
+    return error;
+}

--- a/src/plugins/ini/lib/inih.h
+++ b/src/plugins/ini/lib/inih.h
@@ -1,0 +1,81 @@
+/* inih -- simple .INI file parser
+
+inih is released under the New BSD license (see LICENSE.txt). Go to the project
+home page for more info:
+
+http://code.google.com/p/inih/
+
+*/
+
+#ifndef __INI_H__
+#define __INI_H__
+
+/* Make this header file easier to include in C++ code */
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stdio.h>
+
+/* Parse given INI-style file. May have [section]s, name=value pairs
+   (whitespace stripped), and comments starting with ';' (semicolon). Section
+   is "" if name=value pair parsed before any section heading. name:value
+   pairs are also supported as a concession to Python's ConfigParser.
+
+   For each name=value pair parsed, call handler function with given user
+   pointer as well as section, name, and value (data only valid for duration
+   of handler call). Handler should return nonzero on success, zero on error.
+
+   Returns 0 on success, line number of first error on parse error (doesn't
+   stop on first error), -1 on file open error, or -2 on memory allocation
+   error (only when INI_USE_STACK is zero).
+*/
+int ini_parse(const char* filename,
+				int (*handler)(void*, const char*, const char*,
+							   const char*),
+				int (*sectionHandler)(void*, const char*),
+				int (*commentHandler)(void*, const char*),
+				void* user);
+
+/* Same as ini_parse(), but takes a FILE* instead of filename. This doesn't
+   close the file when it's finished -- the caller must do that. */
+int ini_parse_file(FILE* file,
+				int (*handler)(void*, const char*, const char*,
+							   const char*),
+				int (*sectionHandler)(void*, const char*),
+				int (*commentHandler)(void*, const char*),
+				void* user);
+
+/* Nonzero to allow multi-line value parsing, in the style of Python's
+   ConfigParser. If allowed, ini_parse() will call the handler with the same
+   name for each subsequent line parsed. */
+#ifndef INI_ALLOW_MULTILINE
+#define INI_ALLOW_MULTILINE 1
+#endif
+
+/* Nonzero to allow a UTF-8 BOM sequence (0xEF 0xBB 0xBF) at the start of
+   the file. See http://code.google.com/p/inih/issues/detail?id=21 */
+#ifndef INI_ALLOW_BOM
+#define INI_ALLOW_BOM 1
+#endif
+
+/* Nonzero to use stack, zero to use heap (malloc/free). */
+#ifndef INI_USE_STACK
+#define INI_USE_STACK 1
+#endif
+
+/* Stop parsing on first error (default is to keep parsing). */
+#ifndef INI_STOP_ON_FIRST_ERROR
+#define INI_STOP_ON_FIRST_ERROR 0
+#endif
+
+/* Maximum line length for any line in INI file. */
+#ifndef INI_MAX_LINE
+#define INI_MAX_LINE 200
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __INI_H__ */

--- a/src/plugins/ini/testmod_ini.c
+++ b/src/plugins/ini/testmod_ini.c
@@ -1,0 +1,200 @@
+/**
+ * \file
+ *
+ * \brief Tests for the ini plugin
+ *
+ * \copyright BSD License (see doc/COPYING or http://www.libelektra.org)
+ *
+ */
+
+#ifdef HAVE_KDBCONFIG_H
+#include "kdbconfig.h"
+#endif
+
+#include <stdio.h>
+#ifdef HAVE_STDLIB_H
+#include <stdlib.h>
+#endif
+#ifdef HAVE_STRING_H
+#include <string.h>
+#endif
+
+#include <tests_plugin.h>
+
+
+void test_plainIniRead(char *fileName)
+{
+	Key *parentKey = keyNew ("user/tests/ini-read", KEY_VALUE,
+			srcdir_file(fileName), KEY_END);
+
+	KeySet *conf = ksNew (0);
+	PLUGIN_OPEN ("ini");
+
+	KeySet *ks = ksNew (0);
+
+	succeed_if(plugin->kdbGet (plugin, ks, parentKey) >= 1,
+			"call to kdbGet was not successful");
+	succeed_if(output_error (parentKey), "error in kdbGet");
+	succeed_if(output_warnings (parentKey), "warnings in kdbGet");
+
+	Key *key = ksLookupByName (ks, "user/tests/ini-read/nosectionkey", KDB_O_NONE);
+	exit_if_fail(key, "nosectionkey not found");
+	succeed_if (!strcmp ("nosectionvalue", keyString(key)), "nosectionkey contained invalid data");
+
+	key = ksLookupByName (ks, "user/tests/ini-read/section1", KDB_O_NONE);
+	exit_if_fail(key, "section1 not found");
+	succeed_if (keyIsDir(key), "section1 is not a directory key");
+
+	key = ksLookupByName (ks, "user/tests/ini-read/section1/key1", KDB_O_NONE);
+	exit_if_fail(key, "key1 not found");
+	succeed_if (!strcmp ("value1", keyString(key)), "key1 contained invalid data");
+
+	key = ksLookupByName (ks, "user/tests/ini-read/section2/emptykey", KDB_O_NONE);
+	exit_if_fail(key, "emptykey not found");
+	succeed_if (!strcmp ("", keyString(key)), "emptykey contained invalid data");
+
+	ksDel (ks);
+	keyDel (parentKey);
+
+	PLUGIN_CLOSE ()
+	;
+}
+
+void test_plainIniWrite(char *fileName)
+{
+	Key *parentKey = keyNew ("user/tests/ini-write", KEY_VALUE,
+			elektraFilename(), KEY_END);
+	KeySet *conf = ksNew (0);
+	PLUGIN_OPEN("ini");
+
+	KeySet *ks = ksNew (30,
+			keyNew ("user/tests/ini-write/nosectionkey",
+					KEY_VALUE, "nosectionvalue",
+					KEY_END),
+			keyNew ("user/tests/ini-write/section1", KEY_DIR, KEY_END),
+			keyNew ("user/tests/ini-write/section1/key1",
+					KEY_VALUE, "value1",
+					KEY_END),
+			keyNew ("user/tests/ini-write/section1/key2",
+					KEY_VALUE, "value2",
+					KEY_END),
+			keyNew ("user/tests/ini-write/section2", KEY_DIR, KEY_END),
+			keyNew ("user/tests/ini-write/section2/key3",
+					KEY_VALUE, "value3",
+					KEY_END),
+			keyNew ("user/tests/ini-write/section2/emptykey", KEY_END),
+			KS_END);
+
+	succeed_if(plugin->kdbSet (plugin, ks, parentKey) >= 1,
+			"call to kdbSet was not successful");
+	succeed_if(output_error (parentKey), "error in kdbSet");
+	succeed_if(output_warnings (parentKey), "warnings in kdbSet");
+
+	succeed_if(
+			compare_line_files (srcdir_file (fileName), keyString (parentKey)),
+			"files do not match as expected");
+
+	ksDel (ks);
+	keyDel (parentKey);
+
+	PLUGIN_CLOSE ()
+	;
+}
+
+
+void test_commentIniRead(char *fileName)
+{
+	Key *parentKey = keyNew ("user/tests/ini-read", KEY_VALUE,
+			srcdir_file(fileName), KEY_END);
+
+	KeySet *conf = ksNew (0);
+	PLUGIN_OPEN ("ini");
+
+	KeySet *ks = ksNew (0);
+
+	succeed_if(plugin->kdbGet (plugin, ks, parentKey) >= 1,
+			"call to kdbGet was not successful");
+	succeed_if(output_error (parentKey), "error in kdbGet");
+	succeed_if(output_warnings (parentKey), "warnings in kdbGet");
+
+	Key *key = ksLookupByName (ks, "user/tests/ini-read/nosectionkey", KDB_O_NONE);
+	exit_if_fail(key, "nosectionkey not found");
+	const Key *noSectionComment = keyGetMeta(key, "comment");
+	exit_if_fail(noSectionComment, "nosectionkey contained no comment");
+	succeed_if (!strcmp ("nosection comment1\nnosection comment2", keyString(noSectionComment)), "nosectionkey contained an invalid comment");
+
+	key = ksLookupByName (ks, "user/tests/ini-read/section1", KDB_O_NONE);
+	exit_if_fail(key, "section1 not found");
+	const Key *sectionComment = keyGetMeta(key, "comment");
+	exit_if_fail(sectionComment, "nosectionkey contained no comment");
+	succeed_if (!strcmp ("section comment1\nsection comment2", keyString(sectionComment)), "section1 contained an invalid comment");
+
+	key = ksLookupByName (ks, "user/tests/ini-read/section1/key1", KDB_O_NONE);
+	exit_if_fail(key, "key1 not found");
+	const Key *keyComment = keyGetMeta(key, "comment");
+	exit_if_fail(keyComment, "key1 contained no comment");
+	succeed_if (!strcmp ("key comment1\nkey comment2", keyString(keyComment)), "key1 contained an invalid comment");
+
+	ksDel (ks);
+	keyDel (parentKey);
+
+	PLUGIN_CLOSE ()
+	;
+}
+
+void test_commentIniWrite(char *fileName)
+{
+	Key *parentKey = keyNew ("user/tests/ini-write", KEY_VALUE,
+			elektraFilename(), KEY_END);
+	KeySet *conf = ksNew (0);
+	PLUGIN_OPEN("ini");
+
+	KeySet *ks = ksNew (30,
+			keyNew ("user/tests/ini-write/nosectionkey",
+					KEY_VALUE, "nosectionvalue",
+					KEY_COMMENT, "nosection comment1\nnosection comment2",
+					KEY_END),
+			keyNew ("user/tests/ini-write/section1",
+					KEY_DIR,
+					KEY_COMMENT, "section comment1\nsection comment2",
+					KEY_END),
+			keyNew ("user/tests/ini-write/section1/key1",
+					KEY_VALUE, "value1",
+					KEY_COMMENT, "key comment1\nkey comment2",
+					KEY_END),
+			KS_END);
+
+	succeed_if(plugin->kdbSet (plugin, ks, parentKey) >= 1,
+			"call to kdbSet was not successful");
+	succeed_if(output_error (parentKey), "error in kdbSet");
+	succeed_if(output_warnings (parentKey), "warnings in kdbSet");
+
+	succeed_if(
+			compare_line_files (srcdir_file (fileName), keyString (parentKey)),
+			"files do not match as expected");
+
+	ksDel (ks);
+	keyDel (parentKey);
+
+	PLUGIN_CLOSE ()
+	;
+}
+
+int main(int argc, char** argv)
+{
+	printf ("INI       TESTS\n");
+	printf ("==================\n\n");
+
+	init (argc, argv);
+
+	test_plainIniRead ("ini/plainini");
+	test_plainIniWrite ("ini/plainini");
+	test_commentIniRead ("ini/commentini");
+	test_commentIniWrite ("ini/commentini");
+
+	printf ("\ntest_hosts RESULTS: %d test(s) done. %d error(s).\n", nbTest,
+			nbError);
+
+	return nbError;
+}
+


### PR DESCRIPTION
Because the simpleini plugin did not work too well for mounting the specification file and even failed to parse other ini files (e.g. samba), I wrote a new one. It uses a slightly patched version of the very small inih library (directly embedded). Although it works fine for now, it is still work in progress though. 

Improvements compared to simpleini:
- graceful handling of sections (keys are subkeys of their sections)
- support for comments (comments, are appended to the next non-comment key)
