### PR TITLE
Changed the rename plugin to rebase new keys to the cutpath

### DIFF
--- a/src/plugins/rename/rename.h
+++ b/src/plugins/rename/rename.h
@@ -16,6 +16,8 @@
 #include <kdbproposal.h>
 #include <kdbextension.h>
 
+#define ELEKTRA_ORIGINAL_NAME_META "origname"
+
 int elektraRenameGet(Plugin *handle, KeySet *ks, Key *parentKey);
 int elektraRenameSet(Plugin *handle, KeySet *ks, Key *parentKey);
 Key *elektraKeyCutNamePart(const Key *key, const Key *parentKey, const char *cutPath);


### PR DESCRIPTION
This pull request should fix the issue discussed in #156. A unit test is included and I did some basic tests with my installation. However, I had no time for extensive testing, so please have a look at it too. 

Currently the implementation uses the private function `char *keyNameGetOneLevel(const char *name, size_t *size);` (and so does yajl). This function is actually really useful and we might consider moving it to the public API.
