### PR TITLE
merge strategies now respect binary data #484

### DIFF
--- a/src/libs/tools/include/merging/mergeconflictstrategy.hpp
+++ b/src/libs/tools/include/merging/mergeconflictstrategy.hpp
@@ -34,6 +34,7 @@ public:
 protected:
 	virtual ConflictOperation getOurConflictOperation(const Key& conflictKey);
 	virtual ConflictOperation getTheirConflictOperation(const Key& conflictKey);
+	virtual void copyKeyValue(const Key& source, Key& destination);
 };
 
 typedef std::unique_ptr<MergeConflictStrategy> MergeConflictStrategyPtr;

--- a/src/libs/tools/src/merging/automergestrategy.cpp
+++ b/src/libs/tools/src/merging/automergestrategy.cpp
@@ -38,7 +38,7 @@ void AutoMergeStrategy::resolveConflict(const MergeTask& task, Key& conflictKey,
 		if (theirOperation == CONFLICT_MODIFY || theirOperation == CONFLICT_ADD)
 		{
 			Key source = task.theirs.lookup(theirLookup);
-			conflictKey.setString(source.getString());
+			copyKeyValue(source, conflictKey);
 			result.resolveConflict(conflictKey);
 			result.addMergeKey(conflictKey);
 		}
@@ -53,7 +53,7 @@ void AutoMergeStrategy::resolveConflict(const MergeTask& task, Key& conflictKey,
 		if (theirOperation == CONFLICT_SAME)
 		{
 			Key source = task.ours.lookup(ourLookup);
-			conflictKey.setString(source.getString());
+			copyKeyValue(source, conflictKey);
 			result.resolveConflict(conflictKey);
 			result.addMergeKey(conflictKey);
 		}

--- a/src/libs/tools/src/merging/mergeconflictstrategy.cpp
+++ b/src/libs/tools/src/merging/mergeconflictstrategy.cpp
@@ -35,6 +35,21 @@ ConflictOperation MergeConflictStrategy::getTheirConflictOperation(const Key& co
 	return theirOperation;
 }
 
+void MergeConflictStrategy::copyKeyValue(const Key& source, Key& destination)
+{
+	if (source && destination)
+	{
+		if (source.isString ())
+		{
+			destination.setString (source.getString ());
+		}
+		else
+		{
+			destination.setBinary (source.getBinary ().c_str (), source.getBinarySize ());
+		}
+	}
+}
+
 }
 }
 }

--- a/src/libs/tools/src/merging/mergeresult.cpp
+++ b/src/libs/tools/src/merging/mergeresult.cpp
@@ -41,7 +41,15 @@ void MergeResult::addConflict(Key& key, ConflictOperation ourOperation,
 		key.delMeta(currentMeta.getName());
 	}
 
-	key.setString("");
+	if (key.isString())
+	{
+		key.setString("");
+	}
+	else
+	{
+		key.setBinary(nullptr, 0);
+	}
+
 	removeMergeKey (key);
 	key.setMeta ("conflict/operation/our",
 			MergeConflictOperation::getFromTag (ourOperation));

--- a/src/libs/tools/src/merging/metamergestrategy.cpp
+++ b/src/libs/tools/src/merging/metamergestrategy.cpp
@@ -85,7 +85,7 @@ void MetaMergeStrategy::resolveConflict(const MergeTask& task, Key& conflictKey,
 			// without this strategy restoring the value the value would be lost
 			// this happens only for CONFLICT_META <--> CONFLICT_META conflicts
 			// add a test for this behaviour
-			conflictKey.setString(ourKey.getString());
+			copyKeyValue(ourKey, conflictKey);
 			result.resolveConflict (conflictKey);
 			result.addMergeKey (conflictKey);
 		}

