### PR TITLE
Tests: Simplify Code in Resolver Check

### DIFF
--- a/tests/shell/check_resolver.sh
+++ b/tests/shell/check_resolver.sh
@@ -5,11 +5,7 @@ echo ELEKTRA CHECK RESOLVER
 echo
 
 #set tmp path (mainly for OS X compatibility)
-if [[ "$OSTYPE" == "darwin"* ]]; then
-	TMPPATH="/private/tmp"
-else
-	TMPPATH="/tmp"
-fi
+TMPPATH=`cd /tmp; pwd -P`
 
 #checks if resolver can be mounted and also partly checks if it resolves
 #correctly (more tests welcome).


### PR DESCRIPTION
I did **not test** this change with `dash`! However the simplified code works fine in `sh` on OS X:

```sh
> TMPPATH=`cd /tmp; pwd -P`
> echo $TMPPATH
/private/tmp
```