### PR TITLE
tests: fix maximum uchar boundary

### DIFF
--- a/tests/cframework/tests.c
+++ b/tests/cframework/tests.c
@@ -287,7 +287,7 @@ void output_backend(Backend *backend)
 void output_trie(Trie *trie)
 {
 	int i;
-	for (i=0; i <= KDB_MAX_UCHAR; ++i)
+	for (i=0; i < KDB_MAX_UCHAR; ++i)
 	{
 		if (trie->value[i])
 		{


### PR DESCRIPTION
Do not overflow when accessing to the trie internal; having `N` as array size means that `N-1` is the maximum index accessable.

PS: there's another occurrence of this error in `tests/ctest/test_trie.c`, but changing it was causing the test to fail, and I'm not too familiar with elektra's internals.
