### PR TITLE
enable OS X compilation for crypto_plugin

### DIFF
--- a/src/plugins/crypto/CMakeLists.txt
+++ b/src/plugins/crypto/CMakeLists.txt
@@ -1,5 +1,8 @@
 include (LibAddPlugin)
 
+# set OPENSSL_MANUAL_CONFIG if you want to configure the OpenSSL development files manually
+# set LIBGCRYPT_MANUAL_CONFIG if you want to configure the libgcrypt development files manually
+
 #
 # base plugin (that does actually nothing on its own)
 #
@@ -25,11 +28,14 @@ foreach (plugin ${PLUGINS})
 	# Compile Variant: OpenSSL
 	if (${plugin} MATCHES "crypto_openssl")
 
-		include (FindPkgConfig)
-		pkg_search_module (OPENSSL openssl)
-		if (NOT OPENSSL_FOUND)
+		if (NOT OPENSSL_MANUAL_CONFIG)
+			include (FindPkgConfig)
+			pkg_search_module (OPENSSL openssl)
+		endif ()
+
+		if ((NOT OPENSSL_FOUND) AND (NOT OPENSSL_MANUAL_CONFIG))
 			remove_plugin ( ${plugin} "OpenSSL development files not found")
-		else  (NOT OPENSSL_FOUND)
+		else  ()
 
 			try_compile (HAS_OPENSSL_4SURE
 				"${CMAKE_BINARY_DIR}"
@@ -56,19 +62,22 @@ foreach (plugin ${PLUGINS})
 						ELEKTRA_CRYPTO_API_OPENSSL
 				)
 			else ()
-				remove_plugin ( ${plugin} "OpenSSL development files not found")
+				remove_plugin ( ${plugin} "OpenSSL compilation test failed")
 			endif (HAS_OPENSSL_4SURE)
-		endif (NOT OPENSSL_FOUND)
+		endif ((NOT OPENSSL_FOUND) AND (NOT OPENSSL_MANUAL_CONFIG))
 
 	endif (${plugin} MATCHES "crypto_openssl")
 
 	# Compile Variant: libgcrypt
 	if (${plugin} MATCHES "crypto_gcrypt")
 
-		find_package (LibGcrypt)
-		if (NOT LIBGCRYPT_FOUND)
+		if (NOT LIBGCRYPT_MANUAL_CONFIG)
+			find_package (LibGcrypt)
+		endif ()
+
+		if ((NOT LIBGCRYPT_FOUND) AND (NOT LIBGCRYPT_MANUAL_CONFIG))
 			remove_plugin ( ${plugin} "libgcrypt development files not found")
-		else (NOT LIBGCRYPT_FOUND)
+		else ()
 
 			try_compile (HAS_GCRYPT_4SURE
 				"${CMAKE_BINARY_DIR}"
@@ -95,9 +104,9 @@ foreach (plugin ${PLUGINS})
 						ELEKTRA_CRYPTO_API_GCRYPT
 				)
 			else ()
-				remove_plugin ( ${plugin} "libgcrypt development files not found")
+				remove_plugin ( ${plugin} "libgcrypt compilation test failed")
 			endif (HAS_GCRYPT_4SURE)
-		endif (NOT LIBGCRYPT_FOUND)
+		endif ((NOT LIBGCRYPT_FOUND) AND (NOT LIBGCRYPT_MANUAL_CONFIG))
 
 	endif (${plugin} MATCHES "crypto_gcrypt")
 

--- a/src/plugins/crypto/CMakeLists.txt
+++ b/src/plugins/crypto/CMakeLists.txt
@@ -1,7 +1,12 @@
 include (LibAddPlugin)
 
-# set OPENSSL_MANUAL_CONFIG if you want to configure the OpenSSL development files manually
-# set LIBGCRYPT_MANUAL_CONFIG if you want to configure the libgcrypt development files manually
+# in order to set up OpenSSL development files, please provide:
+# - OPENSSL_INCLUDE_DIR
+# - OPENSSL_LIBRARIES
+#
+# in order to set up libgcrypt development files, please provide:
+# - LIBGCRYPT_INCLUDE_DIR
+# - LIBGCRYPT_LIBRARIES
 
 #
 # base plugin (that does actually nothing on its own)
@@ -19,6 +24,23 @@ add_plugin (crypto
 )
 
 add_plugintest (crypto)
