### PR TITLE
Another cascading merge fix

### DIFF
--- a/src/libtools/include/helper/keyhelper.hpp
+++ b/src/libtools/include/helper/keyhelper.hpp
@@ -51,6 +51,9 @@ Key rebaseKey(const Key& key, const Key& oldParent, const Key& newParent);
  * /user/example and the new parent /user/newexample/newpath would
  * result in /user/newexample/newpath/config/key1
  *
+ * If any of the parent keys is a cascading key the namespace of the
+ * key to be rebased is assumed instead.
+ *
  * @param key the key whose path should be rebased
  * @param oldParent the old parent of the key
  * @param newParent the new parent of the key

--- a/src/libtools/src/helper/keyhelper.cpp
+++ b/src/libtools/src/helper/keyhelper.cpp
@@ -25,19 +25,23 @@ string rebasePath(const Key& key, const Key& oldParent,
 {
 	string oldKeyPath = key.getName ();
 
-	Key actualParent = oldParent.dup();
-
+	Key actualOldParent = oldParent.dup();
 	if (oldParent.getNamespace() == "/")
 	{
-		actualParent = oldParent.dup();
-		actualParent.setName(key.getNamespace() + oldParent.getName());
+		actualOldParent.setName(key.getNamespace() + oldParent.getName());
 	}
 
-	if (!key.isBelowOrSame(actualParent)) throw InvalidRebaseException("the supplied key " + key.getName() + " is not below the old parent " + actualParent.getName());
+	Key actualNewParent = newParent.dup();
+	if (newParent.getNamespace() == "/")
+	{
+		actualNewParent.setName(key.getNamespace() + newParent.getName());
+	}
 
-	string relativePath = oldKeyPath.substr (actualParent.getName().length (),
+	if (!key.isBelowOrSame(actualOldParent)) throw InvalidRebaseException("the supplied key is not below the old parent");
+
+	string relativePath = oldKeyPath.substr (actualOldParent.getName().length (),
 			oldKeyPath.length ());
-	string newPath = newParent.getName () + relativePath;
+	string newPath = actualNewParent.getName () + relativePath;
 
 	return newPath;
 }

--- a/src/libtools/tests/testtool_mergecases.cpp
+++ b/src/libtools/tests/testtool_mergecases.cpp
@@ -33,6 +33,24 @@ TEST_F(ThreeWayMergeTest, EqualKeySetsMerge)
 	compareAllKeys (merged);
 }
 
+TEST_F(ThreeWayMergeTest, CascadingParentsCauseNoCascadingKeys)
+{
+	Key root("/", KEY_END);
+	MergeResult result = merger.mergeKeySet(MergeTask(BaseMergeKeys(base, Key("/parentb", KEY_END)),
+			  OurMergeKeys(ours, Key("/parento", KEY_END)),
+			  TheirMergeKeys (theirs, Key("/parentt", KEY_END)),
+			  root));
+	EXPECT_FALSE(result.hasConflicts()) << "Invalid conflict detected";
+
+	Key current;
+	KeySet merged = result.getMergedKeys ();
+	merged.rewind();
+	while ((current = merged.next ()))
+	{
+		EXPECT_FALSE(current.getNamespace() == "/");
+	}
+}
+
 TEST_F(ThreeWayMergeTest, SameDeletedKeyMerge)
 {
 	ours.lookup ("user/parento/config/key1", KDB_O_POP);


### PR DESCRIPTION
Another try to fix the issue discussed in #174. When I try the qt-gui now with "/" instead of "user" the only problem left is an error to set information below the version mountpoint. However, this seems unrelated to the merging framework. When stepping through the code in the debugger, added keys are merged fine.
