### PR TITLE
bindings: in tests don't check KDB_VERSION if CHECK_VERSION is set

### DIFF
--- a/src/bindings/gi/lua/testgi_kdb.lua
+++ b/src/bindings/gi/lua/testgi_kdb.lua
@@ -28,8 +28,10 @@ do
 	local ks = kdb.KeySet(100)
 	db:get(ks, "system/elektra")
 
-	local key = ks:lookup("system/elektra/version/constants/KDB_VERSION")
-	assert(key.value == kdb.VERSION)
+	if os.getenv("CHECK_VERSION") == nil then
+		local key = ks:lookup("system/elektra/version/constants/KDB_VERSION")
+		assert(key.value == kdb.VERSION)
+	end
 end
 
 -- set

--- a/src/bindings/gi/python/testgi_kdb.py
+++ b/src/bindings/gi/python/testgi_kdb.py
@@ -32,8 +32,10 @@ class KDB(unittest.TestCase):
 			ks = kdb.KeySet()
 			db.get(ks, "system/elektra")
 
-			key = ks["system/elektra/version/constants/KDB_VERSION"]
-			self.assertEqual(key.value, kdb.VERSION)
+			import os
+			if os.getenv("CHECK_VERSION") is None:
+				key = ks["system/elektra/version/constants/KDB_VERSION"]
+				self.assertEqual(key.value, kdb.VERSION)
 
 	def test_set(self):
 		with kdb.KDB() as db:

--- a/src/bindings/swig/lua/tests/test_kdb.lua
+++ b/src/bindings/swig/lua/tests/test_kdb.lua
@@ -28,8 +28,10 @@ do
 	local ks = kdb.KeySet(100)
 	db:get(ks, "system/elektra")
 
-	local key = ks["system/elektra/version/constants/KDB_VERSION"]
-	assert(key.value == kdb.VERSION)
+	if os.getenv("CHECK_VERSION") == nil then
+		local key = ks["system/elektra/version/constants/KDB_VERSION"]
+		assert(key.value == kdb.VERSION)
+	end
 end
 
 -- set

--- a/src/bindings/swig/python/tests/test_kdb.py
+++ b/src/bindings/swig/python/tests/test_kdb.py
@@ -31,8 +31,10 @@ class KDB(unittest.TestCase):
 			ks = kdb.KeySet()
 			db.get(ks, "system/elektra")
 
-			key = ks["system/elektra/version/constants/KDB_VERSION"]
-			self.assertEqual(key.value, kdb.VERSION)
+			import os
+			if os.getenv("CHECK_VERSION") is None:
+				key = ks["system/elektra/version/constants/KDB_VERSION"]
+				self.assertEqual(key.value, kdb.VERSION)
 
 	def test_set(self):
 		with kdb.KDB() as db:

--- a/src/bindings/swig/python2/tests/testpy2_kdb.py
+++ b/src/bindings/swig/python2/tests/testpy2_kdb.py
@@ -32,8 +32,10 @@ class KDB(unittest.TestCase):
 			ks = kdb.KeySet()
 			db.get(ks, "system/elektra")
 
-			key = ks["system/elektra/version/constants/KDB_VERSION"]
-			self.assertEqual(key.value, kdb.VERSION)
+			import os
+			if os.getenv("CHECK_VERSION") is None:
+				key = ks["system/elektra/version/constants/KDB_VERSION"]
+				self.assertEqual(key.value, kdb.VERSION)
 
 	def test_set(self):
 		with kdb.KDB() as db:


### PR DESCRIPTION
fixes #272