### PR TITLE
Fixed an issue causing the rename plugin to handle the parentKey incorrectly

### DIFF
--- a/src/plugins/rename/rename.c
+++ b/src/plugins/rename/rename.c
@@ -93,8 +93,13 @@ static Key *restoreKeyName(Key *key, const Key *parentKey, const Key *configKey)
 			Key *result = keyDup(key);
 			keySetName(result, keyName(parentKey));
 			keyAddUnescapedBasePath(result, keyString(configKey));
-			const char *relativePath = keyName(key) + keyGetNameSize(parentKey);
-			keyAddUnescapedBasePath(result, relativePath);
+
+			if (keyGetNameSize(key) > keyGetNameSize(parentKey)) {
+				/* this calculation does not work for the parent key but is also not needed */
+				const char *relativePath = keyName(key) + keyGetNameSize(parentKey);
+				keyAddUnescapedBasePath(result, relativePath);
+			}
+
 			return result;
 		}
 	}

--- a/src/plugins/rename/testmod_rename.c
+++ b/src/plugins/rename/testmod_rename.c
@@ -291,6 +291,30 @@ static void test_rebaseOfNewKeys()
 	PLUGIN_CLOSE ();
 }
 
+static void test_addNewBaseToParentKey()
+{
+	Key *parentKey = keyNew ("user/tests/rename", KEY_END);
+	KeySet *conf = ksNew (20,
+			keyNew ("system/cut", KEY_VALUE, "new/base", KEY_END), KS_END);
+
+	PLUGIN_OPEN("rename");
+
+	KeySet *ks = ksNew(0);
+	ksAppendKey (ks, parentKey);
+
+	succeed_if(plugin->kdbSet (plugin, ks, parentKey) >= 1,
+			"call to kdbSet was not successful");
+	succeed_if(output_error (parentKey), "error in kdbSet");
+	succeed_if(output_warnings (parentKey), "warnings in kdbSet");
+
+	Key *key = ksLookupByName (ks, "user/tests/rename/new/base", KEY_END);
+	succeed_if (key, "new base was not correctly appended to parent key");
+
+	ksDel(ks);
+	PLUGIN_CLOSE ();
+
+}
+
 
 int main(int argc, char** argv)
 {
@@ -305,6 +329,7 @@ int main(int argc, char** argv)
 	test_metaCutOnGet();
 	test_metaConfigTakesPrecedence();
 	test_rebaseOfNewKeys();
+	test_addNewBaseToParentKey();
 
 	test_keyCutNamePart();
 


### PR DESCRIPTION
This pull request should fix #206. A test that failed before this commit is appended