### PR TITLE
Few spelling fixes

### DIFF
--- a/doc/NEWS.md
+++ b/doc/NEWS.md
@@ -255,10 +255,10 @@ The C++ API changed, including:
 - does not wrongly convert garbage to default types using get<T>
 - getMeta now interally uses get<T> and both throw the KeyTypeConversion
   Exception
-- KeySet::at directly allows to use ksAtCursor()
+- KeySet::at directly allows one to use ksAtCursor()
 - KeyTypeConversion (or former KeyBadMeta) is not thrown anymore if key
   is not available
-- Key::hasMeta allows to directly check if meta data is available
+- Key::hasMeta allows one to directly check if meta data is available
 
 CMake: ENABLE_CXX11 is now default OFF (because gcc 4.6 and older won't
        work with it). It disables some tests, though.
@@ -428,7 +428,7 @@ pages.
 Test data for the test cases will be installed, too. The path can be
 configured with:
 TARGET_TEST_DATA_FOLDER
-The path allows to run tests from an installed version.
+The path allows one to run tests from an installed version.
 
 Additionally, many small bugs were fixed. The release is, as always,
 100% binary and API compatible, so you can drop it in and all

--- a/doc/todo/TODO
+++ b/doc/todo/TODO
@@ -164,7 +164,7 @@ spec:
 	has metadata only for all other hierarchies
 	including explanation, description
 	(but not comments which are specific for individual keys)
-	allows to retrieve config with globs and placeholders
+	allows one to retrieve config with globs and placeholders
 	metadata in unapplied form
 	other hierarchies get the metadata copied by struct checker
 

--- a/doc/todo/TOOLS
+++ b/doc/todo/TOOLS
@@ -85,7 +85,7 @@ environment parsing support
 static compilation model
 
 has_ queries
-(allows to differ between default fallback and intentional set default)
+(allows one to differ between default fallback and intentional set default)
 
 new generators:
 	all hardcoded (without elektra dependency)?

--- a/src/libtools/tests/testtool_backend.cpp
+++ b/src/libtools/tests/testtool_backend.cpp
@@ -17,7 +17,7 @@
 #include <gtest/gtest.h>
 
 /**
- * @brief Easily allows to generate regression tests for keysets.
+ * @brief Easily allows one to generate regression tests for keysets.
  *
  * @param tocheck the keyset to check (name + string)
  * @param name the name of the keyset

--- a/src/plugins/keytometa/README.md
+++ b/src/plugins/keytometa/README.md
@@ -70,7 +70,7 @@ resulting from key1 and key4 would receive the metadata resulting from key3.
 
 ### PREVIOUS STRATEGY ###
 
-The metadata is added to the key preceeding the converted key in a sorted keyset. 
+The metadata is added to the key preceding the converted key in a sorted keyset. 
 If no such key is found (for example because the key to be converted is the first one), 
 the strategy is reverted to parent. For example consider the following keyset:
 


### PR DESCRIPTION
- allows to -> allows one to
- preceeding -> preceding
