### PR TITLE
Documentation: Add Accent to Name

### DIFF
--- a/doc/NEWS.md
+++ b/doc/NEWS.md
@@ -48,14 +48,14 @@ of keysets, added lots of documentation, and many unit tests.
 
 ## Documentation
 
-Rene Schwaiger<sanssecours> reworked most of the documentation and
+René Schwaiger<sanssecours> reworked most of the documentation and
 fixed countless spelling mistakes and other problems.
 
 - Peter Nirschl updated the status of the crypto-plugin
   and fixed a typo
 - Daniel Bugl wrote a cascading tutorial
 - Daniel Bugl fixed all broken links
-- Rene Schwaiger also draw a new logo with SVG.
+- René Schwaiger also draw a new logo with SVG.
   It is already used on github as avatar for the organisation.
 
 


### PR DESCRIPTION
We had problems with the character `é` (small letter e + combining acute accent — code points 101 and 769) before. LaTeX – with input encoding set to `utf8` – is not able to use this character. Because of
this problem, we could not translate the reference manual. We fix this by using `é` (small letter e with acute — code point 233) instead of `é`.

Just for reference: You can determine the code points of a string by using  the function `codepoints` in Ruby:
```ruby
pry(main)> 'éé'.codepoints
=> [101, 769, 233]
```