### PR TITLE
INI Plugin: Add Dependency Libmeta

### DIFF
--- a/src/plugins/ini/CMakeLists.txt
+++ b/src/plugins/ini/CMakeLists.txt
@@ -13,6 +13,7 @@ add_plugin(ini
 		${INIH_INCLUDE}
 	LINK_ELEKTRA
 		elektra-ease
+		elektra-meta
 		elektra-proposal
 	)
 


### PR DESCRIPTION
Before this change building of the plugin would fail on OS X.