### PR TITLE
Add the KEY_END marker on key creation where missing

### DIFF
--- a/src/libtools/tests/testtool_keyhelper.cpp
+++ b/src/libtools/tests/testtool_keyhelper.cpp
@@ -15,27 +15,27 @@ using namespace kdb::tools::helper;
 
 TEST(RebasePath, RebasesCorrectlyWithValidArguments)
 {
-	Key target = Key ("user/test/configold/subdir/k1");
-	Key oldParent = Key ("user/test/configold");
-	Key newParent = Key ("user/test/confignew");
+	Key target = Key ("user/test/configold/subdir/k1", KEY_END);
+	Key oldParent = Key ("user/test/configold", KEY_END);
+	Key newParent = Key ("user/test/confignew", KEY_END);
 
 	EXPECT_EQ ("user/test/confignew/subdir/k1", rebasePath (target, oldParent, newParent));
 }
 
 TEST(RebasePath, WorksForKeyOnSameLevel)
 {
-	Key target = Key ("user/test/configold");
-	Key oldParent = Key ("user/test/configold");
-	Key newParent = Key ("user/test/confignew");
+	Key target = Key ("user/test/configold", KEY_END);
+	Key oldParent = Key ("user/test/configold", KEY_END);
+	Key newParent = Key ("user/test/confignew", KEY_END);
 
 	EXPECT_EQ ("user/test/confignew", rebasePath (target, oldParent, newParent));
 }
 
 TEST(RebasePath, ThrowsExceptionOnInvalidRebase)
 {
-	Key target = Key ("user/test/k1");
-	Key oldParent = Key ("user/test/configold");
-	Key newParent = Key ("user/test/confignew");
+	Key target = Key ("user/test/k1", KEY_END);
+	Key oldParent = Key ("user/test/configold", KEY_END);
+	Key newParent = Key ("user/test/confignew", KEY_END);
 
 	EXPECT_THROW (rebasePath (target, oldParent, newParent), InvalidRebaseException);
 }
@@ -44,8 +44,8 @@ TEST(RebasePath, ThrowsExceptionOnInvalidRebase)
 TEST(RebaseKey, RebasesCorrectlyWithValidArguments)
 {
 	Key target = Key ("user/test/configold/subdir/k1", KEY_VALUE, "testvalue", KEY_END);
-	Key oldParent = Key ("user/test/configold");
-	Key newParent = Key ("user/test/confignew");
+	Key oldParent = Key ("user/test/configold", KEY_END);
+	Key newParent = Key ("user/test/confignew", KEY_END);
 	Key expected = Key ("user/test/confignew/subdir/k1", KEY_VALUE, "testvalue", KEY_END);
 
 	Key result = rebaseKey (target, oldParent, newParent);
@@ -56,9 +56,9 @@ TEST(RebaseKey, RebasesCorrectlyWithValidArguments)
 
 TEST(RebaseKey, ThrowsExceptionOnInvalidRebase)
 {
-	Key target = Key ("user/test/k1");
-	Key oldParent = Key ("user/test/configold");
-	Key newParent = Key ("user/test/confignew");
+	Key target = Key ("user/test/k1", KEY_END);
+	Key oldParent = Key ("user/test/configold", KEY_END);
+	Key newParent = Key ("user/test/confignew", KEY_END);
 
 	EXPECT_THROW (rebasePath (target, oldParent, newParent), InvalidRebaseException);
 }
@@ -66,8 +66,8 @@ TEST(RebaseKey, ThrowsExceptionOnInvalidRebase)
 TEST(RebaseKey, CreatesCopy)
 {
 	Key target = Key ("user/test/configold/subdir/k1", KEY_VALUE, "testvalue", KEY_END);
-	Key oldParent = Key ("user/test/configold");
-	Key newParent = Key ("user/test/confignew");
+	Key oldParent = Key ("user/test/configold", KEY_END);
+	Key newParent = Key ("user/test/confignew", KEY_END);
 
 	Key result = rebaseKey (target, oldParent, newParent);
 	target.setString("newvalue");

--- a/src/libtools/tests/testtool_mergeresult.cpp
+++ b/src/libtools/tests/testtool_mergeresult.cpp
@@ -24,7 +24,7 @@ TEST(MergeResult, ResolveConflictDeletesConflictMeta)
 	Key conflictKey = Key ("user/test/config/key1", KEY_VALUE, "testvalue", KEY_META, "conflict/operation/our",
 			"delete", KEY_META, "conflict/operation/their", "modify", KEY_META, "conflict/test", "testvalue", KEY_END);
 
-	Key test = Key ("");
+	Key test = Key ("", KEY_END);
 
 	result.resolveConflict (conflictKey);
 


### PR DESCRIPTION
Add the KEY_END vararg where missing when creating a new key, either
using the C keyNew or the C++ kdb::Key, as done everywhere else.

This fixes crashes in some tests.
