### PR TITLE
Fix Tests

### DIFF
--- a/cmake/ElektraCache.cmake
+++ b/cmake/ElektraCache.cmake
@@ -365,12 +365,6 @@ set (LIB_SUFFIX ""
 		"Optional suffix to use on lib folders (e.g. 64 for lib64)"
     )
 
-set (MEMORYCHECK_COMMAND
-		/usr/bin/valgrind
-		CACHE FILEPATH
-		"Full path to valgrind"
-    )
-
 set(MEMORYCHECK_SUPPRESSIONS_FILE
 		${CMAKE_SOURCE_DIR}/tests/valgrind.suppression
 		CACHE FILEPATH

--- a/cmake/ElektraCache.cmake
+++ b/cmake/ElektraCache.cmake
@@ -366,7 +366,7 @@ set (LIB_SUFFIX ""
     )
 
 set(MEMORYCHECK_SUPPRESSIONS_FILE
-		${CMAKE_SOURCE_DIR}/tests/valgrind.suppression
+		"${CMAKE_SOURCE_DIR}/tests/valgrind.suppression"
 		CACHE FILEPATH
 		"Full path to suppression file for valgrind")
 

--- a/cmake/TestScript.cmake
+++ b/cmake/TestScript.cmake
@@ -3,6 +3,4 @@ set (CTEST_BINARY_DIRECTORY /home/markus/Projekte/Elektra/current/build)
 set (CTEST_COMMAND ctest)
 set ($ENV{srcdir} /home/markus/Projekte/Elektra/current/build/tests)
 
-set (MemoryCheckCommand /usr/bin/valgrind)
-
 ctest_memcheck ()

--- a/tests/shell/CMakeLists.txt
+++ b/tests/shell/CMakeLists.txt
@@ -87,7 +87,7 @@ function (add_scripttest testname)
 			endif ()
 			set(RACE_COMMAND "${CMAKE_BINARY_DIR}/bin/race")
 			set(INCLUDE_COMMON
-				"${INCLUDE_COMMON_FILE}KDB=${KDB_COMMAND}"
+				"${INCLUDE_COMMON_FILE}KDB=\"${KDB_COMMAND}\""
 				)
 			set(testscriptname
 				"${CMAKE_CURRENT_BINARY_DIR}/testscr_${testname}")

--- a/tests/shell/check_basic.sh
+++ b/tests/shell/check_basic.sh
@@ -16,25 +16,25 @@ echo "Testing version"
 
 if [ "x$CHECK_VERSION" != "xNO" ]
 then
-	$KDB -V | grep KDB_VERSION | grep $KDB_VERSION > /dev/null
+	"$KDB" -V | grep KDB_VERSION | grep $KDB_VERSION > /dev/null
 	exit_if_fail "could not get correct version"
 
-	$KDB --version | grep KDB_VERSION | grep $KDB_VERSION > /dev/null
+	"$KDB" --version | grep KDB_VERSION | grep $KDB_VERSION > /dev/null
 	exit_if_fail "could not get correct version"
 fi
 
 
 echo "Testing invalid"
 
-$KDB ls --ww >/dev/null
+"$KDB" ls --ww >/dev/null
 [ $? = 1 ]
 exit_if_fail "invalid options"
 
-$KDB ls x x x x  >/dev/null
+"$KDB" ls x x x x  >/dev/null
 [ $? = 2 ]
 exit_if_fail "invalid argument"
 
-$KDB xx  >/dev/null
+"$KDB" xx  >/dev/null
 [ $? = 4 ]
 exit_if_fail "invalid command"
 

--- a/tests/shell/check_distribution.sh
+++ b/tests/shell/check_distribution.sh
@@ -26,40 +26,40 @@ check_distribution()
 	[ ! -e $FILE2 ]
 	exit_if_fail $FILE2 already exists
 
-	$KDB mount $FILE1 $MOUNTPOINT1 $KDB_DEFAULT_STORAGE 1>/dev/null
+	"$KDB" mount $FILE1 $MOUNTPOINT1 $KDB_DEFAULT_STORAGE 1>/dev/null
 	succeed_if "could not mount 1: $FILE1 at $MOUNTPOINT1"
 
-	$KDB mount $FILE2 $MOUNTPOINT2 $KDB_DEFAULT_STORAGE 1>/dev/null
+	"$KDB" mount $FILE2 $MOUNTPOINT2 $KDB_DEFAULT_STORAGE 1>/dev/null
 	succeed_if "could not mount 2: $FILE2 at $MOUNTPOINT2"
 
-	FILE=`$KDB file -N system -n $MOUNTPOINT1`
+	FILE=`"$KDB" file -N system -n $MOUNTPOINT1`
 	[ "x$FILE"  = "x$FILE1" ]
 	succeed_if "resolving of $MOUNTPOINT1 did not yield $FILE1 but $FILE"
 
-	FILE=`$KDB file -N system -n $MOUNTPOINT1/xxx`
+	FILE=`"$KDB" file -N system -n $MOUNTPOINT1/xxx`
 	[ "x$FILE"  = "x$FILE1" ]
 	succeed_if "resolving of $MOUNTPOINT1/xxx did not yield $FILE1 but $FILE"
 
-	FILE=`$KDB file -N system -n $MOUNTPOINT2`
+	FILE=`"$KDB" file -N system -n $MOUNTPOINT2`
 	[ "x$FILE"  = "x$FILE2" ]
 	succeed_if "resolving of $MOUNTPOINT2 did not yield $FILE2 but $FILE"
 
-	FILE=`$KDB file -N system -n $MOUNTPOINT2/xxx`
+	FILE=`"$KDB" file -N system -n $MOUNTPOINT2/xxx`
 	[ "x$FILE"  = "x$FILE2" ]
 	succeed_if "resolving of $MOUNTPOINT2/xxx did not yield $FILE2 but $FILE"
 
 	KEY1=$MOUNTPOINT1/key
-	$KDB set -N system $KEY1 $VALUE1 > /dev/null
+	"$KDB" set -N system $KEY1 $VALUE1 > /dev/null
 	succeed_if "could not set $KEY1"
 
 	KEY2=$MOUNTPOINT2/key
-	$KDB set -N system $KEY2 $VALUE2 > /dev/null
+	"$KDB" set -N system $KEY2 $VALUE2 > /dev/null
 	succeed_if "could not set $KEY2"
 
-	[ "x`$KDB sget $KEY1 defvalue 2> /dev/null`" = "x$VALUE1" ]
+	[ "x`"$KDB" sget $KEY1 defvalue 2> /dev/null`" = "x$VALUE1" ]
 	succeed_if "Did not get value $VALUE1 for $KEY1"
 
-	[ "x`$KDB sget $KEY2 defvalue 2> /dev/null`" = "x$VALUE2" ]
+	[ "x`"$KDB" sget $KEY2 defvalue 2> /dev/null`" = "x$VALUE2" ]
 	succeed_if "Did not get value $VALUE2 for $KEY2"
 
 	grep $VALUE1 $FILE1 >/dev/null
@@ -68,16 +68,16 @@ check_distribution()
 	grep $VALUE2 $FILE2 >/dev/null
 	succeed_if "did not find $VALUE2 within $FILE2"
 
-	$KDB rm $KEY1
+	"$KDB" rm $KEY1
 	succeed_if "Could not remove $KEY1"
 
-	$KDB rm $KEY2
+	"$KDB" rm $KEY2
 	succeed_if "Could not remove $KEY2"
 
-	$KDB umount $MOUNTPOINT1 >/dev/null
+	"$KDB" umount $MOUNTPOINT1 >/dev/null
 	succeed_if "could not umount $MOUNTPOINT1"
 
-	$KDB umount $MOUNTPOINT2 >/dev/null
+	"$KDB" umount $MOUNTPOINT2 >/dev/null
 	succeed_if "could not umount $MOUNTPOINT2"
 
 	rm -f $FILE1

--- a/tests/shell/check_error.sh
+++ b/tests/shell/check_error.sh
@@ -15,13 +15,13 @@ ROOT_FILE=${FILE_SUFFIX}_root.ecf
 ROOT_MOUNTPOINT=/test/script
 if is_plugin_available dump
 then
-	$KDB mount $ROOT_FILE $ROOT_MOUNTPOINT dump > /dev/null 2>&1
+	"$KDB" mount $ROOT_FILE $ROOT_MOUNTPOINT dump > /dev/null 2>&1
 	succeed_if "could not mount root: $ROOT_FILE at $ROOT_MOUNTPOINT"
 
-	$KDB set $ROOT/valueable_data important_unrecoverable_data > /dev/null
+	"$KDB" set $ROOT/valueable_data important_unrecoverable_data > /dev/null
 	succeed_if "cannot set valueable data"
 
-	$KDB setmeta $ROOT/valueable_data trigger/error 10
+	"$KDB" setmeta $ROOT/valueable_data trigger/error 10
 	succeed_if "cannot set meta data"
 fi
 
@@ -43,11 +43,11 @@ if is_plugin_available error
 then
 	echo "Testing operations on errornous backends"
 
-	$KDB mount $ERROR_FILE $ERROR_MOUNTPOINT dump error > /dev/null 2>&1
+	"$KDB" mount $ERROR_FILE $ERROR_MOUNTPOINT dump error > /dev/null 2>&1
 	succeed_if "could not mount error at $ERROR_MOUNTPOINT"
 
 
-	$KDB mv $ROOT/valueable_data $ROOT/error/dump > $TMPFILE 2>&1
+	"$KDB" mv $ROOT/valueable_data $ROOT/error/dump > $TMPFILE 2>&1
 	[ $? -ne 0 ]
 	succeed_if "Was able to move to error plugin"
 
@@ -57,14 +57,14 @@ then
 	grep "Reason: from error plugin" $TMPFILE > /dev/null
 	succeed_if "Error does not stem from error plugin"
 
-	[ "x`$KDB ls $ROOT 2> /dev/null`" = "x$ROOT/valueable_data" ]
+	[ "x`"$KDB" ls $ROOT 2> /dev/null`" = "x$ROOT/valueable_data" ]
 	succeed_if "cant ls $ROOT (may mean that $ROOT folder is not clean)"
 
-	[ "x`$KDB get $ROOT/valueable_data 2> /dev/null`" = "ximportant_unrecoverable_data" ]
+	[ "x`"$KDB" get $ROOT/valueable_data 2> /dev/null`" = "ximportant_unrecoverable_data" ]
 	succeed_if "Important data lost"
 
 
-	$KDB cp $ROOT/valueable_data $ROOT/error/dump > $TMPFILE 2>&1
+	"$KDB" cp $ROOT/valueable_data $ROOT/error/dump > $TMPFILE 2>&1
 	[ $? -ne 0 ]
 	succeed_if "Was able to copy to error plugin"
 
@@ -74,13 +74,13 @@ then
 	grep "Reason: from error plugin" $TMPFILE > /dev/null
 	succeed_if "Error does not stem from error plugin"
 
-	[ "x`$KDB ls $ROOT 2> /dev/null`" = "x$ROOT/valueable_data" ]
+	[ "x`"$KDB" ls $ROOT 2> /dev/null`" = "x$ROOT/valueable_data" ]
 	succeed_if "cant ls $ROOT (may mean that $ROOT folder is not clean)"
 
-	[ "x`$KDB get $ROOT/valueable_data 2> /dev/null`" = "ximportant_unrecoverable_data" ]
+	[ "x`"$KDB" get $ROOT/valueable_data 2> /dev/null`" = "ximportant_unrecoverable_data" ]
 	succeed_if "data would have been lost"
 
-	$KDB umount $ERROR_MOUNTPOINT >/dev/null
+	"$KDB" umount $ERROR_MOUNTPOINT >/dev/null
 	succeed_if "could not umount $ERROR_MOUNTPOINT"
 
 
@@ -127,7 +127,7 @@ rm $TMPFILE
 
 if is_plugin_available dump
 then
-	$KDB umount $ROOT_MOUNTPOINT >/dev/null
+	"$KDB" umount $ROOT_MOUNTPOINT >/dev/null
 	succeed_if "could not umount $ROOT_MOUNTPOINT"
 fi
 

--- a/tests/shell/check_export.sh
+++ b/tests/shell/check_export.sh
@@ -32,50 +32,50 @@ do
 
 	echo -------- $PLUGIN -----------
 
-	$KDB set $ROOT "root" >/dev/null
+	"$KDB" set $ROOT "root" >/dev/null
 	exit_if_fail "could not set root"
 
-	test `$KDB ls $ROOT` = $ROOT
+	test `"$KDB" ls $ROOT` = $ROOT
 	succeed_if "Root key not found"
 
-	$KDB export $ROOT $PLUGIN > $FILE
+	"$KDB" export $ROOT $PLUGIN > $FILE
 	succeed_if "Could not run kdb export"
 
-	diff $DATADIR/one_value.$PLUGIN $FILE
+	diff "$DATADIR"/one_value.$PLUGIN $FILE
 	succeed_if "Export file one_value.$PLUGIN was not equal"
 
 
-	test "`$KDB set $ROOT/key "value"`" = "Create a new key $ROOT/key with string value"
+	test "`"$KDB" set $ROOT/key "value"`" = "Create a new key $ROOT/key with string value"
 	succeed_if "Could not set $ROOT/key"
 
-	$KDB export $ROOT $PLUGIN > $FILE
+	"$KDB" export $ROOT $PLUGIN > $FILE
 	succeed_if "Could not run kdb export"
 
-	diff $DATADIR/two_value.$PLUGIN $FILE
+	diff "$DATADIR"/two_value.$PLUGIN $FILE
 	succeed_if "Export file two_value.$PLUGIN was not equal"
 
 
-	$KDB set $ROOT/key/subkey "another value" > /dev/null
+	"$KDB" set $ROOT/key/subkey "another value" > /dev/null
 	succeed_if "Could not set $ROOT/key/subkey"
 
-	$KDB export $ROOT $PLUGIN > $FILE
+	"$KDB" export $ROOT $PLUGIN > $FILE
 	succeed_if "Could not run kdb export"
 
-	diff $DATADIR/three_value.$PLUGIN $FILE
+	diff "$DATADIR"/three_value.$PLUGIN $FILE
 	succeed_if "Export file three_value.$PLUGIN was not equal"
 
 
-	$KDB rm $ROOT/key > /dev/null
+	"$KDB" rm $ROOT/key > /dev/null
 	succeed_if "Could not rm $ROOT/key"
 
-	$KDB export $ROOT $PLUGIN > $FILE
+	"$KDB" export $ROOT $PLUGIN > $FILE
 	succeed_if "Could not run kdb export"
 
-	diff $DATADIR/again_two_value.$PLUGIN $FILE
+	diff "$DATADIR"/again_two_value.$PLUGIN $FILE
 	succeed_if "Export file again_two_value.$PLUGIN was not equal"
 
 
-	$KDB rm -r $ROOT
+	"$KDB" rm -r $ROOT
 	succeed_if "Could not remove root"
 
 

--- a/tests/shell/check_external.sh
+++ b/tests/shell/check_external.sh
@@ -18,7 +18,7 @@ fi
 
 check_version
 
-EXTERNAL_FOLDER=@CMAKE_SOURCE_DIR@/examples/external
+EXTERNAL_FOLDER="@CMAKE_SOURCE_DIR@/examples/external"
 
 set -x
 
@@ -27,11 +27,11 @@ do_tests()
 	SKEY=system/test/myapp/key
 	UKEY=user/test/myapp/key
 
-	$KDB rm "$SKEY"
-	$KDB rm "$UKEY"
+	"$KDB" rm "$SKEY"
+	"$KDB" rm "$UKEY"
 
 	VALUE="Hello World"
-	$KDB set "$SKEY"  "$VALUE"
+	"$KDB" set "$SKEY"  "$VALUE"
 	succeed_if "could not set key $SKEY"
 
 	./application
@@ -39,22 +39,22 @@ do_tests()
 	succeed_if "application did not output $VALUE"
 
 	VALUE="More world"
-	$KDB set "$UKEY"  "$VALUE"
+	"$KDB" set "$UKEY"  "$VALUE"
 	succeed_if "could not set key $SKEY"
 
 	./application
 	./application | grep "$VALUE"
 	succeed_if "application did not prefer $UKEY with $VALUE"
 
-	$KDB rm "$SKEY"
-	$KDB rm "$UKEY"
+	"$KDB" rm "$SKEY"
+	"$KDB" rm "$UKEY"
 }
 
 
 
 echo "Testing build with cmake"
 
