### PR TITLE
getenv example: do not link to elektra/elektratools

### DIFF
--- a/src/libgetenv/examples/CMakeLists.txt
+++ b/src/libgetenv/examples/CMakeLists.txt
@@ -10,9 +10,6 @@ macro (do_example source)
 	add_executable (${source} ${SOURCES})
 	install(TARGETS ${source} DESTINATION ${TARGET_TOOL_EXEC_FOLDER})
 
-	target_link_elektra(${source})
-	target_link_elektratools(${source})
-
 	set_target_properties (${source} PROPERTIES
 			COMPILE_DEFINITIONS HAVE_KDBCONFIG_H)
 endmacro (do_example)


### PR DESCRIPTION
This small C application just dumps the content of the environment, printing also the environment variables requested as arguments.
Since this is usually run as tool in a `elektrify-getenv` context, it will get the effects of elektragetenv, and thus linking elektra and elektratools is not needed.