### PR TITLE
lua: fix Key:tostring()

### DIFF
--- a/src/bindings/swig/lua/kdb.i
+++ b/src/bindings/swig/lua/kdb.i
@@ -229,7 +229,9 @@
   }
 
   const char *__tostring() {
-    return self->getName().c_str();
+    ckdb::Key *rawKey = self->getKey();
+    if (!rawKey) throw kdb::KeyException();
+    return ckdb::keyName(rawKey);
   }
 
   myswig::LuaSTLIterator_T<kdb::Key::iterator> *name_iterator() {


### PR DESCRIPTION
`self->getName()` returns a new temporary `std::string`, and passing its internal buffer as return value of `__tostring` means using free'd memory.

Copy a bit of the `kdb::Key::getName()` implementation, returning the raw const data from the underlying `Key` object.