-cd $EXTERNAL_FOLDER
+cd "$EXTERNAL_FOLDER"
 mkdir build
 cd build
 
@@ -74,7 +74,7 @@ rm -r build
 
 echo "Testing build with pkgconfig"
 
-cd $EXTERNAL_FOLDER/pkgconfig
+cd "$EXTERNAL_FOLDER/pkgconfig"
 make
 succeed_if "could not build pkgconfig project"
 

--- a/tests/shell/check_gen.sh
+++ b/tests/shell/check_gen.sh
@@ -48,22 +48,22 @@ LIFT_FILE=test_lift.ini
 LIFT_USERROOT=user/test/lift
 LIFT_SYSTEMROOT=system/test/lift
 LIFT_MOUNTPOINT=/test/lift
-$KDB mount $LIFT_FILE $LIFT_MOUNTPOINT ni 1>/dev/null
+"$KDB" mount $LIFT_FILE $LIFT_MOUNTPOINT ni 1>/dev/null
 succeed_if "could not mount: $LIFT_FILE at $LIFT_MOUNTPOINT"
 
 MATERIAL_LIFT_FILE=test_material_lift.ini
 MATERIAL_LIFT_MOUNTPOINT=/test/material_lift
-$KDB mount $MATERIAL_LIFT_FILE $MATERIAL_LIFT_MOUNTPOINT ni 1>/dev/null
+"$KDB" mount $MATERIAL_LIFT_FILE $MATERIAL_LIFT_MOUNTPOINT ni 1>/dev/null
 succeed_if "could not mount: $MATERIAL_LIFT_FILE at $MATERIAL_LIFT_MOUNTPOINT"
 
 PERSON_LIFT_FILE=test_person_lift.ini
 PERSON_LIFT_MOUNTPOINT=/test/person_lift
-$KDB mount $PERSON_LIFT_FILE $PERSON_LIFT_MOUNTPOINT ni 1>/dev/null
+"$KDB" mount $PERSON_LIFT_FILE $PERSON_LIFT_MOUNTPOINT ni 1>/dev/null
 succeed_if "could not mount: $PERSON_LIFT_FILE at $PERSON_LIFT_MOUNTPOINT"
 
 HEAVY_MATERIAL_LIFT_FILE=test_heavy_material_lift.ini
 HEAVY_MATERIAL_LIFT_MOUNTPOINT=/test/heavy_material_lift
-$KDB mount $HEAVY_MATERIAL_LIFT_FILE $HEAVY_MATERIAL_LIFT_MOUNTPOINT ni 1>/dev/null
+"$KDB" mount $HEAVY_MATERIAL_LIFT_FILE $HEAVY_MATERIAL_LIFT_MOUNTPOINT ni 1>/dev/null
 succeed_if "could not mount: $HEAVY_MATERIAL_LIFT_FILE at $HEAVY_MATERIAL_LIFT_MOUNTPOINT"
 
 
@@ -152,10 +152,10 @@ echo "Test with keys in KDB"
 SKEY=$LIFT_SYSTEMROOT/emergency/delay
 UKEY=$LIFT_USERROOT/emergency/delay
 VALUE=3
-$KDB set "$SKEY" "$VALUE" 1>/dev/null
+"$KDB" set "$SKEY" "$VALUE" 1>/dev/null
 succeed_if "could not set $SKEY to value $VALUE"
 
-[ "x`$KDB get $SKEY 2> /dev/null`" = "x$VALUE" ]
+[ "x`"$KDB" get $SKEY 2> /dev/null`" = "x$VALUE" ]
 succeed_if "cant get $SKEY"
 
 for TESTPROG in $TESTPROGS
@@ -178,17 +178,17 @@ done
 
 echo "test writeback to user using -w"
 
-$KDB get $UKEY 1> /dev/null
+"$KDB" get $UKEY 1> /dev/null
 [ $? != "0" ]
 succeed_if "got nonexisting key $UKEY"
 
 ./lift -d 4 -w | grep "delay: 4"
 succeed_if "delay commandline parameter with writeback not working"
 
-[ "x`$KDB get $UKEY 2> /dev/null`" = "x4" ]
+[ "x`"$KDB" get $UKEY 2> /dev/null`" = "x4" ]
 succeed_if "cant get $UKEY (writeback problem)"
 
-[ "x`$KDB get $SKEY 2> /dev/null`" = "x$VALUE" ]
+[ "x`"$KDB" get $SKEY 2> /dev/null`" = "x$VALUE" ]
 succeed_if "cant get $SKEY with $VALUE (writeback)"
 
 for TESTPROG in $TESTPROGS
@@ -197,10 +197,10 @@ do
 	succeed_if "writeback  in $TESTPROG was not permenent"
 done
 
-$KDB rm "$SKEY" 1>/dev/null
+"$KDB" rm "$SKEY" 1>/dev/null
 succeed_if "cannot rm $SKEY"
 
-$KDB rm "$UKEY" 1>/dev/null
+"$KDB" rm "$UKEY" 1>/dev/null
 succeed_if "cannot rm $UKEY"
 
 
@@ -219,11 +219,11 @@ echo "test override with limit"
 UKEY=$LIFT_USERROOT/limit
 OKEY=system/test/material_lift/limit
 VALUE=33
-$KDB get $UKEY 1> /dev/null
+"$KDB" get $UKEY 1> /dev/null
 [ $? != "0" ]
 succeed_if "got nonexisting key $UKEY"
 
-$KDB get $OKEY 1> /dev/null
+"$KDB" get $OKEY 1> /dev/null
 [ $? != "0" ]
 succeed_if "got nonexisting key $OKEY"
 
@@ -254,7 +254,7 @@ succeed_if "limit commandline validation was not detected"
 ./lift -l 22 -w | grep "limit: 22"
 succeed_if "limit commandline parameter with writeback not working"
 
-[ "x`$KDB get $UKEY 2> /dev/null`" = "x22" ]
+[ "x`"$KDB" get $UKEY 2> /dev/null`" = "x22" ]
 succeed_if "cant get $UKEY (writeback problem)"
 
 for TESTPROG in $TESTPROGS
@@ -272,7 +272,7 @@ succeed_if "limit commandline below limit not working (with param)"
 ./lift -l -1 | grep "limit: 22"
 succeed_if "limit commandline negativ not working (with param)"
 
-$KDB set "$OKEY" "$VALUE" 1>/dev/null
+"$KDB" set "$OKEY" "$VALUE" 1>/dev/null
 succeed_if "could not set $OKEY to value $VALUE"
 
 
@@ -285,7 +285,7 @@ done
 ./lift -l 22 -w | grep "limit: $VALUE"
 succeed_if "override was not in favour to commandline parameter"
 
-[ "x`$KDB get $UKEY 2> /dev/null`" = "x22" ]
+[ "x`"$KDB" get $UKEY 2> /dev/null`" = "x22" ]
 succeed_if "cant get $UKEY which will not be used"
 
 for TESTPROG in $TESTPROGS
@@ -294,10 +294,10 @@ do
 	succeed_if "override  in $TESTPROG was not in favour to writeback"
 done
 
-$KDB rm "$OKEY" 1>/dev/null
+"$KDB" rm "$OKEY" 1>/dev/null
 succeed_if "cannot rm $OKEY"
 
-$KDB rm "$UKEY" 1>/dev/null
+"$KDB" rm "$UKEY" 1>/dev/null
 succeed_if "cannot rm $UKEY"
 
 
@@ -317,14 +317,14 @@ KKEY=user/test/lift/floor/#3/height
 UKEY=user/test/lift/floor/height
 SKEY=system/test/lift/floor/height
 
-$KDB set "$SKEY" "$VALUE" 1>/dev/null
+"$KDB" set "$SKEY" "$VALUE" 1>/dev/null
 succeed_if "could not set $SKEY to value $VALUE"
 
 ./lift | grep "height #3: $VALUE"
 succeed_if "fallback of height $VALUE was not used"
 
 VALUE=9.5
-$KDB set "$UKEY" "$VALUE" 1>/dev/null
+"$KDB" set "$UKEY" "$VALUE" 1>/dev/null
 succeed_if "could not set $UKEY to value $VALUE"
 
 for TESTPROG in $TESTPROGS
@@ -339,12 +339,12 @@ succeed_if "commandline parameter did not overwrite fallback"
 ./lift -h 14.4 -w | grep "height #3: 14.4"
 succeed_if "commandline parameter did not overwrite fallback"
 
-[ "x`$KDB get $KKEY 2> /dev/null`" = "x14.4" ]
+[ "x`"$KDB" get $KKEY 2> /dev/null`" = "x14.4" ]
 succeed_if "cant get $KKEY which was written back"
 
 
 VALUE=18.8
-$KDB set "$KKEY" "$VALUE" 1>/dev/null
+"$KDB" set "$KKEY" "$VALUE" 1>/dev/null
 succeed_if "could not set $KKEY to value $VALUE"
 
 for TESTPROG in $TESTPROGS
@@ -353,13 +353,13 @@ do
 	succeed_if "fallback  in $TESTPROG of height $VALUE was not used"
 done
 
-$KDB rm "$KKEY" 1>/dev/null
+"$KDB" rm "$KKEY" 1>/dev/null
 succeed_if "cannot rm $KKEY"
 
-$KDB rm "$SKEY" 1>/dev/null
+"$KDB" rm "$SKEY" 1>/dev/null
 succeed_if "cannot rm $SKEY"
 
-$KDB rm "$UKEY" 1>/dev/null
+"$KDB" rm "$UKEY" 1>/dev/null
 succeed_if "cannot rm $UKEY"
 
 make clean
@@ -369,16 +369,16 @@ make clean
 
 
 
-$KDB umount $LIFT_MOUNTPOINT >/dev/null
+"$KDB" umount $LIFT_MOUNTPOINT >/dev/null
 succeed_if "could not umount $LIFT_MOUNTPOINT"
 
-$KDB umount $MATERIAL_LIFT_MOUNTPOINT >/dev/null
+"$KDB" umount $MATERIAL_LIFT_MOUNTPOINT >/dev/null
 succeed_if "could not umount $MATERIAL_LIFT_MOUNTPOINT"
 
-$KDB umount $PERSON_LIFT_MOUNTPOINT >/dev/null
+"$KDB" umount $PERSON_LIFT_MOUNTPOINT >/dev/null
 succeed_if "could not umount $PERSON_LIFT_MOUNTPOINT"
 
-$KDB umount $HEAVY_MATERIAL_LIFT_MOUNTPOINT >/dev/null
+"$KDB" umount $HEAVY_MATERIAL_LIFT_MOUNTPOINT >/dev/null
 succeed_if "could not umount $HEAVY_MATERIAL_LIFT_MOUNTPOINT"
 
 rm -f $USER_FOLDER/test_*lift.ini

--- a/tests/shell/check_get_set.sh
+++ b/tests/shell/check_get_set.sh
@@ -48,12 +48,12 @@ do
 
 	check_remaining_files $FILE
 
