### PR TITLE
fixes #645

### DIFF
--- a/src/plugins/ini/ini.c
+++ b/src/plugins/ini/ini.c
@@ -1113,7 +1113,7 @@ static int iniWriteKeySet (FILE * fh, Key * parentKey, KeySet * returned, IniPlu
 	ssize_t arraySize = ksGetSize (returned);
 	keyArray = elektraCalloc (arraySize * sizeof (Key *));
 	elektraKsToMemArray (returned, keyArray);
-	qsort (keyArray, arraySize, sizeof (Key *), iniCmpOrder);
+	mergesort (keyArray, arraySize, sizeof (Key *), iniCmpOrder);
 	Key * cur = NULL;
 	Key * sectionKey = parentKey;
 	int ret = 1;

--- a/src/plugins/ini/ini.c
+++ b/src/plugins/ini/ini.c
@@ -25,6 +25,11 @@
 #include <stdlib.h>
 #include <string.h>
 
+#if defined(__APPLE__) || defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__)
+#define SORT mergesort
+#else
+#define SORT qsort
+#endif
 
 char * keyNameGetOneLevel (const char *, size_t *);
 
@@ -1113,7 +1118,7 @@ static int iniWriteKeySet (FILE * fh, Key * parentKey, KeySet * returned, IniPlu
 	ssize_t arraySize = ksGetSize (returned);
 	keyArray = elektraCalloc (arraySize * sizeof (Key *));
 	elektraKsToMemArray (returned, keyArray);
-	mergesort (keyArray, arraySize, sizeof (Key *), iniCmpOrder);
+	SORT (keyArray, arraySize, sizeof (Key *), iniCmpOrder);
 	Key * cur = NULL;
 	Key * sectionKey = parentKey;
 	int ret = 1;


### PR DESCRIPTION
fixes #645 for me after countless debugging hours on:
- Mac OS X (10.11.4)
- FreeBSD (10.3-RELEASE-p2)

The only change is in `iniWriteKeySet `: using `mergesort` instead of `qsort`. The implementations appear to differ vastly and I'm still not sure why qsort is causing problems here. I hope that mergesort is acceptable here, but I don't suppose it will have much impact on runtime.