### PR TITLE
update status of crypto-plugin

### DIFF
--- a/src/plugins/crypto/README.md
+++ b/src/plugins/crypto/README.md
@@ -6,9 +6,9 @@
 - infos/recommends =
 - infos/placements = postgetstorage presetstorage
 #ifdef ELEKTRA_CRYPTO_API_GCRYPT
-- infos/status = experimental unfinished memleak
+- infos/status = experimental unfinished memleak discouraged
 #else
-- infos/status = experimental unfinished
+- infos/status = experimental unfinished discouraged
 #endif
 - infos/metadata = crypto/encrypt
 - infos/description = Cryptographic operations


### PR DESCRIPTION
I added the "discouraged" flag to the status as for now "crypto" might suggest a false sense of security. As long as there is no key derivation interface there is no way of keeping the secret stuff (cryptographic keys) secret.