### PR TITLE
Added an example and documentation on how to use the merge framework

### DIFF
--- a/src/libtools/examples/merging.cpp
+++ b/src/libtools/examples/merging.cpp
@@ -1,0 +1,173 @@
+#include <kdb.hpp>
+#include <keysetio.hpp>
+
+#include <iostream>
+#include <string>
+
+#include <merging/threewaymerge.hpp>
+#include <merging/metamergestrategy.hpp>
+#include <merging/automergestrategy.hpp>
+#include <merging/onesidestrategy.hpp>
+
+
+using namespace kdb;
+using namespace kdb::tools::merging;
+using namespace std;
+
+int main()
+{
+	KeySet ours;
+	KeySet theirs;
+	KeySet base;
+
+	// the root of the subtree containing our keys (i.e. our side of the merge)
+	Key oursRoot ("user/ours", KEY_END);
+
+	// the root of the subtree containing their keys (i.e. their side of the merge)
+	Key theirsRoot ("user/theirs", KEY_END);
+
+	// the root of the subtree containing the base keys (i.e. the common ancestor of the merge)
+	Key baseRoot ("user/base", KEY_END);
+
+	// the root of the subtree that will contain the merge result
+	Key resultRoot ("user/result", KEY_END);
+
+	// Step 1: retrieve clean KeySets containing only those
+	// keys that should be merged. This is a bit trickier than
+	// it seems at first. Have a look at the documentation of kdbGet
+	// for detailed information
+	// things to note:
+	//   * use blocks with local KDB instances so we don't have to worry about
+	//     writing the keys back
+	//   * remove the root key itself from the result KeySet because it usually
+	//     contains the mounted filename and cannot be merged anyway
+	{
+		KDB lkdb;
+		lkdb.get (ours, oursRoot);
+		ours = ours.cut (oursRoot);
+		ours.lookup(oursRoot, KDB_O_POP);
+	}
+	{
+		KDB lkdb;
+		lkdb.get (theirs, theirsRoot);
+		theirs = theirs.cut (theirsRoot);
+		ours.lookup(oursRoot, KDB_O_POP);
+	}
+	{
+		KDB lkdb;
+		lkdb.get (base, baseRoot);
+		base = base.cut (baseRoot);
+		ours.lookup(oursRoot, KDB_O_POP);
+	}
+
+
+	// Step 2: Make sure that no keys reside below the intended merge result root
+	// Usually the merge can be either aborted if this is the case or the existing
+	// keys can be overwritten.
+	KeySet resultKeys;
+	kdb::KDB kdb;
+	kdb.get (resultKeys, resultRoot);
+
+	KeySet discard = resultKeys.cut (resultRoot);
+	if (discard.size () != 0)
+	{
+		// handle existing keys below the result root
+		return -1;
+	}
+
+	ThreeWayMerge merger;
+
+	// Step 3: Decide which resolution strategies to use. The stratgies are registered
+	// with the merge and applied in order as soon as a conflict is detected. If a strategy
+	// marks a conflict as resolved, no further strategies are consulted. Therefore the order
+	// in which they are registered is absolutely crucial. With this chaining the strategies
+	// remain simple, but can be combined to powerful resolution strategies.
+	// Have a look at the strategy documentation for further details on what they do and how they work.
+	// The unit tests also provide insight into how the strategies work.
+
+	// TODO:
+	// Currently the MetaMergeStrategy has to be registered first. Otherwise the meta information
+	// of merged keys is lost. This is due to the way that strategies are currently implemented and
+	// is subject to change.
+
+	// TODO:
+	// Currently the strategies have to be instantiated and freed manually. This is also subject to change
+	// and will be simplified in future versions.
+
+
+
+	MetaMergeStrategy metaStrategy(merger);
+	merger.addConflictStrategy(&metaStrategy);
+
+	// in this example we first resolve all the keys that can be automatically
+	// resolved (e.g. only one side was modified). This is done by the AutoMergeStrategy.
+	// If keys remain that cannot be automatically merged (e.g. both sides were modified)
+	// we unconditionally accept our version of the key. This is done by the OneSideStrategy.
+	// MetaKeys are merged in the exact same way, because the MetaMergeStrategy we instantiated
+	// above uses the same merger instance. Alternatively we could have instantiated and configured
+	// a different merger only for the MetaKeys.
+
+	MergeConflictStrategy *autoMerge = new AutoMergeStrategy();
+	MergeConflictStrategy *ourVersion = new OneSideStrategy(OURS);
+
+	merger.addConflictStrategy(autoMerge);
+	merger.addConflictStrategy(ourVersion);
+
+	// Step 4: Perform the actual merge
+	MergeResult result = merger.mergeKeySet (
+			MergeTask (BaseMergeKeys (base, baseRoot), OurMergeKeys (ours, oursRoot),
+					TheirMergeKeys (theirs, theirsRoot), resultRoot));
+
+	// Step 5: work with the result. The merger will return an object containing information
+	// about the merge result.
+	if (!result.hasConflicts ())
+	{
+		// output some statistical information
+		cout << result.getMergedKeys().size() << " keys in the result" << endl;
+		cout << result.getNumberOfEqualKeys() << " keys were equal" << endl;
+		cout << result.getNumberOfResolvedKeys() << " keys were resolved" << endl;
+
+		// write the result
+		resultKeys.append(result.getMergedKeys());
+		kdb.set (resultKeys, resultRoot);
+	}
+	else
+	{
+		KeySet conflicts = result.getConflictSet();
+
+		cerr << conflicts.size() << " conflicts were detected that could not be resolved automatically:" << endl;
+		conflicts.rewind();
+		Key current;
+		while ((current = conflicts.next()))
+		{
+			// For each unresolved conflict there is a conflict key in the merge result.
+			// This conflict key contains meta information about the reason of the conflict.
+			// In particular the metakeys conflict/operation/our and conflict/operation/their contain
+			// the operations done on our version of the key and their version of the key relative to
+			// the base version of the key.
+			string ourConflict = current.getMeta<string> ("conflict/operation/our");
+			string theirConflict = current.getMeta<string> ("conflict/operation/their");
+
+			cerr << current << endl;
+			cerr << "ours: " << ourConflict << ", theirs: " << theirConflict << endl;
+			cerr << endl;
+		}
+
+		cerr << "Merge unsuccessful." << endl;
+	}
+
+	// Step 6: clean the instantiated strategies
+	delete autoMerge;
+	delete ourVersion;
+
+	if (!result.hasConflicts())
+	{
+		return 0;
+	}
+	else
+	{
+		return -1;
+	}
+
+}
+

