### PR TITLE
fix libsplit benchmark: POSIX compatibility

### DIFF
--- a/scripts/benchmark_libsplit.sh
+++ b/scripts/benchmark_libsplit.sh
@@ -6,13 +6,13 @@ fi
 
 BENCHMARK=./build/bin/large
 CURRTIME=`date +"%H-%M-%S_%m-%d-%Y"`
-LOGFILE="./doc/benchmark/logs/$(echo $KDB)_log_$CURRTIME.log"
+#LOGFILE="./doc/benchmark/logs/$(echo $KDB)_log_$CURRTIME.log"
+RUNS=21
 
-
-echo "Runtime as IEEE Std 1003.2-1992 (``POSIX.2'')" >> $LOGFILE
-for run in {0..20}; do
-	echo "RUN: #$run"
-	WALLTIME=$((time -p $BENCHMARK) 2>&1)
-	echo $WALLTIME | awk -F"real" '{print $1;}' # print programs stdout
-	echo $WALLTIME | awk -F"real" '{print $2;}' | awk '{print $1;}' >> $LOGFILE
+echo "Runtime as IEEE Std 1003.2-1992 (``POSIX.2'')"
+echo "Doing $RUNS runs:"
+for run in $(seq 1 $RUNS); do
+	WALLTIME=$( (time -p $BENCHMARK) 2>&1 )
+	#echo $WALLTIME | awk -F"real" '{print $1;}' # print programs stdout
+	echo $WALLTIME | awk -F"real" '{print $2;}' | awk '{print $1;}'
 done

--- a/scripts/benchmark_libsplit.sh
+++ b/scripts/benchmark_libsplit.sh
@@ -11,8 +11,10 @@ RUNS=21
 
 echo "Runtime as IEEE Std 1003.2-1992 (``POSIX.2'')"
 echo "Doing $RUNS runs:"
-for run in $(seq 1 $RUNS); do
+i=0
+while [ $i -lt $RUNS ] ; do
 	WALLTIME=$( (time -p $BENCHMARK) 2>&1 )
 	#echo $WALLTIME | awk -F"real" '{print $1;}' # print programs stdout
 	echo $WALLTIME | awk -F"real" '{print $2;}' | awk '{print $1;}'
+	i=$((i+1))
 done

--- a/scripts/benchmark_libsplit.sh
+++ b/scripts/benchmark_libsplit.sh
@@ -12,7 +12,7 @@ RUNS=21
 echo "Runtime as IEEE Std 1003.2-1992 (``POSIX.2'')"
 echo "Doing $RUNS runs:"
 i=0
-while [ $i -lt $RUNS ] ; do
+while [ "$i" -lt "$RUNS" ] ; do
 	WALLTIME=$( (time -p $BENCHMARK) 2>&1 )
 	#echo $WALLTIME | awk -F"real" '{print $1;}' # print programs stdout
 	echo $WALLTIME | awk -F"real" '{print $2;}' | awk '{print $1;}'


### PR DESCRIPTION
Should fix #530 .

Tested on FreeBSD which is:
> close to the IEEE	Std 1003.1 (``POSIX.1'')

Prints just to stdout now, instead of creating logfiles which I have used to evaluate the results in R.