### PR TITLE
lua+python: add config keyset to open-call

### DIFF
--- a/src/plugins/lua/lua.cpp
+++ b/src/plugins/lua/lua.cpp
@@ -169,7 +169,7 @@ int elektraLuaOpen(ckdb::Plugin *handle, ckdb::Key *errorKey)
 	elektraPluginSetData(handle, data);
 
 	/* call lua function */
-	return Lua_CallFunction_Helper1(data->L, "elektraOpen", errorKey);
+	return Lua_CallFunction_Helper2(data->L, "elektraOpen", config, errorKey);
 
 error_print:
 	if (!lua_isnil(data->L, -1))

--- a/src/plugins/lua/lua/lua_filter.lua
+++ b/src/plugins/lua/lua/lua_filter.lua
@@ -1,6 +1,6 @@
 local x = 1
 
-function elektraOpen(errorKey)
+function elektraOpen(config, errorKey)
 	print("[LUA-FILTER] open -->")
 	x = x + 1
 	return 0

--- a/src/plugins/lua/lua/lua_plugin.lua
+++ b/src/plugins/lua/lua/lua_plugin.lua
@@ -1,6 +1,6 @@
 require("kdb")
 
-function elektraOpen(errorKey)
+function elektraOpen(config, errorKey)
 	print("[LUA-1] open -->")
 	return 0
 end

--- a/src/plugins/lua/lua/lua_plugin2.lua
+++ b/src/plugins/lua/lua/lua_plugin2.lua
@@ -1,6 +1,6 @@
 local x = 1
 
-function elektraOpen(errorKey)
+function elektraOpen(config, errorKey)
 	print("[LUA-2] open -->")
 	x = x + 1
 	return 0

--- a/src/plugins/lua/lua/lua_plugin_fail.lua
+++ b/src/plugins/lua/lua/lua_plugin_fail.lua
@@ -1,4 +1,4 @@
-function elektraOpen(errorKey)
+function elektraOpen(config, errorKey)
 	return 0
 end
 

--- a/src/plugins/lua/lua/lua_plugin_wrong.lua
+++ b/src/plugins/lua/lua/lua_plugin_wrong.lua
@@ -1,4 +1,4 @@
-function elektraOpen(errorKey)
+function elektraOpen(config, errorKey)
 	wrong("foo")
 	return 0
 end

--- a/src/plugins/python/python.cpp
+++ b/src/plugins/python/python.cpp
@@ -313,7 +313,7 @@ int PYTHON_PLUGIN_FUNCTION(Open)(ckdb::Plugin *handle, ckdb::Key *errorKey)
 	elektraPluginSetData(handle, data);
 
 	/* call python function */
-	return Python_CallFunction_Helper1(data, "open", errorKey);
+	return Python_CallFunction_Helper2(data, "open", config, errorKey);
 
 error_print:
 	if (data->printError)

--- a/src/plugins/python/python/python_configparser.py
+++ b/src/plugins/python/python/python_configparser.py
@@ -5,7 +5,7 @@ class ElektraPlugin(object):
 	def __init__(self):
 		pass
 
-	def open(self, errorKey):
+	def open(self, config, errorKey):
 		print("[CLASS-PYTHON-C] open")
 		return 0
 

--- a/src/plugins/python/python/python_plugin.py
+++ b/src/plugins/python/python/python_plugin.py
@@ -4,7 +4,7 @@ class ElektraPlugin(object):
 	def __init__(self):
 		pass
 
-	def open(self, errorKey):
+	def open(self, config, errorKey):
 		print("[CLASS-PYTHON-1] open -->")
 		return 0
 

--- a/src/plugins/python/python/python_plugin2.py
+++ b/src/plugins/python/python/python_plugin2.py
@@ -3,7 +3,7 @@ class ElektraPlugin(object):
 		self.x = 1
 		pass
 
-	def open(self, errorKey):
+	def open(self, config, errorKey):
 		print("[CLASS-PYTHON-2] open -->")
 		self.x = self.x + 1
 		return 1

--- a/src/plugins/python/python/python_plugin_fail.py
+++ b/src/plugins/python/python/python_plugin_fail.py
@@ -1,5 +1,5 @@
 class ElektraPlugin(object):
-	def open(self, errorKey):
+	def open(self, config, errorKey):
 		return 0
 
 	def get(self, returned, parentKey):


### PR DESCRIPTION
As discussed in #394 this adds the config keyset (from elektraPluginGetConfig) to the open-call in both scripting plugins