### PR TITLE
Fix OS X build

### DIFF
--- a/src/bindings/cpp/include/key.hpp
+++ b/src/bindings/cpp/include/key.hpp
@@ -1665,7 +1665,6 @@ inline int Key::del ()
 
 namespace std
 {
-	template< class Key > struct hash;
 	/**
 	 * @brief Support for putting Key in a hash
 	 */


### PR DESCRIPTION
Starting with commit 330b276f `make` was not able to build Elektra on OS X any more. This commit fixes this issue. Here is a rather long list of error messages that `make` prints on my machine if I do not remove line 1668 in `key.hpp`:

```
[ 30%] Built target elektra-static
[ 30%] Building CXX object src/libs/tools/src/CMakeFiles/elektratools.dir/backends.cpp.o
In file included from libelektra/src/libs/tools/src/backend.cpp:13:
In file included from libelektra/src/libs/tools/include/backend.hpp:14:
In file included from libelektra/src/libs/tools/include/plugin.hpp:13:
In file included from libelektra/src/bindings/cpp/include/kdb.hpp:14:
libelektra/src/bindings/cpp/include/key.hpp:1672:21: error: explicit specialization of non-template struct 'hash'
        template <> struct hash<kdb::Key>
                           ^   ~~~~~~~~~~
libelektra/src/bindings/cpp/include/key.hpp:1672:21: error: redefinition of 'hash' as different kind of symbol
libelektra/src/bindings/cpp/include/key.hpp:1668:31: note: previous definition is here
        template< class Key > struct hash;
                                     ^
[ 30%] Built target html
[ 30%] Building CXX object src/libs/tools/src/CMakeFiles/elektratools.dir/helper/comparison.cpp.o
[ 30%] Built target man3
In file included from libelektra/src/libs/tools/src/backendbuilder.cpp:12:
In file included from libelektra/src/libs/tools/include/backend.hpp:14:
In file included from libelektra/src/libs/tools/include/plugin.hpp:13:
In file included from libelektra/src/bindings/cpp/include/kdb.hpp:14:
libelektra/src/bindings/cpp/include/key.hpp:1672:21: error: explicit specialization of non-template struct 'hash'
        template <> struct hash<kdb::Key>
                           ^   ~~~~~~~~~~
libelektra/src/bindings/cpp/include/key.hpp:1672:21: error: redefinition of 'hash' as different kind of symbol
libelektra/src/bindings/cpp/include/key.hpp:1668:31: note: previous definition is here
        template< class Key > struct hash;
                                     ^
In file included from libelektra/src/libs/tools/src/backend.cpp:13:
In file included from libelektra/src/libs/tools/include/backend.hpp:14:
In file included from libelektra/src/libs/tools/include/plugin.hpp:14:
libelektra/src/libs/tools/include/pluginspec.hpp:100:15: error: reference to 'hash' is ambiguous
                return std::hash<std::string>()(s.getName());
                       ~~~~~^
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/memory:3093:29: note: candidate found by name lookup is 'std::__1::hash'
template <class _Tp> struct hash;
                            ^
libelektra/src/bindings/cpp/include/key.hpp:1668:31: note: candidate found by name lookup is 'std::hash'
        template< class Key > struct hash;
                                     ^
In file included from libelektra/src/libs/tools/src/backend.cpp:13:
In file included from libelektra/src/libs/tools/include/backend.hpp:14:
In file included from libelektra/src/libs/tools/include/plugin.hpp:14:
libelektra/src/libs/tools/include/pluginspec.hpp:100:31: error: expected '(' for function-style cast or type construction
                return std::hash<std::string>()(s.getName());
                                 ~~~~~~~~~~~^
libelektra/src/libs/tools/include/pluginspec.hpp:100:33: error: expected expression
                return std::hash<std::string>()(s.getName());
                                              ^
[ 30%] Building CXX object src/libs/tools/src/CMakeFiles/elektratools.dir/helper/keyhelper.cpp.o
In file included from libelektra/src/libs/tools/src/backendbuilder.cpp:12:
In file included from libelektra/src/libs/tools/include/backend.hpp:14:
In file included from libelektra/src/libs/tools/include/plugin.hpp:14:
libelektra/src/libs/tools/include/pluginspec.hpp:100:15: error: reference to 'hash' is ambiguous
                return std::hash<std::string>()(s.getName());
                       ~~~~~^
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/memory:3093:29: note: candidate found by name lookup is 'std::__1::hash'
template <class _Tp> struct hash;
                            ^
libelektra/src/bindings/cpp/include/key.hpp:1668:31: note: candidate found by name lookup is 'std::hash'
        template< class Key > struct hash;
                                     ^
In file included from libelektra/src/libs/tools/src/backendbuilder.cpp:12:
In file included from libelektra/src/libs/tools/include/backend.hpp:14:
In file included from libelektra/src/libs/tools/include/plugin.hpp:14:
libelektra/src/libs/tools/include/pluginspec.hpp:100:31: error: expected '(' for function-style cast or type construction
                return std::hash<std::string>()(s.getName());
                                 ~~~~~~~~~~~^
libelektra/src/libs/tools/include/pluginspec.hpp:100:33: error: expected expression
                return std::hash<std::string>()(s.getName());
                                              ^
In file included from libelektra/src/libs/tools/src/backendparser.cpp:10:
In file included from libelektra/src/libs/tools/include/backendparser.hpp:21:
In file included from libelektra/src/libs/tools/include/pluginspec.hpp:17:
In file included from libelektra/src/bindings/cpp/include/kdb.hpp:14:
libelektra/src/bindings/cpp/include/key.hpp:1672:21: error: explicit specialization of non-template struct 'hash'
        template <> struct hash<kdb::Key>
                           ^   ~~~~~~~~~~
libelektra/src/bindings/cpp/include/key.hpp:1672:21: error: redefinition of 'hash' as different kind of symbol
libelektra/src/bindings/cpp/include/key.hpp:1668:31: note: previous definition is here
        template< class Key > struct hash;
                                     ^
In file included from libelektra/src/libs/tools/src/backendparser.cpp:10:
In file included from libelektra/src/libs/tools/include/backendparser.hpp:21:
libelektra/src/libs/tools/include/pluginspec.hpp:100:15: error: reference to 'hash' is ambiguous
                return std::hash<std::string>()(s.getName());
                       ~~~~~^
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/memory:3093:29: note: candidate found by name lookup is 'std::__1::hash'
template <class _Tp> struct hash;
                            ^
libelektra/src/bindings/cpp/include/key.hpp:1668:31: note: candidate found by name lookup is 'std::hash'
        template< class Key > struct hash;
                                     ^
In file included from libelektra/src/libs/tools/src/backendparser.cpp:10:
In file included from libelektra/src/libs/tools/include/backendparser.hpp:21:
libelektra/src/libs/tools/include/pluginspec.hpp:100:31: error: expected '(' for function-style cast or type construction
                return std::hash<std::string>()(s.getName());
                                 ~~~~~~~~~~~^
libelektra/src/libs/tools/include/pluginspec.hpp:100:33: error: expected expression
                return std::hash<std::string>()(s.getName());
                                              ^
In file included from libelektra/src/libs/tools/src/backends.cpp:9:
In file included from libelektra/src/libs/tools/include/backends.hpp:16:
In file included from libelektra/src/bindings/cpp/include/keyset.hpp:14:
libelektra/src/bindings/cpp/include/key.hpp:1672:21: error: explicit specialization of non-template struct 'hash'
        template <> struct hash<kdb::Key>
                           ^   ~~~~~~~~~~
libelektra/src/bindings/cpp/include/key.hpp:1672:21: error: redefinition of 'hash' as different kind of symbol
libelektra/src/bindings/cpp/include/key.hpp:1668:31: note: previous definition is here
        template< class Key > struct hash;
                                     ^
5 errors generated.
make[2]: *** [src/libs/tools/src/CMakeFiles/elektratools.dir/backendparser.cpp.o] Error 1
make[2]: *** Waiting for unfinished jobs....
Scanning dependencies of target testmod_dump
[ 30%] Building C object src/plugins/dump/CMakeFiles/testmod_dump.dir/testmod_dump.c.o
2 errors generated.
make[2]: *** [src/libs/tools/src/CMakeFiles/elektratools.dir/backends.cpp.o] Error 1
[ 30%] Linking CXX static library ../lib/libgtest.a
Scanning dependencies of target testmod_resolver
[ 30%] Building C object src/plugins/resolver/CMakeFiles/testmod_resolver.dir/testmod_resolver.c.o
[ 31%] Linking C executable ../../../bin/testmod_dump
[ 31%] Built target gtest
Scanning dependencies of target elektratools-full
[ 31%] Built target testmod_dump
In file included from libelektra/src/libs/tools/src/helper/comparison.cpp:10:
In file included from libelektra/src/libs/tools/include/helper/comparison.hpp:14:
In file included from libelektra/src/bindings/cpp/include/kdb.hpp:14:
libelektra/src/bindings/cpp/include/key.hpp:1672:21: error: explicit specialization of non-template struct 'hash'
        template <> struct hash<kdb::Key>
                           ^   ~~~~~~~~~~
libelektra/src/bindings/cpp/include/key.hpp:1672:21: error: redefinition of 'hash' as different kind of symbol
libelektra/src/bindings/cpp/include/key.hpp:1668:31: note: previous definition is here
        template< class Key > struct hash;
                                     ^
5 errors generated.
Scanning dependencies of target elektratools-static
make[2]: *** [src/libs/tools/src/CMakeFiles/elektratools.dir/backend.cpp.o] Error 1
5 errors generated.
Scanning dependencies of target cpp_cascading
[ 31%] Building CXX object src/libs/tools/src/CMakeFiles/elektratools-full.dir/backend.cpp.o
make[2]: *** [src/libs/tools/src/CMakeFiles/elektratools.dir/backendbuilder.cpp.o] Error 1
In file included from libelektra/src/libs/tools/src/helper/keyhelper.cpp:10:
In file included from libelektra/src/libs/tools/include/helper/keyhelper.hpp:14:
In file included from libelektra/src/bindings/cpp/include/kdb.hpp:14:
libelektra/src/bindings/cpp/include/key.hpp:1672:21: error: explicit specialization of non-template struct 'hash'
        template <> struct hash<kdb::Key>
                           ^   ~~~~~~~~~~
libelektra/src/bindings/cpp/include/key.hpp:1672:21: error: redefinition of 'hash' as different kind of symbol
libelektra/src/bindings/cpp/include/key.hpp:1668:31: note: previous definition is here
        template< class Key > struct hash;
                                     ^
2 errors generated.
[ 31%] Building CXX object src/bindings/cpp/examples/CMakeFiles/cpp_cascading.dir/cpp_cascading.cpp.o
make[2]: *** [src/libs/tools/src/CMakeFiles/elektratools.dir/helper/comparison.cpp.o] Error 1
Scanning dependencies of target cpp_example_dup
[ 31%] Building CXX object src/libs/tools/src/CMakeFiles/elektratools-static.dir/backend.cpp.o
Scanning dependencies of target cpp_example_get
[ 31%] Building CXX object src/bindings/cpp/examples/CMakeFiles/cpp_example_dup.dir/cpp_example_dup.cpp.o
[ 31%] Building CXX object src/bindings/cpp/examples/CMakeFiles/cpp_example_get.dir/cpp_example_get.cpp.o
2 errors generated.
make[2]: *** [src/libs/tools/src/CMakeFiles/elektratools.dir/helper/keyhelper.cpp.o] Error 1
make[1]: *** [src/libs/tools/src/CMakeFiles/elektratools.dir/all] Error 2
make[1]: *** Waiting for unfinished jobs....
[ 31%] Building CXX object src/libs/tools/src/CMakeFiles/elektratools-full.dir/backendbuilder.cpp.o
[ 31%] Linking C executable ../../../bin/testmod_resolver
[ 31%] Built target testmod_resolver
[ 31%] Building CXX object src/libs/tools/src/CMakeFiles/elektratools-static.dir/backendbuilder.cpp.o
[ 31%] Linking C shared module ../../../lib/libelektra-error.so
[ 31%] Built target elektra-error
[ 31%] Building CXX object src/libs/tools/src/CMakeFiles/elektratools-static.dir/backendparser.cpp.o
In file included from libelektra/src/libs/tools/src/backend.cpp:13:
In file included from libelektra/src/libs/tools/include/backend.hpp:14:
In file included from libelektra/src/libs/tools/include/plugin.hpp:13:
In file included from libelektra/src/bindings/cpp/include/kdb.hpp:14:
libelektra/src/bindings/cpp/include/key.hpp:1672:21: error: explicit specialization of non-template struct 'hash'
        template <> struct hash<kdb::Key>
                           ^   ~~~~~~~~~~
libelektra/src/bindings/cpp/include/key.hpp:1672:21: error: redefinition of 'hash' as different kind of symbol
libelektra/src/bindings/cpp/include/key.hpp:1668:31: note: previous definition is here
        template< class Key > struct hash;
                                     ^
In file included from libelektra/src/libs/tools/src/backend.cpp:13:
In file included from libelektra/src/libs/tools/include/backend.hpp:14:
In file included from libelektra/src/libs/tools/include/plugin.hpp:13:
In file included from libelektra/src/bindings/cpp/include/kdb.hpp:14:
libelektra/src/bindings/cpp/include/key.hpp:1672:21: error: explicit specialization of non-template struct 'hash'
        template <> struct hash<kdb::Key>
                           ^   ~~~~~~~~~~
libelektra/src/bindings/cpp/include/key.hpp:1672:21: error: redefinition of 'hash' as different kind of symbol
libelektra/src/bindings/cpp/include/key.hpp:1668:31: note: previous definition is here
        template< class Key > struct hash;
                                     ^
In file included from libelektra/src/bindings/cpp/examples/cpp_cascading.cpp:9:
In file included from libelektra/src/bindings/cpp/include/kdb.hpp:14:
libelektra/src/bindings/cpp/include/key.hpp:1672:21: error: explicit specialization of non-template struct 'hash'
        template <> struct hash<kdb::Key>
                           ^   ~~~~~~~~~~
libelektra/src/bindings/cpp/include/key.hpp:1672:21: error: redefinition of 'hash' as different kind of symbol
libelektra/src/bindings/cpp/include/key.hpp:1668:31: note: previous definition is here
        template< class Key > struct hash;
                                     ^
In file included from libelektra/src/bindings/cpp/examples/cpp_example_dup.cpp:9:
In file included from libelektra/src/bindings/cpp/include/keyset.hpp:14:
libelektra/src/bindings/cpp/include/key.hpp:1672:21: error: explicit specialization of non-template struct 'hash'
        template <> struct hash<kdb::Key>
                           ^   ~~~~~~~~~~
libelektra/src/bindings/cpp/include/key.hpp:1672:21: error: redefinition of 'hash' as different kind of symbol
libelektra/src/bindings/cpp/include/key.hpp:1668:31: note: previous definition is here
        template< class Key > struct hash;
                                     ^
In file included from libelektra/src/libs/tools/src/backend.cpp:13:
In file included from libelektra/src/libs/tools/include/backend.hpp:14:
In file included from libelektra/src/libs/tools/include/plugin.hpp:14:
libelektra/src/libs/tools/include/pluginspec.hpp:100:15: error: reference to 'hash' is ambiguous
                return std::hash<std::string>()(s.getName());
                       ~~~~~^
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/memory:3093:29: note: candidate found by name lookup is 'std::__1::hash'
template <class _Tp> struct hash;
                            ^
libelektra/src/bindings/cpp/include/key.hpp:1668:31: note: candidate found by name lookup is 'std::hash'
        template< class Key > struct hash;
                                     ^
In file included from libelektra/src/libs/tools/src/backend.cpp:13:
In file included from libelektra/src/libs/tools/include/backend.hpp:14:
In file included from libelektra/src/libs/tools/include/plugin.hpp:14:
libelektra/src/libs/tools/include/pluginspec.hpp:100:31: error: expected '(' for function-style cast or type construction
                return std::hash<std::string>()(s.getName());
                                 ~~~~~~~~~~~^
libelektra/src/libs/tools/include/pluginspec.hpp:100:33: error: expected expression
                return std::hash<std::string>()(s.getName());
                                              ^
In file included from libelektra/src/bindings/cpp/examples/cpp_example_get.cpp:9:
In file included from libelektra/src/bindings/cpp/include/kdb.hpp:14:
libelektra/src/bindings/cpp/include/key.hpp:1672:21: error: explicit specialization of non-template struct 'hash'
        template <> struct hash<kdb::Key>
                           ^   ~~~~~~~~~~
libelektra/src/bindings/cpp/include/key.hpp:1672:21: error: redefinition of 'hash' as different kind of symbol
libelektra/src/bindings/cpp/include/key.hpp:1668:31: note: previous definition is here
        template< class Key > struct hash;
                                     ^
2 errors generated.
In file included from libelektra/src/libs/tools/src/backendbuilder.cpp:12:
In file included from libelektra/src/libs/tools/include/backend.hppmake[2]: *** [src/bindings/cpp/examples/CMakeFiles/cpp_example_dup.dir/cpp_example_dup.cpp.o] Error 1
:14:
In file included from make[1]: *** [src/bindings/cpp/examples/CMakeFiles/cpp_example_dup.dir/all] Error 2
libelektra/src/libs/tools/include/plugin.hpp:13:
In file included from libelektra/src/bindings/cpp/include/kdb.hpp:14:
libelektra/src/bindings/cpp/include/key.hpp:1672:21: error: explicit specialization of non-template struct 'hash'
        template <> struct hash<kdb::Key>
                           ^   ~~~~~~~~~~
libelektra/src/bindings/cpp/include/key.hpp:1672:21: error: redefinition of 'hash' as different kind of symbol
libelektra/src/bindings/cpp/include/key.hpp:1668:31: note: previous definition is here
        template< class Key > struct hash;
                                     ^
[ 32%] Building CXX object src/libs/tools/src/CMakeFiles/elektratools-full.dir/backendparser.cpp.o
In file included from libelektra/src/libs/tools/src/backend.cpp:13:
In file included from libelektra/src/libs/tools/include/backend.hpp:14:
In file included from libelektra/src/libs/tools/include/plugin.hpp:14:
libelektra/src/libs/tools/include/pluginspec.hpp:100:15: error: reference to 'hash' is ambiguous
                return std::hash<std::string>()(s.getName());
                       ~~~~~^
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/memory:3093:29: note: candidate found by name lookup is 'std::__1::hash'
template <class _Tp> struct hash;
                            ^
libelektra/src/bindings/cpp/include/key.hpp:1668:31: note: candidate found by name lookup is 'std::hash'
        template< class Key > struct hash;
                                     ^
In file included from libelektra/src/libs/tools/src/backend.cpp:13:
In file included from libelektra/src/libs/tools/include/backend.hpp:14:
In file included from libelektra/src/libs/tools/include/plugin.hpp:14:
libelektra/src/libs/tools/include/pluginspec.hpp:100:31: error: expected '(' for function-style cast or type construction
                return std::hash<std::string>()(s.getName());
                                 ~~~~~~~~~~~^
libelektra/src/libs/tools/include/pluginspec.hpp:100:33: error: expected expression
                return std::hash<std::string>()(s.getName());
                                              ^
2 errors generated.
make[2]: *** [src/bindings/cpp/examples/CMakeFiles/cpp_cascading.dir/cpp_cascading.cpp.o] Error 1
make[1]: *** [src/bindings/cpp/examples/CMakeFiles/cpp_cascading.dir/all] Error 2
2 errors generated.
[ 33%] Building CXX object src/libs/tools/src/CMakeFiles/elektratools-static.dir/backends.cpp.o
make[2]: *** [src/bindings/cpp/examples/CMakeFiles/cpp_example_get.dir/cpp_example_get.cpp.o] Error 1
make[1]: *** [src/bindings/cpp/examples/CMakeFiles/cpp_example_get.dir/all] Error 2
[ 33%] Building CXX object src/libs/tools/src/CMakeFiles/elektratools-full.dir/backends.cpp.o
In file included from libelektra/src/libs/tools/src/backendbuilder.cpp:12:
In file included from libelektra/src/libs/tools/include/backend.hpp:14:
In file included from libelektra/src/libs/tools/include/plugin.hpp:14:
libelektra/src/libs/tools/include/pluginspec.hpp:100:15: error: reference to 'hash' is ambiguous
                return std::hash<std::string>()(s.getName());
                       ~~~~~^
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/memory:3093:29: note: candidate found by name lookup is 'std::__1::hash'
template <class _Tp> struct hash;
                            ^
libelektra/src/bindings/cpp/include/key.hpp:1668:31: note: candidate found by name lookup is 'std::hash'
        template< class Key > struct hash;
                                     ^
In file included from libelektra/src/libs/tools/src/backendbuilder.cpp:12:
In file included from libelektra/src/libs/tools/include/backend.hpp:14:
In file included from libelektra/src/libs/tools/include/plugin.hpp:14:
libelektra/src/libs/tools/include/pluginspec.hpp:100:31: error: expected '(' for function-style cast or type construction
                return std::hash<std::string>()(s.getName());
                                 ~~~~~~~~~~~^
libelektra/src/libs/tools/include/pluginspec.hpp:100:33: error: expected expression
                return std::hash<std::string>()(s.getName());
                                              ^
In file included from libelektra/src/libs/tools/src/backendbuilder.cpp:12:
In file included from libelektra/src/libs/tools/include/backend.hpp:14:
In file included from libelektra/src/libs/tools/include/plugin.hpp:13:
In file included from libelektra/src/bindings/cpp/include/kdb.hpp:14:
libelektra/src/bindings/cpp/include/key.hpp:1672:21: error: explicit specialization of non-template struct 'hash'
        template <> struct hash<kdb::Key>
                           ^   ~~~~~~~~~~
libelektra/src/bindings/cpp/include/key.hpp:1672:21: error: redefinition of 'hash' as different kind of symbol
libelektra/src/bindings/cpp/include/key.hpp:1668:31: note: previous definition is here
        template< class Key > struct hash;
                                     ^
In file included from libelektra/src/libs/tools/src/backendbuilder.cpp:12:
In file included from libelektra/src/libs/tools/include/backend.hpp:14:
In file included from libelektra/src/libs/tools/include/plugin.hpp:14:
libelektra/src/libs/tools/include/pluginspec.hpp:100:15: error: reference to 'hash' is ambiguous
                return std::hash<std::string>()(s.getName());
                       ~~~~~^
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/memory:3093:29: note: candidate found by name lookup is 'std::__1::hash'
template <class _Tp> struct hash;
                            ^
libelektra/src/bindings/cpp/include/key.hpp:1668:31: note: candidate found by name lookup is 'std::hash'
        template< class Key > struct hash;
                                     ^
In file included from libelektra/src/libs/tools/src/backendbuilder.cpp:12:
In file included from libelektra/src/libs/tools/include/backend.hpp:14:
In file included from libelektra/src/libs/tools/include/plugin.hpp:14:
libelektra/src/libs/tools/include/pluginspec.hpp:100:31: error: expected '(' for function-style cast or type construction
                return std::hash<std::string>()(s.getName());
                                 ~~~~~~~~~~~^
libelektra/src/libs/tools/include/pluginspec.hpp:100:33: error: expected expression
                return std::hash<std::string>()(s.getName());
                                              ^
In file included from libelektra/src/libs/tools/src/backendparser.cpp:10:
In file included from libelektra/src/libs/tools/include/backendparser.hpp:21:
In file included from libelektra/src/libs/tools/include/pluginspec.hpp:17:
In file included from libelektra/src/bindings/cpp/include/kdb.hpp:14:
libelektra/src/bindings/cpp/include/key.hpp:1672:21: error: explicit specialization of non-template struct 'hash'
        template <> struct hash<kdb::Key>
                           ^   ~~~~~~~~~~
libelektra/src/bindings/cpp/include/key.hpp:1672:21: error: redefinition of 'hash' as different kind of symbol
libelektra/src/bindings/cpp/include/key.hpp:1668:31: note: previous definition is here
        template< class Key > struct hash;
                                     ^
In file included from libelektra/src/libs/tools/src/backendparser.cpp:10:
In file included from libelektra/src/libs/tools/include/backendparser.hpp:21:
libelektra/src/libs/tools/include/pluginspec.hpp:100:15: error: reference to 'hash' is ambiguous
                return std::hash<std::string>()(s.getName());
                       ~~~~~^
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/memory:3093:29: note: candidate found by name lookup is 'std::__1::hash'
template <class _Tp> struct hash;
                            ^
libelektra/src/bindings/cpp/include/key.hpp:1668:31: note: candidate found by name lookup is 'std::hash'
        template< class Key > struct hash;
                                     ^
In file included from libelektra/src/libs/tools/src/backendparser.cpp:10:
In file included from libelektra/src/libs/tools/include/backendparser.hpp:21:
libelektra/src/libs/tools/include/pluginspec.hpp:100:31: error: expected '(' for function-style cast or type construction
                return std::hash<std::string>()(s.getName());
                                 ~~~~~~~~~~~^
libelektra/src/libs/tools/include/pluginspec.hpp:100:33: error: expected expression
                return std::hash<std::string>()(s.getName());
                                              ^
5 errors generated.
make[2]: *** [src/libs/tools/src/CMakeFiles/elektratools-full.dir/backend.cpp.o] Error 1
make[2]: *** Waiting for unfinished jobs....
[ 33%] Building CXX object src/libs/tools/src/CMakeFiles/elektratools-static.dir/helper/comparison.cpp.o
5 errors generated.
make[2]: *** [src/libs/tools/src/CMakeFiles/elektratools-static.dir/backend.cpp.o] Error 1
make[2]: *** Waiting for unfinished jobs....
5 errors generated.
make[2]: *** [src/libs/tools/src/CMakeFiles/elektratools-full.dir/backendbuilder.cpp.o] Error 1
5 errors generated.
make[2]: *** [src/libs/tools/src/CMakeFiles/elektratools-static.dir/backendparser.cpp.o] Error 1
In file included from libelektra/src/libs/tools/src/backendparser.cpp:10:
In file included from libelektra/src/libs/tools/include/backendparser.hpp:21:
In file included from libelektra/src/libs/tools/include/pluginspec.hpp:17:
In file included from libelektra/src/bindings/cpp/include/kdb.hpp:14:
libelektra/src/bindings/cpp/include/key.hpp:1672:21: error: explicit specialization of non-template struct 'hash'
        template <> struct hash<kdb::Key>
                           ^   ~~~~~~~~~~
libelektra/src/bindings/cpp/include/key.hpp:1672:21: error: redefinition of 'hash' as different kind of symbol
libelektra/src/bindings/cpp/include/key.hpp:1668:31: note: previous definition is here
        template< class Key > struct hash;
                                     ^
In file included from libelektra/src/libs/tools/src/backends.cpp:9:
In file included from libelektra/src/libs/tools/include/backends.hpp:16:
In file included from libelektra/src/bindings/cpp/include/keyset.hpp:14:
libelektra/src/bindings/cpp/include/key.hpp:1672:21: error: explicit specialization of non-template struct 'hash'
        template <> struct hash<kdb::Key>
                           ^   ~~~~~~~~~~
libelektra/src/bindings/cpp/include/key.hpp:1672:21: error: redefinition of 'hash' as different kind of symbol
libelektra/src/bindings/cpp/include/key.hpp:1668:31: note: previous definition is here
        template< class Key > struct hash;
                                     ^
In file included from libelektra/src/libs/tools/src/backends.cpp:9:
In file included from libelektra/src/libs/tools/include/backends.hpp:16:
In file included from libelektra/src/bindings/cpp/include/keyset.hpp:14:
libelektra/src/bindings/cpp/include/key.hpp:1672:21: error: explicit specialization of non-template struct 'hash'
        template <> struct hash<kdb::Key>
                           ^   ~~~~~~~~~~
libelektra/src/bindings/cpp/include/key.hpp:1672:21: error: redefinition of 'hash' as different kind of symbol
libelektra/src/bindings/cpp/include/key.hpp:1668:31: note: previous definition is here
        template< class Key > struct hash;
                                     ^
In file included from libelektra/src/libs/tools/src/backendparser.cpp:10:
In file included from libelektra/src/libs/tools/include/backendparser.hpp:21:
libelektra/src/libs/tools/include/pluginspec.hpp:100:15: error: reference to 'hash' is ambiguous
                return std::hash<std::string>()(s.getName());
                       ~~~~~^
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/memory:3093:29: note: candidate found by name lookup is 'std::__1::hash'
template <class _Tp> struct hash;
                            ^
libelektra/src/bindings/cpp/include/key.hpp:1668:31: note: candidate found by name lookup is 'std::hash'
        template< class Key > struct hash;
                                     ^
In file included from libelektra/src/libs/tools/src/backendparser.cpp:10:
In file included from libelektra/src/libs/tools/include/backendparser.hpp:21:
libelektra/src/libs/tools/include/pluginspec.hpp:100:31: error: expected '(' for function-style cast or type construction
                return std::hash<std::string>()(s.getName());
                                 ~~~~~~~~~~~^
libelektra/src/libs/tools/include/pluginspec.hpp:100:33: error: expected expression
                return std::hash<std::string>()(s.getName());
                                              ^
2 errors generated.
make[2]: *** [src/libs/tools/src/CMakeFiles/elektratools-full.dir/backends.cpp.o] Error 1
2 errors generated.
make[2]: *** [src/libs/tools/src/CMakeFiles/elektratools-static.dir/backends.cpp.o] Error 1
5 errors generated.
make[2]: *** [src/libs/tools/src/CMakeFiles/elektratools-full.dir/backendparser.cpp.o] Error 1
make[1]: *** [src/libs/tools/src/CMakeFiles/elektratools-full.dir/all] Error 2
5 errors generated.
make[2]: *** [src/libs/tools/src/CMakeFiles/elektratools-static.dir/backendbuilder.cpp.o] Error 1
In file included from libelektra/src/libs/tools/src/helper/comparison.cpp:10:
In file included from libelektra/src/libs/tools/include/helper/comparison.hpp:14:
In file included from libelektra/src/bindings/cpp/include/kdb.hpp:14:
libelektra/src/bindings/cpp/include/key.hpp:1672:21: error: explicit specialization of non-template struct 'hash'
        template <> struct hash<kdb::Key>
                           ^   ~~~~~~~~~~
libelektra/src/bindings/cpp/include/key.hpp:1672:21: error: redefinition of 'hash' as different kind of symbol
libelektra/src/bindings/cpp/include/key.hpp:1668:31: note: previous definition is here
        template< class Key > struct hash;
                                     ^
2 errors generated.
make[2]: *** [src/libs/tools/src/CMakeFiles/elektratools-static.dir/helper/comparison.cpp.o] Error 1
make[1]: *** [src/libs/tools/src/CMakeFiles/elektratools-static.dir/all] Error 2
make: *** [all] Error 2
```