### PR TITLE
Fix: Generating Doxygen documentation works if build path contains spaces

### DIFF
--- a/doc/Doxyfile
+++ b/doc/Doxyfile
@@ -58,7 +58,7 @@ PROJECT_LOGO           =
 # entered, it will be relative to the location where doxygen was started. If
 # left blank the current directory will be used.
 
-OUTPUT_DIRECTORY       = @OUTPUT_DIRECTORY@
+OUTPUT_DIRECTORY       = "@OUTPUT_DIRECTORY@"
 
 # If the CREATE_SUBDIRS tag is set to YES, then doxygen will create 4096 sub-
 # directories (in 2 levels) under the output directory of each output format and
@@ -162,7 +162,7 @@ FULL_PATH_NAMES        = NO
 # will be relative from the directory where doxygen is started.
 # This tag requires that the tag FULL_PATH_NAMES is set to YES.
 
-STRIP_FROM_PATH        = @PROJECT_SOURCE_DIR@
+STRIP_FROM_PATH        = "@PROJECT_SOURCE_DIR@"
 
 # The STRIP_FROM_INC_PATH tag can be used to strip a user-defined part of the
 # path mentioned in the documentation of a class, which tells the reader which
@@ -751,7 +751,7 @@ WARN_FORMAT            = "$file:$line: $text"
 # messages should be written. If left blank the output is written to standard
 # error (stderr).
 
-WARN_LOGFILE           = @OUTPUT_DIRECTORY@/doxygen.log
+WARN_LOGFILE           = "@OUTPUT_DIRECTORY@/doxygen.log"
 
 #---------------------------------------------------------------------------
 # Configuration options related to the input files
@@ -763,15 +763,15 @@ WARN_LOGFILE           = @OUTPUT_DIRECTORY@/doxygen.log
 # spaces.
 # Note: If this tag is empty the current directory is searched.
 
-INPUT                  = @PROJECT_SOURCE_DIR@/src/libs \
-                         @PROJECT_SOURCE_DIR@/src/libs/loader/doc.c \
-                         @PROJECT_SOURCE_DIR@/src/libs/getenv/README.md \
-                         @PROJECT_SOURCE_DIR@/src/include \
-                         @PROJECT_SOURCE_DIR@/src/bindings/cpp/include \
-                         @PROJECT_SOURCE_DIR@/src/plugins \
-                         @PROJECT_SOURCE_DIR@/src/plugins/doc/doc.h \
-                         @PROJECT_SOURCE_DIR@/doc \
-                         @PROJECT_SOURCE_DIR@/README.md
+INPUT                  = "@PROJECT_SOURCE_DIR@/src/libs" \
+                         "@PROJECT_SOURCE_DIR@/src/libs/loader/doc.c" \
+                         "@PROJECT_SOURCE_DIR@/src/libs/getenv/README.md" \
+                         "@PROJECT_SOURCE_DIR@/src/include" \
+                         "@PROJECT_SOURCE_DIR@/src/bindings/cpp/include" \
+                         "@PROJECT_SOURCE_DIR@/src/plugins" \
+                         "@PROJECT_SOURCE_DIR@/src/plugins/doc/doc.h" \
+                         "@PROJECT_SOURCE_DIR@/doc" \
+                         "@PROJECT_SOURCE_DIR@/README.md"
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding. Doxygen uses
@@ -920,7 +920,7 @@ INPUT_FILTER           =
 # filters are used. If the FILTER_PATTERNS tag is empty or if none of the
 # patterns match the file name, INPUT_FILTER is applied.
 
-FILTER_PATTERNS        = *.md=@MARKDOWN_LINK_CONVERTER@
+FILTER_PATTERNS        = *.md="@MARKDOWN_LINK_CONVERTER@"
 
 # If the FILTER_SOURCE_FILES tag is set to YES, the input filter (if set using
 # INPUT_FILTER ) will also be used to filter the input files that are used for


### PR DESCRIPTION
Hi,

hope this fix is helpful. If there are any problems with the pull request, please let me know. 

One thing I noticed while I tested the changes was that `cmake` also seems to produce two (useless?) directories with the names `(` and `)` inside `libelektra/doc`. Is this intentional?

Kind regards,
  René