### PR TITLE
fix #452

### DIFF
--- a/cmake/ElektraCompiling.cmake
+++ b/cmake/ElektraCompiling.cmake
@@ -121,7 +121,9 @@ if (ENABLE_COVERAGE)
 	set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -fprofile-arcs -ftest-coverage -lgcov")
 endif (ENABLE_COVERAGE)
 
-if (UNIX AND NOT APPLE)
+# check if native librt is available
+find_library(CMAKE_HAS_LIBRT "rt")
+if (CMAKE_HAS_LIBRT)
 	set(CMAKE_REALTIME_LIBS_INIT rt)
 endif()
 

--- a/src/plugins/resolver/resolver.c
+++ b/src/plugins/resolver/resolver.c
@@ -272,7 +272,7 @@ static void elektraAddErrnoText (char * errorText)
 	{
 		strcpy (buffer, "could not find a / in the pathname");
 	}
-	else if (errno == EBADMSG)
+	else if (errno == EINVAL)
 	{
 		strcpy (buffer, "went up to root for creating directory");
 	}
@@ -568,7 +568,7 @@ static int elektraMkdirParents (resolverHandle * pk, const char * pathname, Key 
 		{
 			// set any errno, corrected in
 			// elektraAddErrnoText
-			errno = EBADMSG;
+			errno = EINVAL;
 			goto error;
 		}
 


### PR DESCRIPTION
I fixed the problems discussed in #452 and tested my solution on:

- OpenBSD 5.8
- Mac OS X 10.11.3 (15D21)
- Fedora 23
- Debian Jessy

It works fine. All the unit tests pass for the plugin set:

    PLUGINS:STRING=dump;resolver;sync;error