-	$KDB mount $FILE $MOUNTPOINT $MOUNT_PLUGIN 1>/dev/null
+	"$KDB" mount $FILE $MOUNTPOINT $MOUNT_PLUGIN 1>/dev/null
 	exit_if_fail "could not mount $FILE at $MOUNTPOINT using $MOUNT_PLUGIN"
 
 	cleanup()
 	{
-		$KDB umount $MOUNTPOINT >/dev/null
+		"$KDB" umount $MOUNTPOINT >/dev/null
 		succeed_if "could not umount $MOUNTPOINT"
 		rm -f $USER_FOLDER/$FILE
 		rm -f $SYSTEM_FOLDER/$FILE
@@ -70,51 +70,51 @@ do
 	for ROOT in $ROOTS
 	do
 		#echo "do preparation for $PLUGIN in $ROOT"
-		$KDB set $ROOT "root" 1>/dev/null
+		"$KDB" set $ROOT "root" 1>/dev/null
 		succeed_if "could not set root"
 
-		[ "x`$KDB sget $ROOT/value defvalue 2> /dev/null`" = "xdefvalue" ]
+		[ "x`"$KDB" sget $ROOT/value defvalue 2> /dev/null`" = "xdefvalue" ]
 		succeed_if "Did not get default value"
 
 		if [ "x$DO_NOT_TEST_ROOT_VALUE" != "xyes" ]
 		then
-			[ "x`$KDB get $ROOT 2> /dev/null`" = "xroot" ]
+			[ "x`"$KDB" get $ROOT 2> /dev/null`" = "xroot" ]
 			succeed_if "could not get root"
 
-			[ "x`$KDB sget $ROOT default 2> /dev/null`" = "xroot" ]
+			[ "x`"$KDB" sget $ROOT default 2> /dev/null`" = "xroot" ]
 			succeed_if "could not shell get root"
 		fi
 
-		$KDB set "$ROOT/value" "$VALUE" 1>/dev/null
+		"$KDB" set "$ROOT/value" "$VALUE" 1>/dev/null
 		succeed_if "could not set value"
 
-		[ "x`$KDB get $ROOT/value 2> /dev/null`" = "x$VALUE" ]
+		[ "x`"$KDB" get $ROOT/value 2> /dev/null`" = "x$VALUE" ]
 		succeed_if "cant get $ROOT/value"
 
-		[ "x`$KDB sget $ROOT/value default 2> /dev/null`" = "x$VALUE" ]
+		[ "x`"$KDB" sget $ROOT/value default 2> /dev/null`" = "x$VALUE" ]
 		succeed_if "cant shell get $ROOT/value"
 
 		echo "testing ls command"
 
-		[ "x`$KDB ls $ROOT/value 2> /dev/null`" = "x$ROOT/value" ]
+		[ "x`"$KDB" ls $ROOT/value 2> /dev/null`" = "x$ROOT/value" ]
 		succeed_if "cant ls $ROOT (may mean that $ROOT folder is not clean)"
 
 		echo "testing rm command"
 
-		$KDB rm $ROOT/value 1> /dev/null
+		"$KDB" rm $ROOT/value 1> /dev/null
 		succeed_if "could not remove user/test/value"
 
-		$KDB get $ROOT/value 1> /dev/null
+		"$KDB" get $ROOT/value 1> /dev/null
 		[ $? != "0" ]
 		succeed_if "got removed key $ROOT/value"
 
-		$KDB rm $ROOT 1>/dev/null
+		"$KDB" rm $ROOT 1>/dev/null
 		succeed_if "could not remove user/test/value"
 
-		[ "x`$KDB sget $ROOT/value value 2> /dev/null`" = "xvalue" ]
+		[ "x`"$KDB" sget $ROOT/value value 2> /dev/null`" = "xvalue" ]
 		succeed_if "Did not get default value after remove"
 
-		$KDB get $ROOT/value 1>/dev/null
+		"$KDB" get $ROOT/value 1>/dev/null
 		[ $? != "0" ]
 		succeed_if "got removed key $ROOT"
 
@@ -123,10 +123,10 @@ do
 		echo "testing array"
 
 		KEY=$ROOT/hello/a/key
-		$KDB set "$KEY" "$VALUE" 1>/dev/null
+		"$KDB" set "$KEY" "$VALUE" 1>/dev/null
 		succeed_if "could not set key $KEY"
 
-		[ "x`$KDB get $KEY`" = "x$VALUE" ]
+		[ "x`"$KDB" get $KEY`" = "x$VALUE" ]
 		succeed_if "$KEY is not $VALUE"
 
 		for i in `seq 0 9`
@@ -134,20 +134,20 @@ do
 			KEY="$ROOT/hello/a/array/#$i"
 			VALUE="$i"
 
-			$KDB set "$KEY" "$VALUE" 1>/dev/null
+			"$KDB" set "$KEY" "$VALUE" 1>/dev/null
 			succeed_if "could not set key $ROOT/hello/a/array/#0"
 
 			if [ "$i" -eq 0 ] && [ "x$PLUGIN" = "xini" ]
 			then
-				[ "x`$KDB get $ROOT/hello/a/array`" = "x$VALUE" ]
+				[ "x`"$KDB" get $ROOT/hello/a/array`" = "x$VALUE" ]
 				succeed_if "$KEY is not $VALUE"
 			else
-				[ "x`$KDB get $KEY`" = "x$VALUE" ]
+				[ "x`"$KDB" get $KEY`" = "x$VALUE" ]
 				succeed_if "$KEY is not $VALUE"
 			fi
 		done
 
-		$KDB rm -r "$ROOT"
+		"$KDB" rm -r "$ROOT"
 		succeed_if "could not remove all keys"
 
 		test ! -f $USER_FOLDER/$FILE

--- a/tests/shell/check_get_set.sh
+++ b/tests/shell/check_get_set.sh
@@ -137,7 +137,7 @@ do
 			$KDB set "$KEY" "$VALUE" 1>/dev/null
 			succeed_if "could not set key $ROOT/hello/a/array/#0"
 
-			if [ "$i" -eq 0 ] && [ "x$PLUGIN" = "xini" ] 
+			if [ "$i" -eq 0 ] && [ "x$PLUGIN" = "xini" ]
 			then
 				[ "x`$KDB get $ROOT/hello/a/array`" = "x$VALUE" ]
 				succeed_if "$KEY is not $VALUE"

--- a/tests/shell/check_import.sh
+++ b/tests/shell/check_import.sh
@@ -37,64 +37,64 @@ do
 
 	if [ "x$PLUGIN" != "xyajl" ]
 	then
-		$KDB set $ROOT "root" >/dev/null
+		"$KDB" set $ROOT "root" >/dev/null
 	else
-		$KDB set $ROOT "" > /dev/null
+		"$KDB" set $ROOT "" > /dev/null
 	fi
 
 	exit_if_fail "could not set root"
 
-	test "x`$KDB ls $ROOT`" = "x$ROOT"
+	test "x`"$KDB" ls $ROOT`" = "x$ROOT"
 	succeed_if "Root key not found"
 
-	$KDB import $ROOT $PLUGIN < $DATADIR/one_value.$PLUGIN
+	"$KDB" import $ROOT $PLUGIN < "$DATADIR"/one_value.$PLUGIN
 	succeed_if "Could not run kdb import"
 
-	test "x`$KDB ls $ROOT`" = "xuser/tests/script"
+	test "x`"$KDB" ls $ROOT`" = "xuser/tests/script"
 	succeed_if "key name not correct one_value"
 
 	if [ "x$PLUGIN" != "xyajl" ]
 	then
 		#TODO: yajl currently cannot hold values within
 		#directories, do not hardcode that
-		test "`$KDB get $ROOT`" = root
+		test "`"$KDB" get $ROOT`" = root
 		succeed_if "root value not correct"
 	fi
 
-	$KDB export $ROOT $PLUGIN > $FILE
+	"$KDB" export $ROOT $PLUGIN > $FILE
 	succeed_if "Could not run kdb export"
 
-	diff $DATADIR/one_value.$PLUGIN $FILE
+	diff "$DATADIR"/one_value.$PLUGIN $FILE
 	succeed_if "Export file one_value.$PLUGIN was not equal"
 
-	$KDB rm -r "$ROOT"
+	"$KDB" rm -r "$ROOT"
 	succeed_if "Could not remove root"
 
 
 
 	echo "Import with empty root"
 
-	$KDB import $ROOT $PLUGIN < $DATADIR/one_value.$PLUGIN
+	"$KDB" import $ROOT $PLUGIN < "$DATADIR"/one_value.$PLUGIN
 	succeed_if "Could not run kdb import"
 
-	test "x`$KDB ls $ROOT`" = "xuser/tests/script"
+	test "x`"$KDB" ls $ROOT`" = "xuser/tests/script"
 	succeed_if "key name not correct one_value empty root"
 
 	if [ "x$PLUGIN" != "xyajl" ]
 	then
 		#TODO: yajl currently cannot hold values within
 		#directories, do not hardcode that
-		test "`$KDB get $ROOT`" = root
+		test "`"$KDB" get $ROOT`" = root
 		succeed_if "root value not correct"
 	fi
 
-	$KDB export $ROOT $PLUGIN > $FILE
+	"$KDB" export $ROOT $PLUGIN > $FILE
 	succeed_if "Could not run kdb export"
 
-	diff $DATADIR/one_value.$PLUGIN $FILE
+	diff "$DATADIR"/one_value.$PLUGIN $FILE
 	succeed_if "Export file one_value.$PLUGIN was not equal"
 
-	$KDB rm -r $ROOT
+	"$KDB" rm -r $ROOT
 	succeed_if "Could not remove root"
 
 
@@ -103,27 +103,27 @@ do
 
 	echo "Import as stream (using cat)"
 
-	cat $DATADIR/one_value.$PLUGIN | $KDB import $ROOT $PLUGIN
+	cat "$DATADIR"/one_value.$PLUGIN | "$KDB" import $ROOT $PLUGIN
 	succeed_if "Could not run kdb import"
 
-	test "x`$KDB ls $ROOT`" = "xuser/tests/script"
+	test "x`"$KDB" ls $ROOT`" = "xuser/tests/script"
 	succeed_if "key name not correct one_value empty root"
 
 	if [ "x$PLUGIN" != "xyajl" ]
 	then
 		#TODO: yajl currently cannot hold values within
 		#directories, do not hardcode that
-		test "`$KDB get $ROOT`" = root
+		test "`"$KDB" get $ROOT`" = root
 		succeed_if "root value not correct"
 	fi
 
-	$KDB export $ROOT $PLUGIN > $FILE
+	"$KDB" export $ROOT $PLUGIN > $FILE
 	succeed_if "Could not run kdb export"
 
-	diff $DATADIR/one_value.$PLUGIN $FILE
+	diff "$DATADIR"/one_value.$PLUGIN $FILE
 	succeed_if "Export file one_value.$PLUGIN was not equal"
 
-	$KDB rm -r $ROOT
+	"$KDB" rm -r $ROOT
 	succeed_if "Could not remove root"
 
 
@@ -131,44 +131,44 @@ do
 
 	echo "Import with wrong root (overwrite)"
 
-	$KDB set $SIDE val
+	"$KDB" set $SIDE val
 	succeed_if "Could not set $SIDE"
 
-	$KDB set $ROOT "wrong_root" >/dev/null
+	"$KDB" set $ROOT "wrong_root" >/dev/null
 	exit_if_fail "could not set wrong_root"
 
-	$KDB import -s "import" $ROOT $PLUGIN < $DATADIR/one_value.$PLUGIN
+	"$KDB" import -s "import" $ROOT $PLUGIN < "$DATADIR"/one_value.$PLUGIN
 	succeed_if "Could not run kdb import"
 
-	test "x`$KDB ls $ROOT`" = "xuser/tests/script"
+	test "x`"$KDB" ls $ROOT`" = "xuser/tests/script"
 	succeed_if "key name not correct"
 
 	if [ "x$PLUGIN" != "xyajl" ]
 	then
 		#TODO: yajl currently cannot hold values within
 		#directories, do not hardcode that
-		test "`$KDB get $ROOT`" = root
+		test "`"$KDB" get $ROOT`" = root
 		succeed_if "root value not correct"
 	fi
 
-	$KDB export $ROOT $PLUGIN > $FILE
+	"$KDB" export $ROOT $PLUGIN > $FILE
 	succeed_if "Could not run kdb export"
 
-	diff $DATADIR/one_value.$PLUGIN $FILE
+	diff "$DATADIR"/one_value.$PLUGIN $FILE
 	succeed_if "Export file one_value.$PLUGIN was not equal"
 
-	$KDB rm -r $ROOT
+	"$KDB" rm -r $ROOT
 	succeed_if "Could not remove root"
 
 	if [ "x$PLUGIN" != "xyajl" ]
 	then
 		#TODO: yajl currently cannot hold values within
 		#directories, do not hardcode that
-		test "`$KDB get $SIDE`" = val
+		test "`"$KDB" get $SIDE`" = val
 		succeed_if "root value not correct"
 	fi
 
-	$KDB rm $SIDE
+	"$KDB" rm $SIDE
 	succeed_if "Could not remove $SIDE"
 
 
@@ -177,10 +177,10 @@ do
 
 	echo "Import two values"
 
-	$KDB import $ROOT $PLUGIN < $DATADIR/two_value.$PLUGIN
+	"$KDB" import $ROOT $PLUGIN < "$DATADIR"/two_value.$PLUGIN
 	succeed_if "Could not run kdb import"
 
-	test "x`$KDB ls $ROOT`" = "xuser/tests/script
+	test "x`"$KDB" ls $ROOT`" = "xuser/tests/script
 user/tests/script/key"
 	succeed_if "key name not correct"
 
@@ -188,50 +188,50 @@ user/tests/script/key"
 	then
 		#TODO: yajl currently cannot hold values within
 		#directories, do not hardcode that
-		test "`$KDB get $ROOT`" = root
+		test "`"$KDB" get $ROOT`" = root
 		succeed_if "root value not correct"
 	fi
 
-	test "x`$KDB get $ROOT/key`" = "xvalue"
+	test "x`"$KDB" get $ROOT/key`" = "xvalue"
 	succeed_if "key value not correct"
 
-	$KDB export $ROOT $PLUGIN > $FILE
+	"$KDB" export $ROOT $PLUGIN > $FILE
 	succeed_if "Could not run kdb export"
 
-	diff $DATADIR/two_value.$PLUGIN $FILE
+	diff "$DATADIR"/two_value.$PLUGIN $FILE
 	succeed_if "Export file two_value.$PLUGIN was not equal"
 
 
 
 	echo "Import one value (cut two values from previous test case)"
 
-	$KDB set $SIDE val
+	"$KDB" set $SIDE val
 	succeed_if "Could not set $SIDE"
 
-	$KDB import -s "cut" $ROOT $PLUGIN < $DATADIR/one_value.$PLUGIN
+	"$KDB" import -s "cut" $ROOT $PLUGIN < "$DATADIR"/one_value.$PLUGIN
 	succeed_if "Could not run kdb import"
 
-	test "x`$KDB ls $ROOT`" = "xuser/tests/script"
+	test "x`"$KDB" ls $ROOT`" = "xuser/tests/script"
 	succeed_if "key name not correct"
 
 	if [ "x$PLUGIN" != "xyajl" ]
 	then
 		#TODO: yajl currently cannot hold values within
 		#directories, do not hardcode that
-		test "`$KDB get $ROOT`" = root
+		test "`"$KDB" get $ROOT`" = root
 		succeed_if "root value not correct"
 	fi
 
-	$KDB export $ROOT $PLUGIN > $FILE
+	"$KDB" export $ROOT $PLUGIN > $FILE
 	succeed_if "Could not run kdb export"
 
-	diff $DATADIR/one_value.$PLUGIN $FILE
+	diff "$DATADIR"/one_value.$PLUGIN $FILE
 	succeed_if "Export file one_value.$PLUGIN was not equal"
 
-	test "x`$KDB get $SIDE`" = "xval"
+	test "x`"$KDB" get $SIDE`" = "xval"
 	succeed_if "side value not correct"
 
-	$KDB rm $SIDE
+	"$KDB" rm $SIDE
 	succeed_if "Could not remove $SIDE"
 
 
@@ -240,48 +240,48 @@ user/tests/script/key"
 
 	echo "Import one value (cut previous value)"
 
-	$KDB set $ROOT wrong_root
+	"$KDB" set $ROOT wrong_root
 	succeed_if "Could not set $ROOT"
 
-	$KDB set $ROOT/val wrong_val
+	"$KDB" set $ROOT/val wrong_val
 	succeed_if "Could not set $ROOT/val"
 
-	$KDB set $SIDE val
+	"$KDB" set $SIDE val
 	succeed_if "Could not set $SIDE"
 
-	$KDB import -s "cut" $ROOT $PLUGIN < $DATADIR/one_value.$PLUGIN
+	"$KDB" import -s "cut" $ROOT $PLUGIN < "$DATADIR"/one_value.$PLUGIN
 	succeed_if "Could not run kdb import"
 
-	test "x`$KDB ls $ROOT`" = "xuser/tests/script"
+	test "x`"$KDB" ls $ROOT`" = "xuser/tests/script"
 	succeed_if "key name not correct"
 
 	if [ "x$PLUGIN" != "xyajl" ]
 	then
 		#TODO: yajl currently cannot hold values within
 		#directories, do not hardcode that
-		test "`$KDB get $ROOT`" = root
+		test "`"$KDB" get $ROOT`" = root
 		succeed_if "root value not correct"
 	fi
 
-	$KDB export $ROOT $PLUGIN > $FILE
+	"$KDB" export $ROOT $PLUGIN > $FILE
 	succeed_if "Could not run kdb export"
 
-	diff $DATADIR/one_value.$PLUGIN $FILE
+	diff "$DATADIR"/one_value.$PLUGIN $FILE
 	succeed_if "Export file one_value.$PLUGIN was not equal"
 
 	if [ "x$PLUGIN" != "xyajl" ]
 	then
 		#TODO: yajl currently cannot hold values within
 		#directories, do not hardcode that
-		test "`$KDB get $SIDE`" = val
+		test "`"$KDB" get $SIDE`" = val
 		succeed_if "root value not correct"
 	fi
 
-	$KDB rm $SIDE
+	"$KDB" rm $SIDE
 	succeed_if "Could not remove $SIDE"
 
 
-	$KDB rm -r $ROOT
+	"$KDB" rm -r $ROOT
 	succeed_if "Could not remove $ROOT"
 
 

--- a/tests/shell/check_import.sh
+++ b/tests/shell/check_import.sh
@@ -49,7 +49,7 @@ do
 
 	$KDB import $ROOT $PLUGIN < $DATADIR/one_value.$PLUGIN
 	succeed_if "Could not run kdb import"
-		
+
 	test "x`$KDB ls $ROOT`" = "xuser/tests/script"
 	succeed_if "key name not correct one_value"
 
@@ -283,7 +283,7 @@ user/tests/script/key"
 
 	$KDB rm -r $ROOT
 	succeed_if "Could not remove $ROOT"
-		
+
 
 done
 

--- a/tests/shell/check_kdb_internal_check.sh
+++ b/tests/shell/check_kdb_internal_check.sh
@@ -30,7 +30,7 @@ do
 	esac
 
 	> $FILE
-	$KDB check $PLUGIN 1> $FILE 2> $FILE
+	"$KDB" check $PLUGIN 1> $FILE 2> $FILE
 	succeed_if "check of plugin $PLUGIN failed"
 
 	test ! -s $FILE

--- a/tests/shell/check_kdb_internal_suite.sh
+++ b/tests/shell/check_kdb_internal_suite.sh
@@ -52,12 +52,12 @@ do
 
 	check_remaining_files $FILE
 
-	$KDB mount $FILE $MOUNTPOINT $MOUNT_PLUGIN 1>/dev/null
+	"$KDB" mount $FILE $MOUNTPOINT $MOUNT_PLUGIN 1>/dev/null
 	exit_if_fail "could not mount $FILE at $MOUNTPOINT using $MOUNT_PLUGIN"
 
 	cleanup()
 	{
-		$KDB umount $MOUNTPOINT >/dev/null
+		"$KDB" umount $MOUNTPOINT >/dev/null
 		succeed_if "could not umount $MOUNTPOINT"
 		rm -f $USER_FOLDER/$FILE
 		rm -f $SYSTEM_FOLDER/$FILE
@@ -76,7 +76,7 @@ do
 	echo "Running tests for $PLUGIN"
 	for ROOT in $USER_ROOT $SYSTEM_ROOT
 	do
-		$KDB test "$ROOT" $TESTS
+		"$KDB" test "$ROOT" $TESTS
 		succeed_if "could not run test suite"
 	done
 

--- a/tests/shell/check_merge.sh
+++ b/tests/shell/check_merge.sh
@@ -14,115 +14,115 @@ MERGED_ROOT=$USER_ROOT/mergetest/merged
 
 echo "Testing trivial merging"
 
-$KDB set $OURS_ROOT/key "init" >/dev/null
+"$KDB" set $OURS_ROOT/key "init" >/dev/null
 exit_if_fail "could not set"
 
-$KDB set $THEIRS_ROOT/key "init" >/dev/null
+"$KDB" set $THEIRS_ROOT/key "init" >/dev/null
 exit_if_fail "could not set"
 
-$KDB set $BASE_ROOT/key "init" >/dev/null
+"$KDB" set $BASE_ROOT/key "init" >/dev/null
 exit_if_fail "could not set"
 
-$KDB ls $MERGED_ROOT
+"$KDB" ls $MERGED_ROOT
 
-$KDB merge $OURS_ROOT $THEIRS_ROOT $BASE_ROOT $MERGED_ROOT
+"$KDB" merge $OURS_ROOT $THEIRS_ROOT $BASE_ROOT $MERGED_ROOT
 exit_if_fail "could not merge"
 
-[ "x`$KDB ls $MERGED_ROOT/key 2> /dev/null`" = "x$MERGED_ROOT/key" ]
+[ "x`"$KDB" ls $MERGED_ROOT/key 2> /dev/null`" = "x$MERGED_ROOT/key" ]
 exit_if_fail "not exactly one result"
 
-[ "x`$KDB get $MERGED_ROOT/key 2> /dev/null`" = "xinit" ]
+[ "x`"$KDB" get $MERGED_ROOT/key 2> /dev/null`" = "xinit" ]
 
-$KDB rm -r $USER_ROOT/mergetest
+"$KDB" rm -r $USER_ROOT/mergetest
 
 
 
 echo "Testing conflict"
 
-$KDB set $OURS_ROOT/key "ours" >/dev/null
+"$KDB" set $OURS_ROOT/key "ours" >/dev/null
 exit_if_fail "could not set"
 
-$KDB set $THEIRS_ROOT/key "theirs" >/dev/null
+"$KDB" set $THEIRS_ROOT/key "theirs" >/dev/null
 exit_if_fail "could not set"
 
-$KDB set $BASE_ROOT/key "init" >/dev/null
+"$KDB" set $BASE_ROOT/key "init" >/dev/null
 exit_if_fail "could not set"
 
-$KDB merge $OURS_ROOT $THEIRS_ROOT $BASE_ROOT $MERGED_ROOT 2> /dev/null
+"$KDB" merge $OURS_ROOT $THEIRS_ROOT $BASE_ROOT $MERGED_ROOT 2> /dev/null
 [ $? != 0 ]
 succeed_if "Merging did not fail"
 
-[ "x`$KDB ls $MERGED_ROOT/key 2> /dev/null`" = "x" ]
+[ "x`"$KDB" ls $MERGED_ROOT/key 2> /dev/null`" = "x" ]
 exit_if_fail "should be no result"
 
-$KDB merge --strategy ours $OURS_ROOT $THEIRS_ROOT $BASE_ROOT $MERGED_ROOT
+"$KDB" merge --strategy ours $OURS_ROOT $THEIRS_ROOT $BASE_ROOT $MERGED_ROOT
 exit_if_fail "could not merge"
 
-[ "x`$KDB ls $MERGED_ROOT/key 2> /dev/null`" = "x$MERGED_ROOT/key" ]
+[ "x`"$KDB" ls $MERGED_ROOT/key 2> /dev/null`" = "x$MERGED_ROOT/key" ]
 exit_if_fail "not exactly one result"
 
-[ "x`$KDB get $MERGED_ROOT/key 2> /dev/null`" = "xours" ]
+[ "x`"$KDB" get $MERGED_ROOT/key 2> /dev/null`" = "xours" ]
 exit_if_fail "merge produced wrong result"
 
-$KDB rm -r $MERGED_ROOT/key
-$KDB rm -r $OURS_ROOT/key
-$KDB rm -r $THEIRS_ROOT/key
-$KDB rm -r $BASE_ROOT/key
+"$KDB" rm -r $MERGED_ROOT/key
+"$KDB" rm -r $OURS_ROOT/key
+"$KDB" rm -r $THEIRS_ROOT/key
+"$KDB" rm -r $BASE_ROOT/key
 
 echo "Testing binary data handling"
 
-$KDB set $OURS_ROOT/nullbinary  >/dev/null
+"$KDB" set $OURS_ROOT/nullbinary  >/dev/null
 exit_if_fail "could not set"
 
-$KDB getmeta $OURS_ROOT/nullbinary "binary" >/dev/null
+"$KDB" getmeta $OURS_ROOT/nullbinary "binary" >/dev/null
 exit_if_fail "created key is not binary"
 
-$KDB merge $OURS_ROOT $THEIRS_ROOT $BASE_ROOT $MERGED_ROOT
+"$KDB" merge $OURS_ROOT $THEIRS_ROOT $BASE_ROOT $MERGED_ROOT
 exit_if_fail "could not merge"
 
-[ "x`$KDB ls $MERGED_ROOT/nullbinary 2> /dev/null`" = "x$MERGED_ROOT/nullbinary" ]
+[ "x`"$KDB" ls $MERGED_ROOT/nullbinary 2> /dev/null`" = "x$MERGED_ROOT/nullbinary" ]
 exit_if_fail "not exactly one result"
 
-$KDB getmeta $MERGED_ROOT/nullbinary "binary" >/dev/null
+"$KDB" getmeta $MERGED_ROOT/nullbinary "binary" >/dev/null
 exit_if_fail "merged key is not binary"
 
-$KDB rm -r $USER_ROOT/mergetest
+"$KDB" rm -r $USER_ROOT/mergetest
 
 echo "Testing metadata"
 
-$KDB set $OURS_ROOT/key "init" >/dev/null
+"$KDB" set $OURS_ROOT/key "init" >/dev/null
 exit_if_fail "could not set"
 
-$KDB setmeta $OURS_ROOT/key comment "init" >/dev/null
+"$KDB" setmeta $OURS_ROOT/key comment "init" >/dev/null
 exit_if_fail "could not set meta"
 
-$KDB set $THEIRS_ROOT/key "init" >/dev/null
+"$KDB" set $THEIRS_ROOT/key "init" >/dev/null
 exit_if_fail "could not set"
 
-$KDB setmeta $THEIRS_ROOT/key comment "theirs" >/dev/null
+"$KDB" setmeta $THEIRS_ROOT/key comment "theirs" >/dev/null
 exit_if_fail "could not set meta"
 
-$KDB set $BASE_ROOT/key "init" >/dev/null
+"$KDB" set $BASE_ROOT/key "init" >/dev/null
 exit_if_fail "could not set"
 
-$KDB setmeta $BASE_ROOT/key comment "base" >/dev/null
+"$KDB" setmeta $BASE_ROOT/key comment "base" >/dev/null
 exit_if_fail "could not set meta"
 
-$KDB merge $OURS_ROOT $THEIRS_ROOT $BASE_ROOT $MERGED_ROOT 2> /dev/null
+"$KDB" merge $OURS_ROOT $THEIRS_ROOT $BASE_ROOT $MERGED_ROOT 2> /dev/null
 [ $? != 0 ]
 succeed_if "Merging did not failed"
 
-[ "x`$KDB ls $MERGED_ROOT/key 2> /dev/null`" = "x" ]
+[ "x`"$KDB" ls $MERGED_ROOT/key 2> /dev/null`" = "x" ]
 exit_if_fail "should be no result"
 
-$KDB merge --strategy ours $OURS_ROOT $THEIRS_ROOT $BASE_ROOT $MERGED_ROOT
+"$KDB" merge --strategy ours $OURS_ROOT $THEIRS_ROOT $BASE_ROOT $MERGED_ROOT
 exit_if_fail "could not merge"
 
-[ "x`$KDB ls $MERGED_ROOT/key 2> /dev/null`" = "x$MERGED_ROOT/key" ]
+[ "x`"$KDB" ls $MERGED_ROOT/key 2> /dev/null`" = "x$MERGED_ROOT/key" ]
 exit_if_fail "not exactly one result"
 
-[ "x`$KDB get $MERGED_ROOT/key 2> /dev/null`" = "xinit" ]
+[ "x`"$KDB" get $MERGED_ROOT/key 2> /dev/null`" = "xinit" ]
 
-$KDB rm -r $USER_ROOT/mergetest
+"$KDB" rm -r $USER_ROOT/mergetest
 
 end_script

--- a/tests/shell/check_mount.sh
+++ b/tests/shell/check_mount.sh
@@ -16,10 +16,10 @@ ROOT_MOUNTPOINT2N=\\/test\\/script\\/remount
 
 if is_plugin_available dump
 then
-	$KDB mount $ROOT_FILE $ROOT_MOUNTPOINT dump 1>/dev/null
+	"$KDB" mount $ROOT_FILE $ROOT_MOUNTPOINT dump 1>/dev/null
 	succeed_if "could not mount root: $ROOT_FILE at $ROOT_MOUNTPOINT"
 
-	$KDB umount $ROOT_MOUNTPOINT
+	"$KDB" umount $ROOT_MOUNTPOINT
 	succeed_if "could not unmount previously mounted mountpoint"
 fi
 
@@ -27,11 +27,11 @@ if is_plugin_available tracer
 then
 	if is_plugin_available sync
 	then
-		$KDB mount $ROOT_FILE $ROOT_MOUNTPOINT tracer sync 1>/dev/null 2>/dev/null
+		"$KDB" mount $ROOT_FILE $ROOT_MOUNTPOINT tracer sync 1>/dev/null 2>/dev/null
 		[ $? != 0 ]
 		succeed_if "could mount the backend, even though tracer+sync conflict"
 
-		$KDB umount $ROOT_MOUNTPOINT
+		"$KDB" umount $ROOT_MOUNTPOINT
 		[ $? != 0 ]
 		succeed_if "could unmount what should not be mounted"
 	fi
@@ -43,68 +43,68 @@ if is_plugin_available hosts
 then
 	if is_plugin_available glob
 	then
-		$KDB mount $ROOT_FILE $ROOT_MOUNTPOINT glob hosts 1>/dev/null
+		"$KDB" mount $ROOT_FILE $ROOT_MOUNTPOINT glob hosts 1>/dev/null
 		succeed_if "could not mount glob and hosts plugin together"
 
-		$KDB mount $ROOT_FILE $ROOT_MOUNTPOINT glob hosts 1>/dev/null 2>/dev/null
+		"$KDB" mount $ROOT_FILE $ROOT_MOUNTPOINT glob hosts 1>/dev/null 2>/dev/null
 		[ $? != 0 ]
 		succeed_if "could remount the same backend"
 
-		$KDB mount $ROOT_FILE dir$ROOT_MOUNTPOINT glob hosts 1>/dev/null 2>/dev/null
+		"$KDB" mount $ROOT_FILE dir$ROOT_MOUNTPOINT glob hosts 1>/dev/null 2>/dev/null
 		[ $? != 0 ]
 		succeed_if "could remount the dir backend, even though cascading already mounted"
 
-		$KDB mount $ROOT_FILE user$ROOT_MOUNTPOINT glob hosts 1>/dev/null 2>/dev/null
+		"$KDB" mount $ROOT_FILE user$ROOT_MOUNTPOINT glob hosts 1>/dev/null 2>/dev/null
 		[ $? != 0 ]
 		succeed_if "could remount the user backend, even though cascading already mounted"
 
-		$KDB mount $ROOT_FILE system$ROOT_MOUNTPOINT glob hosts 1>/dev/null 2>/dev/null
+		"$KDB" mount $ROOT_FILE system$ROOT_MOUNTPOINT glob hosts 1>/dev/null 2>/dev/null
 		[ $? != 0 ]
 		succeed_if "could remount the system backend, even though cascading already mounted"
 
-		$KDB umount $ROOT_MOUNTPOINT
+		"$KDB" umount $ROOT_MOUNTPOINT
 		succeed_if "could not unmount previously mounted mountpoint"
 
 		echo "Test simple mount configuration"
 
-		$KDB mount -c "test1=testvalue1" $ROOT_FILE $ROOT_MOUNTPOINT glob "test1=testvalue1" hosts 1>/dev/null
+		"$KDB" mount -c "test1=testvalue1" $ROOT_FILE $ROOT_MOUNTPOINT glob "test1=testvalue1" hosts 1>/dev/null
 		succeed_if "could not mount glob and hosts plugin together"
 
-		#$KDB ls "system/elektra/mountpoints/$ROOT_MOUNTPOINTN"
+		#"$KDB" ls "system/elektra/mountpoints/$ROOT_MOUNTPOINTN"
 
 		# TODO: check correcly + reenable
-		configvalue=$($KDB get "system/elektra/mountpoints/$ROOT_MOUNTPOINTN/config/test1")
+		configvalue=$("$KDB" get "system/elektra/mountpoints/$ROOT_MOUNTPOINTN/config/test1")
 		test "$configvalue" = "testvalue1"
 		succeed_if "config key was not set correctly"
 
-		$KDB umount $ROOT_MOUNTPOINT
+		"$KDB" umount $ROOT_MOUNTPOINT
 		succeed_if "could not unmount previously mounted mountpoint"
 
 		echo "Test multiple mount configurations"
 
-		$KDB mount -c "test1=testvalue1,test2=test value2" $ROOT_FILE $ROOT_MOUNTPOINT glob "test1=testvalue1" hosts "test2=test value2" 1>/dev/null
+		"$KDB" mount -c "test1=testvalue1,test2=test value2" $ROOT_FILE $ROOT_MOUNTPOINT glob "test1=testvalue1" hosts "test2=test value2" 1>/dev/null
 		succeed_if "could not mount glob and hosts plugin together"
 
 		# TODO: reenable
-		configvalue=$($KDB get "system/elektra/mountpoints/$ROOT_MOUNTPOINTN/config/test2")
+		configvalue=$("$KDB" get "system/elektra/mountpoints/$ROOT_MOUNTPOINTN/config/test2")
 		test "$configvalue" = "test value2"
 		succeed_if "config key was not set correctly"
 
 		echo "Test remounting the existing mount"
 
-		$KDB remount "testfile" $ROOT_MOUNTPOINT2 $ROOT_MOUNTPOINT
+		"$KDB" remount "testfile" $ROOT_MOUNTPOINT2 $ROOT_MOUNTPOINT
 		succeed_if "could not remount previous mountpoint"
 
 		#$KDB ls "system/elektra/mountpoints"
 		#$KDB mount
 
-		$KDB umount $ROOT_MOUNTPOINT
+		"$KDB" umount $ROOT_MOUNTPOINT
 		succeed_if "could not unmount previously mounted mountpoint"
 
-		$KDB ls "system/elektra/mountpoints/$ROOT_MOUNTPOINT2N/" | grep glob 1> /dev/null
+		"$KDB" ls "system/elektra/mountpoints/$ROOT_MOUNTPOINT2N/" | grep glob 1> /dev/null
 		succeed_if "glob plugin does not exist in the remounted mountpoint"
 
-		$KDB ls "system/elektra/mountpoints/$ROOT_MOUNTPOINT2N/" | grep hosts 1> /dev/null
+		"$KDB" ls "system/elektra/mountpoints/$ROOT_MOUNTPOINT2N/" | grep hosts 1> /dev/null
 		succeed_if "hosts plugin does not exist in the remounted mountpoint"
 
 		# TODO: reenable
@@ -118,7 +118,7 @@ then
 
 		echo "Testing unmount via path"
 
-		$KDB umount $ROOT_MOUNTPOINT2
+		"$KDB" umount $ROOT_MOUNTPOINT2
 		succeed_if "unable to unmount $ROOT_MOUNTPOINT2"
 
 	fi

--- a/tests/shell/check_mount.sh
+++ b/tests/shell/check_mount.sh
@@ -18,7 +18,7 @@ if is_plugin_available dump
 then
 	$KDB mount $ROOT_FILE $ROOT_MOUNTPOINT dump 1>/dev/null
 	succeed_if "could not mount root: $ROOT_FILE at $ROOT_MOUNTPOINT"
-	
+
 	$KDB umount $ROOT_MOUNTPOINT
 	succeed_if "could not unmount previously mounted mountpoint"
 fi
@@ -66,7 +66,7 @@ then
 		succeed_if "could not unmount previously mounted mountpoint"
 
 		echo "Test simple mount configuration"
-		
+
 		$KDB mount -c "test1=testvalue1" $ROOT_FILE $ROOT_MOUNTPOINT glob "test1=testvalue1" hosts 1>/dev/null
 		succeed_if "could not mount glob and hosts plugin together"
 
@@ -76,24 +76,24 @@ then
 		configvalue=$($KDB get "system/elektra/mountpoints/$ROOT_MOUNTPOINTN/config/test1")
 		test "$configvalue" = "testvalue1"
 		succeed_if "config key was not set correctly"
-		
+
 		$KDB umount $ROOT_MOUNTPOINT
 		succeed_if "could not unmount previously mounted mountpoint"
-		
+
 		echo "Test multiple mount configurations"
-		
+
 		$KDB mount -c "test1=testvalue1,test2=test value2" $ROOT_FILE $ROOT_MOUNTPOINT glob "test1=testvalue1" hosts "test2=test value2" 1>/dev/null
 		succeed_if "could not mount glob and hosts plugin together"
-		
+
 		# TODO: reenable
 		configvalue=$($KDB get "system/elektra/mountpoints/$ROOT_MOUNTPOINTN/config/test2")
-		test "$configvalue" = "test value2" 
+		test "$configvalue" = "test value2"
 		succeed_if "config key was not set correctly"
 
 		echo "Test remounting the existing mount"
 
 		$KDB remount "testfile" $ROOT_MOUNTPOINT2 $ROOT_MOUNTPOINT
-		succeed_if "could not remount previous mountpoint"             
+		succeed_if "could not remount previous mountpoint"
 
 		#$KDB ls "system/elektra/mountpoints"
 		#$KDB mount
@@ -109,11 +109,11 @@ then
 
 		# TODO: reenable
 		#configvalue=$($KDB get "system/elektra/mountpoints/$ROOT_MOUNTPOINT2N/config/test2")
-		#test "$configvalue" = "test value2" 
+		#test "$configvalue" = "test value2"
 		#succeed_if "config key was not copied correctly"
 
 		#configvalue=$($KDB get "system/elektra/mountpoints/$ROOT_MOUNTPOINT2N/config/path")
-		#test "$configvalue" = "testfile" 
+		#test "$configvalue" = "testfile"
 		#succeed_if "path was not set correctly"
 
 		echo "Testing unmount via path"

--- a/tests/shell/check_race.sh
+++ b/tests/shell/check_race.sh
@@ -14,7 +14,7 @@ exit 0
 RACE="@RACE_COMMAND@"
 RACEKEYS=user/test/race/keys
 
-if [ "x`$KDB ls $RACEKEYS | wc -l 2> /dev/null`" != "x0" ]
+if [ "x`"$KDB" ls $RACEKEYS | wc -l 2> /dev/null`" != "x0" ]
 then
 	echo "There are already keys in $RACEKEYS"
 	exit 1
@@ -35,7 +35,7 @@ do_race_test()
 
 	WHERE=user/test/race/keys
 
-	KEYS=`$KDB ls "$WHERE"`
+	KEYS=`"$KDB" ls "$WHERE"`
 	succeed_if "could not run $KDB ls $WHERE successfully"
 
 	WON=`echo "$RES" | grep won`
@@ -57,7 +57,7 @@ do_race_test()
 	[ "$IS" -eq "1" ]
 	succeed_if "keyset had not one, but $IS, key(s)! $OUTPUT"
 
-	$KDB rm -r $WHERE
+	"$KDB" rm -r $WHERE
 	succeed_if "could not remove key! $OUTPUT"
 }
 

--- a/tests/shell/check_race.sh
+++ b/tests/shell/check_race.sh
@@ -54,7 +54,7 @@ do_race_test()
 	#[ "$SHOULD" -le "1"  ]
 	#succeed_if "race had not one or zero, but $SHOULD, winner(s)! $OUTPUT"
 
-	[ "$IS" -eq "1" ] 
+	[ "$IS" -eq "1" ]
 	succeed_if "keyset had not one, but $IS, key(s)! $OUTPUT"
 
 	$KDB rm -r $WHERE

--- a/tests/shell/check_real_world.sh
+++ b/tests/shell/check_real_world.sh
@@ -14,7 +14,7 @@ ROOT_FILE=${FILE_SUFFIX}_root.ecf
 ROOT_MOUNTPOINT=/test/script
 if is_plugin_available dump
 then
-	$KDB mount $ROOT_FILE $ROOT_MOUNTPOINT dump 1>/dev/null
+	"$KDB" mount $ROOT_FILE $ROOT_MOUNTPOINT dump 1>/dev/null
 	succeed_if "could not mount root: $ROOT_FILE at $ROOT_MOUNTPOINT"
 fi
 
@@ -23,7 +23,7 @@ SYS_FILE=${FILE_SUFFIX}_sys.ni
 SYS_MOUNTPOINT=/test/script/sys
 if is_plugin_available ni
 then
-	$KDB mount $SYS_FILE $SYS_MOUNTPOINT ni 1>/dev/null
+	"$KDB" mount $SYS_FILE $SYS_MOUNTPOINT ni 1>/dev/null
 	succeed_if "could not mount SYS: $SYS_FILE at $SYS_MOUNTPOINT"
 fi
 
@@ -32,7 +32,7 @@ HOSTS_FILE=${FILE_SUFFIX}_hosts
 HOSTS_MOUNTPOINT=/test/script/sys/hosts
 if is_plugin_available hosts
 then
-	$KDB mount $HOSTS_FILE $HOSTS_MOUNTPOINT hosts 1>/dev/null
+	"$KDB" mount $HOSTS_FILE $HOSTS_MOUNTPOINT hosts 1>/dev/null
 	succeed_if "could not mount hosts: $HOSTS_FILE at $HOSTS_MOUNTPOINT/hosts"
 fi
 
@@ -42,22 +42,22 @@ UNAME_MOUNTPOINT=system/test/script/sys/uname
 if is_plugin_available uname
 then
 	touch $SYSTEM_FOLDER/$UNAME_FILE
-	$KDB mount $UNAME_FILE $UNAME_MOUNTPOINT uname
+	"$KDB" mount $UNAME_FILE $UNAME_MOUNTPOINT uname
 	succeed_if "could not mount uname: $UNAME_FILE at $UNAME_MOUNTPOINT"
 
 	# following keys must exist:
-	$KDB ls $UNAME_MOUNTPOINT | grep "system/test/script/sys/uname/machine"
+	"$KDB" ls $UNAME_MOUNTPOINT | grep "system/test/script/sys/uname/machine"
 	succeed_if "machine key missing"
-	$KDB ls $UNAME_MOUNTPOINT | grep "system/test/script/sys/uname/nodename"
+	"$KDB" ls $UNAME_MOUNTPOINT | grep "system/test/script/sys/uname/nodename"
 	succeed_if "nodename key missing"
-	$KDB ls $UNAME_MOUNTPOINT | grep "system/test/script/sys/uname/release"
+	"$KDB" ls $UNAME_MOUNTPOINT | grep "system/test/script/sys/uname/release"
 	succeed_if "release key missing"
-	$KDB ls $UNAME_MOUNTPOINT | grep "system/test/script/sys/uname/sysname"
+	"$KDB" ls $UNAME_MOUNTPOINT | grep "system/test/script/sys/uname/sysname"
 	succeed_if "sysname key missing"
-	$KDB ls $UNAME_MOUNTPOINT | grep "system/test/script/sys/uname/version"
+	"$KDB" ls $UNAME_MOUNTPOINT | grep "system/test/script/sys/uname/version"
 	succeed_if "version key missing"
 
-	$KDB get "system/test/script/sys/uname/machine"
+	"$KDB" get "system/test/script/sys/uname/machine"
 	succeed_if "could not get machine key"
 fi
 
@@ -65,7 +65,7 @@ APPS_FILE=${FILE_SUFFIX}_apps.ini
 APPS_MOUNTPOINT=/test/script/apps
 if is_plugin_available simpleini
 then
-	$KDB mount $APPS_FILE $APPS_MOUNTPOINT simpleini ccode null
+	"$KDB" mount $APPS_FILE $APPS_MOUNTPOINT simpleini ccode null
 	succeed_if "could not mount simpleini: $APPS_FILE at $APPS_MOUNTPOINT"
 fi
 
@@ -73,7 +73,7 @@ DESKTOP_FILE=${FILE_SUFFIX}_desktop.yajl
 DESKTOP_MOUNTPOINT=/test/script/apps/desktop
 if is_plugin_available yajl
 then
-	$KDB mount $DESKTOP_FILE $DESKTOP_MOUNTPOINT yajl
+	"$KDB" mount $DESKTOP_FILE $DESKTOP_MOUNTPOINT yajl
 	succeed_if "could not mount DESKTOP: $DESKTOP_FILE at $DESKTOP_MOUNTPOINT"
 
 	check_set_rm system/test/script/apps/desktop/x y
@@ -89,7 +89,7 @@ fi
 
 if is_plugin_available dump
 then
-	$KDB mount | grep "test_real_world_root.ecf on /test/script"
+	"$KDB" mount | grep "test_real_world_root.ecf on /test/script"
 	succeed_if "mountpoint $ROOT_MOUNTPOINT missing"
 
 	check_set_rm system/test/script/next/key value
@@ -98,7 +98,7 @@ fi
 
 if is_plugin_available ni
 then
-	$KDB mount | grep "test_real_world_sys.ni on /test/script/sys"
+	"$KDB" mount | grep "test_real_world_sys.ni on /test/script/sys"
 	succeed_if "mountpoint $SYS_MOUNTPOINT missing"
 
 	check_set_rm system/test/script/sys/next/key value
@@ -109,7 +109,7 @@ fi
 
 if is_plugin_available hosts
 then
-	$KDB mount | grep "test_real_world_hosts on /test/script/sys/hosts"
+	"$KDB" mount | grep "test_real_world_hosts on /test/script/sys/hosts"
 	succeed_if "mountpoint $HOSTS_MOUNTPOINT missing"
 
 	check_set_rm system/test/script/sys/hosts/ipv4/localhost 127.0.0.1
@@ -125,7 +125,7 @@ fi
 
 if is_plugin_available simpleini
 then
-	$KDB mount | grep "test_real_world_apps.ini on /test/script/apps"
+	"$KDB" mount | grep "test_real_world_apps.ini on /test/script/apps"
 	succeed_if "mountpoint $APPS_MOUNTPOINT missing"
 
 	check_set_rm system/test/script/apps/next/x y
@@ -148,44 +148,44 @@ fi
 
 if is_plugin_available yajl
 then
-	$KDB umount $DESKTOP_MOUNTPOINT >/dev/null
+	"$KDB" umount $DESKTOP_MOUNTPOINT >/dev/null
 	succeed_if "could not umount $DESKTOP_MOUNTPOINT"
 fi
 
 if is_plugin_available simpleini
 then
-	$KDB umount $APPS_MOUNTPOINT >/dev/null
+	"$KDB" umount $APPS_MOUNTPOINT >/dev/null
 	succeed_if "could not umount $APPS_MOUNTPOINT"
 fi
 
 if is_plugin_available uname
 then
-	$KDB umount $UNAME_MOUNTPOINT >/dev/null
+	"$KDB" umount $UNAME_MOUNTPOINT >/dev/null
 	succeed_if "could not umount $UNAME_MOUNTPOINT"
 fi
 
 if is_plugin_available hosts
 then
-	$KDB mount | grep "test_real_world_hosts on /test/script/sys/hosts"
+	"$KDB" mount | grep "test_real_world_hosts on /test/script/sys/hosts"
 	succeed_if "mountpoint $HOSTS_MOUNTPOINT missing"
 
-	$KDB umount $HOSTS_MOUNTPOINT >/dev/null
+	"$KDB" umount $HOSTS_MOUNTPOINT >/dev/null
 	succeed_if "could not umount $HOSTS_MOUNTPOINT"
 
-	$KDB mount | grep "test_real_world_hosts on /test/script/sys/hosts"
+	"$KDB" mount | grep "test_real_world_hosts on /test/script/sys/hosts"
 	[ "$!" != "0"  ]
 	succeed_if "mountpoint $HOSTS_MOUNTPOINT still there"
 fi
 
 if is_plugin_available ni
 then
-	$KDB umount $SYS_MOUNTPOINT >/dev/null
+	"$KDB" umount $SYS_MOUNTPOINT >/dev/null
 	succeed_if "could not umount $SYS_MOUNTPOINT"
 fi
 
 if is_plugin_available dump
 then
-	$KDB umount $ROOT_MOUNTPOINT >/dev/null
+	"$KDB" umount $ROOT_MOUNTPOINT >/dev/null
 	succeed_if "could not umount $ROOT_MOUNTPOINT"
 fi
 

--- a/tests/shell/check_resolver.sh
+++ b/tests/shell/check_resolver.sh
@@ -203,7 +203,7 @@ check_resolver dir b /a/b $TMPPATH/a/b
 check_resolver dir b a $TMPPATH/@KDB_DB_DIR@/a
 check_resolver dir b a/b $TMPPATH/@KDB_DB_DIR@/a/b
 
-T="$(mktempdir_elektra)"
+T="`cd $(mktempdir_elektra); pwd -P`"
 
 cleanup()
 {

--- a/tests/shell/check_resolver.sh
+++ b/tests/shell/check_resolver.sh
@@ -62,17 +62,17 @@ check_resolver()
 
 	MOUNTPOINT=$1$ROOT_MOUNTPOINT
 
-	$KDB mount --resolver $PLUGIN $3 $MOUNTPOINT dump 1>/dev/null
-	succeed_if "could not mount root using: $KDB mount --resolver $PLUGIN $3 $MOUNTPOINT dump"
+	"$KDB" mount --resolver $PLUGIN $3 $MOUNTPOINT dump 1>/dev/null
+	succeed_if "could not mount root using: "$KDB" mount --resolver $PLUGIN $3 $MOUNTPOINT dump"
 
-	FILE=`$KDB file -N $1 -n $ROOT_MOUNTPOINT 2> /dev/null`
+	FILE=`"$KDB" file -N $1 -n $ROOT_MOUNTPOINT 2> /dev/null`
 	echo "For $1 $2 $3 we got $FILE"
 	[ "x$FILE"  = "x$4" ]
 	succeed_if "resolving of $MOUNTPOINT did not yield $4 but $FILE"
 
 	if [ "x$WRITE_TO_SYSTEM" = "xYES" ]; then
 		KEY=$ROOT_MOUNTPOINT/key
-		$KDB set -N $1 $KEY value
+		"$KDB" set -N $1 $KEY value
 		succeed_if "could not set $KEY"
 
 		echo "remove $FILE and its directories"
@@ -83,7 +83,7 @@ check_resolver()
 		rmdir -p --ignore-fail-on-non-empty `dirname $FILE`
 	fi
 
-	$KDB umount $MOUNTPOINT >/dev/null
+	"$KDB" umount $MOUNTPOINT >/dev/null
 	succeed_if "could not umount $MOUNTPOINT"
 }
 
@@ -132,7 +132,7 @@ check_resolver dir x /a $TMPPATH/a
 check_resolver dir x /a/b $TMPPATH/a/b
 check_resolver dir x a $TMPPATH/@KDB_DB_DIR@/a
 check_resolver dir x a/b $TMPPATH/@KDB_DB_DIR@/a/b
-cd $OD
+cd "$OD"
 
 fi # end of XDG tests
 
@@ -160,7 +160,7 @@ check_resolver dir w /a $TMPPATH//a
 check_resolver dir w /a/b $TMPPATH//a/b
 check_resolver dir w a $TMPPATH/a #@KDB_DB_DIR@ not impl
 check_resolver dir w a/b $TMPPATH/a/b #@KDB_DB_DIR@ not impl
-cd $OD
+cd "$OD"
 
 
 

--- a/tests/shell/check_spec.sh
+++ b/tests/shell/check_spec.sh
@@ -15,41 +15,41 @@ ROOT_MOUNTPOINT=/test/script/spec
 
 if is_plugin_available dump
 then
-	$KDB mount $ROOT_FILE $ROOT_MOUNTPOINT dump 1>/dev/null
+	"$KDB" mount $ROOT_FILE $ROOT_MOUNTPOINT dump 1>/dev/null
 	succeed_if "could not mount root: $ROOT_FILE at $ROOT_MOUNTPOINT"
 
-	SYSTEM_FILE="`$KDB file -n system$ROOT_MOUNTPOINT`"
+	SYSTEM_FILE="`"$KDB" file -n system$ROOT_MOUNTPOINT`"
 	[ ! -f $SYSTEM_FILE ]
 	exit_if_fail "System File $SYSTEM_FILE already exists"
 
-	$KDB mount $ROOT_FILE spec$ROOT_MOUNTPOINT dump 1>/dev/null
+	"$KDB" mount $ROOT_FILE spec$ROOT_MOUNTPOINT dump 1>/dev/null
 	succeed_if "could not mount spec root: $ROOT_FILE at spec$ROOT_MOUNTPOINT"
 
-	SPEC_FILE="`$KDB file -n spec$ROOT_MOUNTPOINT`"
+	SPEC_FILE="`"$KDB" file -n spec$ROOT_MOUNTPOINT`"
 	[ ! -f $SPEC_FILE ]
 	exit_if_fail "Spec File $SPEC_FILE already exists"
 
-	$KDB get $ROOT_MOUNTPOINT
+	"$KDB" get $ROOT_MOUNTPOINT
 	[ $? != 0 ]
 	succeed_if "getting cascading should fail if nothing is there"
 
-	$KDB set spec$ROOT_MOUNTPOINT/test > /dev/null
+	"$KDB" set spec$ROOT_MOUNTPOINT/test > /dev/null
 	succeed_if "could not create key"
 
-	$KDB get $ROOT_MOUNTPOINT
+	"$KDB" get $ROOT_MOUNTPOINT
 	[ $? != 0 ]
 	succeed_if "getting cascading should fail if nothing is there"
 
-	$KDB setmeta spec$ROOT_MOUNTPOINT/first default 20
+	"$KDB" setmeta spec$ROOT_MOUNTPOINT/first default 20
 	succeed_if "could not set meta"
 
-	[ "x`$KDB get $ROOT_MOUNTPOINT/first`" = "x20" ]
+	[ "x`"$KDB" get $ROOT_MOUNTPOINT/first`" = "x20" ]
 	succeed_if "could not get default value"
 
-	$KDB umount $ROOT_MOUNTPOINT
+	"$KDB" umount $ROOT_MOUNTPOINT
 	succeed_if "could not unmount previously mounted mountpoint"
 
-	$KDB umount spec$ROOT_MOUNTPOINT
+	"$KDB" umount spec$ROOT_MOUNTPOINT
 	succeed_if "could not unmount previously mounted spec mountpoint"
 
 	rm -f $SYSTEM_FILE

--- a/tests/shell/check_spec.sh
+++ b/tests/shell/check_spec.sh
@@ -51,7 +51,7 @@ then
 
 	$KDB umount spec$ROOT_MOUNTPOINT
 	succeed_if "could not unmount previously mounted spec mountpoint"
-	
+
 	rm -f $SYSTEM_FILE
 	rm -f $SPEC_FILE
 fi

--- a/tests/shell/generate_data.sh
+++ b/tests/shell/generate_data.sh
@@ -21,38 +21,38 @@ do
 
 	echo -------- $PLUGIN -----------
 
-	$KDB set $ROOT "root" >/dev/null
+	"$KDB" set $ROOT "root" >/dev/null
 	exit_if_fail "could not set root"
 
-	test `$KDB ls $ROOT` = $ROOT
+	test `"$KDB" ls $ROOT` = $ROOT
 	succeed_if "Root key not found"
 
-	$KDB export $ROOT $PLUGIN > $DATADIR/one_value.$PLUGIN
+	"$KDB" export $ROOT $PLUGIN > "$DATADIR"/one_value.$PLUGIN
 	succeed_if "Could not run kdb export"
 
 
-	test "`$KDB set $ROOT/key "value"`" = "create a new key $ROOT/key with string value"
+	test "`"$KDB" set $ROOT/key "value"`" = "create a new key $ROOT/key with string value"
 	succeed_if "Could not set $ROOT/key"
 
-	$KDB export $ROOT $PLUGIN > $DATADIR/two_value.$PLUGIN
+	"$KDB" export $ROOT $PLUGIN > "$DATADIR"/two_value.$PLUGIN
 	succeed_if "Could not run kdb export"
 
 
-	$KDB set $ROOT/key/subkey "another value" > /dev/null
+	"$KDB" set $ROOT/key/subkey "another value" > /dev/null
 	succeed_if "Could not set $ROOT/key/subkey"
 
-	$KDB export $ROOT $PLUGIN > $DATADIR/three_value.$PLUGIN
+	"$KDB" export $ROOT $PLUGIN > "$DATADIR"/three_value.$PLUGIN
 	succeed_if "Could not run kdb export"
 
 
-	$KDB rm $ROOT/key > /dev/null
+	"$KDB" rm $ROOT/key > /dev/null
 	succeed_if "Could not rm $ROOT/key"
 
-	$KDB export $ROOT $PLUGIN > $DATADIR/again_two_value.$PLUGIN
+	"$KDB" export $ROOT $PLUGIN > "$DATADIR"/again_two_value.$PLUGIN
 	succeed_if "Could not run kdb export"
 
 
-	$KDB rm -r $ROOT
+	"$KDB" rm -r $ROOT
 	succeed_if "Could not remove root"
 done
 

--- a/tests/shell/include_common.sh.in
+++ b/tests/shell/include_common.sh.in
@@ -208,7 +208,7 @@ is_not_rw_storage()
 	-o "x$PLUGIN" = "xaugeas" \
 	-o "x$PLUGIN" = "xcsvstorage" \
 	-o "x$PLUGIN" = "xdpkg" \
-	-o "x$PLUGIN" = "xregexstore" 
+	-o "x$PLUGIN" = "xregexstore"
 }
 
 is_plugin_available()

