### PR TITLE
CMake: Do not create directories `(` and `)` inside `doc`

### DIFF
--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -11,7 +11,7 @@ find_package(Doxygen)
 #
 macro (do_doc target folder file install)
 	# sometimes doxygen is too slow and fails with "Could not create output directory .../doc/html"
-	file(MAKE_DIRECTORY(${folder}))
+	file(MAKE_DIRECTORY ${folder})
 
 	add_custom_command (
 		OUTPUT ${folder}/${file}


### PR DESCRIPTION
From issue #438:

> You are on the right track! It won't, however, be fixed by adding an if (folder is always set). When you read about the syntax and how the `cmake` command file works, it will immediately obvious what the problem is. I will leave it to you to find out, I think fixing this bug will be a good way to learn CMake ;)

Thank you for the useful hints. Hope the description in the commit message is correct. If not, please just comment below. This pull request (hopefully) fixes issue #438.