### PR TITLE
Fix profile.d script sourcing on some distros

### DIFF
--- a/scripts/CMakeLists.txt
+++ b/scripts/CMakeLists.txt
@@ -26,7 +26,7 @@ if (INSTALL_SYSTEM_FILES)
 			RENAME kdb)
 	install (FILES elektraenv.sh
 			DESTINATION /etc/profile.d
-			RENAME kdb)
+			RENAME kdb.sh)
 endif()
 
 configure_file(


### PR DESCRIPTION
Currently the elektraenv.sh was added to the /etc/profile.d/ folder
as kdb without .sh extension. Distributions like Arch Linux use *.sh
globing to source all files in the /etc/profile.d/ folder and
therefore do not read the kdb file without extension.
Adding sh when renaming the file on cmake install should fix this.