### PR TITLE
Resolver Plugin: Fix Compiler Warning on OS X

### DIFF
--- a/src/include/CMakeLists.txt
+++ b/src/include/CMakeLists.txt
@@ -24,6 +24,10 @@ check_type_size("long long"     SIZEOF_LONG_LONG)
 check_type_size("long double"   SIZEOF_LONG_DOUBLE)
 check_type_size(mode_t          SIZEOF_MODE_T)
 
+set(CMAKE_EXTRA_INCLUDE_FILES "sys/time.h")
+	check_type_size("((struct timeval*)0)->tv_usec" SIZEOF_TV_USEC)
+set(CMAKE_EXTRA_INCLUDE_FILES)
+
 set (BUILTIN_EXEC_FOLDER
 	"${CMAKE_INSTALL_PREFIX}/${TARGET_TOOL_EXEC_FOLDER}")
 set (BUILTIN_DATA_FOLDER

--- a/src/include/kdbconfig.h.in
+++ b/src/include/kdbconfig.h.in
@@ -82,6 +82,7 @@
 #define SIZEOF_INT               @SIZEOF_INT@
 #define SIZEOF_LONG              @SIZEOF_LONG@
 #define SIZEOF_MODE_T            @SIZEOF_MODE_T@
+#define SIZEOF_TV_USEC           @SIZEOF_TV_USEC@
 
 #cmakedefine HAVE_SIZEOF_LONG_LONG
 #ifdef HAVE_SIZEOF_LONG_LONG

--- a/src/include/kdbtypes.h
+++ b/src/include/kdbtypes.h
@@ -98,4 +98,10 @@ typedef long double kdb_long_double_t;
 typedef long double kdb_long_double_t;
 #endif
 
+#if SIZEOF_TV_USEC == SIZEOF_INT
+#define ELEKTRA_TIME_USEC_F "%d"
+#else
+#define ELEKTRA_TIME_USEC_F "%ld"
+#endif
+
 #endif

--- a/src/plugins/resolver/filename.c
+++ b/src/plugins/resolver/filename.c
@@ -10,6 +10,7 @@
 
 #include <errno.h>
 #include <kdbproposal.h>
+#include <kdbtypes.h>
 #include <libgen.h>
 #include <pwd.h>
 #include <stdbool.h>
@@ -75,7 +76,7 @@ static void elektraGenTempFilename (char * where, const char * filename)
 	struct timeval tv;
 	gettimeofday (&tv, 0);
 	size_t len = sprintf (where, "%s", filename);
-	snprintf (where + len, POSTFIX_SIZE - 1, ".%d:%ld.%ld.tmp", getpid (), tv.tv_sec, tv.tv_usec);
+	snprintf (where + len, POSTFIX_SIZE - 1, ".%d:%ld." ELEKTRA_TIME_USEC_F ".tmp", getpid (), tv.tv_sec, tv.tv_usec);
 }
 /**
  * @brief Given filename, calcualtes dirname+tempfile


### PR DESCRIPTION
If you know a better solution to fix this problem, then please let me know. Here is the warning message:

```
[126/925] Building C object src/plugins/resolver/CMakeFiles/elektra-resolver_fm_ub_x-objects.dir/filename.c.o
../src/plugins/resolver/filename.c:78:84: warning: format specifies type 'long' but the argument has type '__darwin_suseconds_t' (aka 'int') [-Wformat]
        snprintf (where + len, POSTFIX_SIZE - 1, ".%d:%ld.%ld.tmp", getpid (), tv.tv_sec, tv.tv_usec);
                                                          ~~~                             ^~~~~~~~~~
                                                          %d
/usr/include/secure/_stdio.h:57:62: note: expanded from macro 'snprintf'
  __builtin___snprintf_chk (str, len, 0, __darwin_obsz(str), __VA_ARGS__)
                                                             ^~~~~~~~~~~
1 warning generated.
```