### PR TITLE
Improved the augeas plugin error messages

### DIFF
--- a/src/plugins/augeas/augeas.c
+++ b/src/plugins/augeas/augeas.c
@@ -66,22 +66,44 @@ static const char *getLensPath(Plugin *handle)
 
 static const char *getAugeasError(augeas* augeasHandle)
 {
-	const char* message = 0;
+	const char* reason = 0;
 	if (aug_error (augeasHandle) != 0)
 	{
-		message = aug_error_message (augeasHandle);
+		reason = aug_error_message (augeasHandle);
 	}
 	else
 	{
-		aug_get (augeasHandle, "/augeas/text"AUGEAS_TREE_ROOT"/error/message",
-				&message);
-		if (!message) message = "No specific reason was reported";
+		const char *augeasError;
+		aug_get (augeasHandle, "/augeas/text"AUGEAS_TREE_ROOT"/error", &augeasError);
+
+		if (augeasError)
+		{
+			const char *lens;
+			const char *line;
+			const char *character;
+			const char *message;
+
+			aug_get (augeasHandle, "/augeas/text"AUGEAS_TREE_ROOT"/error/lens", &lens);
+			aug_get (augeasHandle, "/augeas/text"AUGEAS_TREE_ROOT"/error/line", &line);
+			aug_get (augeasHandle, "/augeas/text"AUGEAS_TREE_ROOT"/error/char", &character);
+			aug_get (augeasHandle, "/augeas/text"AUGEAS_TREE_ROOT"/error/message", &message);
+
+			const char *format = "%s\n\tposition: %s:%s\n\tmessage: %s\n\tlens: %s";
+			size_t messageSize = strlen(lens) + strlen(line) + strlen(character) + strlen(message) + strlen(format);
+			char *buffer = malloc (messageSize);
+			sprintf(buffer, format, augeasError, line, character, message);
+			reason = buffer;
+		}
+		else
+		{
+			reason = "No specific reason was reported";
+		}
 	}
 
 	/* should not happen, but avoid 0 return */
-	if (!message) message = "";
+	if (!reason) reason = "";
 
-	return message;
+	return reason;
 }
 
 static Key *createKeyFromPath(Key *parentKey, const char *treePath)


### PR DESCRIPTION
Partly fixes the issue discussed in #206. As you have guessed, the error messages stem from Augeas. However, the augeas plugin now includes all the information available from Augeas. The message reported in #206 now looks like this:
```
The command ls failed while accessing the key database with the info:
Error (#85) occurred!
Description: an Augeas error occurred
Ingroup: plugin
Module: storage
At: /path/to/augeas.c:425
Reason: parse_failed
	position: 58:0
	message: Iterated lens matched less than it should
	lens: /raw/tree
Mountpoint: system/limits
Configfile: /etc/security/limits.conf
