### PR TITLE
fix broken links

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,29 +5,29 @@ parameters in a global, hierarchical key database._
 
 <img src="https://cdn.rawgit.com/ElektraInitiative/libelektra/master/doc/images/circle.svg" alt="Elektra" width="50" />
 
-Elektra provides a mature and easily comprehensible API for applications to access 
+Elektra provides a mature and easily comprehensible API for applications to access
 and update configuration data with a focus on modularity and application integration.
-**Modularity** effectively eliminates code duplication across applications regarding 
-configuration tasks while easy **application integration** is obtained by allowing 
+**Modularity** effectively eliminates code duplication across applications regarding
+configuration tasks while easy **application integration** is obtained by allowing
 applications to be aware of each others configuration.
 
 To highlight a few concrete things about Elektra, configuration data can come from any
-data source, but usually comes from configuration files that are [_mounted_](doc/help/elektra-mounting.md) into Elektra 
-similar to mounting a file system. As Elektra is a plugin based framework, there are a 
-lot of _storage plugins_ that support various configuration formats like ini, json, xml, 
-etc. However, there's a lot more to discover like executing scripts (`python`, `lua` or 
-`shell`) when a configuration value changes, or, enhanced validation plugins that won't 
+data source, but usually comes from configuration files that are [_mounted_](doc/help/elektra-mounting.md) into Elektra
+similar to mounting a file system. As Elektra is a plugin based framework, there are a
+lot of _storage plugins_ that support various configuration formats like ini, json, xml,
+etc. However, there's a lot more to discover like executing scripts (`python`, `lua` or
+`shell`) when a configuration value changes, or, enhanced validation plugins that won't
 allow corrupted configuration to reach your application.
 
 As an application developer you get instant access to various configuration formats and the ability
 to fallback to a default configuration without having to deal with this on your own. As an administrator
 you can choose your favourite configuration format and _mount_ this configuration for the application.
-This features easy application integration as any application using Elektra can access any _mounted_ 
-configuration. You can even _mount_ `/etc` files such as `hosts` or `fstab` if needed, no need to 
+This features easy application integration as any application using Elektra can access any _mounted_
+configuration. You can even _mount_ `/etc` files such as `hosts` or `fstab` if needed, no need to
 configure the same data twice in different files.
 
