### PR TITLE
typo fixes

### DIFF
--- a/doc/NEWS.md
+++ b/doc/NEWS.md
@@ -822,14 +822,14 @@ Note that there are still [some bugs](http://git.libelektra.org/issues).
 - CMake: Fix gtest to be build if `BUILD_TESTING` activated, but not `ENABLE_TESTING`
 - CMake: Allow compilation without BUILD_STATIC
 - Explain compilation options more, thanks to Kai-Uwe Behrmann for asking the question
-- CMake: always build examples, allow to only build documentation
+- CMake: always build examples, allow one to only build documentation
 - add common header file for C++ plugins (used by plugins struct and type)
 - fix compilation of race tool under oS-11.4 thanks to Kai-Uwe Behrmann
 - CMake: find python3 correctly
 - CMake: fix BUILD_SHARED_LIBS
 - Doxygen: remove `HTML_TIMESTAMP` to make build reproduceable
 - Doxygen: rewrite of main page+add info about all five namespaces
-- CMake: allow to use qt-gui with qt built with -reduce-relocations
+- CMake: allow one to use qt-gui with qt built with -reduce-relocations
 - fix kdb ls, get to list warnings during open
 - during kdbOpen() use Configfile: to state phase
 - add -f option to kdb check+improve docu
@@ -1753,7 +1753,7 @@ is the new proposed API method ksLookupBySpec (and ksLookup implementing
 cascading search). It introduces a `logical view` of
 configuration that in difference to the `physical view` of
 configuration does not have namespaces, but everything is below the root
-"/". Additionally, contextual values now allow to be compile-time
+"/". Additionally, contextual values now allow one to be compile-time
 configured using C++-Policies. These are small puzzle pieces that will
 fit into a greater picture at a later time.
 
@@ -1822,7 +1822,7 @@ how comments can be improved.
 - support non-system installation (e.g. in home directory)
 - rewrote test cases to use succeed_if_same to avoid crashes on
   null pointers
-- allow to use python 2.6 for kdb gen
+- allow one to use python 2.6 for kdb gen
 - improve exception messages
 - use memcasecmp (fix lookup ignoring case)
 - fix memory leaks (ini)
@@ -2004,11 +2004,11 @@ it says on that line 94 in test_ks.c:
 see above for more information:
 - keyAddName         ..  add key name without escaping, like keySetName
 - keyUnescapedName   ..  get access to null-separated unescaped name
-- keyLock            ..  to allow to secure keys against modifications
+- keyLock            ..  to allow one to secure keys against modifications
 
 some new ideas:
 - keySetStringF      ..  printf format-style changing of the key string
-- elektraKeySetName  ..  to allow to set meta + cascading keys
+- elektraKeySetName  ..  to allow one to set meta + cascading keys
 
 elektraArrayIncName() now works correctly with empty arrays embedded in
 other arrays (yajl+line plugin)

--- a/doc/VERSION.md
+++ b/doc/VERSION.md
@@ -43,7 +43,7 @@ with #ifdefs).
 
 Following points are allowed:
 When you add a new function you break ABI and API backward-
-compatibilty, but not forward, so you are allowed to do so.
+compatibility, but not forward, so you are allowed to do so.
 
 In the signature you are only allowed to add const to
 any parameter. You are *not* allowed to use subtypes to

--- a/doc/decisions/script_testing.md
+++ b/doc/decisions/script_testing.md
@@ -10,7 +10,7 @@
 * robotframework
  - additional (fat) dependency
  - integration with cmake?
- - does not allow to capture stdout, stderr + return code
+ - does not allow one to capture stdout, stderr + return code
 
 * expect
  + interactive testing (e.g. for kdb mount)

--- a/doc/help/elektra-namespaces.md
+++ b/doc/help/elektra-namespaces.md
@@ -107,7 +107,7 @@ e.g. by seteuid() or by environment variables like HOME, USER
 The system configuration is the same for every chroot.
 
 The configuration is typically located below KDB_DB_SYSTEM.
-Other absolut pathes, e.g. below /opt or /usr/local/etc are possible
+Other absolute pathes, e.g. below /opt or /usr/local/etc are possible
 too.
 
 

--- a/doc/help/kdb-convert.md
+++ b/doc/help/kdb-convert.md
@@ -41,5 +41,5 @@ Another way to convert an Elektra dump file to xml:
 
 To print an xml file using the `line` format:  
 	`cat ../tests/xml_file.xml | kdb convert xmltool line`  
-Note that this command won't save the output, it will just diplay it to `stdout`.
+Note that this command won't save the output, it will just display it to `stdout`.
 

--- a/doc/help/kdb-info.md
+++ b/doc/help/kdb-info.md
@@ -12,8 +12,8 @@ The optional `clause name` argument can be used to just print information from a
 
 This command will print out all the information about an Elektra plugin except it's configuration.  
 This command will also print out any functions that are exported by the plugin.  
-Information about a plugin will be read from `system/elektra/modules/`. If the information could not be lcoated there, such as when a plugin is not mounted, the module will be loaded dynamically and then the infromation will be requested directly from the plugin.  
-If a user wishes to load the infromation directly from the plugin, they can force that by using the `-l` option.  
+Information about a plugin will be read from `system/elektra/modules/`. If the information could not be located there, such as when a plugin is not mounted, the module will be loaded dynamically and then the information will be requested directly from the plugin.  
+If a user wishes to load the information directly from the plugin, they can force that by using the `-l` option.  
 
 ## RETURN VALUES
 

--- a/doc/help/kdb-test.md
+++ b/doc/help/kdb-test.md
@@ -12,7 +12,7 @@ If no `test-name` is provided, all the tests will be run.
 ## DESCRIPTION
 
 This command is used to run part or all of the key database test suite.  
-These tests allow to user to verify that a backend is capable of storing and retrieving all kinds of configuration keys and values.  
+These tests allow one to user to verify that a backend is capable of storing and retrieving all kinds of configuration keys and values.  
 
 The following tests are available: basic string umlauts binary naming meta  
 

--- a/doc/tutorials/plugins.md
+++ b/doc/tutorials/plugins.md
@@ -207,7 +207,7 @@ Lets start with the most important parameters, the KeySet and the `parentKey`. T
 the file. In our case it would contain the Keys representing the lines. The `parentKey` is the topmost Key of the KeySet at serves several purposes.
 First, it contains the filename of the destination file as its value. Second, errors and warnings can be emitted via the parentKey. We will discuss
 error handling in more detail later. The Plugin handle can be used to persist state information in a threadsafe way with `elektraPluginSetData`.
-As our plugin is not stateful and therefore does not use the handle, it is marked as unused in order to supress compiler warnings.
+As our plugin is not stateful and therefore does not use the handle, it is marked as unused in order to suppress compiler warnings.
 
 Basically the implementation of `elektraLineSet` can be described with the following pseudocode:
 

--- a/src/plugins/augeas/README.md
+++ b/src/plugins/augeas/README.md
@@ -21,7 +21,7 @@ can be found at http://augeas.net/
 
 ## INSTALLATION ##
 
-If you have installed Augeas manually, it may be neccessary to update the ld configuration. This is especially
+If you have installed Augeas manually, it may be necessary to update the ld configuration. This is especially
 true if an older version of Augeas is installed also. Such a situation may lead to an error similar to this:
 
 /usr/lib/libaugeas.so.0: version `AUGEAS_0.16.0' not found (required by kdb)

--- a/src/plugins/line/README.md
+++ b/src/plugins/line/README.md
@@ -11,7 +11,7 @@
 This plugin is designed to save each line from input as a key. The
 keys are stored in an array. The key names are determined by the 
 line number such as `#3` or `#_12` and the value of each key 
-is the infromation stored in that line of the file. The plugin considers
+is the information stored in that line of the file. The plugin considers
 `#0` to be the first line and will automatically add `_` to the beginning
 of key names in order to keep them in numerical order.  
 


### PR DESCRIPTION
- "absolut" -> "absolute"
- "allow to" -> "allow one to"
- "compatibilty" -> "compatibility"
- "diplay" -> "display"
- "infromation" -> "information"
- "lcoated" -> "located"
- "neccessary" -> "necessary"
- "supress" -> "suppress"