### PR TITLE
Fixed merge problems with cascading keys

### DIFF
--- a/src/libtools/src/helper/comparison.cpp
+++ b/src/libtools/src/helper/comparison.cpp
@@ -23,10 +23,18 @@ namespace helper
 bool keyDataEqual(const Key& k1, const Key& k2)
 {
 	if (!k1 || !k2) return false;
-	if (k1.getString () != k2.getString ())
+
+	if (k1.isBinary() != k2.isBinary()) return false;
+
+	if (k1.isBinary() && k2.isBinary())
 	{
-		return false;
+		return k1.getBinary() == k2.getBinary();
 	}
+	else
+	{
+		return k1.getString() == k2.getString();
+	}
+
 	return true;
 }
 

--- a/src/libtools/src/helper/keyhelper.cpp
+++ b/src/libtools/src/helper/keyhelper.cpp
@@ -25,9 +25,17 @@ string rebasePath(const Key& key, const Key& oldParent,
 {
 	string oldKeyPath = key.getName ();
 
-	if (!key.isBelowOrSame(oldParent)) throw InvalidRebaseException("the supplied key is not below the old parent");
+	Key actualParent = oldParent.dup();
 
-	string relativePath = oldKeyPath.substr (oldParent.getName().length (),
+	if (oldParent.getNamespace() == "/")
+	{
+		actualParent = oldParent.dup();
+		actualParent.setName(key.getNamespace() + oldParent.getName());
+	}
+
+	if (!key.isBelowOrSame(actualParent)) throw InvalidRebaseException("the supplied key is not below the old parent");
+
+	string relativePath = oldKeyPath.substr (actualParent.getName().length (),
 			oldKeyPath.length ());
 	string newPath = newParent.getName () + relativePath;
 

--- a/src/libtools/tests/testtool_comparison.cpp
+++ b/src/libtools/tests/testtool_comparison.cpp
@@ -29,6 +29,14 @@ TEST(KeyDataEqualTest, IsFalseForDifferentValuedKeys)
 	EXPECT_FALSE(keyDataEqual (k1, k2));
 }
 
+TEST(KeyDataEqualTest, IsFalseForDifferentTypedKeys)
+{
+	Key k1 = Key ("user/test/config/key1", KEY_VALUE, "keyvalue1", KEY_END);
+	Key k2 = Key ("user/test/config/key2", KEY_VALUE, "keyvalue1", KEY_BINARY, KEY_END);
+
+	EXPECT_FALSE(keyDataEqual (k1, k2));
+}
+
 TEST(KeyDataEqualTest, HandlesNullKeys)
 {
 	Key k1 = Key ("user/test/config/key1", KEY_VALUE, "keyvalue1", KEY_END);

--- a/src/libtools/tests/testtool_keyhelper.cpp
+++ b/src/libtools/tests/testtool_keyhelper.cpp
@@ -22,6 +22,15 @@ TEST(RebasePath, RebasesCorrectlyWithValidArguments)
 	EXPECT_EQ ("user/test/confignew/subdir/k1", rebasePath (target, oldParent, newParent));
 }
 
+TEST(RebasePath, RebasesCorrectlyWithCascadingParent)
+{
+	Key target = Key ("user/test/configold/subdir/k1", KEY_END);
+	Key oldParent = Key ("/test/configold", KEY_END);
+	Key newParent = Key ("user/test/confignew", KEY_END);
+
+	EXPECT_EQ ("user/test/confignew/subdir/k1", rebasePath (target, oldParent, newParent));
+}
+
 TEST(RebasePath, WorksForKeyOnSameLevel)
 {
 	Key target = Key ("user/test/configold", KEY_END);
@@ -45,6 +54,19 @@ TEST(RebaseKey, RebasesCorrectlyWithValidArguments)
 {
 	Key target = Key ("user/test/configold/subdir/k1", KEY_VALUE, "testvalue", KEY_END);
 	Key oldParent = Key ("user/test/configold", KEY_END);
+	Key newParent = Key ("user/test/confignew", KEY_END);
+	Key expected = Key ("user/test/confignew/subdir/k1", KEY_VALUE, "testvalue", KEY_END);
+
+	Key result = rebaseKey (target, oldParent, newParent);
+
+	EXPECT_EQ (expected.getName(), result.getName());
+	EXPECT_EQ (expected.getString(), result.getString());
+}
+
+TEST(RebaseKey, RebasesCorrectlyWithCascadingParent)
+{
+	Key target = Key ("user/test/configold/subdir/k1", KEY_VALUE, "testvalue", KEY_END);
+	Key oldParent = Key ("/test/configold", KEY_END);
 	Key newParent = Key ("user/test/confignew", KEY_END);
 	Key expected = Key ("user/test/confignew/subdir/k1", KEY_VALUE, "testvalue", KEY_END);
 


### PR DESCRIPTION
This patch fixes the problem discussed in #174 as well as another issue that caused the synchronization in the qt-gui to fail. The problem discussed in #174 is not really about merging cascading keys, but about handling cascading parent keys (cascading parent keys caused the InvalidRebaseException).

More special treatment for cascading keys in the ThreeWayMerger is thinkable. For example what should happen if one of the keys in the merged keysets is a cascading key? This issue is currently not addressed, but for now I concentrated on fixing the issues affecting the qt-gui. I would suggest renaming #174 and creating another issue that is really about the treatment of cascading keys during a merge.