### PR TITLE
fix typo in hook placement + uninitialized hook placements

### DIFF
--- a/src/libs/elektra/kdb.c
+++ b/src/libs/elektra/kdb.c
@@ -870,7 +870,7 @@ static int elektraSetPrepare (Split * split, Key * parentKey, Key ** errorKey, P
 
 			if (p == 0)
 			{
-				if (hooks[PREGETSTORAGE])
+				if (hooks[PRESETSTORAGE])
 				{
 					// the only place global presetstorage hooks can be executed
 					ksRewind (split->keysets[i]);

--- a/src/libs/elektra/mount.c
+++ b/src/libs/elektra/mount.c
@@ -273,6 +273,7 @@ int elektraMountGlobals (KDB * kdb, KeySet * keys, KeySet * modules, Key * error
 		}
 		for (GlobalpluginPositions i = 0; i < NR_GLOBAL_PLUGINS; ++i)
 		{
+			kdb->globalPlugins[i] = NULL;
 			if (!strcmp (placement, globalPlacements[i]))
 			{
 #if DEBUG && VERBOSE


### PR DESCRIPTION
had a typo in PRESETSTORAGE placement + forgot to initialize the globalPugins array. 