### PR TITLE
Profile Plugin: Add dependency Libease

### DIFF
--- a/src/plugins/profile/CMakeLists.txt
+++ b/src/plugins/profile/CMakeLists.txt
@@ -4,6 +4,8 @@ add_plugin (profile
 	SOURCES
 		profile.h
 		profile.c
+	LINK_ELEKTRA
+		elektra-ease
 	)
 
 add_plugintest (profile)


### PR DESCRIPTION
Before this change the build system was not able to translate Elektra on OS X.