+
+#
+# check if library detection is required
+#
+if (DEFINED OPENSSL_INCLUDE_DIR AND DEFINED OPENSSL_LIBRARIES)
+	set (OPENSSL_MANUAL_CONFIG on)
+	set (OPENSSL_FOUND on)
+else ()
+	set (OPENSSL_MANUAL_CONFIG off)
+endif ()
+
+if (DEFINED LIBGCRYPT_INCLUDE_DIR AND DEFINED LIBGCRYPT_LIBRARIES)
+	set (LIBGCRYPT_MANUAL_CONFIG on)
+	set (LIBGCRYPT_FOUND on)
+else ()
+	set (LIBGCRYPT_MANUAL_CONFIG off)
+endif ()
 
 #
 # Compile Variants
@@ -63,6 +85,7 @@ foreach (plugin ${PLUGINS})
 				)
 			else ()
 				remove_plugin ( ${plugin} "OpenSSL compilation test failed")
+				set (OPENSSL_FOUND off)
 			endif (HAS_OPENSSL_4SURE)
 		endif ((NOT OPENSSL_FOUND) AND (NOT OPENSSL_MANUAL_CONFIG))
 
@@ -105,9 +128,13 @@ foreach (plugin ${PLUGINS})
 				)
 			else ()
 				remove_plugin ( ${plugin} "libgcrypt compilation test failed")
+				set (LIBGCRYPT_FOUND off)
 			endif (HAS_GCRYPT_4SURE)
 		endif ((NOT LIBGCRYPT_FOUND) AND (NOT LIBGCRYPT_MANUAL_CONFIG))
 
 	endif (${plugin} MATCHES "crypto_gcrypt")
 
 endforeach (plugin)
+
+unset (OPENSSL_MANUAL_CONFIG)
+unset (LIBGCRYPT_MANUAL_CONFIG)

--- a/src/plugins/crypto/CMakeLists.txt
+++ b/src/plugins/crypto/CMakeLists.txt
@@ -1,12 +1,16 @@
 include (LibAddPlugin)
 
-# in order to set up OpenSSL development files, please provide:
+#
+# NOTE
+#
+# in order to set up OpenSSL development files manually, please provide:
 # - OPENSSL_INCLUDE_DIR
 # - OPENSSL_LIBRARIES
 #
-# in order to set up libgcrypt development files, please provide:
+# in order to set up libgcrypt development files manually, please provide:
 # - LIBGCRYPT_INCLUDE_DIR
 # - LIBGCRYPT_LIBRARIES
+#
 
 #
 # base plugin (that does actually nothing on its own)
