### PR TITLE
Ni Plugin: Fix elektraKeyGetRelativeName

### DIFF
--- a/src/plugins/ni/ni.c
+++ b/src/plugins/ni/ni.c
@@ -96,7 +96,7 @@ const char * elektraKeyGetRelativeName (Key const * cur, Key const * parentKey)
 
 	if (!strcmp (keyName (parentKey), "/"))
 	{
-		return keyName (cur) + 2;
+		return keyName (cur);
 	}
 	else if (keyName (parentKey)[0] == '/' && keyName (cur)[0] != '/')
 	{


### PR DESCRIPTION
I hope this fix has no unintended consequences. What is the reason behind the decision to cut off the first  two characters if the plugin is mounted at `/`?