### PR TITLE
Fix building of certain plugins on OS X

### DIFF
--- a/cmake/Modules/LibAddPlugin.cmake
+++ b/cmake/Modules/LibAddPlugin.cmake
@@ -80,7 +80,7 @@ function(add_plugin PLUGIN_SHORT_NAME)
 		add_library (${PLUGIN_NAME} MODULE ${ARG_SOURCES}
 			${PLUGIN_SHARED_SOURCES})
 		if (ARG_LINK_ELEKTRA)
-			target_link_libraries (${PLUGIN_NAME} ${ARG_LINK_ELEKTRA})
+			target_link_libraries (${PLUGIN_NAME} elektra-plugin ${ARG_LINK_ELEKTRA})
 		else()
 			target_link_libraries (${PLUGIN_NAME} elektra-plugin)
 		endif ()


### PR DESCRIPTION
There might be another (and better) option to fix this problem. However, this one at least works on my machine. For reference, the command

```fish
cmake ..  -DPLUGINS='dump;resolver;sync;error;spec'; and make
```

prints the following error message before this commit on OS X:

```
Undefined symbols for architecture x86_64:
  "_elektraPluginExport", referenced from:
      _elektraPluginSymbol in spec.c.o
  "_elektraPluginGetConfig", referenced from:
      _elektraSpecGet in spec.c.o
      _elektraSpecSet in spec.c.o
ld: symbol(s) not found for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
make[2]: *** [lib/libelektra-spec.so] Error 1
make[1]: *** [src/plugins/spec/CMakeFiles/elektra-spec.dir/all] Error 2
make: *** [all] Error 2
```