### PR TITLE
Python: subinterpreter support + some fixes

### DIFF
--- a/src/plugins/python/CMakeLists.txt
+++ b/src/plugins/python/CMakeLists.txt
@@ -35,10 +35,6 @@ if (PYTHONLIBS_FOUND AND SWIG_FOUND)
 		# output directory + our test adds the current directory to pythons sys.path
 		add_plugintest (python
 			MEMLEAK
-			INCLUDE_DIRECTORIES
-				${PYTHON_INCLUDE_DIR}
-			LINK_LIBRARIES
-				${PYTHON_LIBRARIES}
 			WORKING_DIRECTORY
 				${CMAKE_CURRENT_BINARY_DIR}/../../bindings/swig/python3/
 			COMPILE_DEFINITIONS

--- a/src/plugins/python/python.cpp
+++ b/src/plugins/python/python.cpp
@@ -192,11 +192,11 @@ static void Python_Shutdown(moduleData *data)
 int PYTHON_PLUGIN_FUNCTION(Open)(ckdb::Plugin *handle, ckdb::Key *errorKey)
 {
 	KeySet *config = elektraPluginGetConfig(handle);
-	Key *script = ksLookupByName(config, "/script", 0);
-	if (script == NULL)
-		return 0; // success if no script to execute
+	if (ksLookupByName(config, "/module", 0) != NULL)
+		return 0; // by convention: success if /module exists
 
-	if (keyString(script) == NULL)
+	Key *script = ksLookupByName(config, "/script", 0);
+	if (script == NULL || !strlen(keyString(script)))
 	{
 		ELEKTRA_SET_ERROR(111, errorKey, "No python script set");
 		return -1;

--- a/src/plugins/python/testmod_python.c
+++ b/src/plugins/python/testmod_python.c
@@ -46,6 +46,7 @@ static void test_variable_passing()
 
 	KeySet *conf = ksNew(1,
 		keyNew("user/script", KEY_VALUE, python_file("python_plugin.py"), KEY_END),
+		keyNew("user/shutdown", KEY_VALUE, "1", KEY_END),
 		keyNew("user/print", KEY_END),
 		KS_END);
 	PLUGIN_OPEN(PYTHON_PLUGIN_NAME);
@@ -72,11 +73,13 @@ static void test_two_scripts()
 
 	KeySet *conf = ksNew(2,
 		keyNew("user/script", KEY_VALUE, python_file("python_plugin.py"), KEY_END),
+		keyNew("user/shutdown", KEY_VALUE, "1", KEY_END),
 		keyNew("user/print", KEY_END),
 		KS_END);
 
 	KeySet *conf2 = ksNew(2,
 		keyNew("user/script", KEY_VALUE, python_file("python_plugin2.py"), KEY_END),
+		keyNew("user/shutdown", KEY_VALUE, "1", KEY_END),
 		keyNew("user/print", KEY_END),
 		KS_END);
 
@@ -107,6 +110,7 @@ static void test_fail()
 
 	KeySet *conf = ksNew(2,
 		keyNew("user/script", KEY_VALUE, python_file("python_plugin_fail.py"), KEY_END),
+		keyNew("user/shutdown", KEY_VALUE, "1", KEY_END),
 		keyNew("user/print", KEY_END),
 		KS_END);
 	PLUGIN_OPEN(PYTHON_PLUGIN_NAME);
@@ -134,6 +138,7 @@ static void test_wrong()
 
 	KeySet *conf = ksNew(2,
 		keyNew("user/script", KEY_VALUE, python_file("python_plugin_wrong.py"), KEY_END),
+		keyNew("user/shutdown", KEY_VALUE, "1", KEY_END),
 		keyNew("user/print", KEY_END),
 		KS_END);
 


### PR DESCRIPTION
after a lot of crashes I finally got subinterpreter support working. In general one shouldn't mix pythons thread state APIs with the GIL API. Thankfully a lot of them is already deprecated (haven't used them).