### PR TITLE
fixes #510

### DIFF
--- a/src/plugins/list/CMakeLists.txt
+++ b/src/plugins/list/CMakeLists.txt
@@ -4,6 +4,8 @@ add_plugin(list
 	SOURCES
 		list.h
 		list.c
-	)
+	LINK_ELEKTRA
+		elektra-kdb
+)
 
 add_plugintest(list)


### PR DESCRIPTION
fixes #510, however unit tests for module `list` fail on my machine (OS X):

```
src/plugins/list/testmod_list.c:43: error in doTest: kdbget failed
src/plugins/list/testmod_list.c:45: error in doTest: key not found
src/plugins/list/testmod_list.c:47: error in doTest: meta key not found
src/plugins/list/testmod_list.c:48: error in doTest: kdbset failed

testmod_list RESULTS: 12 test(s) done. 4 error(s).
```