### PR TITLE
doku: change the welcome message in the top of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,12 +5,30 @@ parameters in a global, hierarchical key database._
 
 <img src="https://cdn.rawgit.com/ElektraInitiative/libelektra/master/doc/images/circle.svg" alt="Elektra" width="50" />
 
-The core is a small library implemented in C. The plugin-based framework fulfills many
-configuration-related tasks to avoid any unnecessary code duplication
-across applications while it still allows the core to stay without any
-external dependency. Elektra abstracts from cross-platform-related issues
-with a consistent API, and allows applications to be aware of other
-applications' configurations, leveraging easy application integration.
+Elektra provides a mature and easily comprehensible API for applications to access 
+and update configuration data with a focus on modularity and application integration.
+**Modularity** effectively eliminates code duplication across applications regarding 
+configuration tasks while easy **application integration** is obtained by allowing 
+applications to be aware of each others configuration.
+
+To highlight a few concrete things about Elektra, configuration data can come from any
+data source, but usually comes from configuration files that are [_mounted_](doc/help/elektra-mounting.md) into Elektra 
+similar to mounting a file system. As Elektra is a plugin based framework, there are a 
+lot of _storage plugins_ that support various configuration formats like ini, json, xml, 
+etc. However, there's a lot more to discover like executing scripts (`python`, `lua` or 
+`shell`) when a configuration value changes, or, enhanced validation plugins that won't 
+allow corrupted configuration to reach your application.
+
+As an application developer you get instant access to various configuration formats and the ability
+to fallback to a default configuration without having to deal with this on your own. As an administrator
+you can choose your favourite configuration format and _mount_ this configuration for the application.
+This features easy application integration as any application using Elektra can access any _mounted_ 
+configuration. You can even _mount_ `/etc` files such as `hosts` or `fstab` if needed, no need to 
+configure the same data twice in different files.
+
+In case you're worried about linking to such a powerful library. The core is a small library 
+implemented in C, works cross-platform, and does not need any external dependencies. There are 
+bindings for other languages in case C is too low-level for you.
 
 [Why should I use Elektra?](#goals)
 


### PR DESCRIPTION
I found that the first thing I read about Elektra wasn't helping me much to understand what it can do. The current message uses a lot of buzzwords, that can mean about anything.

I tried to concretely describe a few things Elektra can help with, use repetition so someone might actually remember something after having read this, and use a language that invites the reader to continue reading (similar to advertising). (I don't claim any skills that I can actually do all that, but I tried...)

What do you think?