### PR TITLE
Keytometa append to samelevel fix

### DIFF
--- a/src/plugins/augeas/contract.h
+++ b/src/plugins/augeas/contract.h
@@ -37,6 +37,7 @@ ksNew (30,
 			KEY_VALUE, "*#comment*",
 			KEY_META, "convert/metaname", "comment", /* comment keys are converted to comments */
 			KEY_META, "convert/append", "next", /* usually comments belong to the following key */
+			KEY_META, "convert/append/samelevel", "1", /* if the configuration has nested structures, comments should stay in the same hierarchy */
 			KEY_END),
 		keyNew ("system/elektra/modules/augeas/config/needs/glob/get/#1/flags",
 			KEY_VALUE, "0", /* disable the path matching mode */

--- a/src/plugins/keytometa/keytometa.c
+++ b/src/plugins/keytometa/keytometa.c
@@ -135,14 +135,22 @@ static void flushConvertedKeys(Key *target, KeySet *converted, KeySet *orig)
 		appendTarget = target;
 		const char *metaName = keyString (keyGetMeta(current, CONVERT_METANAME));
 
+		Key *currentDup = keyDup(current);
+		Key *targetDup = keyDup(appendTarget);
+		keySetBaseName(currentDup, 0);
+		keySetBaseName(targetDup, 0);
+
 		/* the convert key request to be converted to a key
 		 * on the same level, but the target is below or above
 		 */
 		if (keyGetMeta (current, CONVERT_APPEND_SAMELEVEL) &&
-				keyRel (current, appendTarget) != 0)
+				keyCmp(currentDup, targetDup))
 		{
 			appendTarget = 0;
 		}
+
+		keyDel(currentDup);
+		keyDel(targetDup);
 
 		/* no target key was found of the target
 		 * was discarded for some reason. Revert to the parent


### PR DESCRIPTION
This PR fixes an issue with the samelevel setting of keytometa. In addition it adds the samelevel setting to the keytometa configuration shipped with the augeas plugin. The included testcase proves that the samelevel setting was not working as intended before the patch. 