### PR TITLE
swig: fix kdb::Key(ckdb::Key) constructor

### DIFF
--- a/src/bindings/swig/lua/tests/test_key.lua
+++ b/src/bindings/swig/lua/tests/test_key.lua
@@ -29,6 +29,10 @@ local k = kdb.Key(key)
 assert(swig_type(k) == "kdb::Key *")
 assert(k:isValid() == true)
 
+local k = kdb.Key(key:dup())
+assert(swig_type(k) == "kdb::Key *")
+assert(k:isValid() == true)
+
 -- operator
 assert(key ~= bkey)
 assert(kdb.Key(key) == key)

--- a/src/bindings/swig/python2/tests/testpy2_key.py
+++ b/src/bindings/swig/python2/tests/testpy2_key.py
@@ -59,6 +59,11 @@ class Key(unittest.TestCase):
 		self.assertIsInstance(k, kdb.Key)
 		self.assertTrue(k.isValid())
 
+		k = kdb.Key(self.key.dup())
+		self.assertIsInstance(k, kdb.Key)
+		self.assertTrue(k.isValid())
+		self.assertEqual(k, self.key)
+
 	def test_operator(self):
 		self.assertNotEqual(self.key, self.bkey)
 		self.assertEqual(kdb.Key(self.key), self.key)

--- a/src/bindings/swig/python3/kdb.i
+++ b/src/bindings/swig/python3/kdb.i
@@ -45,7 +45,7 @@
   value = None
   meta  = {}
   # check for copy constructor
-  if len(args) and not isinstance(args[0], self.__class__):
+  if len(args) and isinstance(args[0], str):
     arg0, args = args[0], args[1:]
 
     flags = 0

--- a/src/bindings/swig/python3/tests/test_key.py
+++ b/src/bindings/swig/python3/tests/test_key.py
@@ -58,6 +58,11 @@ class Key(unittest.TestCase):
 		self.assertIsInstance(k, kdb.Key)
 		self.assertTrue(k.isValid())
 
+		k = kdb.Key(self.key.dup())
+		self.assertIsInstance(k, kdb.Key)
+		self.assertTrue(k.isValid())
+		self.assertEqual(k, self.key)
+
 	def test_operator(self):
 		self.assertNotEqual(self.key, self.bkey)
 		self.assertEqual(kdb.Key(self.key), self.key)


### PR DESCRIPTION
fixing the copy constructor doesn't hurt anyway.

this fixes #237