### PR TITLE
Ignore `Makefile` in Project Root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ build*
 
 #ignore emacs backup files
 \#*#
+
+#ignore Makefile in project root
+/Makefile


### PR DESCRIPTION
This is a rather specific change. If you do not like it, then please just close this issue.