### PR TITLE
Make sure plugins don't export any of their symbols

### DIFF
--- a/cmake/Modules/LibAddPlugin.cmake
+++ b/cmake/Modules/LibAddPlugin.cmake
@@ -101,6 +101,12 @@ function(add_plugin PLUGIN_SHORT_NAME)
 			${ARG_INCLUDE_DIRECTORIES}
 			${CMAKE_CURRENT_BINARY_DIR} #for readme
 			)
+		if (${LD_ACCEPTS_VERSION_SCRIPT})
+			set_property(TARGET ${PLUGIN_NAME}
+				APPEND PROPERTY LINK_FLAGS
+				"-Wl,--version-script=${PROJECT_SOURCE_DIR}/src/plugins/plugin-symbols.map"
+				)
+		endif ()
 	endif()
 
 	set_property (GLOBAL APPEND PROPERTY "elektra-full_SRCS"

--- a/src/plugins/plugin-symbols.map
+++ b/src/plugins/plugin-symbols.map
@@ -1,0 +1,5 @@
+{
+	global:
+		elektraPluginSymbol;
+	local: *;
+};


### PR DESCRIPTION
The one and only (allowed) is elektraPluginSymbol