### PR TITLE
fix linking for OS X #495

### DIFF
--- a/src/libs/tools/src/CMakeLists.txt
+++ b/src/libs/tools/src/CMakeLists.txt
@@ -18,7 +18,7 @@ if (BUILD_SHARED)
 		"ELEKTRA_SHARED"
 		)
 
-	target_link_libraries (elektratools elektra-core elektra-plugin elektra-ease)
+	target_link_libraries (elektratools elektra-core elektra-kdb elektra-plugin elektra-ease)
 
 	if (${LD_ACCEPTS_VERSION_SCRIPT})
 		set_target_properties (elektratools PROPERTIES


### PR DESCRIPTION
this fixes #495 for me
@markus2330 is this an acceptable fix? I'm not sure if you intended not to link against elektra-kdb