--- a/tests/shell/include_common.sh.in
+++ b/tests/shell/include_common.sh.in
@@ -130,11 +130,11 @@ check_version()
 		return 0
 	fi
 
-	REAL_KDB_VERSION="`$KDB get system/elektra/version/constants/KDB_VERSION 2> /dev/null`"
+	REAL_KDB_VERSION="`"$KDB" get system/elektra/version/constants/KDB_VERSION 2> /dev/null`"
 	[ "x$REAL_KDB_VERSION" = "x$KDB_VERSION" ]
 	exit_if_fail "Script was not compiled ($KDB_VERSION) with this elektra version ($REAL_KDB_VERSION): KDB_VERSION mismatch use CHECK_VERSION=NO to disable"
 
-	REAL_SO_VERSION="`$KDB get system/elektra/version/constants/SO_VERSION 2> /dev/null`"
+	REAL_SO_VERSION="`"$KDB" get system/elektra/version/constants/SO_VERSION 2> /dev/null`"
 	[ "x$REAL_SO_VERSION" = "x$SO_VERSION" ]
 	exit_if_fail "Script was not compiled ($SO_VERSION) with this elektra version ($REAL_SO_VERSION): SO_VERSION mismatch"
 }
@@ -152,41 +152,41 @@ check_remaining_files()
 
 check_set_rm()
 {
-	$KDB set "$1" "$2" 1>/dev/null
+	"$KDB" set "$1" "$2" 1>/dev/null
 	succeed_if "could not set $1 with $2"
 
-	[ "x`$KDB get "$1" 2> /dev/null`" = "x$2" ]
+	[ "x`"$KDB" get "$1" 2> /dev/null`" = "x$2" ]
 	succeed_if "cant get $1 (expected $2)"
 
-	$KDB rm "$1" 1>/dev/null
+	"$KDB" rm "$1" 1>/dev/null
 	succeed_if "could not rm $1 (having value $2)"
 
-	[ "x`$KDB sget $1 defvalue 2> /dev/null`" = "xdefvalue" ]
+	[ "x`"$KDB" sget $1 defvalue 2> /dev/null`" = "xdefvalue" ]
 	succeed_if "Value still there after remove"
 }
 
 
 check_set_mv_rm()
 {
-	$KDB set "$1" "$3" 1>/dev/null
+	"$KDB" set "$1" "$3" 1>/dev/null
 	succeed_if "could not set $1 with $3"
 
-	[ "x`$KDB get "$1" 2> /dev/null`" = "x$3" ]
+	[ "x`"$KDB" get "$1" 2> /dev/null`" = "x$3" ]
 	succeed_if "cant get $1 (expected $3)"
 
-	$KDB mv "$1" "$2" 1>/dev/null
+	"$KDB" mv "$1" "$2" 1>/dev/null
 	succeed_if "could not mv $1 to $2"
 
-	[ "x`$KDB sget $1 defvalue 2> /dev/null`" = "xdefvalue" ]
+	[ "x`"$KDB" sget $1 defvalue 2> /dev/null`" = "xdefvalue" ]
 	succeed_if "Value still there after move"
 
-	[ "x`$KDB get "$2" 2> /dev/null`" = "x$3" ]
+	[ "x`"$KDB" get "$2" 2> /dev/null`" = "x$3" ]
 	succeed_if "cant get $2 (expected $3)"
 
-	$KDB rm "$2" 1>/dev/null
+	"$KDB" rm "$2" 1>/dev/null
 	succeed_if "could not rm $2 (having value $3)"
 
-	[ "x`$KDB sget $2 defvalue 2> /dev/null`" = "xdefvalue" ]
+	[ "x`"$KDB" sget $2 defvalue 2> /dev/null`" = "xdefvalue" ]
 	succeed_if "Value still there after remove"
 }
 
