### PR TITLE
fix ambiguity of KeySet(alloc, ...) constructor

### DIFF
--- a/src/bindings/cpp/include/keyset.hpp
+++ b/src/bindings/cpp/include/keyset.hpp
@@ -31,7 +31,9 @@ public:
 	inline KeySet(ckdb::KeySet *k);
 	inline KeySet(const KeySet &other);
 
-	inline explicit KeySet(size_t alloc, va_list ap);
+#if defined(__amd64__) || defined(__x86_64__) || defined(__i386__)
+	inline explicit KeySet(size_t alloc, va_list va)  __attribute__((deprecated("use 'KeySet::fromVA' instead!")));
+#endif
 	inline explicit KeySet(size_t alloc, ...);
 
 	inline ~KeySet ();
@@ -40,6 +42,7 @@ public:
 
 	ckdb::KeySet * getKeySet() const;
 	void setKeySet(ckdb::KeySet * k);
+	void fromVA(size_t alloc, va_list va);
 
 	KeySet& operator=(KeySet const& other);
 
@@ -387,14 +390,17 @@ inline KeySet::KeySet (const KeySet &other)
  * @brief Create a new keyset.
  *
  * @param alloc minimum number of keys to allocate
- * @param ap variable arguments list
+ * @param va variable arguments list
  *
  * @copydoc ksVNew
+ * @deprecated use fromVA instead!
  */
-inline KeySet::KeySet (size_t alloc, va_list av)
+#if defined(__amd64__) || defined(__x86_64__) || defined(__i386__)
+inline KeySet::KeySet (size_t alloc, va_list va)
 {
-	ks = ckdb::ksVNew (alloc, av);
+	ks = ckdb::ksVNew (alloc, va);
 }
+#endif
 
 /**
  * @brief Create a new keyset
@@ -458,6 +464,20 @@ inline void KeySet::setKeySet (ckdb::KeySet * k)
 {
 	ckdb::ksDel(ks);
 	ks = k;
+}
+
+/**
+ * @brief Creates a new keyset from variable arguments list and takes ownership.
+ *
+ * @param alloc minimum number of keys to allocate
+ * @param va variable arguments list
+ *
+ * @copydoc ksVNew
+ */
+inline void KeySet::fromVA (size_t alloc, va_list va)
+{
+	ckdb::ksDel(ks);
+	ks = ckdb::ksVNew (alloc, va);
 }
 
 /**

--- a/src/bindings/cpp/tests/testcpp_ks.cpp
+++ b/src/bindings/cpp/tests/testcpp_ks.cpp
@@ -835,7 +835,8 @@ KeySet fill_vaargs(size_t size, ...)
 {
 	va_list ap;
 	va_start(ap, size);
-	KeySet ks(size, ap);
+	KeySet ks;
+	ks.fromVA(size, ap);
 	va_end(ap);
 	return ks;
 }


### PR DESCRIPTION
Make the KeySet(alloc, va_list) constructor available as KeySet::fromVA instead.
Usage:
  KeySet ks;
  ks.fromVA(...);

Additional mark the constructor as deprecated and make it available on x86
and x64 platforms only. On this platforms the ambiguity is no problem.

Fixes #42