--- a/src/libs/tools/src/merging/newkeystrategy.cpp
+++ b/src/libs/tools/src/merging/newkeystrategy.cpp
@@ -40,7 +40,7 @@ void NewKeyStrategy::resolveConflict(const MergeTask& task, Key& conflictKey, Me
 		if (theirOperation == CONFLICT_ADD)
 		{
 			Key source = task.theirs.lookup(theirLookup);
-			conflictKey.setString(source.getString());
+			copyKeyValue(source, conflictKey);
 			result.resolveConflict(conflictKey);
 			result.addMergeKey(conflictKey);
 		}
@@ -49,7 +49,7 @@ void NewKeyStrategy::resolveConflict(const MergeTask& task, Key& conflictKey, Me
 		if (theirOperation == CONFLICT_SAME)
 		{
 			Key source = task.ours.lookup(ourLookup);
-			conflictKey.setString(source.getString());
+			copyKeyValue(source, conflictKey);
 			result.resolveConflict(conflictKey);
 			result.addMergeKey(conflictKey);
 		}

--- a/src/libs/tools/src/merging/onesidestrategy.cpp
+++ b/src/libs/tools/src/merging/onesidestrategy.cpp
@@ -46,7 +46,7 @@ void OneSideStrategy::resolveConflict(const MergeTask& task, Key& conflictKey, M
 
 	if (winningKey)
 	{
-		conflictKey.setString(winningKey.getString());
+		copyKeyValue(winningKey, conflictKey);
 		result.resolveConflict(conflictKey);
 		result.addMergeKey(conflictKey);
 	} else

--- a/src/libs/tools/src/merging/onesidevaluestrategy.cpp
+++ b/src/libs/tools/src/merging/onesidevaluestrategy.cpp
@@ -56,7 +56,7 @@ void OneSideValueStrategy::resolveConflict(const MergeTask& task, Key& conflictK
 
 		if (winningKey)
 		{
-			conflictKey.setString (winningKey.getString ());
+			copyKeyValue(winningKey, conflictKey);
 			result.resolveConflict (conflictKey);
 			result.addMergeKey (conflictKey);
 		}

--- a/src/libs/tools/tests/testtool_automergestrategy.cpp
+++ b/src/libs/tools/tests/testtool_automergestrategy.cpp
@@ -87,6 +87,19 @@ TEST_F(AutoMergeStrategyTest, EqualsModifyMerges)
 	compareAllExceptKey1 (merged);
 }
 
+// the expected behaviour is the same for EqualsModify, EqualsDelete and EqualsAdd
+TEST_F(AutoMergeStrategyTest, EqualsModifyRespectsBinaryData)
+{
+	task.theirs.lookup ("user/parentt/config/key1").setBinary ("modifiedvalue", 13);
+	Key conflictKey = mergeKeys.lookup (mk1);
+	result.addConflict (conflictKey, CONFLICT_SAME, CONFLICT_MODIFY);
+	conflictKey = result.getConflictSet ().at (0);
+
+	strategy.resolveConflict (task, conflictKey, result);
+
+	EXPECT_TRUE(conflictKey.isBinary());
+}
+
 TEST_F(AutoMergeStrategyTest, ModifyEqualsMerges)
 {
 	task.ours.lookup ("user/parento/config/key1").setString ("modifiedvalue");
@@ -105,6 +118,19 @@ TEST_F(AutoMergeStrategyTest, ModifyEqualsMerges)
 			<< "was not modified correctly";
 
 	compareAllExceptKey1 (merged);
+}
+
+// the expected behaviour is the same for ModifyEquals, DeleteEquals and AddEquals
+TEST_F(AutoMergeStrategyTest, ModifyEqualsRespectsBinaryData)
+{
+	task.ours.lookup ("user/parento/config/key1").setBinary ("modifiedvalue", 13);
+	Key conflictKey = mergeKeys.lookup (mk1);
+	result.addConflict (conflictKey, CONFLICT_MODIFY, CONFLICT_SAME);
+	conflictKey = result.getConflictSet ().at (0);
+
+	strategy.resolveConflict (task, conflictKey, result);
+
+	EXPECT_TRUE (conflictKey.isBinary());
 }
 
 TEST_F(AutoMergeStrategyTest, AddEqualsKeyMerge)

--- a/src/libs/tools/tests/testtool_newkeystrategy.cpp
+++ b/src/libs/tools/tests/testtool_newkeystrategy.cpp
@@ -49,6 +49,18 @@ TEST_F(NewKeyStrategyTest, AddEqualsKeyMerge)
 	compareAllKeys (merged);
 }
 
+TEST_F(NewKeyStrategyTest, AddEqualsRespectsBinaryData)
+{
+	Key addedKey = Key ("user/parento/config/key5", KEY_BINARY, KEY_VALUE, "value5", KEY_END);
+	task.ours.append (addedKey);
+	Key conflictKey = mk5;
+	result.addConflict (conflictKey, CONFLICT_ADD, CONFLICT_SAME);
+	conflictKey = result.getConflictSet ().at (0);
+
+	strategy.resolveConflict (task, conflictKey, result);
+	EXPECT_TRUE(conflictKey.isBinary());
+}
+
 TEST_F(NewKeyStrategyTest, EqualsAddKeyMerge)
 {
 	Key addedKey = Key ("user/parentt/config/key5", KEY_VALUE, "value5", KEY_END);
@@ -64,4 +76,16 @@ TEST_F(NewKeyStrategyTest, EqualsAddKeyMerge)
 	KeySet merged = result.getMergedKeys ();
 	EXPECT_EQ(5, merged.size ());
 	compareAllKeys (merged);
+}
+
+TEST_F(NewKeyStrategyTest, EqualsAddRespectsBinaryData)
+{
+	Key addedKey = Key ("user/parentt/config/key5", KEY_BINARY, KEY_VALUE, "value5", KEY_END);
+	task.theirs.append (addedKey);
+	Key conflictKey = mk5;
+	result.addConflict (conflictKey, CONFLICT_SAME, CONFLICT_ADD);
+	conflictKey = result.getConflictSet ().at (0);
+
+	strategy.resolveConflict (task, conflictKey, result);
+	EXPECT_TRUE(conflictKey.isBinary());
 }

--- a/src/libs/tools/tests/testtool_onesidestrategy.cpp
+++ b/src/libs/tools/tests/testtool_onesidestrategy.cpp
@@ -51,6 +51,21 @@ TEST_F(OneSideStrategyTest, BaseWinsCorrectly)
 	compareKeys (Key ("user/parentm/config/key1", KEY_VALUE, "valueb", KEY_END), merged.lookup (mk1));
 }
 
+TEST_F(OneSideStrategyTest, BaseWinnerRespectsBinaryData)
+{
+	base.lookup ("user/parentb/config/key1").setBinary("valueb", 6);
+	ours.lookup ("user/parento/config/key1").setString ("valueo");
+	theirs.lookup ("user/parentt/config/key1").setString ("valuet");
+	Key conflictKey = mk1;
+	result.addConflict (conflictKey, CONFLICT_MODIFY, CONFLICT_MODIFY);
+	conflictKey = result.getConflictSet ().at (0);
+
+	OneSideStrategy strategy (BASE);
+	strategy.resolveConflict (task, conflictKey, result);
+
+	EXPECT_TRUE(conflictKey.isBinary());
+}
+
 TEST_F(OneSideStrategyTest, OursWinsCorrectly)
 {
 	base.lookup ("user/parentb/config/key1").setString ("valueb");
@@ -71,6 +86,21 @@ TEST_F(OneSideStrategyTest, OursWinsCorrectly)
 	compareKeys (Key ("user/parentm/config/key1", KEY_VALUE, "valueo", KEY_END), merged.lookup (mk1));
 }
 
+TEST_F(OneSideStrategyTest, OursWinnerRespectsBinaryData)
+{
+	base.lookup ("user/parentb/config/key1").setString("valueb");
+	ours.lookup ("user/parento/config/key1").setBinary ("valueo", 6);
+	theirs.lookup ("user/parentt/config/key1").setString ("valuet");
+	Key conflictKey = mk1;
+	result.addConflict (conflictKey, CONFLICT_MODIFY, CONFLICT_MODIFY);
+	conflictKey = result.getConflictSet ().at (0);
+
+	OneSideStrategy strategy (OURS);
+	strategy.resolveConflict (task, conflictKey, result);
+
+	EXPECT_TRUE(conflictKey.isBinary());
+}
+
 TEST_F(OneSideStrategyTest, TheirsWinsCorrectly)
 {
 	base.lookup ("user/parentb/config/key1").setString ("valueb");
@@ -89,5 +119,20 @@ TEST_F(OneSideStrategyTest, TheirsWinsCorrectly)
 	EXPECT_EQ(4, merged.size ());
 
 	compareKeys (Key ("user/parentm/config/key1", KEY_VALUE, "valuet", KEY_END), merged.lookup (mk1));
+}
+
+TEST_F(OneSideStrategyTest, TheirsWinnerRespectsBinaryData)
+{
+	base.lookup ("user/parentb/config/key1").setString("valueb");
+	ours.lookup ("user/parento/config/key1").setString ("valueo");
+	theirs.lookup ("user/parentt/config/key1").setBinary ("valuet", 6);
+	Key conflictKey = mk1;
+	result.addConflict (conflictKey, CONFLICT_MODIFY, CONFLICT_MODIFY);
+	conflictKey = result.getConflictSet ().at (0);
+
+	OneSideStrategy strategy (THEIRS);
+	strategy.resolveConflict (task, conflictKey, result);
+
+	EXPECT_TRUE(conflictKey.isBinary());
 }
 

--- a/tests/shell/check_merge.sh
+++ b/tests/shell/check_merge.sh
@@ -61,13 +61,32 @@ exit_if_fail "could not merge"
 [ "x`$KDB ls $MERGED_ROOT/key 2> /dev/null`" = "x$MERGED_ROOT/key" ]
 exit_if_fail "not exactly one result"
 
-[ "x`$KDB get $MERGED_ROOT/key 2> /dev/null`" = "xinit" ]
+[ "x`$KDB get $MERGED_ROOT/key 2> /dev/null`" = "xours" ]
+exit_if_fail "merge produced wrong result"
+
+$KDB rm -r $MERGED_ROOT/key
+$KDB rm -r $OURS_ROOT/key
+$KDB rm -r $THEIRS_ROOT/key
+$KDB rm -r $BASE_ROOT/key
+
+echo "Testing binary data handling"
+
+$KDB set $OURS_ROOT/nullbinary  >/dev/null
+exit_if_fail "could not set"
+
+$KDB getmeta $OURS_ROOT/nullbinary "binary" >/dev/null
+exit_if_fail "created key is not binary"
+
+$KDB merge $OURS_ROOT $THEIRS_ROOT $BASE_ROOT $MERGED_ROOT
+exit_if_fail "could not merge"
+
+[ "x`$KDB ls $MERGED_ROOT/nullbinary 2> /dev/null`" = "x$MERGED_ROOT/nullbinary" ]
+exit_if_fail "not exactly one result"
+
+$KDB getmeta $MERGED_ROOT/nullbinary "binary" >/dev/null
+exit_if_fail "merged key is not binary"
 
 $KDB rm -r $USER_ROOT/mergetest
-
-
-
-
 
 echo "Testing metadata"
 


### PR DESCRIPTION
This PR should fix the problem discussed in #484 along with unit tests that verify the changed behaviour in the strategies and an extended shell merge test that verifies the behaviour on the commandline. However, there is no specific INI test for now. This is because 1. I have no example of a failed merge 2. the problem was not really INI specifc and easy to understand.