@@ -199,7 +199,7 @@ check_set_mv_rm()
 
 is_not_rw_storage()
 {
-	test ! "x`$KDB info $PLUGIN provides 2>/dev/null`" = "xstorage" \
+	test ! "x`"$KDB" info $PLUGIN provides 2>/dev/null`" = "xstorage" \
 	-o "x$PLUGIN" = "xhosts" \
 	-o "x$PLUGIN" = "xfstab" \
 	-o "x$PLUGIN" = "xline" \

--- a/tests/shell/run_all.sh
+++ b/tests/shell/run_all.sh
@@ -50,19 +50,19 @@ checkFailed()
 	exit 1
 }
 
-$KDB export spec dump > "$SPECEXPORT"
+"$KDB" export spec dump > "$SPECEXPORT"
 exit_if_fail "Could not export spec config"
 
-$KDB export dir dump > "$DIREXPORT"
+"$KDB" export dir dump > "$DIREXPORT"
 exit_if_fail "Could not export dir config"
 
-$KDB export user dump > "$USEREXPORT"
+"$KDB" export user dump > "$USEREXPORT"
 exit_if_fail "Could not export user config"
 
-$KDB export system --without-elektra dump > "$SYSTEMEXPORT"
+"$KDB" export system --without-elektra dump > "$SYSTEMEXPORT"
 exit_if_fail "Could not export system config"
 
