### PR TITLE
resolver: fix portability issue; fixes #439

### DIFF
--- a/src/plugins/resolver/resolver.c
+++ b/src/plugins/resolver/resolver.c
@@ -46,10 +46,12 @@
 # define statNanoSeconds(status) status.st_mtim.tv_nsec
 #endif
 
-#if defined(__APPLE__) && defined(__MACH__)
+#ifdef ELEKTRA_LOCK_MUTEX
+#ifndef PTHREAD_RECURSIVE_MUTEX_INITIALIZER_NP
 static pthread_mutex_t elektra_resolver_mutex = PTHREAD_RECURSIVE_MUTEX_INITIALIZER;
 #else
 static pthread_mutex_t elektra_resolver_mutex = PTHREAD_RECURSIVE_MUTEX_INITIALIZER_NP;
+#endif
 #endif
 
 static void resolverInit (resolverHandle *p, const char *path)


### PR DESCRIPTION
makes the definition of `elektra_resolver_mutex` dependent of `ELEKTRA_LOCK_MUTEX`. See #439 for further information.