### PR TITLE
resolver: restore recursive mutex init (see #439)

### DIFF
--- a/src/plugins/resolver/CMakeLists.txt
+++ b/src/plugins/resolver/CMakeLists.txt
@@ -18,7 +18,7 @@ add_plugin(resolver
 		ELEKTRA_PLUGIN_NAME=\"resolver\"
 		ELEKTRA_LOCK_FILE
 		ELEKTRA_LOCK_MUTEX
-)
+	)
 
 add_plugintest(resolver)
 

--- a/src/plugins/resolver/CMakeLists.txt
+++ b/src/plugins/resolver/CMakeLists.txt
@@ -8,12 +8,17 @@ find_package(Threads)
 add_plugin(resolver
 	SOURCES
 		${SOURCES}
+	LINK_LIBRARIES
+		${CMAKE_THREAD_LIBS_INIT}
+		${CMAKE_REALTIME_LIBS_INIT}
 	COMPILE_DEFINITIONS
 		ELEKTRA_VARIANT_BASE=\"\"
 		ELEKTRA_VARIANT_USER=\"hpu\"
 		ELEKTRA_VARIANT_SYSTEM=\"b\"
 		ELEKTRA_PLUGIN_NAME=\"resolver\"
-	)
+		ELEKTRA_LOCK_FILE
+		ELEKTRA_LOCK_MUTEX
+)
 
 add_plugintest(resolver)
 


### PR DESCRIPTION
as discussed in #439 I restored the manual initialization code for the recursive mutex in the resolver. The resolver compiles now under `musl-gcc` with the `ELEKTRA_LOCK_MUTEX` compile definition set.