@@ -26,20 +30,21 @@ add_plugin (crypto
 add_plugintest (crypto)
 
 #
+# HACK for non-Linux systems
 # check if library detection is required
 #
 if (DEFINED OPENSSL_INCLUDE_DIR AND DEFINED OPENSSL_LIBRARIES)
-	set (OPENSSL_MANUAL_CONFIG on)
+	set (OPENSSL_MANUAL_OSX_HACK on)
 	set (OPENSSL_FOUND on)
 else ()
-	set (OPENSSL_MANUAL_CONFIG off)
+	set (OPENSSL_MANUAL_OSX_HACK off)
 endif ()
 
 if (DEFINED LIBGCRYPT_INCLUDE_DIR AND DEFINED LIBGCRYPT_LIBRARIES)
-	set (LIBGCRYPT_MANUAL_CONFIG on)
+	set (LIBGCRYPT_MANUAL_OSX_HACK on)
 	set (LIBGCRYPT_FOUND on)
 else ()
-	set (LIBGCRYPT_MANUAL_CONFIG off)
+	set (LIBGCRYPT_MANUAL_OSX_HACK off)
 endif ()
 
 #
@@ -50,12 +55,12 @@ foreach (plugin ${PLUGINS})
 	# Compile Variant: OpenSSL
 	if (${plugin} MATCHES "crypto_openssl")
 
-		if (NOT OPENSSL_MANUAL_CONFIG)
+		if (NOT OPENSSL_MANUAL_OSX_HACK)
 			include (FindPkgConfig)
 			pkg_search_module (OPENSSL openssl)
 		endif ()
 
-		if ((NOT OPENSSL_FOUND) AND (NOT OPENSSL_MANUAL_CONFIG))
+		if ((NOT OPENSSL_FOUND) AND (NOT OPENSSL_MANUAL_OSX_HACK))
 			remove_plugin ( ${plugin} "OpenSSL development files not found")
 		else  ()
 
@@ -87,18 +92,18 @@ foreach (plugin ${PLUGINS})
 				remove_plugin ( ${plugin} "OpenSSL compilation test failed")
 				set (OPENSSL_FOUND off)
 			endif (HAS_OPENSSL_4SURE)
-		endif ((NOT OPENSSL_FOUND) AND (NOT OPENSSL_MANUAL_CONFIG))
+		endif ((NOT OPENSSL_FOUND) AND (NOT OPENSSL_MANUAL_OSX_HACK))
 
 	endif (${plugin} MATCHES "crypto_openssl")
 
 	# Compile Variant: libgcrypt
 	if (${plugin} MATCHES "crypto_gcrypt")
 
-		if (NOT LIBGCRYPT_MANUAL_CONFIG)
+		if (NOT LIBGCRYPT_MANUAL_OSX_HACK)
 			find_package (LibGcrypt)
 		endif ()
 
-		if ((NOT LIBGCRYPT_FOUND) AND (NOT LIBGCRYPT_MANUAL_CONFIG))
+		if ((NOT LIBGCRYPT_FOUND) AND (NOT LIBGCRYPT_MANUAL_OSX_HACK))
 			remove_plugin ( ${plugin} "libgcrypt development files not found")
 		else ()
 
@@ -130,11 +135,11 @@ foreach (plugin ${PLUGINS})
 				remove_plugin ( ${plugin} "libgcrypt compilation test failed")
 				set (LIBGCRYPT_FOUND off)
 			endif (HAS_GCRYPT_4SURE)
-		endif ((NOT LIBGCRYPT_FOUND) AND (NOT LIBGCRYPT_MANUAL_CONFIG))
+		endif ((NOT LIBGCRYPT_FOUND) AND (NOT LIBGCRYPT_MANUAL_OSX_HACK))
 
 	endif (${plugin} MATCHES "crypto_gcrypt")
 
 endforeach (plugin)
 
-unset (OPENSSL_MANUAL_CONFIG)
-unset (LIBGCRYPT_MANUAL_CONFIG)
+unset (OPENSSL_MANUAL_OSX_HACK)
+unset (LIBGCRYPT_MANUAL_OSX_HACK)

--- a/src/plugins/crypto/CMakeLists.txt
+++ b/src/plugins/crypto/CMakeLists.txt
@@ -30,21 +30,32 @@ foreach (plugin ${PLUGINS})
 		if (NOT OPENSSL_FOUND)
 			remove_plugin ( ${plugin} "OpenSSL development files not found")
 		else  (NOT OPENSSL_FOUND)
-			add_plugin (${plugin}
-				SOURCES
-					openssl_operations.h
-					openssl_operations.c
-					crypto.h
-					crypto.c
-				INCLUDE_DIRECTORIES
-					${OPENSSL_INCLUDE_DIR}
-				LINK_LIBRARIES
-					${OPENSSL_LIBRARIES}
-				COMPILE_DEFINITIONS
-					ELEKTRA_PLUGIN_NAME=\"${plugin}\"
-					ELEKTRA_VARIANT=openssl
-					ELEKTRA_CRYPTO_API_OPENSSL
+
+			try_compile (HAS_OPENSSL_4SURE
+				"${CMAKE_BINARY_DIR}"
+				"${PROJECT_SOURCE_DIR}/src/plugins/crypto/compile_openssl.c"
+				CMAKE_FLAGS
+					-DINCLUDE_DIRECTORIES:STRING=${OPENSSL_INCLUDE_DIR}
+					-DLINK_LIBRARIES:PATH=${OPENSSL_LIBRARIES}
 			)
+
+			if (HAS_OPENSSL_4SURE)
+				add_plugin (${plugin}
+					SOURCES
+						openssl_operations.h
+						openssl_operations.c
+						crypto.h
+						crypto.c
+					INCLUDE_DIRECTORIES
+						${OPENSSL_INCLUDE_DIR}
+					LINK_LIBRARIES
+						${OPENSSL_LIBRARIES}
+					COMPILE_DEFINITIONS
+						ELEKTRA_PLUGIN_NAME=\"${plugin}\"
+						ELEKTRA_VARIANT=openssl
+						ELEKTRA_CRYPTO_API_OPENSSL
+				)
+			endif (HAS_OPENSSL_4SURE)
 		endif (NOT OPENSSL_FOUND)
 
 	endif (${plugin} MATCHES "crypto_openssl")
@@ -56,21 +67,32 @@ foreach (plugin ${PLUGINS})
 		if (NOT LIBGCRYPT_FOUND)
 			remove_plugin ( ${plugin} "libgcrypt development files not found")
 		else (NOT LIBGCRYPT_FOUND)
-			add_plugin (${plugin}
-				SOURCES
-					gcrypt_operations.h
-					gcrypt_operations.c
-					crypto.h
-					crypto.c
-				INCLUDE_DIRECTORIES
-					${LIBGCRYPT_INCLUDE_DIR}
-				LINK_LIBRARIES
-					${LIBGCRYPT_LIBRARIES}
-				COMPILE_DEFINITIONS
-					ELEKTRA_PLUGIN_NAME=\"${plugin}\"
-					ELEKTRA_VARIANT=gcrypt
-					ELEKTRA_CRYPTO_API_GCRYPT
+
+			try_compile (HAS_GCRYPT_4SURE
+				"${CMAKE_BINARY_DIR}"
+				"${PROJECT_SOURCE_DIR}/src/plugins/crypto/compile_gcrypt.c"
+				CMAKE_FLAGS
+					-DINCLUDE_DIRECTORIES:STRING=${LIBGCRYPT_INCLUDE_DIR}
+					-DLINK_LIBRARIES:PATH=${LIBGCRYPT_LIBRARIES}
 			)
+
+			if (HAS_GCRYPT_4SURE)
+				add_plugin (${plugin}
+					SOURCES
+						gcrypt_operations.h
+						gcrypt_operations.c
+						crypto.h
+						crypto.c
+					INCLUDE_DIRECTORIES
+						${LIBGCRYPT_INCLUDE_DIR}
+					LINK_LIBRARIES
+						${LIBGCRYPT_LIBRARIES}
+					COMPILE_DEFINITIONS
+						ELEKTRA_PLUGIN_NAME=\"${plugin}\"
+						ELEKTRA_VARIANT=gcrypt
+						ELEKTRA_CRYPTO_API_GCRYPT
+				)
+			endif (HAS_GCRYPT_4SURE)
 		endif (NOT LIBGCRYPT_FOUND)
 
 	endif (${plugin} MATCHES "crypto_gcrypt")

--- a/src/plugins/crypto/compile_gcrypt.c
+++ b/src/plugins/crypto/compile_gcrypt.c
@@ -1,0 +1,16 @@
+/**
+ * @file
+ *
+ * @brief tests if compilation works (include and build paths set correct, etc...)
+ *
+ * @copyright BSD License (see doc/COPYING or http://www.libelektra.org)
+ *
+ */
+ 
+#include <gcrypt.h>
+
+int main()
+{
+	gcry_cipher_hd_t elektraCryptoHandle;
+	return 0;
+}

--- a/src/plugins/crypto/compile_openssl.c
+++ b/src/plugins/crypto/compile_openssl.c
@@ -1,0 +1,17 @@
+/**
+ * @file
+ *
+ * @brief tests if compilation works (include and build paths set correct, etc...)
+ *
+ * @copyright BSD License (see doc/COPYING or http://www.libelektra.org)
+ *
+ */
+ 
+#include <openssl/evp.h>
+
+int main()
+{
+	EVP_CIPHER_CTX opensslSpecificType;
+
+	return 0;
+}

--- a/src/plugins/crypto/gcrypt_operations.c
+++ b/src/plugins/crypto/gcrypt_operations.c
@@ -14,7 +14,8 @@
 #include <stdlib.h>
 #include <gcrypt.h>
 #include <pthread.h>
-#include <asm-generic/errno-base.h>
+#include <errno.h>
+
 
 // initialize the gcrypt threading subsystem
 // NOTE: old versions of libgcrypt require the functions defined in this macro!


### PR DESCRIPTION
prevents OS X from accidentally compiling the crypto plugin (see #487).

- [X] test gcrypt compile variant on OS X
- [X] test OpenSSL compile variant on OS X
- [X] improve CMake library detection (specifically the manual setup)