-$KDB export system/elektra/mountpoints dump > "$MOUNTEXPORT"
+"$KDB" export system/elektra/mountpoints dump > "$MOUNTEXPORT"
 exit_if_fail "Could not export mount config"
 
 for t in test* check*
@@ -71,7 +71,7 @@ do
 	echo
 	echo
 
-	$KDB $t
+	"$KDB" $t
 
 	if [ $? != "0" ]
 	then
@@ -81,19 +81,19 @@ do
 	fi
 	nbTest=$(( $nbTest + 1 ))
 
-	$KDB export spec dump > "$SPECCHECK"
+	"$KDB" export spec dump > "$SPECCHECK"
 	exit_if_fail "Could not export spec config"
 
-	$KDB export dir dump > "$DIRCHECK"
+	"$KDB" export dir dump > "$DIRCHECK"
 	exit_if_fail "Could not export dir config"
 
-	$KDB export user dump > "$USERCHECK"
+	"$KDB" export user dump > "$USERCHECK"
 	exit_if_fail "Could not export user config"
 
-	$KDB export system --without-elektra dump > "$SYSTEMCHECK"
+	"$KDB" export system --without-elektra dump > "$SYSTEMCHECK"
 	exit_if_fail "Could not export system config"
 
-	$KDB export system/elektra/mountpoints dump > "$MOUNTCHECK"
+	"$KDB" export system/elektra/mountpoints dump > "$MOUNTCHECK"
 	exit_if_fail "Could not export mount config"
 
 