--- a/src/libtools/include/merging/automergestrategy.hpp
+++ b/src/libtools/include/merging/automergestrategy.hpp
@@ -20,6 +20,14 @@ namespace tools
 namespace merging
 {
 
+// This strategy resolves all conflicts where only one side was modified relative to
+// the base version. This means that the folllowing operation pairs can be resolved (ouroperation - theiroperation)
+// SAME - MODIFY
+// SAME - ADD
+// SAME - DELETE
+// MODIFY - SAME
+// ADD - SAME
+// DELETE - SAME
 class AutoMergeStrategy : public MergeConflictStrategy
 {
 public:

--- a/src/libtools/include/merging/interactivemergestrategy.hpp
+++ b/src/libtools/include/merging/interactivemergestrategy.hpp
@@ -21,6 +21,10 @@ namespace tools
 namespace merging
 {
 
+// This strategy can be used to interactively merging keys. It will ask
+// the user for each conflict which key version should be used. All
+// questions will be asked via the supplied input stream and results
+// will only be printed to the supplied outputstream.
 class InteractiveMergeStrategy : public MergeConflictStrategy
 {
 public:

--- a/src/libtools/include/merging/metamergestrategy.hpp
+++ b/src/libtools/include/merging/metamergestrategy.hpp
@@ -21,7 +21,17 @@ namespace tools
 
 namespace merging
 {
-
+// The MetaMergeStrategy differs from other MergeConflictStrategies because
+// it does not resolve conflicts by itself. Instead it uses the supplied ThreeWayMerger
+// instance and applies it to the MetaKeys of conflicting Keys.
+// Only if both conflict operations are META (i.e. if both sides modified only the MetaKeys of a key) and
+// the supplied ThreeWayMerger is able to successfully merge the meta keys, the
+// MetaMergeStrategy will mark the conflict as resolved.
+// If the supplied merger is not able to resolve all conflicts
+// in the MetaKeys this strategy won't resolve even a META <--> META conflict.
+// If the conflict operations are anything else than META the MetaMergeStrategy will also
+// not resolve the conflict, although the MetaKeys might be merged successul. This allows
+// strategies later in the chain to resolve the value conflict of the conflicting key.
 class MetaMergeStrategy : public MergeConflictStrategy
 {
 

--- a/src/libtools/include/merging/newkeystrategy.hpp
+++ b/src/libtools/include/merging/newkeystrategy.hpp
@@ -20,7 +20,8 @@ namespace tools
 
 namespace merging
 {
-
+// This strategy is basically a subset of the AutoMergeStrategy. It resolves
+// only conflicts where one side added key, while the other side did nothing.
 class NewKeyStrategy : public MergeConflictStrategy
 {
 public:

--- a/src/libtools/include/merging/onesidestrategy.hpp
+++ b/src/libtools/include/merging/onesidestrategy.hpp
@@ -20,7 +20,9 @@ namespace tools
 
 namespace merging
 {
-
+// This strategy is able to resolve every kind of conflict by always
+// using the key of the winning side. Note that this also includes removing
+// keys if the keys were deleted at the winning side.
 class OneSideStrategy : public MergeConflictStrategy
 {
 

--- a/src/libtools/include/merging/onesidevaluestrategy.hpp
+++ b/src/libtools/include/merging/onesidevaluestrategy.hpp
@@ -18,7 +18,10 @@ namespace tools
 
 namespace merging
 {
-
+// This strategy is a subset of the OneSideStrategy. It also uses
+// the key of the winning side in case of a conflict. However, different
+// than the OneSideStrategy it only resolves conflicts where no new keys are
+// introduced or old ones deleted.
 class OneSideValueStrategy : public MergeConflictStrategy
 {
 


### PR DESCRIPTION
I put together a small example (basically a simplified version of kdb merge) and a bit documentation around the merging framework as requested in #167. It is not much, but together with the unit tests it should provide a good idea on how the ThreeWayMerger works. If anyone (especially Raffael) has any questions concerning the merge framework, please don't hesitate to ask. I will try to clean up and simplify the framework as soon as I can.