### PR TITLE
Fix issue #364 - compiler warning

### DIFF
--- a/src/plugins/crypto/crypto.h
+++ b/src/plugins/crypto/crypto.h
@@ -21,6 +21,7 @@ int elektraCryptoError(Plugin *handle, KeySet *ks, Key *parentKey);
 
 
 int elektraCryptoInit(Key *errorKey);
+void elektraCryptoTeardown();
 int elektraCryptoHandleCreate(elektraCryptoHandle **handle, KeySet *config, Key *errorKey);
 void elektraCryptoHandleDestroy(elektraCryptoHandle *handle);
 int elektraCryptoEncrypt(elektraCryptoHandle *handle, Key *k, Key *errorKey);


### PR DESCRIPTION
I forgot to add `elektraCryptoTeardown()`'s declaration to `crypto.h`.