### PR DESCRIPTION
This pull request contains various fixes for the test system. Below is the current result of `make run_all` on my machine (OS X), after I apply the changes (Spoiler: Two tests fail). I also tested `make run_memcheck`, which takes quite a lot of time to execute. Looks like all memory checks on OS X currently fail :(. At least I did not notice a working one yet… (The command is still running).

```
        Start   1: testmod_augeas
  1/104 Test   #1: testmod_augeas .....................   Passed    0.06 sec
        Start   2: testmod_ccode
  2/104 Test   #2: testmod_ccode ......................   Passed    0.02 sec
        Start   3: testmod_conditionals
  3/104 Test   #3: testmod_conditionals ...............***Failed    0.02 sec
CONDITIONALS     TESTS
==================

/Users/rene/Dropbox/Studium/Master Thesis/Configuration Parsing/Source/Elektra/src/plugins/conditionals/testmod_conditionals.c:28: error in test_ifthenelseint: error
/Users/rene/Dropbox/Studium/Master Thesis/Configuration Parsing/Source/Elektra/src/plugins/conditionals/testmod_conditionals.c:44: error in test_ifthenint: error
/Users/rene/Dropbox/Studium/Master Thesis/Configuration Parsing/Source/Elektra/src/plugins/conditionals/testmod_conditionals.c:60: error in test_ifthenltint: error
/Users/rene/Dropbox/Studium/Master Thesis/Configuration Parsing/Source/Elektra/src/plugins/conditionals/testmod_conditionals.c:93: error in test_ifthenkey: error
/Users/rene/Dropbox/Studium/Master Thesis/Configuration Parsing/Source/Elektra/src/plugins/conditionals/testmod_conditionals.c:111: error in test_emptyisempty: error
/Users/rene/Dropbox/Studium/Master Thesis/Configuration Parsing/Source/Elektra/src/plugins/conditionals/testmod_conditionals.c:129: error in test_notempty: error
/Users/rene/Dropbox/Studium/Master Thesis/Configuration Parsing/Source/Elektra/src/plugins/conditionals/testmod_conditionals.c:146: error in test_ifsetthenval: error
/Users/rene/Dropbox/Studium/Master Thesis/Configuration Parsing/Source/Elektra/src/plugins/conditionals/testmod_conditionals.c:148: error in test_ifsetthenval: error setting then value
/Users/rene/Dropbox/Studium/Master Thesis/Configuration Parsing/Source/Elektra/src/plugins/conditionals/testmod_conditionals.c:164: error in test_ifsetthenkey: error
/Users/rene/Dropbox/Studium/Master Thesis/Configuration Parsing/Source/Elektra/src/plugins/conditionals/testmod_conditionals.c:166: error in test_ifsetthenkey: error setting then value
/Users/rene/Dropbox/Studium/Master Thesis/Configuration Parsing/Source/Elektra/src/plugins/conditionals/testmod_conditionals.c:180: error in test_assignThen: error
/Users/rene/Dropbox/Studium/Master Thesis/Configuration Parsing/Source/Elektra/src/plugins/conditionals/testmod_conditionals.c:182: error in test_assignThen: error setting then value
/Users/rene/Dropbox/Studium/Master Thesis/Configuration Parsing/Source/Elektra/src/plugins/conditionals/testmod_conditionals.c:197: error in test_assignElse: error
/Users/rene/Dropbox/Studium/Master Thesis/Configuration Parsing/Source/Elektra/src/plugins/conditionals/testmod_conditionals.c:199: error in test_assignElse: error setting then value
/Users/rene/Dropbox/Studium/Master Thesis/Configuration Parsing/Source/Elektra/src/plugins/conditionals/testmod_conditionals.c:215: error in test_assignKeyThen: error
/Users/rene/Dropbox/Studium/Master Thesis/Configuration Parsing/Source/Elektra/src/plugins/conditionals/testmod_conditionals.c:217: error in test_assignKeyThen: error setting then value
/Users/rene/Dropbox/Studium/Master Thesis/Configuration Parsing/Source/Elektra/src/plugins/conditionals/testmod_conditionals.c:233: error in test_assignKeyElse: error
/Users/rene/Dropbox/Studium/Master Thesis/Configuration Parsing/Source/Elektra/src/plugins/conditionals/testmod_conditionals.c:235: error in test_assignKeyElse: error setting then value
/Users/rene/Dropbox/Studium/Master Thesis/Configuration Parsing/Source/Elektra/src/plugins/conditionals/testmod_conditionals.c:292: error in test_nested1Success: error
/Users/rene/Dropbox/Studium/Master Thesis/Configuration Parsing/Source/Elektra/src/plugins/conditionals/testmod_conditionals.c:332: error in test_nested2Success: error
/Users/rene/Dropbox/Studium/Master Thesis/Configuration Parsing/Source/Elektra/src/plugins/conditionals/testmod_conditionals.c:254: error in test_doesntExistSuccess: error
/Users/rene/Dropbox/Studium/Master Thesis/Configuration Parsing/Source/Elektra/src/plugins/conditionals/testmod_conditionals.c:370: error in test_suffix: error

testmod_conditionals RESULTS: 90 test(s) done. 22 error(s).

        Start   4: testmod_crypto
  4/104 Test   #4: testmod_crypto .....................   Passed    0.02 sec
        Start   5: testmod_csvstorage
  5/104 Test   #5: testmod_csvstorage .................   Passed    0.02 sec
        Start   6: testmod_curlget
  6/104 Test   #6: testmod_curlget ....................   Passed    0.02 sec
        Start   7: testmod_dpkg
  7/104 Test   #7: testmod_dpkg .......................   Passed    0.02 sec
        Start   8: testmod_dump
  8/104 Test   #8: testmod_dump .......................   Passed    0.02 sec
        Start   9: testmod_enum
  9/104 Test   #9: testmod_enum .......................   Passed    0.02 sec
        Start  10: testmod_filecheck
 10/104 Test  #10: testmod_filecheck ..................   Passed    0.02 sec
        Start  11: testmod_glob
 11/104 Test  #11: testmod_glob .......................   Passed    0.02 sec
        Start  12: testmod_hexcode
 12/104 Test  #12: testmod_hexcode ....................   Passed    0.02 sec
        Start  13: testmod_hosts
 13/104 Test  #13: testmod_hosts ......................   Passed    0.02 sec
        Start  14: testmod_iconv
 14/104 Test  #14: testmod_iconv ......................   Passed    0.02 sec
        Start  15: testmod_ini
 15/104 Test  #15: testmod_ini ........................   Passed    0.02 sec
        Start  16: testmod_iterate
 16/104 Test  #16: testmod_iterate ....................   Passed    0.02 sec
        Start  17: testmod_keytometa
 17/104 Test  #17: testmod_keytometa ..................   Passed    0.02 sec
        Start  18: testmod_line
 18/104 Test  #18: testmod_line .......................   Passed    0.02 sec
        Start  19: testmod_lineendings
 19/104 Test  #19: testmod_lineendings ................   Passed    0.02 sec
        Start  20: testmod_list
 20/104 Test  #20: testmod_list .......................   Passed    0.02 sec
        Start  21: testmod_mathcheck
 21/104 Test  #21: testmod_mathcheck ..................   Passed    0.02 sec
        Start  22: testmod_network
 22/104 Test  #22: testmod_network ....................   Passed    0.02 sec
        Start  23: testmod_ni
 23/104 Test  #23: testmod_ni .........................   Passed    0.02 sec
        Start  24: testmod_rename
 24/104 Test  #24: testmod_rename .....................   Passed    0.02 sec
        Start  25: testmod_resolver
 25/104 Test  #25: testmod_resolver ...................   Passed    0.02 sec
        Start  26: testmod_shell
 26/104 Test  #26: testmod_shell ......................   Passed    0.02 sec
        Start  27: testmod_spec
 27/104 Test  #27: testmod_spec .......................   Passed    0.02 sec
        Start  28: testmod_template
 28/104 Test  #28: testmod_template ...................   Passed    0.02 sec
        Start  29: testmod_type
 29/104 Test  #29: testmod_type .......................   Passed    0.03 sec
        Start  30: testmod_uname
 30/104 Test  #30: testmod_uname ......................   Passed    0.02 sec
        Start  31: testmod_validation
 31/104 Test  #31: testmod_validation .................   Passed    0.02 sec
        Start  32: testmod_xmltool
 32/104 Test  #32: testmod_xmltool ....................   Passed    0.02 sec
        Start  33: testtool_automergestrategy
 33/104 Test  #33: testtool_automergestrategy .........   Passed    0.02 sec
        Start  34: testtool_backend
 34/104 Test  #34: testtool_backend ...................   Passed    0.02 sec
        Start  35: testtool_backendbuilder
 35/104 Test  #35: testtool_backendbuilder ............   Passed    0.14 sec
        Start  36: testtool_backendparser
 36/104 Test  #36: testtool_backendparser .............   Passed    0.03 sec
        Start  37: testtool_comparison
 37/104 Test  #37: testtool_comparison ................   Passed    0.02 sec
        Start  38: testtool_keyhelper
 38/104 Test  #38: testtool_keyhelper .................   Passed    0.02 sec
        Start  39: testtool_mergecases
 39/104 Test  #39: testtool_mergecases ................   Passed    0.02 sec
        Start  40: testtool_mergeresult
 40/104 Test  #40: testtool_mergeresult ...............   Passed    0.02 sec
        Start  41: testtool_metamergestrategy
 41/104 Test  #41: testtool_metamergestrategy .........   Passed    0.02 sec
        Start  42: testtool_newkeystrategy
 42/104 Test  #42: testtool_newkeystrategy ............   Passed    0.02 sec
        Start  43: testtool_onesidestrategy
 43/104 Test  #43: testtool_onesidestrategy ...........   Passed    0.02 sec
        Start  44: testtool_pluginspec
 44/104 Test  #44: testtool_pluginspec ................   Passed    0.02 sec
        Start  45: testtool_samemountpoint
 45/104 Test  #45: testtool_samemountpoint ............   Passed    0.02 sec
        Start  46: testtool_specreader
 46/104 Test  #46: testtool_specreader ................   Passed    0.03 sec
        Start  47: testtool_umount
 47/104 Test  #47: testtool_umount ....................   Passed    0.02 sec
        Start  48: testcpp_contextual_basic
 48/104 Test  #48: testcpp_contextual_basic ...........   Passed    0.04 sec
        Start  49: testcpp_contextual_nocontext
 49/104 Test  #49: testcpp_contextual_nocontext .......   Passed    0.02 sec
        Start  50: testcpp_contextual_policy
 50/104 Test  #50: testcpp_contextual_policy ..........   Passed    0.02 sec
        Start  51: testcpp_contextual_thread
 51/104 Test  #51: testcpp_contextual_thread ..........   Passed    0.28 sec
        Start  52: testcpp_contextual_update
 52/104 Test  #52: testcpp_contextual_update ..........   Passed    0.03 sec
        Start  53: testcpp_iter
 53/104 Test  #53: testcpp_iter .......................   Passed    0.02 sec
        Start  54: testcpp_iter_name
 54/104 Test  #54: testcpp_iter_name ..................   Passed    0.02 sec
        Start  55: testcpp_kdb
 55/104 Test  #55: testcpp_kdb ........................   Passed    0.02 sec
        Start  56: testcpp_key
 56/104 Test  #56: testcpp_key ........................   Passed    0.02 sec
        Start  57: testcpp_ks
 57/104 Test  #57: testcpp_ks .........................   Passed    0.03 sec
        Start  58: testcpp_ksget
 58/104 Test  #58: testcpp_ksget ......................   Passed    0.02 sec
        Start  59: testcpp_meta
 59/104 Test  #59: testcpp_meta .......................   Passed    0.02 sec
        Start  60: testscr_check_basic
 60/104 Test  #60: testscr_check_basic ................   Passed    0.18 sec
        Start  61: testscr_check_distribution
 61/104 Test  #61: testscr_check_distribution .........   Passed    6.31 sec
        Start  62: testscr_check_error
 62/104 Test  #62: testscr_check_error ................   Passed    0.38 sec
        Start  63: testscr_check_export
 63/104 Test  #63: testscr_check_export ...............   Passed    2.52 sec
        Start  64: testscr_check_external
 64/104 Test  #64: testscr_check_external .............   Passed    1.82 sec
        Start  65: testscr_check_get_set
 65/104 Test  #65: testscr_check_get_set ..............   Passed   10.52 sec
        Start  66: testscr_check_import
 66/104 Test  #66: testscr_check_import ...............   Passed    7.17 sec
        Start  67: testscr_check_kdb_internal_check
 67/104 Test  #67: testscr_check_kdb_internal_check ...   Passed    1.53 sec
        Start  68: testscr_check_kdb_internal_suite
 68/104 Test  #68: testscr_check_kdb_internal_suite ...   Passed    5.65 sec
        Start  69: testscr_check_merge
 69/104 Test  #69: testscr_check_merge ................   Passed    0.92 sec
        Start  70: testscr_check_mount
 70/104 Test  #70: testscr_check_mount ................   Passed    0.56 sec
        Start  71: testscr_check_plugins
 71/104 Test  #71: testscr_check_plugins ..............   Passed    0.99 sec
        Start  72: testscr_check_race
 72/104 Test  #72: testscr_check_race .................   Passed    0.08 sec
        Start  73: testscr_check_real_world
 73/104 Test  #73: testscr_check_real_world ...........   Passed    2.04 sec
        Start  74: testscr_check_resolver
 74/104 Test  #74: testscr_check_resolver .............   Passed    4.86 sec
        Start  75: testscr_check_spec
 75/104 Test  #75: testscr_check_spec .................   Passed    0.34 sec
        Start  76: testscr_generate_data
 76/104 Test  #76: testscr_generate_data ..............   Passed    0.02 sec
        Start  77: testabi_key
 77/104 Test  #77: testabi_key ........................   Passed    0.02 sec
        Start  78: testabi_ks
 78/104 Test  #78: testabi_ks .........................   Passed    0.04 sec
        Start  79: testabi_meta
 79/104 Test  #79: testabi_meta .......................   Passed    0.02 sec
        Start  80: testabi_rel
 80/104 Test  #80: testabi_rel ........................   Passed    0.02 sec
        Start  81: test_args
 81/104 Test  #81: test_args ..........................   Passed    0.02 sec
        Start  82: test_array
 82/104 Test  #82: test_array .........................   Passed    0.02 sec
        Start  83: test_backend
 83/104 Test  #83: test_backend .......................   Passed    0.02 sec
        Start  84: test_internal
 84/104 Test  #84: test_internal ......................   Passed    0.02 sec
        Start  85: test_key
 85/104 Test  #85: test_key ...........................   Passed    0.04 sec
        Start  86: test_keyname
 86/104 Test  #86: test_keyname .......................   Passed    0.02 sec
        Start  87: test_ks
 87/104 Test  #87: test_ks ............................   Passed    0.02 sec
        Start  88: test_meta
 88/104 Test  #88: test_meta ..........................   Passed    0.02 sec
        Start  89: test_mount
 89/104 Test  #89: test_mount .........................   Passed    0.02 sec
        Start  90: test_mountsplit
 90/104 Test  #90: test_mountsplit ....................   Passed    0.02 sec
        Start  91: test_namespace
 91/104 Test  #91: test_namespace .....................   Passed    0.02 sec
        Start  92: test_operation
 92/104 Test  #92: test_operation .....................   Passed    0.02 sec
        Start  93: test_order
 93/104 Test  #93: test_order .........................   Passed    0.02 sec
        Start  94: test_plugin
 94/104 Test  #94: test_plugin ........................   Passed    0.02 sec
        Start  95: test_proposal
 95/104 Test  #95: test_proposal ......................   Passed    0.02 sec
        Start  96: test_size
 96/104 Test  #96: test_size ..........................   Passed    0.02 sec
        Start  97: test_spec
 97/104 Test  #97: test_spec ..........................   Passed    0.02 sec
        Start  98: test_split
 98/104 Test  #98: test_split .........................   Passed    0.02 sec
        Start  99: test_splitget
 99/104 Test  #99: test_splitget ......................   Passed    0.02 sec
        Start 100: test_splitset
100/104 Test #100: test_splitset ......................   Passed    0.02 sec
        Start 101: test_trie
101/104 Test #101: test_trie ..........................   Passed    0.02 sec
        Start 102: testkdb_allplugins
102/104 Test #102: testkdb_allplugins .................***Exception: Other  0.48 sec
Running main() from gtest_main.cc
[==========] Running 1 test from 1 test case.
[----------] Global test environment set-up.
[----------] 1 test from BackendBuilder
[ RUN      ] BackendBuilder.loadAllPlugins
open	0000000000	di	0000000000
close	0000000287	di	0000000287

        Start 103: testkdb_nested
103/104 Test #103: testkdb_nested .....................   Passed    0.21 sec
        Start 104: testkdb_simple
104/104 Test #104: testkdb_simple .....................   Passed    0.31 sec

98% tests passed, 2 tests failed out of 104

Label Time Summary:
kdbtests    =  46.92 sec (21 tests)
memleak     =  45.96 sec (19 tests)

Total Test time (real) =  49.17 sec

The following tests FAILED:
	  3 - testmod_conditionals (Failed)
	102 - testkdb_allplugins (OTHER_FAULT)
Errors while running CTest
make[3]: *** [tests/CMakeFiles/run_all] Error 8
make[2]: *** [tests/CMakeFiles/run_all.dir/all] Error 2
make[1]: *** [tests/CMakeFiles/run_all.dir/rule] Error 2
make: *** [run_all] Error 2
```