### PR TITLE
Add install target for *.desktop file for qt-gui

### DIFF
--- a/src/tools/qt-gui/CMakeLists.txt
+++ b/src/tools/qt-gui/CMakeLists.txt
@@ -53,6 +53,8 @@ target_link_libraries(qt-gui ${Qt5Quick_LIBRARIES} ${Qt5Gui_LIBRARIES}
 tool_link_elektratools(qt-gui elektra-ease)
 
 install(TARGETS qt-gui DESTINATION ${TARGET_TOOL_EXEC_FOLDER})
+install(FILES org.elektra.elektra-qt.desktop DESTINATION share/applications)
+install(FILES ../../../doc/images/circle.svg DESTINATION share/icons/hicolor/scalable/apps RENAME elektra.svg)
 
 generate_manpage (kdb-qt-gui FILENAME ${CMAKE_CURRENT_SOURCE_DIR}/README.md)
 

--- a/src/tools/qt-gui/org.elektra.elektra-qt.desktop
+++ b/src/tools/qt-gui/org.elektra.elektra-qt.desktop
@@ -1,0 +1,9 @@
+[Desktop Entry]
+Name=Elektra QT Editor
+GenericName=QT Configuration editor for elektra
+Comment=Directly edit your entire elektra configuration with a QT GUI
+Exec=kdb qt-gui
+Terminal=false
+Type=Application
+Icon=elektra
+Categories=Elektra;System;Configuration;


### PR DESCRIPTION
This commit adds a desktop file for the elektra qt gui, install target
for it in cmake as well as install target for the icon. The desktop file
still misses i18n.