### PR TITLE
cmake: change again the modules install directory

### DIFF
--- a/cmake/ElektraCache.cmake
+++ b/cmake/ElektraCache.cmake
@@ -424,7 +424,7 @@ set (TARGET_INCLUDE_FOLDER
     )
 
 set (TARGET_CMAKE_FOLDER
-		"share/cmake-${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION}/Modules"
+		"lib${LIB_SUFFIX}/cmake/Elektra"
 		CACHE STRING
 		"This folder (below prefix) will be used to install cmake files."
     )


### PR DESCRIPTION
Commit 4363c4d3683c7587dd3eea35875afe43d3116e80 changes it to a location within the Elektra libdir, which is not inside the own CMake modules but still used by CMake;
recent commit ad3c1169946eefbcc105284ada930472f58af9a8 changes it back with no reason (possibly a merge mistake).

Change it as commit 4363c4d3683c7587dd3eea35875afe43d3116e80 intended, so CMake modules are installed in the correct place for them.