### PR TITLE
Ini hierarchies

### DIFF
--- a/src/plugins/ini/README.md
+++ b/src/plugins/ini/README.md
@@ -16,6 +16,73 @@ for example "[section]". Each section is converted into a directory key
 key. If the same section appears multiple times, the keys of all sections
 with the same name are merged together under the section key.
 
+## SECTIONS ##
+
+When converting a KeySet to an INI file it is important to differentiate between
+regular keys and section keys. The ini plugin treats all keys with a binary NULL
+value as section key. Note that binary NULL is not the same as an empty value (i.e. "").
+
+For example consider the following ini file:
+
+				[section1]
+				key1 =
+				key2 = value2
+			
+This would result in a KeySet containing three keys. The section key `section1` would be
+a binary key with value NULL (i.e. 0). `section1/key1` would be a regular key with value "".
+`section1/key2` would be a regular key with value "value2". In the other direction this requires
+section keys to be manually created with a binary NULL value.  
+
+For example consider the following KeySet:
+
+				section1 = ""
+				section1/subkey = "value1"
+				
+Although section1 might look like a section, it would result in the following ini file:
+
+				section1 =
+				section1\/subkey = value1
+
+### AUTOSECTIONS ###
+
+Creating the section keys manually can be cumbersome. This is especially true because
+KeySets resulting in INI files usually do not contain keys with a depth greater than
+1 relative to the parent key. For that reason a good guess can be made what should be
+sections and what not. This is done by activanting the autosections option. 
+
+The autosections feature can be enabled by creating a key named `autosections` 
+in the configuration of the plugin. Note that only the existence of the key is relevant, not its value.
+
+As soon as this key exists, the plugin will automatically create section keys for keys
+with a depth greater than 1 relative to the parent key.	
+
+For example consider the following ini file:
+
+				[section1]
+				key1 =
+				key2 = value2
+				[section2]
+				key3 = value3
+				
+Without the autosections option the following KeySet is required to create this ini file:
+
+				parent/section1 = NULL
+				parent/section1/key1 = ""
+				parent/section1/key2 = "value2"
+				parent/section2 = NULL
+				parent/section2/key3 = "value3"
+
+The section keys have to be inserted manually. With the autosections option the KeySet can
+be reduced to the following:
+
+				parent/section1/key1 = ""
+				parent/section1/key2 = "value2"
+				parent/section2/key3 = "value3"
+
+All three keys have a depth greater than 1 relative to the parent key `parent`. Therefore
+the key name part directly below the parent key is considered to be the section name.
+For example, for the keys `parent/section1/key1` and `parent/section1/key2` `section1` is considered
+to be the section and is automatically created in the INI file.
 
 
 ## COMMENTS ##

--- a/src/plugins/ini/ini.c
+++ b/src/plugins/ini/ini.c
@@ -12,11 +12,9 @@
 #endif
 
 #include <errno.h>
-#include <string.h>
 #include <stdlib.h>
+#include <string.h>
 #include <kdberrors.h>
-#include <kdbextension.h>
-#include <kdbproposal.h>
 #include <inih.h>
 #include "ini.h"
 
@@ -294,6 +292,13 @@ static short isSectionKey(Key *key)
 	return keyIsBinary(key) && !keyValue(key);
 }
 