-In case you're worried about linking to such a powerful library. The core is a small library 
-implemented in C, works cross-platform, and does not need any external dependencies. There are 
+In case you're worried about linking to such a powerful library. The core is a small library
+implemented in C, works cross-platform, and does not need any external dependencies. There are
 bindings for other languages in case C is too low-level for you.
 
 [Why should I use Elektra?](#goals)
@@ -84,7 +84,7 @@ kdb get /env/override/HTTP_PROXY
 ```
 
 For information about elektrified environment variables, see
-[src/libgetenv/README.md](src/libgetenv/README.md)
+[/src/libgetenv/README.md](/src/libgetenv/README.md)
 
 
 ### Documentation ###

--- a/doc/API.md
+++ b/doc/API.md
@@ -175,6 +175,6 @@ Read more about [mounting](/doc/help/elektra-mounting.md)
 
 ## SEE ALSO
 
-- See [elektra-glossary(7)](elektra-glossary.md)
-- More information about [elektra-backends(7)](elektra-backends.md)
-- More information about [elektra-plugins(7)](elektra-plugins.md)
+- See [elektra-glossary(7)](/doc/help/elektra-glossary.md)
+- More information about [elektra-backends(7)](/doc/help/elektra-backends.md)
+- More information about [elektra-plugins-framework(7)](/doc/help/elektra-plugins-framework.md)

--- a/doc/CODING.md
+++ b/doc/CODING.md
@@ -102,7 +102,7 @@ next line.
  * Use `static` methods if they should not be externally visible.
  * C-Files have extension `.c`, Header files `.h`.
 
-**Example:** [src/libelektra/kdb.c](../src/libelektra/kdb.c)
+**Example:** [src/libs/elektra/kdb.c](/src/libs/elektra/kdb.c)
 
 
 ### C++ Guidelines ###
@@ -145,7 +145,7 @@ Files should start with:
 	 *
 	 * @copyright BSD License (see doc/COPYING or http://www.libelektra.org)
 	 */
-	
+
 
 \endverbatim
 

--- a/doc/DESIGN.md
+++ b/doc/DESIGN.md
@@ -215,7 +215,7 @@ Elektra does not set `errno`. If a function you call sets `errno`, make
 sure to set it back to the old value again.
 
 Additional information about error handling is available
-[here](doc/help/elektra-error-handling.md).
+[here](/doc/help/elektra-error-handling.md).
 
 ## Naming ##
 

--- a/doc/INSTALL.md
+++ b/doc/INSTALL.md
@@ -43,7 +43,7 @@ Then use:
 	cpack
 
 which should create a package for distributions where a Generator is
-implemented. See [this cmake file](cmake/ElektraPackaging.cmake) for available Generators
+implemented. See [this cmake file](/cmake/ElektraPackaging.cmake) for available Generators
 and send a merge request for your system.
 
 ## TROUBLESHOOTING ##

--- a/doc/TESTING.md
+++ b/doc/TESTING.md
@@ -80,7 +80,7 @@ ABI relevant.
 ABI tests can be done on theses tests, too. But by nature from time to
 time these tests will fail.
 
-They are located [here](/tests/cunit).
+They are located [here](/tests/ctest).
 
 
 ### Module Tests ###
@@ -121,4 +121,3 @@ Bindings, other than C++ typically have their own way of testing.
  copy some import files to testcase_dir and run:
 
  /usr/src/afl/afl-1.46b/./afl-fuzz -i testcase_dir -o findings_dir bin/kdb import user/tests
-

--- a/doc/help/elektra-architecture.md
+++ b/doc/help/elektra-architecture.md
@@ -54,7 +54,7 @@ issues that matter and show how Elektra has solved them.
 A design goal is to detect errors early.  As easy as it sounds, as
 difficult it is to actually achieve this goal.  Elektra tries to avoid
 the problem by checking data being inserted into `Key` and `KeySet`.
-Elektra catches many errors like invalid key names soon. 
+Elektra catches many errors like invalid key names soon.
 Elektra allows plugins to check
 the configuration before it is written into the key database so that
 problematic values are never stored.

--- a/doc/help/elektra-backends.md
+++ b/doc/help/elektra-backends.md
@@ -59,6 +59,6 @@ can choose from a pool of existing plugins.
 
 ## SEE ALSO
 
-- More information about [elektra-plugins(7)](elektra-plugins.md)
+- More information about [elektra-plugins-framework(7)](elektra-plugins-framework.md)
 - The tool for mounting a backend is [kdb-mount(1)](kdb-mount.md)
 - The plugins are ordered as described in [elektra-plugins-ordering(7)](elektra-plugins-ordering.md)

--- a/doc/help/elektra-classes.md
+++ b/doc/help/elektra-classes.md
@@ -32,7 +32,7 @@ order of the `Key` objects.
 Some configuration storage systems need
 this property, because they
 cannot remember a specific order.
-On the other hand, any particular order can easily be introduced 
+On the other hand, any particular order can easily be introduced
 (See [order](/doc/METADATA.ini)).
 
 On the one side
@@ -99,4 +99,3 @@ For details and background
 [read more about elektra data structures](elektra-data-structures.md).
 For further information see
 [the API documentation](http://doc.libelektra.org/api/current/html/).
-

--- a/doc/help/elektra-contracts.md
+++ b/doc/help/elektra-contracts.md
@@ -60,4 +60,4 @@ preconditions and weak postconditions for the plugins.
 
 ## SEE ALSO
 
-- [elektra-ordering(7)](elektra-ordering.md)
+- [elektra-plugins-ordering(7)](elektra-plugins-ordering.md)

--- a/doc/help/elektra-data-structures.md
+++ b/doc/help/elektra-data-structures.md
@@ -85,9 +85,9 @@ Instead, we try to reuse sets in the following ways:
   resemble the mathematical ideal closely. This operation would be
   expensive. Every `Key` needs to be duplicated and
   inserted into a new `KeySet`.
-  
+
   Such a **deep duplication** was only needed in `kdbSet()`.
-  
+
 - The resulting
   `KeySet` is created during the operation, but only a flat copy is
   made. This means that the keys in it are actually not duplicated, but only
@@ -96,25 +96,25 @@ Instead, we try to reuse sets in the following ways:
   Compared with a deep copy it can achieve good performance.
   But all changes to the values of keys in the resulting `KeySet`
   affect the original `KeySet`, too.
-  
+
   `ksDup(const KeySet *source)` produces a new `KeySet` that way. The
   `source` is not changed as shown by the `const` modifier.
-  
+
 - The result of the operation is applied to the
   `KeySet` passed as argument directly.
   This is actually quite common, but for this situation
   other names of the operations are more suitable.
-  
+
   For example, a union
   which changes the `KeySet` is called `ksAppend()`.
-  
+
 - A new `KeySet` is created, but the `KeySet` passed as
   parameter is reduced by the keys needed for the new `KeySet`. This
   is useful in situations where many operations have to be applied in
   a sequence reducing the given `KeySet` until no
   more keys are left.
   None of the reference pointers changes in this situation.
-  
+
   `ksCut(KeySet *ks, const Key *cutpoint)` works that way.
   All keys below the `cutpoint` are moved from `ks` to the returned key
   set.

--- a/doc/help/elektra-error-handling.md
+++ b/doc/help/elektra-error-handling.md
@@ -55,7 +55,7 @@ the adding of warning information is possible:
   setting error information is prohibited.  Warning information is, however,
   very useful to tell the user the circumstance that some actions during
   cleanup failed.
-  
+
 - Also in `kdbOpen()`, only adding warning information is allowed.
   If `kdbOpen()` is not able to open a plugin, the affected backend will be
   dropped out.  The user is certainly interested why that happened.  But it
@@ -63,7 +63,7 @@ the adding of warning information is possible:
   not even access the faulty part of the key hierarchy.  An exception
   to this rule is if `kdbOpen()` fails to open the default backend.
   This situation will induce an faulty state.
-  
+
 - In `kdbSet()`, the cleaning up of resources involves calling
   plugins.  But during this process Elektra is in a faulty state, so only
   adding of warning information is allowed.  This ensures that the original

--- a/doc/help/elektra-hierarchy.md
+++ b/doc/help/elektra-hierarchy.md
@@ -37,5 +37,5 @@ between metadata is supported.
 
 ## SEE ALSO
 
-- [see namespaces tutorial](doc/tutorials/namespaces.md)
+- [see namespaces tutorial](/doc/tutorials/namespaces.md)
 - [elektra-namespaces(7)](elektra-namespaces.md)

--- a/doc/help/elektra-introduction.md
+++ b/doc/help/elektra-introduction.md
@@ -63,7 +63,7 @@ In order to extend its functionality, the program had to be rewritten
 with a new approach to configuration: xinetd emerged. Both of these
 projects are now almost defined by their configuration files giving them
 identity and separating them from each other.  Elektra has introduced
-[backend](backends) to support the storage of key databases in different
+[backend](elektra-backends.md) to support the storage of key databases in different
 formats.
 
 

--- a/doc/help/elektra-key-names.md
+++ b/doc/help/elektra-key-names.md
@@ -101,8 +101,8 @@ the key names of software-applications should always start with:
 
 ## SEE ALSO
 
-- [see application integration tutorial](doc/tutorials/application-integration.md)
-- [see namespaces tutorial](doc/tutorials/namespaces.md)
+- [see application integration tutorial](/doc/tutorials/application-integration.md)
+- [see namespaces tutorial](/doc/tutorials/namespaces.md)
 
 - [elektra-namespaces(7)](elektra-namespaces.md)
 - [elektra-cascading(7)](elektra-cascading.md)

--- a/doc/help/elektra-mounting.md
+++ b/doc/help/elektra-mounting.md
@@ -44,6 +44,6 @@ same configuration values on multiple places..
 
 - See [elektra-glossary(7)](elektra-glossary.md)
 - More information about [elektra-backends(7)](elektra-backends.md)
-- More information about [elektra-plugins(7)](elektra-plugins.md)
+- More information about [elektra-plugins-framework(7)](elektra-plugins-framework.md)
 - The tool for mounting plugins is [kdb-mount(1)](kdb-mount.md)
 - The plugins are ordered as described in [elektra-plugins-ordering(7)](elektra-plugins-ordering.md)

--- a/doc/help/elektra-plugins-ordering.md
+++ b/doc/help/elektra-plugins-ordering.md
@@ -5,7 +5,7 @@ You should first read [elektra-plugins(7)](/src/plugins/) to get
 an idea about plugins.
 
 This document describes how [elektra-plugins(7)](/src/plugins/) are
-ordered with an [elektra-backend(7)](elektra-backend.md).
+ordered with [elektra-backends(7)](elektra-backends.md).
 
 Multiple plugins open up many ways in which they can be arranged.
 A simple way is to have one array with pointers to plugins.  To store a
@@ -47,18 +47,18 @@ Another use case is logging after a failure has happened.
 ## Placements
 
 The ordering of plugins inside these three arrays is controlled by
-[elektra-contracts(7)](elektra-contracts).
+[elektra-contracts(7)](elektra-contracts.md).
 Each of the three arrays has ten slots.  These slots have
 names to be referred to in the contract.
 
 Here you see a table that contains all names:
 
 	0     prerollback       getresolver         setresolver  
-	1     prerollback       pregetstorage      presetstorage 
-	2     prerollback       pregetstorage      presetstorage 
-	3     prerollback       pregetstorage      presetstorage 
-	4     prerollback       pregetstorage      presetstorage 
-	5      rollback            getstorage         setstorage 
+	1     prerollback       pregetstorage      presetstorage
+	2     prerollback       pregetstorage      presetstorage
+	3     prerollback       pregetstorage      presetstorage
+	4     prerollback       pregetstorage      presetstorage
+	5      rollback            getstorage         setstorage
 	6    postrollback      postgetstorage      precommit     
 	7    postrollback      postgetstorage         commit     
 	8    postrollback      postgetstorage     postcommit     
@@ -67,4 +67,3 @@ Here you see a table that contains all names:
 how the placement is influenced using infos/placement, infos/ordering
 and infos/stacking as described in
 [CONTRACT.ini](/doc/CONTRACT.ini).
-

--- a/doc/help/elektra-related.md
+++ b/doc/help/elektra-related.md
@@ -36,7 +36,7 @@ creates a new view to configuration files which is not necessarily
 the same as applications see it.
 Additionally, Augeas has a rather poor level of abstraction and many
 syntactical details must be reflected in the configuration tree.
-Nevertheless, Elektra provides an [/src/plugins/augeas/](augeas plugin)
+Nevertheless, Elektra provides an [augeas plugin](/src/plugins/augeas/)
 which allows parts of Elektra's global configuration tree to
 be implemented using lenses. Lenses are a promising technology,
 which allow mapping from and to configuration files to be specified
@@ -81,7 +81,7 @@ and thus handle conflicts in a much more fine-grained way.
 
 ## Freedesktop.org
 
-The [freedesktop.org](freedesktop.org) initiative unifies different desktops
+The [freedesktop.org](https://freedesktop.org) initiative unifies different desktops
 using the X Window System in various ways.
 The main focus, however, lies in KDE and Gnome integration.
 One of the most disturbing and

--- a/doc/help/elektra-spec.md
+++ b/doc/help/elektra-spec.md
@@ -112,9 +112,9 @@ infos/recommends = hexcode
 
 ## SEE ALSO
 
-- [see application integration tutorial (towards end)](doc/tutorials/application-integration.md)
-- [see namespaces tutorial](doc/tutorials/namespaces.md)
+- [see application integration tutorial (towards end)](/doc/tutorials/application-integration.md)
+- [see namespaces tutorial](/doc/tutorials/namespaces.md)
 
 - [elektra-namespaces(7)](elektra-namespaces.md)
 - [elektra-cascading(7)](elektra-cascading.md)
-- [elektra-ordering(7)](elektra-ordering.md)
+- [elektra-plugins-ordering(7)](elektra-plugins-ordering.md)

--- a/doc/help/kdb-check.md
+++ b/doc/help/kdb-check.md
@@ -39,7 +39,7 @@ Each bit represents a specific outcome as described below:
  * 0:
    No errors (no output)  
 
- * Bit 1: 
+ * Bit 1:
    Warning on opening the key database.  
 
  * Bit 2:
@@ -108,6 +108,6 @@ To check the `line` plugin:
 
 ## SEE ALSO
 
-- For an introductions into plugins, read [elektra-plugins(7)](elektra-plugins.md).
+- For an introductions into plugins, read [elektra-plugins-framemwork(7)](elektra-plugins-framework.md).
 - To list all plugins use [kdb-list(1)](kdb-list.md).
 - For information on a plugin use [kdb-info(1)](kdb-info.md).

--- a/doc/help/kdb-editor.md
+++ b/doc/help/kdb-editor.md
@@ -60,4 +60,4 @@ To change the configuration in KDB below `user/ini` with `/usr/bin/vim`, you wou
 
 ## SEE ALSO
 
-- [elektra-merge-strategies(7)](elektra-merge-strategies)
+- [elektra-merge-strategies(7)](elektra-merge-strategies.md)

--- a/doc/help/kdb-export.md
+++ b/doc/help/kdb-export.md
@@ -47,5 +47,5 @@ To backup a keyset stored in `user/keyset` in the `ini` format to a file called 
 
 ## SEE ALSO
 
-- For an introductions into plugins, read [elektra-plugins(7)](elektra-plugins.md).
+- For an introductions into plugins, read [elektra-plugins-framework(7)](elektra-plugins-framework.md).
 - Only storage plugins can be used for formatting.

--- a/doc/help/kdb-global-mount.md
+++ b/doc/help/kdb-global-mount.md
@@ -60,4 +60,4 @@ For every change of KDB, write to syslog and notify by dbus:
 - [elektra-glossary(7)](elektra-glossary.md).
 - [kdb-umount(7)](kdb-umount.md).
 - [elektra-mounting(7)](elektra-mounting.md).
-- [elektra-plugins(7)](elektra-plugins.md).
+- [elektra-plugins-framework(7)](elektra-plugins-framework.md).

--- a/doc/help/kdb-import.md
+++ b/doc/help/kdb-import.md
@@ -66,4 +66,4 @@ To restore a backup (stored as `sw.ecf`) of a user's configuration below `system
 
 ## SEE ALSO
 
-- [elektra-merge-strategies(7)](elektra-merge-strategies)
+- [elektra-merge-strategy(7)](elektra-merge-strategy.md)

--- a/doc/help/kdb-merge.md
+++ b/doc/help/kdb-merge.md
@@ -75,4 +75,4 @@ To complete a three-way merge and overwrite all current keys in the `resultpath`
 
 ## SEE ALSO
 
-- [elektra-merge-strategies(7)](elektra-merge-strategies)
+- [elektra-merge-strategy(7)](elektra-merge-strategy.md)

--- a/doc/help/kdb-mount.md
+++ b/doc/help/kdb-mount.md
@@ -97,4 +97,4 @@ To recode and rename a configuration file using Elektra:
 - [kdb-spec-mount(7)](kdb-spec-mount.md).
 - [kdb-umount(7)](kdb-umount.md).
 - [elektra-mounting(7)](elektra-mounting.md).
-- [elektra-plugins(7)](elektra-plugins.md).
+- [elektra-plugins-framework(7)](elektra-plugins-framework.md).

--- a/doc/help/kdb-spec-mount.md
+++ b/doc/help/kdb-spec-mount.md
@@ -75,4 +75,4 @@ Additionally, add `ini` plugin (instead of some default resolver) with `some` as
 - [elektra-glossary(7)](elektra-glossary.md).
 - [kdb-umount(7)](kdb-umount.md).
 - [elektra-mounting(7)](elektra-mounting.md).
-- [elektra-plugins(7)](elektra-plugins.md).
+- [elektra-plugins-framework(7)](elektra-plugins-framework.md).

--- a/doc/help/kdb-umount.md
+++ b/doc/help/kdb-umount.md
@@ -22,4 +22,4 @@ Unmount backend from key database.
 
 - [kdb-mount(7)](kdb-mount.md).
 - [elektra-mounting(7)](elektra-mounting.md).
-- [elektra-plugins(7)](elektra-plugins.md).
+- [elektra-plugins-framework(7)](elektra-plugins-framework.md).

--- a/doc/tutorials/elektra-merge-integration.md
+++ b/doc/tutorials/elektra-merge-integration.md
@@ -12,61 +12,61 @@ using Elektra.
 The addition of the `--three-way-merge-command` option was a part of my Google
 Summer of Code Project. This option takes the form:  
 	--three-way-merge-command command  <New File> <Destination>
-	
+
 Where `command` is the command you would like to use for the merge. `New File` and
-`Destination` are the same as always. 
+`Destination` are the same as always.
 
 ## elektra-merge ##
 
-We added a new script to Elektra called [elektra-merge](script/elektra-merge) for use with
+We added a new script to Elektra called [elektra-merge](/scripts/elektra-merge) for use with
 this new option in ucf. This script acts as a liaison between ucf and Elektra, allowing a regular
-ucf command to run a `kdb merge` even though ucf commands only pass `New File` and 
+ucf command to run a `kdb merge` even though ucf commands only pass `New File` and
 `Destination` whereas kdb merge requires `ourpath`, `theirpath`, `basepath`, and `resultpath`.
 Since ucf already performs a three-way merge, it keeps track of all the necessary files to do
-so, even though it only takes in `New File` and `Destination`. 
+so, even though it only takes in `New File` and `Destination`.
 
 In order to use `elektra-merge`, the current configuration file must be mounted to KDB to
-serve as `ours` in the merge. The script automatically mounts `theirs`, `base`, and `result` 
+serve as `ours` in the merge. The script automatically mounts `theirs`, `base`, and `result`
 using the `kdb remount` command in order to use the same backend as `ours` (since all versions
 of the same file should use the same backend anyway) and this way users don't need to worry
-about specifying the backend for each version of the file. Then the script attempts a merge 
+about specifying the backend for each version of the file. Then the script attempts a merge
 on the newly mounted KeySets. Once this is finished, either on success or not, the script finishes
 by unmouting all but `our` copy of the file to cleanup KDB. Then, if the merge was successful ucf
-will replace `ours` with the result providing the package with an automatically merged 
-configuration which will also be updated in KDB itself. 
+will replace `ours` with the result providing the package with an automatically merged
+configuration which will also be updated in KDB itself.
 
 Additionally, we added two other scripts, `elektra-mount` and `elektra-umount` which act
 as simple wrappers for `kdb mount` and `kdb umount`. That work identically but are more
-script friendly. 
+script friendly.
 
 ## The Full Command ##
 
 The full command to use `elektra-merge` to perform a three-way merge on a file managed
 by ucf is:
 	ucf --three-way --threeway-merge-command elektra-merge <New File> <Destination>
-	
+
 Thats it! As described above, `elektra-merge` is smart enough to run the whole merge off
 of the information from that command and utilizes the new `kdb remount` command to
-do so. 
+do so.
 
 ## How-To Integrate ##
 
 Integrating `elektra-merge` into a package that already uses ucf is very easy! In `postinst` you
 should have a line similar to:
 	ucf <New File> <Destination>
-	
+
 or perhaps:
 	ucf --three-way <New File> <Destination>
-	
+
 All you must do is in `postinst`, when run with the `configure` option you must mount the
 config file to Elektra:
 	kdb elektra-mount <New File> <Mouting Destination> <Backend>
 
 Next, you must update the line containing `ucf` with the options `--three-way` and `--threeway-merge-command` like so:
 	ucf --three-way --threeway-merge-command elektra-merge <New File> <Destination>
-	
-Then, in your `postrm` script, during a purge, you must umount the config file before deleting it: 
-	kdb elektra-umount <name> 
+
+Then, in your `postrm` script, during a purge, you must umount the config file before deleting it:
+	kdb elektra-umount <name>
 
 That's it! With those small changes you can use Elektra to perform automatic three-way merges on any files
 that your package uses ucf to handle!
@@ -88,6 +88,6 @@ Here is the patch showing what we changed:
 	diff samba_orig/samba-3.6.6/debian/samba-common.postrm samba/samba-3.6.6/debian/samba-common.postrm
 	4a5
 	> 	kdb elektra-umount system/samba/smb
-	
+
 As you can see, all we had to do was add the line to mount `smb.conf` during install, update the ucf command to include the
 new `--threeway-merge-command` option, and unmount `system/samba/smb` during a purge. It really is that easy!

--- a/doc/tutorials/plugins.md
+++ b/doc/tutorials/plugins.md
@@ -42,7 +42,7 @@ and `ELEKTRA_EXPORT_PLUGIN(Plugin)`.
 
 Because remembering all these functions can be cumbersome, we provide a skeleton plugin in order to easily create a new plugin.
 The skeleton plugin is called "template" and a new plugin can be created by calling the
-[copy-template script](scripts/copy-template) .
+[copy-template script](/scripts/copy-template) .
 For example for my plugin I called `../../scripts/copy-template line` from within the plugins directory. Afterwards two
 important things are left to be done:
 

--- a/src/plugins/README.md
+++ b/src/plugins/README.md
@@ -51,7 +51,7 @@ All plugins implement the same interface:
 ## See also
 
 For an easy introduction, see [this tutorial how to write a storage plugin](/doc/tutorials/plugins.md).
-For more background information of the [plugin framework, continue here](/doc/help/plugin-framework.md).
+For more background information of the [plugins framework, continue here](/doc/help/elektra-plugins-framework.md).
 Otherwise, you can visit the [the API documentation](http://doc.libelektra.org/api/current/html/group__plugin.html).
 
 
@@ -110,7 +110,7 @@ productive use:
 ## System Information ##
 
 Information compiled in Elektra:
-- [version](version/) is a build-in plugin directly within the
+- version is a built-in plugin directly within the
   core so that it cannot give wrong version information
 - [constants](constants/) various constants, including version
   information

--- a/src/plugins/ni/README.md
+++ b/src/plugins/ni/README.md
@@ -89,4 +89,4 @@ rewrote first ) line ini file with 1.1MB size is 16.88 MB.
 The sort order is not stable, even not with the same file
 rewritten again.
 
-[https://github.com/chazomaticus/bohr](bohr libraries)
+[bohr libraries](https://github.com/chazomaticus/bohr)


### PR DESCRIPTION
 * doc/help/elektra-introduction.md:66 - not sure if `backends` link means `elektra-backends.md`
 * doc/tutorials/compilation-variants.md:5 - not sure what `contract.md` should be

All other broken links should be fixed now.

BTW: There seems to be an off-by-one error (line number is always +1 of what the error message shows)