### PR TITLE
Updated FindSystemdJournal CMakeModule

### DIFF
--- a/cmake/Modules/FindSystemdJournal.cmake
+++ b/cmake/Modules/FindSystemdJournal.cmake
@@ -35,17 +35,18 @@ else (LIBSYSTEMD_JOURNAL_INCLUDE_DIR AND LIBSYSTEMD_ID128_INCLUDE_DIR)
     /usr/local/include
   )
 
-  find_library (LIBSYSTEMD_JOURNAL_LIBRARIES NAMES systemd-journal systemd-id128
+  # try to use the merged library libsystemd
+  find_library (LIBSYSTEMD_JOURNAL_LIBRARIES NAMES systemd
     PATHS
-    ${_LIBSYSTEMD_JOURNAL_PC_LIBDIR}
-    ${_LIBSYSTEMD_ID128_PC_LIBDIR}
+    ${_LIBSYSTEMD_PC_LIBDIR}
   )
 
-  # at least on newer versions of debian the libraries have been merged
+  # if the merged library was not found try to use the old split library
   if (NOT LIBSYSTEMD_JOURNAL_LIBRARIES)
-    find_library (LIBSYSTEMD_JOURNAL_LIBRARIES NAMES systemd
+    find_library (LIBSYSTEMD_JOURNAL_LIBRARIES NAMES systemd-journal systemd-id128
       PATHS
-      ${_LIBSYSTEMD_PC_LIBDIR}
+      ${_LIBSYSTEMD_JOURNAL_PC_LIBDIR}
+      ${_LIBSYSTEMD_ID128_PC_LIBDIR}
     )
   endif (NOT LIBSYSTEMD_JOURNAL_LIBRARIES)
 

--- a/cmake/Modules/FindSystemdJournal.cmake
+++ b/cmake/Modules/FindSystemdJournal.cmake
@@ -16,7 +16,7 @@ else (LIBSYSTEMD_JOURNAL_INCLUDE_DIR AND LIBSYSTEMD_ID128_INCLUDE_DIR)
   find_package(PkgConfig)
 
   if (PKG_CONFIG_FOUND)
-    pkg_check_modules(_LIBSYSTEMD_JOURNAL_PC QUIET "libsystemd")
+    pkg_check_modules(_LIBSYSTEMD_JOURNAL_PC QUIET "libsystemd-journal")
     pkg_check_modules(_LIBSYSTEMD_ID128_PC QUIET "libsystemd-id128")
     pkg_check_modules(_LIBSYSTEMD_PC QUIET "libsystemd")
   endif (PKG_CONFIG_FOUND)
@@ -35,7 +35,7 @@ else (LIBSYSTEMD_JOURNAL_INCLUDE_DIR AND LIBSYSTEMD_ID128_INCLUDE_DIR)
     /usr/local/include
   )
 
-  find_library (LIBSYSTEMD_JOURNAL_LIBRARIES NAMES systemd systemd-id128
+  find_library (LIBSYSTEMD_JOURNAL_LIBRARIES NAMES systemd-journal systemd-id128
     PATHS
     ${_LIBSYSTEMD_JOURNAL_PC_LIBDIR}
     ${_LIBSYSTEMD_ID128_PC_LIBDIR}

--- a/cmake/Modules/FindSystemdJournal.cmake
+++ b/cmake/Modules/FindSystemdJournal.cmake
@@ -16,7 +16,7 @@ else (LIBSYSTEMD_JOURNAL_INCLUDE_DIR AND LIBSYSTEMD_ID128_INCLUDE_DIR)
   find_package(PkgConfig)
 
   if (PKG_CONFIG_FOUND)
-    pkg_check_modules(_LIBSYSTEMD_JOURNAL_PC QUIET "libsystemd-journal")
+    pkg_check_modules(_LIBSYSTEMD_JOURNAL_PC QUIET "libsystemd")
     pkg_check_modules(_LIBSYSTEMD_ID128_PC QUIET "libsystemd-id128")
     pkg_check_modules(_LIBSYSTEMD_PC QUIET "libsystemd")
   endif (PKG_CONFIG_FOUND)
@@ -35,7 +35,7 @@ else (LIBSYSTEMD_JOURNAL_INCLUDE_DIR AND LIBSYSTEMD_ID128_INCLUDE_DIR)
     /usr/local/include
   )
 
-  find_library (LIBSYSTEMD_JOURNAL_LIBRARIES NAMES systemd-journal systemd-id128
+  find_library (LIBSYSTEMD_JOURNAL_LIBRARIES NAMES systemd systemd-id128
     PATHS
     ${_LIBSYSTEMD_JOURNAL_PC_LIBDIR}
     ${_LIBSYSTEMD_ID128_PC_LIBDIR}


### PR DESCRIPTION
This could fix the warning described in #264. However, as the warning did not occur on my development machine I am not able to test it. Note also that this change might break the build for older Debian systems (which I am also not able to test)