### PR TITLE
python: fix flags in Key()

### DIFF
--- a/src/bindings/swig/common.i
+++ b/src/bindings/swig/common.i
@@ -23,6 +23,8 @@
   #include "keyset.hpp"
   #include "kdb.hpp"
   using namespace kdb;
+
+  #include <limits>
 %}
 
 %apply long { ssize_t }

--- a/src/bindings/swig/python/kdb.i
+++ b/src/bindings/swig/python/kdb.i
@@ -120,11 +120,17 @@
   $result = PyBytes_FromStringAndSize((const char*)$1, (size > 0) ? size : 0);
 }
 
+%typemap(check) (char const *name, uint64_t flags) {
+  if ($2 > std::numeric_limits<int>::max()) {
+    SWIG_exception(SWIG_ValueError, "Too big value for flags in Key()");
+  }
+}
+
 // add some other useful methods
 %extend kdb::Key {
   Key(const char *name, uint64_t flags = 0) {
     return new kdb::Key(name,
-      KEY_FLAGS, flags,
+      KEY_FLAGS, static_cast<int>(flags),
       KEY_END);
   }
 


### PR DESCRIPTION
One of the constructors of `Key` takes `uint64_t`, coming from what swig maps for an `int` value. OTOH, passing a `uint64_t` as vararg value for `KEY_FLAGS` will lead to mismatches later, as `KEY_FLAGS` is read as `int`.

Hence, check that the value passed in the `uint64_t` can fit into an `int`, and cast it as such when passing it to `KEY_FLAGS`.