+/**
+ * Returns the name of the corresponding ini key based on
+ * the structure and parentKey of the supplied key.
+ *
+ * The returned string has to be freed by the caller
+ *
+ */
 static char *getIniName(KeySet *keys, Key *parent, Key *key)
 {
 	cursor_t currentCursor = ksGetCursor(keys);

--- a/src/plugins/ini/ini/sectionini
+++ b/src/plugins/ini/ini/sectionini
@@ -1,0 +1,7 @@
+akey/looking/like/sections = value
+[emptysection]
+[section1]
+key/with/subkey = value2
+key1 = value1
+[section2/with/subkey]
+key2 = value2

--- a/src/plugins/ini/testmod_ini.c
+++ b/src/plugins/ini/testmod_ini.c
@@ -412,17 +412,6 @@ int main(int argc, char** argv)
 
 	init (argc, argv);
 
-	succeed_if (keyIsDirectBelow(
-			keyNew("user/tests/ini-section-write", KEY_END),
-			keyNew("user/tests/ini-section-write/akey\\/looking\\/like\\/sections", KEY_END)),
-			"keyIsDirectBelow does not work correctly");
-
-
-	succeed_if (!keyIsDirectBelow(
-			keyNew("user/tests/ini-section-write", KEY_END),
-			keyNew("	user/tests/ini-section-write/section1/key\\/with\\/subkey", KEY_END)),
-			"keyIsDirectBelow does not work correctly");
-
 	test_plainIniRead ("ini/plainini");
 	test_plainIniWrite ("ini/plainini");
 	test_commentIniRead ("ini/commentini");

--- a/src/plugins/ini/testmod_ini.c
+++ b/src/plugins/ini/testmod_ini.c
@@ -43,7 +43,7 @@ static void test_plainIniRead(char *fileName)
 
 	key = ksLookupByName (ks, "user/tests/ini-read/section1", KDB_O_NONE);
 	exit_if_fail(key, "section1 not found");
-	succeed_if (!strcmp ("", keyString(key)), "section value was not empty");
+	succeed_if (!keyValue(key), "section value was not empty");
 
 	key = ksLookupByName (ks, "user/tests/ini-read/section1/key1", KDB_O_NONE);
 	exit_if_fail(key, "key1 not found");
@@ -70,14 +70,18 @@ static void test_plainIniWrite(char *fileName)
 			keyNew ("user/tests/ini-write/nosectionkey",
 					KEY_VALUE, "nosectionvalue",
 					KEY_END),
-			keyNew ("user/tests/ini-write/section1", KEY_DIR, KEY_END),
+			keyNew ("user/tests/ini-write/section1",
+					KEY_BINARY,
+					KEY_END),
 			keyNew ("user/tests/ini-write/section1/key1",
 					KEY_VALUE, "value1",
 					KEY_END),
 			keyNew ("user/tests/ini-write/section1/key2",
 					KEY_VALUE, "value2",
 					KEY_END),
-			keyNew ("user/tests/ini-write/section2", KEY_DIR, KEY_END),
+			keyNew ("user/tests/ini-write/section2",
+					KEY_BINARY,
+					KEY_END),
 			keyNew ("user/tests/ini-write/section2/key3",
 					KEY_VALUE, "value3",
 					KEY_END),
@@ -89,10 +93,9 @@ static void test_plainIniWrite(char *fileName)
 	succeed_if(output_error (parentKey), "error in kdbSet");
 	succeed_if(output_warnings (parentKey), "warnings in kdbSet");
 
-	/*TODO: fix sections
 	succeed_if(
 			compare_line_files (srcdir_file (fileName), keyString (parentKey)),
-			"files do not match as expected");*/
+			"files do not match as expected");
 
 	ksDel (ks);
 	keyDel (parentKey);
