### PR TITLE
cmake: require Boost for tcl plugin

### DIFF
--- a/src/plugins/tcl/CMakeLists.txt
+++ b/src/plugins/tcl/CMakeLists.txt
@@ -1,13 +1,19 @@
-include (LibAddMacros)
+find_package(Boost)
+if (Boost_FOUND)
+	include (LibAddMacros)
 
-set (SOURCES tcl.hpp tcl.cpp action.hpp action.cpp printer.hpp printer.cpp)
-add_sources (elektra-full ${SOURCES})
-add_headers (SOURCES)
-add_cppheaders (SOURCES)
+	set (SOURCES tcl.hpp tcl.cpp action.hpp action.cpp printer.hpp printer.cpp)
+	add_sources (elektra-full ${SOURCES})
+	add_headers (SOURCES)
+	add_cppheaders (SOURCES)
+	include_directories (${Boost_INCLUDE_DIRS})
 
-set (PLUGIN_NAME elektra-tcl)
-add_library (${PLUGIN_NAME} MODULE ${SOURCES})
-target_link_libraries (${PLUGIN_NAME} elektra)
+	set (PLUGIN_NAME elektra-tcl)
+	add_library (${PLUGIN_NAME} MODULE ${SOURCES})
+	target_link_libraries (${PLUGIN_NAME} elektra)
 
-install (TARGETS ${PLUGIN_NAME}
-	DESTINATION lib${LIB_SUFFIX}/${TARGET_PLUGIN_FOLDER})
+	install (TARGETS ${PLUGIN_NAME}
+		DESTINATION lib${LIB_SUFFIX}/${TARGET_PLUGIN_FOLDER})
+else (Boost_FOUND)
+        remove_plugin (tcl "boost not found")
+endif (Boost_FOUND)


### PR DESCRIPTION
Look for Boost and enable the tcl plugin only if found, as it is used
there.

Also, make use of the Boost include directory, so a Boost installation
in an own path can be used.
