### PR TITLE
merger sync key problem

### DIFF
--- a/src/libtools/include/merging/mergeresult.hpp
+++ b/src/libtools/include/merging/mergeresult.hpp
@@ -48,7 +48,10 @@ public:
 
 	void addMergeKey(const Key& key)
 	{
-		mergedKeys.append (key);
+		if (!mergedKeys.lookup(key))
+		{
+			mergedKeys.append (key);
+		}
 	}
 
 	void removeMergeKey(const Key& key)

--- a/src/libtools/src/merging/threewaymerge.cpp
+++ b/src/libtools/src/merging/threewaymerge.cpp
@@ -54,7 +54,16 @@ void ThreeWayMerge::detectConflicts(const MergeTask& task, MergeResult& mergeRes
 			// keydata matches, see if metakeys match
 			if (keyMetaEqual (our, theirLookupResult))
 			{
-				mergeResult.addMergeKey (mergeKey);
+				if (task.ourParent.getFullName() == task.mergeRoot.getFullName())
+				{
+					// the key was not rebased, we can reuse our (prevents that the key is rewritten)
+					mergeResult.addMergeKey (our);
+				}
+				else
+				{
+					// the key causes no merge conflict, but the merge result is below a new parent
+					mergeResult.addMergeKey (mergeKey);
+				}
 			}
 			else
 			{
@@ -115,7 +124,16 @@ void ThreeWayMerge::detectConflicts(const MergeTask& task, MergeResult& mergeRes
 						if (keyMetaEqual (our, theirLookupResult))
 						{
 							// the key was added on both sides with the same value
-							mergeResult.addMergeKey (mergeKey);
+							if (task.ourParent.getFullName() == task.mergeRoot.getFullName())
+							{
+								// the key was not rebased, we can reuse our and prevent the sync flag being set
+								mergeResult.addMergeKey (our);
+							}
+							else
+							{
+								// the key causes no merge conflict, but the merge result is below a new parent
+								mergeResult.addMergeKey (mergeKey);
+							}
 						}
 						else
 						{

--- a/src/libtools/tests/mergetestutils.cpp
+++ b/src/libtools/tests/mergetestutils.cpp
@@ -11,6 +11,7 @@
 #include <keysetio.hpp>
 #include <gtest/gtest.h>
 #include <merging/threewaymerge.hpp>
+#include <kdbprivate.h>
 
 using namespace kdb;
 using namespace kdb::tools::merging;
@@ -79,6 +80,19 @@ protected:
 
 	virtual void TearDown()
 	{
+	}
+
+	virtual void unsyncKeys(KeySet& ks)
+	{
+		Key current;
+		ks.rewind();
+		while ((current = ks.next()))
+		{
+			current.getKey()->flags = static_cast<ckdb::keyflag_t>(current.getKey()->flags & ~(ckdb::KEY_FLAG_SYNC));
+
+			// This does not work because C++ complains about an invalid conversion from int to keyflags_t
+			//clear_bit(current.getKey()->flags, static_cast<int>(ckdb::KEY_FLAG_SYNC));
+		}
 	}
 
 	virtual void compareKeys(const Key& k1, const Key& k2)

--- a/src/libtools/tests/testtool_mergecases.cpp
+++ b/src/libtools/tests/testtool_mergecases.cpp
@@ -9,6 +9,7 @@
 
 #include <iostream>
 #include <gtest/gtest.h>
+#include <kdbprivate.h>
 #include "mergetestutils.cpp"
 
 using namespace kdb;
@@ -31,6 +32,25 @@ TEST_F(ThreeWayMergeTest, EqualKeySetsMerge)
 
 	EXPECT_EQ(5, merged.size ());
 	compareAllKeys (merged);
+}
+
+TEST_F(ThreeWayMergeTest, EqualKeySetsWontCauseSync)
+{
+	unsyncKeys(ours);
+	unsyncKeys(theirs);
+	unsyncKeys(base);
+
+	MergeResult result = merger.mergeKeySet (base, ours, theirs, ourParent);
+	EXPECT_FALSE(result.hasConflicts()) << "Invalid conflict detected";
+
+	KeySet merged = result.getMergedKeys();
+
+	Key current;
+	merged.rewind();
+	while ((current = merged.next ()))
+	{
+		EXPECT_FALSE(current.needSync());
+	}
 }
 
 TEST_F(ThreeWayMergeTest, CascadingParentsCauseNoCascadingKeys)


### PR DESCRIPTION
The commit should fix the issue discussed in #295. However, I could not test the fix with the gui. The gui eats up all my system ressources until the system grinds to a halt. When it finally starts it is so slow that I can hardly click anything. Please let me know if the issue is resolved. 