@@ -153,7 +156,7 @@ static void test_commentIniWrite(char *fileName)
 					KEY_COMMENT, "nosection comment1\nnosection comment2",
 					KEY_END),
 			keyNew ("user/tests/ini-write/section1",
-					KEY_DIR,
+					KEY_BINARY,
 					KEY_COMMENT, "section comment1\nsection comment2",
 					KEY_END),
 			keyNew ("user/tests/ini-write/section1/key1",
@@ -167,10 +170,8 @@ static void test_commentIniWrite(char *fileName)
 	succeed_if(output_error (parentKey), "error in kdbSet");
 	succeed_if(output_warnings (parentKey), "warnings in kdbSet");
 
-	/* TODO: fix sections
 	succeed_if(compare_line_files (srcdir_file (fileName), keyString (parentKey)),
 			"files do not match as expected");
-	*/
 
 	ksDel (ks);
 	keyDel (parentKey);
@@ -224,11 +225,11 @@ static void test_multilineIniWrite(char *fileName)
 	PLUGIN_OPEN("ini");
 
 	KeySet *ks = ksNew (30,
-			keyNew ("user/tests/ini-multiline-write/multilinesection", KEY_DIR, KEY_END),
+			keyNew ("user/tests/ini-multiline-write/multilinesection", KEY_BINARY, KEY_END),
 			keyNew ("user/tests/ini-multiline-write/multilinesection/key1",
 					KEY_VALUE, "value1\nwith continuation\nlines",
 					KEY_END),
-			keyNew ("user/tests/ini-multiline-write/singlelinesection", KEY_DIR, KEY_END),
+			keyNew ("user/tests/ini-multiline-write/singlelinesection", KEY_BINARY, KEY_END),
 			keyNew ("user/tests/ini-multiline-write/singlelinesection/key2",
 					KEY_VALUE, "",
 					KEY_END),
@@ -242,10 +243,8 @@ static void test_multilineIniWrite(char *fileName)
 	succeed_if(output_error (parentKey), "error in kdbSet");
 	succeed_if(output_warnings (parentKey), "warnings in kdbSet");
 
-	/* TODO: fix sections
 	succeed_if(compare_line_files (srcdir_file (fileName), keyString (parentKey)),
 			"files do not match as expected");
-	*/
 
 	ksDel (ks);
 	keyDel (parentKey);
@@ -260,7 +259,7 @@ static void test_multilineIniInvalidConfigWrite()
 	PLUGIN_OPEN("ini");
 
 	KeySet *ks = ksNew (30,
-			keyNew ("user/tests/ini-multiline-write/multilinesection", KEY_DIR, KEY_END),
+			keyNew ("user/tests/ini-multiline-write/multilinesection", KEY_BINARY, KEY_END),
 			keyNew ("user/tests/ini-multiline-write/multilinesection/key1",
 					KEY_VALUE, "value1\nwith continuation\nlines",
 					KEY_END),
@@ -273,6 +272,94 @@ static void test_multilineIniInvalidConfigWrite()
 	exit_if_fail(metaError, "No error was produced on the parentKey");
 
 	succeed_if(!strcmp(keyString(keyGetMeta(parentKey, "error/number")), "97"), "The plugin threw the wrong error");
+
+	ksDel (ks);
+	keyDel (parentKey);
+
+	PLUGIN_CLOSE ();
+}
+
+static void test_sectionRead(char *fileName)
+{
+	Key *parentKey = keyNew ("user/tests/ini-section-read", KEY_VALUE,
+			srcdir_file(fileName), KEY_END);
+	KeySet *conf = ksNew(0, KS_END);
+	PLUGIN_OPEN("ini");
+
+	KeySet *ks = ksNew(0, KS_END);
+
+	succeed_if(plugin->kdbGet (plugin, ks, parentKey) >= 1,
+			"call to kdbGet was not successful");
+	succeed_if(output_error (parentKey), "error in kdbGet");
+	succeed_if(output_warnings (parentKey), "warnings in kdbGet");
+
+	Key *key = ksLookupByName (ks, "user/tests/ini-section-read/akey\\/looking\\/like\\/sections", KDB_O_NONE);
+	exit_if_fail(key, "section like key not found not found");
+	succeed_if (!strcmp ("value", keyString(key)), "section like key contained invalid data");
+
+	key = ksLookupByName(ks, "user/tests/ini-section-read/emptysection", KDB_O_NONE);
+	exit_if_fail(key, "empty section key not found");
+	succeed_if (keyIsBinary(key), "empty section key is not a binary key");
+	succeed_if (!keyValue(key), "section key contains non null data");
+
+	key = ksLookupByName(ks, "user/tests/ini-section-read/section1", KDB_O_NONE);
+	exit_if_fail(key, "section1 key not found");
+	succeed_if (keyIsBinary(key), "section1 key is not a binary key");
+	succeed_if (!keyValue(key), "section1 contains non null data");
+
+	key = ksLookupByName (ks, "user/tests/ini-section-read/section1/key1", KDB_O_NONE);
+	exit_if_fail(key, "key1 not found not found");
+	succeed_if (!strcmp ("value1", keyString(key)), "key1 contained invalid data");
+
+	key = ksLookupByName (ks, "user/tests/ini-section-read/section1/key\\/with\\/subkey", KDB_O_NONE);
+	exit_if_fail(key, "key with subkey not found not found");
+	succeed_if (!strcmp ("value2", keyString(key)), "key with subkey contained invalid data");
+
+	key = ksLookupByName(ks, "user/tests/ini-section-read/section2\\/with\\/subkey", KDB_O_NONE);
+	exit_if_fail(key, "section2 key not found");
+	succeed_if (keyIsBinary(key), "section2 key is not a binary key");
+	succeed_if (!keyValue(key), "section2 contains non null data");
+
+	key = ksLookupByName (ks, "user/tests/ini-section-read/section2\\/with\\/subkey/key2", KDB_O_NONE);
+	exit_if_fail(key, "key2 not found not found");
+	succeed_if (!strcmp ("value2", keyString(key)), "key2 contained invalid data");
+
+	ksDel (ks);
+	keyDel (parentKey);
+
+	PLUGIN_CLOSE ();
+}
+
+static void test_sectionWrite(char *fileName)
+{
+	Key *parentKey = keyNew ("user/tests/ini-section-write", KEY_VALUE,
+			elektraFilename(), KEY_END);
+	KeySet *conf = ksNew(0);
+	PLUGIN_OPEN("ini");
+
+	KeySet *ks = ksNew (30,
+			keyNew ("user/tests/ini-section-write/akey\\/looking\\/like\\/sections", KEY_VALUE, "value", KEY_END),
+			keyNew ("user/tests/ini-section-write/emptysection", KEY_BINARY, KEY_END),
+			keyNew ("user/tests/ini-section-write/section1", KEY_BINARY, KEY_END),
+			keyNew ("user/tests/ini-section-write/section1/key1",
+					KEY_VALUE, "value1",
+					KEY_END),
+			keyNew ("user/tests/ini-section-write/section1/key\\/with\\/subkey",
+					KEY_VALUE, "value2",
+					KEY_END),
+			keyNew("user/tests/ini-section-write/section2\\/with\\/subkey", KEY_BINARY, KEY_END),
+			keyNew("user/tests/ini-section-write/section2\\/with\\/subkey/key2",
+					KEY_VALUE, "value2",
+					KEY_END),
+			KS_END);
+
+	succeed_if(plugin->kdbSet (plugin, ks, parentKey) >= 1,
+			"call to kdbSet was not successful");
+	succeed_if(output_error (parentKey), "error in kdbSet");
+	succeed_if(output_warnings (parentKey), "warnings in kdbSet");
+
+	succeed_if(compare_line_files (srcdir_file (fileName), keyString (parentKey)),
+			"files do not match as expected");
 
 	ksDel (ks);
 	keyDel (parentKey);
@@ -294,6 +381,8 @@ int main(int argc, char** argv)
 	test_multilineIniRead ("ini/multilineini");
 	test_multilineIniWrite("ini/multilineini");
 	test_multilineIniInvalidConfigWrite();
+	test_sectionRead("ini/sectionini");
+	test_sectionWrite("ini/sectionini");
 
 	printf ("\ntest_ini RESULTS: %d test(s) done. %d error(s).\n", nbTest,
 			nbError);


### PR DESCRIPTION
A first proposal of how the improved ini section handling discussed in #138 could look like. The plugin behaves as follows:
* keys with a NULL value (i.e. binary keys with value 0) are treated as sections
* all other keys are treated as plain ini keys
* if the autosection option exists, the plugin will automatically create a section entry on write for keys with a level greater than 1 relative to the parent key (see the autosection testcase for a illustrative example)

If you like it this way, I will update the README accordingly. Additionally an option would be thinkable that prevents uses `keyChangeName` to directly use the names of ini keys / sections (see #138) for an example. If you have any further ideas on how to make the the use of the plugin more intuitive, please don't hesitate to ask.