### PR TITLE
DEBUG_BUILD flag corrected

### DIFF
--- a/doc/COMPILE.md
+++ b/doc/COMPILE.md
@@ -186,7 +186,7 @@ Debug, Release or RelWithDebInfo
 See help bar at bottom of ccmake for that option or:
 http://www.cmake.org/Wiki/CMake_Useful_Variables
 
-#### DEBUG_BUILD and ELEKTRA_VERBOSE_BUILD  ####
+#### ELEKTRA_DEBUG_BUILD and ELEKTRA_VERBOSE_BUILD  ####
 Only needed by elektra developers.
 Make the library to output some or a lot of things.
 It is not recommended to use these options.


### PR DESCRIPTION
debug flag was wrong in doc/COMPILE.md.
Cmake said:
"CMake Warning:
  Manually-specified variables were not used by the project:

    DEBUG_BUILD"

Changed to ELEKTRA_DEBUG_BUILD and it works.