### PR TITLE
Add ANSI colors escapes to kdb

### DIFF
--- a/doc/AUTHORS
+++ b/doc/AUTHORS
@@ -39,7 +39,7 @@ Charles Lindsay
 ni library
 
 Gabriel Rauter <rauter.gabriel@gmail.com>
-xdg-icon theme, ansi colors in terminal kdb
+desktop environment integration & usability
 
 Avi Alkalay <avi@unix.sh>
 Initial concept, previous website

--- a/doc/AUTHORS
+++ b/doc/AUTHORS
@@ -38,6 +38,8 @@ Devel/Test on: Debian Stable
 Charles Lindsay
 ni library
 
+Gabriel Rauter <rauter.gabriel@gmail.com>
+xdg-icon theme, ansi colors in terminal kdb
 
 Avi Alkalay <avi@unix.sh>
 Initial concept, previous website

--- a/doc/help/kdb-check.md
+++ b/doc/help/kdb-check.md
@@ -28,8 +28,8 @@ Special values are returned upon exit to represent the outcome of a check.
   Explain what is happening.
 - `-c`, `--plugins-config`=<pluginconfig>:
   Add a plugin configuration in addition to `/module`.
-- `-C`, `--nocolor`:
-  Disable colored output.
+- `-C`, `--color`=[when]:
+  Print never/auto(default)/always colored output.
 
 
 ## RETURN VALUES

--- a/doc/help/kdb-check.md
+++ b/doc/help/kdb-check.md
@@ -28,6 +28,8 @@ Special values are returned upon exit to represent the outcome of a check.
   Explain what is happening.
 - `-c`, `--plugins-config`=<pluginconfig>:
   Add a plugin configuration in addition to `/module`.
+- `-C`, `--nocolor`:
+  Disable colored output.
 
 
 ## RETURN VALUES

--- a/doc/help/kdb-convert.md
+++ b/doc/help/kdb-convert.md
@@ -32,8 +32,8 @@ If either `import-file` or `export-file` are not specified, `stdin` and `stdout`
   Use a different kdb profile.
 - `-v`, `--verbose`:
   Explain what is happening.
-- `-C`, `--nocolor`:
-  Disable colored output.
+- `-C`, `--color`=[when]:
+  Print never/auto(default)/always colored output.
 
 
 ## EXAMPLES

--- a/doc/help/kdb-convert.md
+++ b/doc/help/kdb-convert.md
@@ -32,6 +32,8 @@ If either `import-file` or `export-file` are not specified, `stdin` and `stdout`
   Use a different kdb profile.
 - `-v`, `--verbose`:
   Explain what is happening.
+- `-C`, `--nocolor`:
+  Disable colored output.
 
 
 ## EXAMPLES

--- a/doc/help/kdb-cp.md
+++ b/doc/help/kdb-cp.md
@@ -28,6 +28,8 @@ Note that when using the `-r` flag, `source` as well as all of the keys below it
   Recursively copy keys.
 - `-v`, `--verbose`:
   Explain what is happening.
+- `-C`, `--nocolor`:
+  Disable colored output.
 
 
 

--- a/doc/help/kdb-cp.md
+++ b/doc/help/kdb-cp.md
@@ -28,8 +28,8 @@ Note that when using the `-r` flag, `source` as well as all of the keys below it
   Recursively copy keys.
 - `-v`, `--verbose`:
   Explain what is happening.
-- `-C`, `--nocolor`:
-  Disable colored output.
+- `-C`, `--color`=[when]:
+  Print never/auto(default)/always colored output.
 
 
 

--- a/doc/help/kdb-editor.md
+++ b/doc/help/kdb-editor.md
@@ -58,6 +58,8 @@ The user should specify the format that the current configuration or keys are in
   Explain what is happening.
 - `-e`, `--editor <editor>`:
   Which editor to use.
+- `-C`, `--nocolor`:
+  Disable colored output.
 
 
 ## EXAMPLES

--- a/doc/help/kdb-editor.md
+++ b/doc/help/kdb-editor.md
@@ -58,8 +58,8 @@ The user should specify the format that the current configuration or keys are in
   Explain what is happening.
 - `-e`, `--editor <editor>`:
   Which editor to use.
-- `-C`, `--nocolor`:
-  Disable colored output.
+- `-C`, `--color`=[when]:
+  Print never/auto(default)/always colored output.
 
 
 ## EXAMPLES

--- a/doc/help/kdb-export.md
+++ b/doc/help/kdb-export.md
@@ -31,6 +31,8 @@ The `storage` plugin can be configured at compile-time or changed by the link `l
   Omit the `system/elektra` directory.
 - `-c`, `--plugins-config`=<pluginconfig>:
   Add a configuration to the format plugin.
+- `-C`, `--nocolor`:
+  Disable colored output.
 
 ## KDB
 

--- a/doc/help/kdb-export.md
+++ b/doc/help/kdb-export.md
@@ -31,8 +31,8 @@ The `storage` plugin can be configured at compile-time or changed by the link `l
   Omit the `system/elektra` directory.
 - `-c`, `--plugins-config`=<pluginconfig>:
   Add a configuration to the format plugin.
-- `-C`, `--nocolor`:
-  Disable colored output.
+- `-C`, `--color`=[when]:
+  Print never/auto(default)/always colored output.
 
 ## KDB
 

--- a/doc/help/kdb-file.md
+++ b/doc/help/kdb-file.md
@@ -26,8 +26,8 @@ This command makes use of Elektra's `resolver` plugin which the uer can learn mo
   Suppress the newline at the end of the output.
 - `-N`, `--namespace`=<ns>:
   Specify the namespace to use when writing cascading keys.
-- `-C`, `--nocolor`:
-  Disable colored output.
+- `-C`, `--color`=[when]:
+  Print never/auto(default)/always colored output.
 
 ## KDB
 

--- a/doc/help/kdb-file.md
+++ b/doc/help/kdb-file.md
@@ -26,6 +26,8 @@ This command makes use of Elektra's `resolver` plugin which the uer can learn mo
   Suppress the newline at the end of the output.
 - `-N`, `--namespace`=<ns>:
   Specify the namespace to use when writing cascading keys.
+- `-C`, `--nocolor`:
+  Disable colored output.
 
 ## KDB
 

--- a/doc/help/kdb-fstab.md
+++ b/doc/help/kdb-fstab.md
@@ -27,8 +27,8 @@ This command will create the new entry with a name of `ZZZNewFstabName` which sh
   Use a different kdb profile.
 - `-v`, `--verbose`:
   Explain what is happening.
-- `-C`, `--nocolor`:
-  Disable colored output.
+- `-C`, `--color`=[when]:
+  Print never/auto(default)/always colored output.
 
 
 ## EXAMPLES

--- a/doc/help/kdb-fstab.md
+++ b/doc/help/kdb-fstab.md
@@ -27,6 +27,8 @@ This command will create the new entry with a name of `ZZZNewFstabName` which sh
   Use a different kdb profile.
 - `-v`, `--verbose`:
   Explain what is happening.
+- `-C`, `--nocolor`:
+  Disable colored output.
 
 
 ## EXAMPLES

--- a/doc/help/kdb-get.md
+++ b/doc/help/kdb-get.md
@@ -35,6 +35,8 @@ Additionally, a user can use the command `kdb ls <same key>` to see if an overri
   Explain what is happening.
   Gives a complete trace of all tried keys.
   Very useful to debug fallback and overrides.
+- `-C`, `--nocolor`:
+  Disable colored output.
 
 
 ## EXAMPLES

--- a/doc/help/kdb-get.md
+++ b/doc/help/kdb-get.md
@@ -35,8 +35,8 @@ Additionally, a user can use the command `kdb ls <same key>` to see if an overri
   Explain what is happening.
   Gives a complete trace of all tried keys.
   Very useful to debug fallback and overrides.
-- `-C`, `--nocolor`:
-  Disable colored output.
+- `-C`, `--color`=[when]:
+  Print never/auto(default)/always colored output.
 
 
 ## EXAMPLES

--- a/doc/help/kdb-getmeta.md
+++ b/doc/help/kdb-getmeta.md
@@ -37,6 +37,8 @@ This command will return the following values as an exit status:
   Use a different kdb profile.
 - `-n`, `--no-newline`:
   Suppress the newline at the end of the output.
+- `-C`, `--nocolor`:
+  Disable colored output.
 
 ## EXAMPLES
 

--- a/doc/help/kdb-getmeta.md
+++ b/doc/help/kdb-getmeta.md
@@ -37,8 +37,8 @@ This command will return the following values as an exit status:
   Use a different kdb profile.
 - `-n`, `--no-newline`:
   Suppress the newline at the end of the output.
-- `-C`, `--nocolor`:
-  Disable colored output.
+- `-C`, `--color`=[when]:
+  Print never/auto(default)/always colored output.
 
 ## EXAMPLES
 

--- a/doc/help/kdb-global-mount.md
+++ b/doc/help/kdb-global-mount.md
@@ -35,8 +35,8 @@ Use `kdb file system/elektra/globalplugins` to find out where exactly it will wr
   Use a different kdb profile.
 - `-W`, `--with-recommends`:
   Also add recommended plugins and warn if they are not available.
-- `-C`, `--nocolor`:
-  Disable colored output.
+- `-C`, `--color`=[when]:
+  Print never/auto(default)/always colored output.
 
 
 

--- a/doc/help/kdb-global-mount.md
+++ b/doc/help/kdb-global-mount.md
@@ -35,6 +35,8 @@ Use `kdb file system/elektra/globalplugins` to find out where exactly it will wr
   Use a different kdb profile.
 - `-W`, `--with-recommends`:
   Also add recommended plugins and warn if they are not available.
+- `-C`, `--nocolor`:
+  Disable colored output.
 
 
 

--- a/doc/help/kdb-import.md
+++ b/doc/help/kdb-import.md
@@ -51,6 +51,8 @@ Currently the following strategies exist for importing configurations:
   Explain what is happening.
 - `-c`, `--plugins-config`:
   Add a configuration to the format plugin.
+- `-C`, `--nocolor`:
+  Disable colored output.
 
 
 ## EXAMPLES

--- a/doc/help/kdb-import.md
+++ b/doc/help/kdb-import.md
@@ -51,8 +51,8 @@ Currently the following strategies exist for importing configurations:
   Explain what is happening.
 - `-c`, `--plugins-config`:
   Add a configuration to the format plugin.
-- `-C`, `--nocolor`:
-  Disable colored output.
+- `-C`, `--color`=[when]:
+  Print never/auto(default)/always colored output.
 
 
 ## EXAMPLES

--- a/doc/help/kdb-info.md
+++ b/doc/help/kdb-info.md
@@ -37,8 +37,8 @@ This command returns the following exit statuses:
   Load plugin even if system/elektra is available.
 - `-c`, `--plugins-config`:
   Add a plugin configuration.
-- `-C`, `--nocolor`:
-  Disable colored output.
+- `-C`, `--color`=[when]:
+  Print never/auto(default)/always colored output.
 
 ## EXAMPLES
 

--- a/doc/help/kdb-info.md
+++ b/doc/help/kdb-info.md
@@ -37,6 +37,8 @@ This command returns the following exit statuses:
   Load plugin even if system/elektra is available.
 - `-c`, `--plugins-config`:
   Add a plugin configuration.
+- `-C`, `--nocolor`:
+  Disable colored output.
 
 ## EXAMPLES
 

--- a/doc/help/kdb-list.md
+++ b/doc/help/kdb-list.md
@@ -24,8 +24,8 @@ The best plugins will be the last in the list.
   `infos/status` clause in the contract.
 - `-0`, `--null`:
   Use binary 0 termination
-- `-C`, `--nocolor`:
-  Disable colored output.
+- `-C`, `--color`=[when]:
+  Print never/auto(default)/always colored output.
 
 ## EXAMPLES
 

--- a/doc/help/kdb-list.md
+++ b/doc/help/kdb-list.md
@@ -24,6 +24,8 @@ The best plugins will be the last in the list.
   `infos/status` clause in the contract.
 - `-0`, `--null`:
   Use binary 0 termination
+- `-C`, `--nocolor`:
+  Disable colored output.
 
 ## EXAMPLES
 

--- a/doc/help/kdb-ls.md
+++ b/doc/help/kdb-ls.md
@@ -23,6 +23,8 @@ This command will list the name of all keys below a given path.
   Explain what is happening.
 - `-0`, `--null`:
   Use binary 0 termination.
+- `-C`, `--nocolor`:
+  Disable colored output.
 
 ## EXAMPLES
 

--- a/doc/help/kdb-ls.md
+++ b/doc/help/kdb-ls.md
@@ -23,8 +23,8 @@ This command will list the name of all keys below a given path.
   Explain what is happening.
 - `-0`, `--null`:
   Use binary 0 termination.
-- `-C`, `--nocolor`:
-  Disable colored output.
+- `-C`, `--color`=[when]:
+  Print never/auto(default)/always colored output.
 
 ## EXAMPLES
 

--- a/doc/help/kdb-lsmeta.md
+++ b/doc/help/kdb-lsmeta.md
@@ -22,8 +22,8 @@ If no meta keys are associated with the given key, nothing will be printed.
   Use binary 0 termination.
 - `-v`, `--verbose`:
   Show which key will be used.
-- `-C`, `--nocolor`:
-  Disable colored output.
+- `-C`, `--color`=[when]:
+  Print never/auto(default)/always colored output.
 
 
 ## EXAMPLE

--- a/doc/help/kdb-lsmeta.md
+++ b/doc/help/kdb-lsmeta.md
@@ -22,6 +22,8 @@ If no meta keys are associated with the given key, nothing will be printed.
   Use binary 0 termination.
 - `-v`, `--verbose`:
   Show which key will be used.
+- `-C`, `--nocolor`:
+  Disable colored output.
 
 
 ## EXAMPLE

--- a/doc/help/kdb-merge.md
+++ b/doc/help/kdb-merge.md
@@ -62,6 +62,8 @@ To interactively resolve conflicts, use the `-i` option.
   Explain what is happening.
 - `-i`, `--interactive`
   Interactively resolve the conflicts.
+- `-C`, `--nocolor`:
+  Disable colored output.
 
 
 ## EXAMPLES

--- a/doc/help/kdb-merge.md
+++ b/doc/help/kdb-merge.md
@@ -62,8 +62,8 @@ To interactively resolve conflicts, use the `-i` option.
   Explain what is happening.
 - `-i`, `--interactive`
   Interactively resolve the conflicts.
-- `-C`, `--nocolor`:
-  Disable colored output.
+- `-C`, `--color`=[when]:
+  Print never/auto(default)/always colored output.
 
 
 ## EXAMPLES

--- a/doc/help/kdb-mount.md
+++ b/doc/help/kdb-mount.md
@@ -57,6 +57,8 @@ Use `kdb file system/elektra/mountpoints` to find out where exactly it will writ
   Suppress the third column.
 - `-c`, `--plugins-config`=<config>:
   Add a plugin configuration for all plugins.
+- `-C`, `--nocolor`:
+  Disable colored output.
 - `-W`, `--with-recommends`:
   Also add recommended plugins and warn if they are not available.
 

--- a/doc/help/kdb-mount.md
+++ b/doc/help/kdb-mount.md
@@ -57,8 +57,8 @@ Use `kdb file system/elektra/mountpoints` to find out where exactly it will writ
   Suppress the third column.
 - `-c`, `--plugins-config`=<config>:
   Add a plugin configuration for all plugins.
-- `-C`, `--nocolor`:
-  Disable colored output.
+- `-C`, `--color`=[when]:
+  Print never/auto(default)/always colored output.
 - `-W`, `--with-recommends`:
   Also add recommended plugins and warn if they are not available.
 

--- a/doc/help/kdb-mv.md
+++ b/doc/help/kdb-mv.md
@@ -26,6 +26,8 @@ You can move keys to another directory within the database or even below another
   Work in a recursive mode.
 - `-v`, `--verbose`:
   Explain what is happening.
+- `-C`, `--nocolor`:
+  Disable colored output.
 
 ## EXAMPLES
 

--- a/doc/help/kdb-mv.md
+++ b/doc/help/kdb-mv.md
@@ -26,8 +26,8 @@ You can move keys to another directory within the database or even below another
   Work in a recursive mode.
 - `-v`, `--verbose`:
   Explain what is happening.
-- `-C`, `--nocolor`:
-  Disable colored output.
+- `-C`, `--color`=[when]:
+  Print never/auto(default)/always colored output.
 
 ## EXAMPLES
 

--- a/doc/help/kdb-remount.md
+++ b/doc/help/kdb-remount.md
@@ -26,6 +26,8 @@ This command allows a user to use an existing backend (such as one from a previo
 - `-i`, `--interactive`:
   Instead of passing all information by parameters
   ask the user interactively.
+- `-C`, `--nocolor`:
+  Disable colored output.
 
 ## EXAMPLES
 

--- a/doc/help/kdb-remount.md
+++ b/doc/help/kdb-remount.md
@@ -26,8 +26,8 @@ This command allows a user to use an existing backend (such as one from a previo
 - `-i`, `--interactive`:
   Instead of passing all information by parameters
   ask the user interactively.
-- `-C`, `--nocolor`:
-  Disable colored output.
+- `-C`, `--color`=[when]:
+  Print never/auto(default)/always colored output.
 
 ## EXAMPLES
 

--- a/doc/help/kdb-rm.md
+++ b/doc/help/kdb-rm.md
@@ -22,6 +22,8 @@ This command removes key(s) from the Key database.
   Use a different kdb profile.
 - `-r`, `--recursive`:
   Work in a recursive mode.
+- `-C`, `--nocolor`:
+  Disable colored output.
 
 ## EXAMPLES
 

--- a/doc/help/kdb-rm.md
+++ b/doc/help/kdb-rm.md
@@ -22,8 +22,8 @@ This command removes key(s) from the Key database.
   Use a different kdb profile.
 - `-r`, `--recursive`:
   Work in a recursive mode.
-- `-C`, `--nocolor`:
-  Disable colored output.
+- `-C`, `--color`=[when]:
+  Print never/auto(default)/always colored output.
 
 ## EXAMPLES
 

--- a/doc/help/kdb-set.md
+++ b/doc/help/kdb-set.md
@@ -29,6 +29,8 @@ To set a key to an empty value, `""` should be passed for the `value` argument.
 - `-N`, `--namespace`=<ns>:
   Specify the namespace to use when writing cascading keys.
   See [below in KDB](#KDB).
+- `-C`, `--nocolor`:
+  Disable colored output.
 
 ## KDB
 

--- a/doc/help/kdb-set.md
+++ b/doc/help/kdb-set.md
@@ -29,8 +29,8 @@ To set a key to an empty value, `""` should be passed for the `value` argument.
 - `-N`, `--namespace`=<ns>:
   Specify the namespace to use when writing cascading keys.
   See [below in KDB](#KDB).
-- `-C`, `--nocolor`:
-  Disable colored output.
+- `-C`, `--color`=[when]:
+  Print never/auto(default)/always colored output.
 
 ## KDB
 

--- a/doc/help/kdb-setmeta.md
+++ b/doc/help/kdb-setmeta.md
@@ -28,8 +28,8 @@ that is the place where you usually want to set meta data.
   Use a different kdb profile.
 - `-v`, `--verbose`:
   Explain what is happening.
-- `-C`, `--nocolor`:
-  Disable colored output.
+- `-C`, `--color`=[when]:
+  Print never/auto(default)/always colored output.
 
 
 ## EXAMPLES

--- a/doc/help/kdb-setmeta.md
+++ b/doc/help/kdb-setmeta.md
@@ -28,6 +28,8 @@ that is the place where you usually want to set meta data.
   Use a different kdb profile.
 - `-v`, `--verbose`:
   Explain what is happening.
+- `-C`, `--nocolor`:
+  Disable colored output.
 
 
 ## EXAMPLES

--- a/doc/help/kdb-sget.md
+++ b/doc/help/kdb-sget.md
@@ -23,6 +23,8 @@ This command will either print the value of the key it retrives or a default val
   Print version info.
 - `-p`, `--profile`=<profile>:
   Use a different kdb profile.
+- `-C`, `--nocolor`:
+  Disable colored output.
 
 
 ## EXAMPLES

--- a/doc/help/kdb-sget.md
+++ b/doc/help/kdb-sget.md
@@ -23,8 +23,8 @@ This command will either print the value of the key it retrives or a default val
   Print version info.
 - `-p`, `--profile`=<profile>:
   Use a different kdb profile.
-- `-C`, `--nocolor`:
-  Disable colored output.
+- `-C`, `--color`=[when]:
+  Print never/auto(default)/always colored output.
 
 
 ## EXAMPLES

--- a/doc/help/kdb-shell.md
+++ b/doc/help/kdb-shell.md
@@ -39,6 +39,8 @@ The kdb shell offers a number of commands to interact with the key database.
   Print version info.
 - `-p`, `--profile`=<profile>:
   Use a different kdb profile.
+- `-C`, `--nocolor`:
+  Disable colored output.
 
 ## EXAMPLES
 

--- a/doc/help/kdb-shell.md
+++ b/doc/help/kdb-shell.md
@@ -39,8 +39,8 @@ The kdb shell offers a number of commands to interact with the key database.
   Print version info.
 - `-p`, `--profile`=<profile>:
   Use a different kdb profile.
-- `-C`, `--nocolor`:
-  Disable colored output.
+- `-C`, `--color`=[when]:
+  Print never/auto(default)/always colored output.
 
 ## EXAMPLES
 

--- a/doc/help/kdb-spec-mount.md
+++ b/doc/help/kdb-spec-mount.md
@@ -48,8 +48,8 @@ Use `kdb file system/elektra/mountpoints` to find out where exactly it will writ
   Note that the resolver will only added as dependency, but not directly added.
 - `-c`, `--plugins-config`=<config>:
   Add a plugin configuration for all plugins.
-- `-C`, `--nocolor`:
-  Disable colored output.
+- `-C`, `--color`=[when]:
+  Print never/auto(default)/always colored output.
 - `-W`, `--with-recommends`:
   Also add recommended plugins and warn if they are not available.
 

--- a/doc/help/kdb-spec-mount.md
+++ b/doc/help/kdb-spec-mount.md
@@ -48,6 +48,8 @@ Use `kdb file system/elektra/mountpoints` to find out where exactly it will writ
   Note that the resolver will only added as dependency, but not directly added.
 - `-c`, `--plugins-config`=<config>:
   Add a plugin configuration for all plugins.
+- `-C`, `--nocolor`:
+  Disable colored output.
 - `-W`, `--with-recommends`:
   Also add recommended plugins and warn if they are not available.
 

--- a/doc/help/kdb-test.md
+++ b/doc/help/kdb-test.md
@@ -24,8 +24,8 @@ The following tests are available: basic string umlauts binary naming meta
   Print version info.
 - `-p`, `--profile`=<profile>:
   Use a different kdb profile.
-- `-C`, `--nocolor`:
-  Disable colored output.
+- `-C`, `--color`=[when]:
+  Print never/auto(default)/always colored output.
 
 ## EXAMPLES
 

--- a/doc/help/kdb-test.md
+++ b/doc/help/kdb-test.md
@@ -24,6 +24,8 @@ The following tests are available: basic string umlauts binary naming meta
   Print version info.
 - `-p`, `--profile`=<profile>:
   Use a different kdb profile.
+- `-C`, `--nocolor`:
+  Disable colored output.
 
 ## EXAMPLES
 

--- a/doc/help/kdb-umount.md
+++ b/doc/help/kdb-umount.md
@@ -19,8 +19,8 @@ Unmount backend from key database.
   Use a different kdb profile.
 - `-v`, `--verbose`:
   Show which mountpoints were considered.
-- `-C`, `--nocolor`:
-  Disable colored output.
+- `-C`, `--color`=[when]:
+  Print never/auto(default)/always colored output.
 
 ## SEE ALSO
 

--- a/doc/help/kdb-umount.md
+++ b/doc/help/kdb-umount.md
@@ -19,6 +19,8 @@ Unmount backend from key database.
   Use a different kdb profile.
 - `-v`, `--verbose`:
   Show which mountpoints were considered.
+- `-C`, `--nocolor`:
+  Disable colored output.
 
 ## SEE ALSO
 

--- a/doc/help/kdb-vset.md
+++ b/doc/help/kdb-vset.md
@@ -26,6 +26,8 @@ Note: In order for this command to work, the `validation` plugin must be mounted
   Print version info.
 - `-p`, `--profile`=<profile>:
   Use a different kdb profile.
+- `-C`, `--nocolor`:
+  Disable colored output.
 
 
 ## EXAMPLES

--- a/doc/help/kdb-vset.md
+++ b/doc/help/kdb-vset.md
@@ -26,8 +26,8 @@ Note: In order for this command to work, the `validation` plugin must be mounted
   Print version info.
 - `-p`, `--profile`=<profile>:
   Use a different kdb profile.
-- `-C`, `--nocolor`:
-  Disable colored output.
+- `-C`, `--color`=[when]:
+  Print never/auto(default)/always colored output.
 
 
 ## EXAMPLES

--- a/doc/help/kdb.md
+++ b/doc/help/kdb.md
@@ -39,8 +39,8 @@ Every core-tool has the following options:
   Print version info.
 - `-p`, `--profile`=<profile>:
   Use a different kdb profile, see below.
-- `-C`, `--nocolor`:
-  Disable colored output.
+- `-C`, `--color`=[when]:
+  Print never/auto(default)/always colored output.
 
 ## KDB
 

--- a/doc/help/kdb.md
+++ b/doc/help/kdb.md
@@ -39,6 +39,8 @@ Every core-tool has the following options:
   Print version info.
 - `-p`, `--profile`=<profile>:
   Use a different kdb profile, see below.
+- `-C`, `--nocolor`:
+  Disable colored output.
 
 ## KDB
 

--- a/src/tools/kdb/ansicolors.cpp
+++ b/src/tools/kdb/ansicolors.cpp
@@ -1,0 +1,72 @@
+#include "ansicolors.hpp"
+
+std::string getColorEscape (ANSI_COLOR color, ANSI_COLOR_LAYER layer)
+{
+	if (color == ANSI_COLOR::RESET) return "\x1b[0m";
+	if (color == ANSI_COLOR::BOLD) return "\x1b[1m";
+	if (color == ANSI_COLOR::UNDERSCORE) return "\x1b[4m";
+	if (layer == ANSI_COLOR_LAYER::FG)
+	{
+		switch (color)
+		{
+		case ANSI_COLOR::BLACK:
+			return "\x1b[30m";
+			break;
+		case ANSI_COLOR::RED:
+			return "\x1b[31m";
+			break;
+		case ANSI_COLOR::GREEN:
+			return "\x1b[32m";
+			break;
+		case ANSI_COLOR::YELLOW:
+			return "\x1b[33m";
+			break;
+		case ANSI_COLOR::MAGENTA:
+			return "\x1b[33m";
+			break;
+		case ANSI_COLOR::BLUE:
+			return "\x1b[34m";
+			break;
+		case ANSI_COLOR::CYAN:
+			return "\x1b[35m";
+			break;
+		case ANSI_COLOR::WHITE:
+			return "\x1b[36m";
+			break;
+		default:
+			return "";
+		}
+	}
+	else
+	{
+		switch (color)
+		{
+		case ANSI_COLOR::BLACK:
+			return "\x1b[40m";
+			break;
+		case ANSI_COLOR::RED:
+			return "\x1b[41m";
+			break;
+		case ANSI_COLOR::GREEN:
+			return "\x1b[42m";
+			break;
+		case ANSI_COLOR::YELLOW:
+			return "\x1b[43m";
+			break;
+		case ANSI_COLOR::MAGENTA:
+			return "\x1b[44m";
+			break;
+		case ANSI_COLOR::BLUE:
+			return "\x1b[45m";
+			break;
+		case ANSI_COLOR::CYAN:
+			return "\x1b[46m";
+			break;
+		case ANSI_COLOR::WHITE:
+			return "\x1b[47m";
+			break;
+		default:
+			return "";
+		}
+	}
+}

--- a/src/tools/kdb/ansicolors.cpp
+++ b/src/tools/kdb/ansicolors.cpp
@@ -1,7 +1,10 @@
 #include "ansicolors.hpp"
 
+bool& nocolors() { static bool nocolors; return nocolors; }
+
 std::string getColorEscape (ANSI_COLOR color, ANSI_COLOR_LAYER layer)
 {
+  if (nocolors()) return "";
 	if (color == ANSI_COLOR::RESET) return "\x1b[0m";
 	if (color == ANSI_COLOR::BOLD) return "\x1b[1m";
 	if (color == ANSI_COLOR::UNDERSCORE) return "\x1b[4m";
@@ -21,17 +24,17 @@ std::string getColorEscape (ANSI_COLOR color, ANSI_COLOR_LAYER layer)
 		case ANSI_COLOR::YELLOW:
 			return "\x1b[33m";
 			break;
-		case ANSI_COLOR::MAGENTA:
-			return "\x1b[33m";
-			break;
 		case ANSI_COLOR::BLUE:
 			return "\x1b[34m";
 			break;
-		case ANSI_COLOR::CYAN:
+		case ANSI_COLOR::MAGENTA:
 			return "\x1b[35m";
 			break;
-		case ANSI_COLOR::WHITE:
+		case ANSI_COLOR::CYAN:
 			return "\x1b[36m";
+			break;
+		case ANSI_COLOR::WHITE:
+			return "\x1b[37m";
 			break;
 		default:
 			return "";
@@ -53,10 +56,10 @@ std::string getColorEscape (ANSI_COLOR color, ANSI_COLOR_LAYER layer)
 		case ANSI_COLOR::YELLOW:
 			return "\x1b[43m";
 			break;
-		case ANSI_COLOR::MAGENTA:
+		case ANSI_COLOR::BLUE:
 			return "\x1b[44m";
 			break;
-		case ANSI_COLOR::BLUE:
+		case ANSI_COLOR::MAGENTA:
 			return "\x1b[45m";
 			break;
 		case ANSI_COLOR::CYAN:

--- a/src/tools/kdb/ansicolors.cpp
+++ b/src/tools/kdb/ansicolors.cpp
@@ -8,8 +8,8 @@
 
 #include "ansicolors.hpp"
 #ifdef _WIN32
-#include <stdio.h>
 #include <io.h>
+#include <stdio.h>
 #undef STDERR_FILENO
 #undef STDOUT_FILENO
 #define STDERR_FILENO _fileno (stderr)

--- a/src/tools/kdb/ansicolors.cpp
+++ b/src/tools/kdb/ansicolors.cpp
@@ -9,6 +9,8 @@
 #include "ansicolors.hpp"
 #ifdef _WIN32
 #include <stdio.h>
+#undef STDERR_FILENO
+#undef STDOUT_FILENO
 #define STDERR_FILENO _fileno (stderr)
 #define STDOUT_FILENO _fileno (stdout)
 #else
@@ -101,3 +103,8 @@ std::string getStdColor (ANSI_COLOR color, ANSI_COLOR_LAYER layer)
 	if (colors ().compare ("never") == 0 || (colors ().compare ("auto") == 0 && !isatty (STDOUT_FILENO))) return "";
 	return getColorEscape (color, layer);
 }
+
+#ifdef _WIN32
+#undef STDERR_FILENO
+#undef STDOUT_FILENO
+#endif

--- a/src/tools/kdb/ansicolors.cpp
+++ b/src/tools/kdb/ansicolors.cpp
@@ -1,10 +1,14 @@
 #include "ansicolors.hpp"
 
-bool& nocolors() { static bool nocolors; return nocolors; }
+bool & nocolors ()
+{
+	static bool nocolors;
+	return nocolors;
+}
 
 std::string getColorEscape (ANSI_COLOR color, ANSI_COLOR_LAYER layer)
 {
-  if (nocolors()) return "";
+	if (nocolors ()) return "";
 	if (color == ANSI_COLOR::RESET) return "\x1b[0m";
 	if (color == ANSI_COLOR::BOLD) return "\x1b[1m";
 	if (color == ANSI_COLOR::UNDERSCORE) return "\x1b[4m";

--- a/src/tools/kdb/ansicolors.cpp
+++ b/src/tools/kdb/ansicolors.cpp
@@ -9,10 +9,12 @@
 #include "ansicolors.hpp"
 #ifdef _WIN32
 #include <stdio.h>
+#include <io.h>
 #undef STDERR_FILENO
 #undef STDOUT_FILENO
 #define STDERR_FILENO _fileno (stderr)
 #define STDOUT_FILENO _fileno (stdout)
+#define isatty _isatty
 #else
 #include <unistd.h>
 #endif
@@ -105,6 +107,7 @@ std::string getStdColor (ANSI_COLOR color, ANSI_COLOR_LAYER layer)
 }
 
 #ifdef _WIN32
+#undef isatty
 #undef STDERR_FILENO
 #undef STDOUT_FILENO
 #endif

--- a/src/tools/kdb/ansicolors.cpp
+++ b/src/tools/kdb/ansicolors.cpp
@@ -1,14 +1,27 @@
-#include "ansicolors.hpp"
+/**
+ * @file
+ *
+ * @brief
+ *
+ * @copyright BSD License (see doc/COPYING or http://www.libelektra.org)
+ */
 
-bool & nocolors ()
+#include "ansicolors.hpp"
+#ifdef _WIN32
+#include <stdio.h>
+#define STDERR_FILENO _fileno (stderr)
+#define STDOUT_FILENO _fileno (stdout)
+#else
+#include <unistd.h>
+#endif
+std::string & colors ()
 {
-	static bool nocolors;
+	static std::string nocolors = "auto";
 	return nocolors;
 }
 
 std::string getColorEscape (ANSI_COLOR color, ANSI_COLOR_LAYER layer)
 {
-	if (nocolors ()) return "";
 	if (color == ANSI_COLOR::RESET) return "\x1b[0m";
 	if (color == ANSI_COLOR::BOLD) return "\x1b[1m";
 	if (color == ANSI_COLOR::UNDERSCORE) return "\x1b[4m";
@@ -76,4 +89,15 @@ std::string getColorEscape (ANSI_COLOR color, ANSI_COLOR_LAYER layer)
 			return "";
 		}
 	}
+}
+
+std::string getErrorColor (ANSI_COLOR color, ANSI_COLOR_LAYER layer)
+{
+	if (colors ().compare ("never") == 0 || (colors ().compare ("auto") == 0 && !isatty (STDERR_FILENO))) return "";
+	return getColorEscape (color, layer);
+}
+std::string getStdColor (ANSI_COLOR color, ANSI_COLOR_LAYER layer)
+{
+	if (colors ().compare ("never") == 0 || (colors ().compare ("auto") == 0 && !isatty (STDOUT_FILENO))) return "";
+	return getColorEscape (color, layer);
 }

--- a/src/tools/kdb/ansicolors.hpp
+++ b/src/tools/kdb/ansicolors.hpp
@@ -32,9 +32,11 @@ enum class ANSI_COLOR_LAYER
 	BG
 };
 
-bool & nocolors ();
+std::string & colors ();
 /*YYY: If you add colored escaped to your command remembter to add the C option
        If you want colored warnings error include coloredkdbio.hpp before kdb.hpp */
 std::string getColorEscape (ANSI_COLOR color, ANSI_COLOR_LAYER layer = ANSI_COLOR_LAYER::FG);
+std::string getErrorColor (ANSI_COLOR color, ANSI_COLOR_LAYER layer = ANSI_COLOR_LAYER::FG);
+std::string getStdColor (ANSI_COLOR color, ANSI_COLOR_LAYER layer = ANSI_COLOR_LAYER::FG);
 
 #endif

--- a/src/tools/kdb/ansicolors.hpp
+++ b/src/tools/kdb/ansicolors.hpp
@@ -32,6 +32,9 @@ enum class ANSI_COLOR_LAYER
 	BG
 };
 
+bool& nocolors();
+/*YYY: If you add colored escaped to your command remembter to add the C option
+       If you want colored warnings error include coloredkdbio.hpp before kdb.hpp */
 std::string getColorEscape (ANSI_COLOR color, ANSI_COLOR_LAYER layer = ANSI_COLOR_LAYER::FG);
 
 #endif

--- a/src/tools/kdb/ansicolors.hpp
+++ b/src/tools/kdb/ansicolors.hpp
@@ -10,7 +10,9 @@
 #define ANSI_COLORS_HPP
 
 #include <string>
-
+/**
+ *  An enum type representing different ansi color escape sequences.
+ */
 enum class ANSI_COLOR
 {
 	RESET,
@@ -25,18 +27,48 @@ enum class ANSI_COLOR
 	CYAN,
 	WHITE
 };
-
+/**
+ *  An enum type representing different ansi color escape layers.
+ */
 enum class ANSI_COLOR_LAYER
 {
 	FG,
 	BG
 };
 
+/**
+ *  colormode handle
+ *  set to "always" to always print colors, "auto" to print colors if the coresponding output channel is a tty
+ *  and to "never" to never print colors.
+ */
 std::string & colors ();
-/*YYY: If you add colored escaped to your command remembter to add the C option
-       If you want colored warnings error include coloredkdbio.hpp before kdb.hpp */
+
+/**
+ *  getColorEscape returns the ansi escape sequence for the requested color and
+ *  the requested layer and shift it to the desired output channel. Do not forget
+ *  to reset it afterwards.
+ *  @param color the desired color or highlite. Use \p ANSI_COLOR::RESET to reset the style.
+ *  @param layer the desired layer: foreground = ANSI_COLOR_LAYER::FG or background = ANSI_COLOR_LAYER::BG.
+ *  @return ansi color escape sequence for tty
+ */
 std::string getColorEscape (ANSI_COLOR color, ANSI_COLOR_LAYER layer = ANSI_COLOR_LAYER::FG);
+
+/**
+ *  @see getColorEscape
+ *  Only returns a color escape sequence if colors="always" or colors="auto" (default) and the cerr handle is a tty
+ *  @param color the desired color or highlite. Use \p ANSI_COLOR::RESET to reset the style.
+ *  @param layer the desired layer: foreground = ANSI_COLOR_LAYER::FG or background = ANSI_COLOR_LAYER::BG.
+ *  @return ansi color escape sequence for tty if colors="always" or "auto" and cerr is a tty, it returns an empty string otherwise
+ */
 std::string getErrorColor (ANSI_COLOR color, ANSI_COLOR_LAYER layer = ANSI_COLOR_LAYER::FG);
+
+/**
+ *  @see getColorEscape
+ *  Only returns a color escape sequence if colors="always" or colors="auto" (default) and the stdout is a tty
+ *  @param color the desired color or highlite. Use \p ANSI_COLOR::RESET to reset the style.
+ *  @param layer the desired layer: foreground = ANSI_COLOR_LAYER::FG or background = ANSI_COLOR_LAYER::BG.
+ *  @return ansi color escape sequence for tty if colors="always" or "auto" and stdout is a tty, it returns an empty string otherwise
+ */
 std::string getStdColor (ANSI_COLOR color, ANSI_COLOR_LAYER layer = ANSI_COLOR_LAYER::FG);
 
 #endif

--- a/src/tools/kdb/ansicolors.hpp
+++ b/src/tools/kdb/ansicolors.hpp
@@ -32,7 +32,7 @@ enum class ANSI_COLOR_LAYER
 	BG
 };
 
-bool& nocolors();
+bool & nocolors ();
 /*YYY: If you add colored escaped to your command remembter to add the C option
        If you want colored warnings error include coloredkdbio.hpp before kdb.hpp */
 std::string getColorEscape (ANSI_COLOR color, ANSI_COLOR_LAYER layer = ANSI_COLOR_LAYER::FG);

--- a/src/tools/kdb/ansicolors.hpp
+++ b/src/tools/kdb/ansicolors.hpp
@@ -9,27 +9,29 @@
 #ifndef ANSI_COLORS_HPP
 #define ANSI_COLORS_HPP
 
-namespace kdb
+#include <string>
+
+enum class ANSI_COLOR
 {
-static const char * ANSI_COLOR_RESET = "\x1b[0m";
-static const char * ANSI_COLOR_BOLD = "\x1b[1m";
-static const char * ANSI_COLOR_UNDERSCORE = "\x1b[4m";
-static const char * ANSI_FG_COLOR_BLACK = "\x1b[30m";
-static const char * ANSI_FG_COLOR_RED = "\x1b[31m";
-static const char * ANSI_FG_COLOR_GREEN = "\x1b[32m";
-static const char * ANSI_FG_COLOR_YELLOW = "\x1b[33m";
-static const char * ANSI_FG_COLOR_BLUE = "\x1b[34m";
-static const char * ANSI_FG_COLOR_MAGENTA = "\x1b[35m";
-static const char * ANSI_FG_COLOR_CYAN = "\x1b[36m";
-static const char * ANSI_FG_COLOR_WHITE = "\x1b[37m";
-static const char * ANSI_BG_COLOR_BLACK = "\x1b[40m";
-static const char * ANSI_BG_COLOR_RED = "\x1b[41m";
-static const char * ANSI_BG_COLOR_GREEN = "\x1b[42m";
-static const char * ANSI_BG_COLOR_YELLOW = "\x1b[43m";
-static const char * ANSI_BG_COLOR_BLUE = "\x1b[44m";
-static const char * ANSI_BG_COLOR_MAGENTA = "\x1b[45m";
-static const char * ANSI_BG_COLOR_CYAN = "\x1b[46m";
-static const char * ANSI_BG_COLOR_WHITE = "\x1b[47m";
-}
+	RESET,
+	BOLD,
+	UNDERSCORE,
+	BLACK,
+	RED,
+	GREEN,
+	YELLOW,
+	MAGENTA,
+	BLUE,
+	CYAN,
+	WHITE
+};
+
+enum class ANSI_COLOR_LAYER
+{
+	FG,
+	BG
+};
+
+std::string getColorEscape (ANSI_COLOR color, ANSI_COLOR_LAYER layer = ANSI_COLOR_LAYER::FG);
 
 #endif

--- a/src/tools/kdb/ansicolors.hpp
+++ b/src/tools/kdb/ansicolors.hpp
@@ -1,0 +1,35 @@
+/**
+ * @file
+ *
+ * @brief
+ *
+ * @copyright BSD License (see doc/COPYING or http://www.libelektra.org)
+ */
+
+#ifndef ANSI_COLORS_HPP
+#define ANSI_COLORS_HPP
+
+namespace kdb
+{
+static const char * ANSI_COLOR_RESET = "\x1b[0m";
+static const char * ANSI_COLOR_BOLD = "\x1b[1m";
+static const char * ANSI_COLOR_UNDERSCORE = "\x1b[4m";
+static const char * ANSI_FG_COLOR_BLACK = "\x1b[30m";
+static const char * ANSI_FG_COLOR_RED = "\x1b[31m";
+static const char * ANSI_FG_COLOR_GREEN = "\x1b[32m";
+static const char * ANSI_FG_COLOR_YELLOW = "\x1b[33m";
+static const char * ANSI_FG_COLOR_BLUE = "\x1b[34m";
+static const char * ANSI_FG_COLOR_MAGENTA = "\x1b[35m";
+static const char * ANSI_FG_COLOR_CYAN = "\x1b[36m";
+static const char * ANSI_FG_COLOR_WHITE = "\x1b[37m";
+static const char * ANSI_BG_COLOR_BLACK = "\x1b[40m";
+static const char * ANSI_BG_COLOR_RED = "\x1b[41m";
+static const char * ANSI_BG_COLOR_GREEN = "\x1b[42m";
+static const char * ANSI_BG_COLOR_YELLOW = "\x1b[43m";
+static const char * ANSI_BG_COLOR_BLUE = "\x1b[44m";
+static const char * ANSI_BG_COLOR_MAGENTA = "\x1b[45m";
+static const char * ANSI_BG_COLOR_CYAN = "\x1b[46m";
+static const char * ANSI_BG_COLOR_WHITE = "\x1b[47m";
+}
+
+#endif

--- a/src/tools/kdb/check.hpp
+++ b/src/tools/kdb/check.hpp
@@ -11,6 +11,7 @@
 
 #include <command.hpp>
 
+#include "coloredkdbio.hpp"
 #include <kdb.hpp>
 
 class CheckCommand : public Command
@@ -21,7 +22,7 @@ public:
 
 	virtual std::string getShortOptions () override
 	{
-		return "vcf";
+		return "vcfC";
 	}
 
 	virtual std::string getSynopsis () override

--- a/src/tools/kdb/cmdline.cpp
+++ b/src/tools/kdb/cmdline.cpp
@@ -330,7 +330,7 @@ Cmdline::Cmdline (int argc, char ** argv, Command * command)
 			break;
 		case 'C':
 			color = false;
-			nocolors() = true;
+			nocolors () = true;
 			break;
 		case 'd':
 			debug = true;

--- a/src/tools/kdb/cmdline.cpp
+++ b/src/tools/kdb/cmdline.cpp
@@ -330,6 +330,7 @@ Cmdline::Cmdline (int argc, char ** argv, Command * command)
 			break;
 		case 'C':
 			color = false;
+			nocolors() = true;
 			break;
 		case 'd':
 			debug = true;
@@ -489,12 +490,6 @@ kdb::Key Cmdline::createKey (int pos) const
 	}
 
 	return root;
-}
-
-const std::string Cmdline::getColor (ANSI_COLOR ansicolor, ANSI_COLOR_LAYER layer) const
-{
-	if (!color) return "";
-	return getColorEscape (ansicolor, layer);
 }
 
 std::ostream & operator<< (std::ostream & os, Cmdline & cl)

--- a/src/tools/kdb/cmdline.cpp
+++ b/src/tools/kdb/cmdline.cpp
@@ -38,8 +38,8 @@ Cmdline::Cmdline (int argc, char ** argv, Command * command)
   /*XXX: Step 2: initialise your option here.*/
   debug (), force (), load (), humanReadable (), help (), interactive (), noNewline (), test (), recursive (), resolver (KDB_RESOLVER),
   strategy ("preserve"), verbose (), version (), withoutElektra (), null (), first (true), second (true), third (true),
-  withRecommends (false), all (), format (KDB_STORAGE), plugins ("sync"), globalPlugins ("spec"), pluginsConfig (""), ns (""), editor (),
-  bookmarks (), profile ("current"),
+  withRecommends (false), all (), format (KDB_STORAGE), plugins ("sync"), globalPlugins ("spec"), pluginsConfig (""), color (true), ns (""),
+  editor (), bookmarks (), profile ("current"),
 
   executable (), commandName ()
 {
@@ -221,6 +221,13 @@ Cmdline::Cmdline (int argc, char ** argv, Command * command)
 		long_options.push_back (o);
 		helpText += "-c --plugins-config      Add a plugin configuration.\n";
 	}
+	optionPos = acceptedOptions.find ('C');
+	if (optionPos != string::npos)
+	{
+		option o = { "nocolor", no_argument, nullptr, 'C' };
+		long_options.push_back (o);
+		helpText += "-C --nocolor             Disable colored output.\n";
+	}
 
 	int index = 0;
 	option o = { nullptr, 0, nullptr, 0 };
@@ -320,6 +327,9 @@ Cmdline::Cmdline (int argc, char ** argv, Command * command)
 		/*XXX: Step 5: and now process the option.*/
 		case 'a':
 			all = true;
+			break;
+		case 'C':
+			color = false;
 			break;
 		case 'd':
 			debug = true;
@@ -479,6 +489,12 @@ kdb::Key Cmdline::createKey (int pos) const
 	}
 
 	return root;
+}
+
+const std::string Cmdline::getColor (ANSI_COLOR ansicolor, ANSI_COLOR_LAYER layer) const
+{
+	if (!color) return "";
+	return getColorEscape (ansicolor, layer);
 }
 
 std::ostream & operator<< (std::ostream & os, Cmdline & cl)

--- a/src/tools/kdb/cmdline.cpp
+++ b/src/tools/kdb/cmdline.cpp
@@ -38,8 +38,8 @@ Cmdline::Cmdline (int argc, char ** argv, Command * command)
   /*XXX: Step 2: initialise your option here.*/
   debug (), force (), load (), humanReadable (), help (), interactive (), noNewline (), test (), recursive (), resolver (KDB_RESOLVER),
   strategy ("preserve"), verbose (), version (), withoutElektra (), null (), first (true), second (true), third (true),
-  withRecommends (false), all (), format (KDB_STORAGE), plugins ("sync"), globalPlugins ("spec"), pluginsConfig (""), color (true), ns (""),
-  editor (), bookmarks (), profile ("current"),
+  withRecommends (false), all (), format (KDB_STORAGE), plugins ("sync"), globalPlugins ("spec"), pluginsConfig (""), color ("auto"),
+  ns (""), editor (), bookmarks (), profile ("current"),
 
   executable (), commandName ()
 {
@@ -224,9 +224,9 @@ Cmdline::Cmdline (int argc, char ** argv, Command * command)
 	optionPos = acceptedOptions.find ('C');
 	if (optionPos != string::npos)
 	{
-		option o = { "nocolor", no_argument, nullptr, 'C' };
+		option o = { "color", optional_argument, nullptr, 'C' };
 		long_options.push_back (o);
-		helpText += "-C --nocolor             Disable colored output.\n";
+		helpText += "-C --color[=WHEN]        Print never/auto(default)/always colored output.\n";
 	}
 
 	int index = 0;
@@ -329,8 +329,12 @@ Cmdline::Cmdline (int argc, char ** argv, Command * command)
 			all = true;
 			break;
 		case 'C':
-			color = false;
-			nocolors () = true;
+			if (!optarg)
+			{
+				colors () = "auto";
+				break;
+			}
+			colors () = color = optarg;
 			break;
 		case 'd':
 			debug = true;

--- a/src/tools/kdb/cmdline.cpp
+++ b/src/tools/kdb/cmdline.cpp
@@ -300,6 +300,9 @@ Cmdline::Cmdline (int argc, char ** argv, Command * command)
 
 			map nks = conf.get<map> (dirname + "bookmarks");
 			bookmarks.insert (nks.begin (), nks.end ());
+
+			k = conf.lookup (dirname + "color");
+			if (k) colors () = color = k.get<std::string> ();
 		}
 	}
 	catch (kdb::KDBException const & ce)

--- a/src/tools/kdb/cmdline.hpp
+++ b/src/tools/kdb/cmdline.hpp
@@ -23,6 +23,8 @@
 #include <string>
 #include <vector>
 
+#include "ansicolors.hpp"
+
 class Command;
 
 namespace kdb
@@ -78,6 +80,7 @@ public:
 	std::string plugins;
 	std::string globalPlugins;
 	std::string pluginsConfig;
+	bool color; /*!< To disable colored output */
 	std::string ns;
 	std::string editor;
 
@@ -98,6 +101,8 @@ public:
 
 	/** The arguments given on the commandline. */
 	std::vector<std::string> arguments;
+
+	const std::string getColor (ANSI_COLOR ansicolor, ANSI_COLOR_LAYER layer = ANSI_COLOR_LAYER::FG) const;
 };
 
 std::ostream & operator<< (std::ostream & os, Cmdline & cl);

--- a/src/tools/kdb/cmdline.hpp
+++ b/src/tools/kdb/cmdline.hpp
@@ -101,8 +101,6 @@ public:
 
 	/** The arguments given on the commandline. */
 	std::vector<std::string> arguments;
-
-	const std::string getColor (ANSI_COLOR ansicolor, ANSI_COLOR_LAYER layer = ANSI_COLOR_LAYER::FG) const;
 };
 
 std::ostream & operator<< (std::ostream & os, Cmdline & cl);

--- a/src/tools/kdb/cmdline.hpp
+++ b/src/tools/kdb/cmdline.hpp
@@ -80,7 +80,7 @@ public:
 	std::string plugins;
 	std::string globalPlugins;
 	std::string pluginsConfig;
-	bool color; /*!< To disable colored output */
+	std::string color; /*!< To disable colored output */
 	std::string ns;
 	std::string editor;
 

--- a/src/tools/kdb/cmdline.hpp
+++ b/src/tools/kdb/cmdline.hpp
@@ -80,7 +80,7 @@ public:
 	std::string plugins;
 	std::string globalPlugins;
 	std::string pluginsConfig;
-	std::string color; /*!< To disable colored output */
+	std::string color; /*!< colormode "never", "always" and "auto" to print color if output channel is a tty */
 	std::string ns;
 	std::string editor;
 

--- a/src/tools/kdb/coloredkdbio.hpp
+++ b/src/tools/kdb/coloredkdbio.hpp
@@ -35,27 +35,27 @@ inline std::ostream & printError (std::ostream & os, kdb::Key const & error)
 			return os;
 		}
 
-		os << getColorEscape (ANSI_COLOR::BOLD) << getColorEscape (ANSI_COLOR::RED) << "Error (#"
-		   << error.getMeta<std::string> ("error/number") << ") occurred!" << getColorEscape (ANSI_COLOR::RESET) << std::endl;
-		os << getColorEscape (ANSI_COLOR::BOLD) << "Description: " << getColorEscape (ANSI_COLOR::RESET)
+		os << getErrorColor (ANSI_COLOR::BOLD) << getErrorColor (ANSI_COLOR::RED) << "Error (#"
+		   << error.getMeta<std::string> ("error/number") << ") occurred!" << getErrorColor (ANSI_COLOR::RESET) << std::endl;
+		os << getErrorColor (ANSI_COLOR::BOLD) << "Description: " << getErrorColor (ANSI_COLOR::RESET)
 		   << error.getMeta<std::string> ("error/description") << std::endl;
-		os << getColorEscape (ANSI_COLOR::BOLD) << "Ingroup: " << getColorEscape (ANSI_COLOR::RESET)
+		os << getErrorColor (ANSI_COLOR::BOLD) << "Ingroup: " << getErrorColor (ANSI_COLOR::RESET)
 		   << error.getMeta<std::string> ("error/ingroup") << std::endl;
-		os << getColorEscape (ANSI_COLOR::BOLD) << "Module: " << getColorEscape (ANSI_COLOR::RESET)
+		os << getErrorColor (ANSI_COLOR::BOLD) << "Module: " << getErrorColor (ANSI_COLOR::RESET)
 		   << error.getMeta<std::string> ("error/module") << std::endl;
-		os << getColorEscape (ANSI_COLOR::BOLD) << "At: " << getColorEscape (ANSI_COLOR::RESET)
+		os << getErrorColor (ANSI_COLOR::BOLD) << "At: " << getErrorColor (ANSI_COLOR::RESET)
 		   << error.getMeta<std::string> ("error/file") << ":" << error.getMeta<std::string> ("error/line") << std::endl;
-		os << getColorEscape (ANSI_COLOR::BOLD) << "Reason: " << getColorEscape (ANSI_COLOR::RESET)
+		os << getErrorColor (ANSI_COLOR::BOLD) << "Reason: " << getErrorColor (ANSI_COLOR::RESET)
 		   << error.getMeta<std::string> ("error/reason") << std::endl;
-		os << getColorEscape (ANSI_COLOR::BOLD) << "Mountpoint: " << getColorEscape (ANSI_COLOR::RESET)
+		os << getErrorColor (ANSI_COLOR::BOLD) << "Mountpoint: " << getErrorColor (ANSI_COLOR::RESET)
 		   << error.getMeta<std::string> ("error/mountpoint") << std::endl;
-		os << getColorEscape (ANSI_COLOR::BOLD) << "Configfile: " << getColorEscape (ANSI_COLOR::RESET)
+		os << getErrorColor (ANSI_COLOR::BOLD) << "Configfile: " << getErrorColor (ANSI_COLOR::RESET)
 		   << error.getMeta<std::string> ("error/configfile") << std::endl;
 	}
 	catch (kdb::KeyTypeConversion const & e)
 	{
-		os << getColorEscape (ANSI_COLOR::BOLD) << getColorEscape (ANSI_COLOR::RED)
-		   << "Error meta data is not set correctly by a plugin: " << getColorEscape (ANSI_COLOR::RESET) << e.what () << std::endl;
+		os << getErrorColor (ANSI_COLOR::BOLD) << getErrorColor (ANSI_COLOR::RED)
+		   << "Error meta data is not set correctly by a plugin: " << getErrorColor (ANSI_COLOR::RESET) << e.what () << std::endl;
 	}
 
 	return os;
@@ -72,38 +72,38 @@ inline std::ostream & printWarnings (std::ostream & os, kdb::Key const & error)
 		}
 
 		int nr = error.getMeta<int> ("warnings");
-		os << getColorEscape (ANSI_COLOR::BOLD) << getColorEscape (ANSI_COLOR::MAGENTA) << nr + 1 << " Warning" << (!nr ? "" : "s")
-		   << " were issued:" << getColorEscape (ANSI_COLOR::RESET) << std::endl;
+		os << getErrorColor (ANSI_COLOR::BOLD) << getErrorColor (ANSI_COLOR::MAGENTA) << nr + 1 << " Warning" << (!nr ? "" : "s")
+		   << " were issued:" << getErrorColor (ANSI_COLOR::RESET) << std::endl;
 
 		for (int i = 0; i <= nr; i++)
 		{
 			std::ostringstream name;
 			name << "warnings/#" << std::setfill ('0') << std::setw (2) << i;
 			// os << "\t" << name.str() << ": " << error.getMeta<std::string>(name.str()) << std::endl;
-			os << getColorEscape (ANSI_COLOR::BOLD) << getColorEscape (ANSI_COLOR::MAGENTA)
-			   << " Warning number: " << getColorEscape (ANSI_COLOR::RESET)
+			os << getErrorColor (ANSI_COLOR::BOLD) << getErrorColor (ANSI_COLOR::MAGENTA)
+			   << " Warning number: " << getErrorColor (ANSI_COLOR::RESET)
 			   << error.getMeta<std::string> (name.str () + "/number") << std::endl;
-			os << getColorEscape (ANSI_COLOR::BOLD) << "\tDescription: " << getColorEscape (ANSI_COLOR::RESET)
+			os << getErrorColor (ANSI_COLOR::BOLD) << "\tDescription: " << getErrorColor (ANSI_COLOR::RESET)
 			   << error.getMeta<std::string> (name.str () + "/description") << std::endl;
-			os << getColorEscape (ANSI_COLOR::BOLD) << "\tIngroup: " << getColorEscape (ANSI_COLOR::RESET)
+			os << getErrorColor (ANSI_COLOR::BOLD) << "\tIngroup: " << getErrorColor (ANSI_COLOR::RESET)
 			   << error.getMeta<std::string> (name.str () + "/ingroup") << std::endl;
-			os << getColorEscape (ANSI_COLOR::BOLD) << "\tModule: " << getColorEscape (ANSI_COLOR::RESET)
+			os << getErrorColor (ANSI_COLOR::BOLD) << "\tModule: " << getErrorColor (ANSI_COLOR::RESET)
 			   << error.getMeta<std::string> (name.str () + "/module") << std::endl;
-			os << getColorEscape (ANSI_COLOR::BOLD) << "\tAt: " << getColorEscape (ANSI_COLOR::RESET)
+			os << getErrorColor (ANSI_COLOR::BOLD) << "\tAt: " << getErrorColor (ANSI_COLOR::RESET)
 			   << error.getMeta<std::string> (name.str () + "/file") << ":"
 			   << error.getMeta<std::string> (name.str () + "/line") << std::endl;
-			os << getColorEscape (ANSI_COLOR::BOLD) << "\tReason: " << getColorEscape (ANSI_COLOR::RESET)
+			os << getErrorColor (ANSI_COLOR::BOLD) << "\tReason: " << getErrorColor (ANSI_COLOR::RESET)
 			   << error.getMeta<std::string> (name.str () + "/reason") << std::endl;
-			os << getColorEscape (ANSI_COLOR::BOLD) << "\tMountpoint: " << getColorEscape (ANSI_COLOR::RESET)
+			os << getErrorColor (ANSI_COLOR::BOLD) << "\tMountpoint: " << getErrorColor (ANSI_COLOR::RESET)
 			   << error.getMeta<std::string> (name.str () + "/mountpoint") << std::endl;
-			os << getColorEscape (ANSI_COLOR::BOLD) << "\tConfigfile: " << getColorEscape (ANSI_COLOR::RESET)
+			os << getErrorColor (ANSI_COLOR::BOLD) << "\tConfigfile: " << getErrorColor (ANSI_COLOR::RESET)
 			   << error.getMeta<std::string> (name.str () + "/configfile") << std::endl;
 		}
 	}
 	catch (kdb::KeyTypeConversion const & e)
 	{
-		os << getColorEscape (ANSI_COLOR::BOLD) << getColorEscape (ANSI_COLOR::MAGENTA)
-		   << "Warnings meta data not set correctly by a plugin: " << getColorEscape (ANSI_COLOR::RESET) << e.what () << std::endl;
+		os << getErrorColor (ANSI_COLOR::BOLD) << getErrorColor (ANSI_COLOR::MAGENTA)
+		   << "Warnings meta data not set correctly by a plugin: " << getErrorColor (ANSI_COLOR::RESET) << e.what () << std::endl;
 	}
 
 	return os;

--- a/src/tools/kdb/coloredkdbio.hpp
+++ b/src/tools/kdb/coloredkdbio.hpp
@@ -1,0 +1,93 @@
+/**
+ * @file
+ *
+ * @brief
+ *
+ * @copyright BSD License (see doc/COPYING or http://www.libelektra.org)
+ */
+
+#ifndef ELEKTRA_KDB_IO_HPP
+#define ELEKTRA_KDB_IO_HPP
+
+/*
+ * @brief See examples/cpp_example_userio.cpp for how to use
+ * USER_DEFINED_IO
+ */
+#define USER_DEFINED_IO
+
+#include <key.hpp>
+
+#include <iomanip>
+#include <ostream>
+
+#include "ansicolors.hpp"
+
+namespace kdb
+{
+
+inline std::ostream & printError (std::ostream & os, kdb::Key const & error)
+{
+	try
+	{
+		if (!error.getMeta<const kdb::Key> ("error"))
+		{
+			// no error available
+			return os;
+		}
+
+		os << getColorEscape(ANSI_COLOR::BOLD) << getColorEscape(ANSI_COLOR::RED) << "Error (#" << error.getMeta<std::string> ("error/number") << ") occurred!" << getColorEscape(ANSI_COLOR::RESET) << std::endl;
+		os << getColorEscape(ANSI_COLOR::BOLD) << "Description: " << getColorEscape(ANSI_COLOR::RESET) << error.getMeta<std::string> ("error/description") << std::endl;
+		os << getColorEscape(ANSI_COLOR::BOLD) << "Ingroup: " << getColorEscape(ANSI_COLOR::RESET) << error.getMeta<std::string> ("error/ingroup") << std::endl;
+		os << getColorEscape(ANSI_COLOR::BOLD) << "Module: " << getColorEscape(ANSI_COLOR::RESET) << error.getMeta<std::string> ("error/module") << std::endl;
+		os << getColorEscape(ANSI_COLOR::BOLD) << "At: " << getColorEscape(ANSI_COLOR::RESET) << error.getMeta<std::string> ("error/file") << ":" << error.getMeta<std::string> ("error/line") << std::endl;
+		os << getColorEscape(ANSI_COLOR::BOLD) << "Reason: " << getColorEscape(ANSI_COLOR::RESET) << error.getMeta<std::string> ("error/reason") << std::endl;
+		os << getColorEscape(ANSI_COLOR::BOLD) << "Mountpoint: " << getColorEscape(ANSI_COLOR::RESET) << error.getMeta<std::string> ("error/mountpoint") << std::endl;
+		os << getColorEscape(ANSI_COLOR::BOLD) << "Configfile: " << getColorEscape(ANSI_COLOR::RESET) << error.getMeta<std::string> ("error/configfile") << std::endl;
+	}
+	catch (kdb::KeyTypeConversion const & e)
+	{
+		os << getColorEscape(ANSI_COLOR::BOLD) << getColorEscape(ANSI_COLOR::RED) << "Error meta data is not set correctly by a plugin: " << getColorEscape(ANSI_COLOR::RESET) << e.what () << std::endl;
+	}
+
+	return os;
+}
+
+inline std::ostream & printWarnings (std::ostream & os, kdb::Key const & error)
+{
+	try
+	{
+		if (!error.getMeta<const kdb::Key> ("warnings"))
+		{
+			// no warnings were issued
+			return os;
+		}
+
+		int nr = error.getMeta<int> ("warnings");
+		os << getColorEscape(ANSI_COLOR::BOLD) << getColorEscape(ANSI_COLOR::MAGENTA) << nr + 1 << " Warning" << (!nr ? "" : "s") << " were issued:" << getColorEscape(ANSI_COLOR::RESET) << std::endl;
+
+		for (int i = 0; i <= nr; i++)
+		{
+			std::ostringstream name;
+			name << "warnings/#" << std::setfill ('0') << std::setw (2) << i;
+			// os << "\t" << name.str() << ": " << error.getMeta<std::string>(name.str()) << std::endl;
+			os << getColorEscape(ANSI_COLOR::BOLD) << getColorEscape(ANSI_COLOR::MAGENTA) << " Warning number: " << getColorEscape(ANSI_COLOR::RESET) << error.getMeta<std::string> (name.str () + "/number") << std::endl;
+			os << getColorEscape(ANSI_COLOR::BOLD) << "\tDescription: " << getColorEscape(ANSI_COLOR::RESET) << error.getMeta<std::string> (name.str () + "/description") << std::endl;
+			os << getColorEscape(ANSI_COLOR::BOLD) << "\tIngroup: " << getColorEscape(ANSI_COLOR::RESET) << error.getMeta<std::string> (name.str () + "/ingroup") << std::endl;
+			os << getColorEscape(ANSI_COLOR::BOLD) << "\tModule: " << getColorEscape(ANSI_COLOR::RESET) << error.getMeta<std::string> (name.str () + "/module") << std::endl;
+			os << getColorEscape(ANSI_COLOR::BOLD) << "\tAt: " << getColorEscape(ANSI_COLOR::RESET) << error.getMeta<std::string> (name.str () + "/file") << ":"
+			   << error.getMeta<std::string> (name.str () + "/line") << std::endl;
+			os << getColorEscape(ANSI_COLOR::BOLD) << "\tReason: " << getColorEscape(ANSI_COLOR::RESET) << error.getMeta<std::string> (name.str () + "/reason") << std::endl;
+			os << getColorEscape(ANSI_COLOR::BOLD) << "\tMountpoint: " << getColorEscape(ANSI_COLOR::RESET) << error.getMeta<std::string> (name.str () + "/mountpoint") << std::endl;
+			os << getColorEscape(ANSI_COLOR::BOLD) << "\tConfigfile: " << getColorEscape(ANSI_COLOR::RESET) << error.getMeta<std::string> (name.str () + "/configfile") << std::endl;
+		}
+	}
+	catch (kdb::KeyTypeConversion const & e)
+	{
+		os << getColorEscape(ANSI_COLOR::BOLD) << getColorEscape(ANSI_COLOR::MAGENTA) << "Warnings meta data not set correctly by a plugin: " << getColorEscape(ANSI_COLOR::RESET) << e.what () << std::endl;
+	}
+
+	return os;
+}
+}
+
+#endif

--- a/src/tools/kdb/coloredkdbio.hpp
+++ b/src/tools/kdb/coloredkdbio.hpp
@@ -35,18 +35,27 @@ inline std::ostream & printError (std::ostream & os, kdb::Key const & error)
 			return os;
 		}
 
-		os << getColorEscape(ANSI_COLOR::BOLD) << getColorEscape(ANSI_COLOR::RED) << "Error (#" << error.getMeta<std::string> ("error/number") << ") occurred!" << getColorEscape(ANSI_COLOR::RESET) << std::endl;
-		os << getColorEscape(ANSI_COLOR::BOLD) << "Description: " << getColorEscape(ANSI_COLOR::RESET) << error.getMeta<std::string> ("error/description") << std::endl;
-		os << getColorEscape(ANSI_COLOR::BOLD) << "Ingroup: " << getColorEscape(ANSI_COLOR::RESET) << error.getMeta<std::string> ("error/ingroup") << std::endl;
-		os << getColorEscape(ANSI_COLOR::BOLD) << "Module: " << getColorEscape(ANSI_COLOR::RESET) << error.getMeta<std::string> ("error/module") << std::endl;
-		os << getColorEscape(ANSI_COLOR::BOLD) << "At: " << getColorEscape(ANSI_COLOR::RESET) << error.getMeta<std::string> ("error/file") << ":" << error.getMeta<std::string> ("error/line") << std::endl;
-		os << getColorEscape(ANSI_COLOR::BOLD) << "Reason: " << getColorEscape(ANSI_COLOR::RESET) << error.getMeta<std::string> ("error/reason") << std::endl;
-		os << getColorEscape(ANSI_COLOR::BOLD) << "Mountpoint: " << getColorEscape(ANSI_COLOR::RESET) << error.getMeta<std::string> ("error/mountpoint") << std::endl;
-		os << getColorEscape(ANSI_COLOR::BOLD) << "Configfile: " << getColorEscape(ANSI_COLOR::RESET) << error.getMeta<std::string> ("error/configfile") << std::endl;
+		os << getColorEscape (ANSI_COLOR::BOLD) << getColorEscape (ANSI_COLOR::RED) << "Error (#"
+		   << error.getMeta<std::string> ("error/number") << ") occurred!" << getColorEscape (ANSI_COLOR::RESET) << std::endl;
+		os << getColorEscape (ANSI_COLOR::BOLD) << "Description: " << getColorEscape (ANSI_COLOR::RESET)
+		   << error.getMeta<std::string> ("error/description") << std::endl;
+		os << getColorEscape (ANSI_COLOR::BOLD) << "Ingroup: " << getColorEscape (ANSI_COLOR::RESET)
+		   << error.getMeta<std::string> ("error/ingroup") << std::endl;
+		os << getColorEscape (ANSI_COLOR::BOLD) << "Module: " << getColorEscape (ANSI_COLOR::RESET)
+		   << error.getMeta<std::string> ("error/module") << std::endl;
+		os << getColorEscape (ANSI_COLOR::BOLD) << "At: " << getColorEscape (ANSI_COLOR::RESET)
+		   << error.getMeta<std::string> ("error/file") << ":" << error.getMeta<std::string> ("error/line") << std::endl;
+		os << getColorEscape (ANSI_COLOR::BOLD) << "Reason: " << getColorEscape (ANSI_COLOR::RESET)
+		   << error.getMeta<std::string> ("error/reason") << std::endl;
+		os << getColorEscape (ANSI_COLOR::BOLD) << "Mountpoint: " << getColorEscape (ANSI_COLOR::RESET)
+		   << error.getMeta<std::string> ("error/mountpoint") << std::endl;
+		os << getColorEscape (ANSI_COLOR::BOLD) << "Configfile: " << getColorEscape (ANSI_COLOR::RESET)
+		   << error.getMeta<std::string> ("error/configfile") << std::endl;
 	}
 	catch (kdb::KeyTypeConversion const & e)
 	{
-		os << getColorEscape(ANSI_COLOR::BOLD) << getColorEscape(ANSI_COLOR::RED) << "Error meta data is not set correctly by a plugin: " << getColorEscape(ANSI_COLOR::RESET) << e.what () << std::endl;
+		os << getColorEscape (ANSI_COLOR::BOLD) << getColorEscape (ANSI_COLOR::RED)
+		   << "Error meta data is not set correctly by a plugin: " << getColorEscape (ANSI_COLOR::RESET) << e.what () << std::endl;
 	}
 
 	return os;
@@ -63,27 +72,38 @@ inline std::ostream & printWarnings (std::ostream & os, kdb::Key const & error)
 		}
 
 		int nr = error.getMeta<int> ("warnings");
-		os << getColorEscape(ANSI_COLOR::BOLD) << getColorEscape(ANSI_COLOR::MAGENTA) << nr + 1 << " Warning" << (!nr ? "" : "s") << " were issued:" << getColorEscape(ANSI_COLOR::RESET) << std::endl;
+		os << getColorEscape (ANSI_COLOR::BOLD) << getColorEscape (ANSI_COLOR::MAGENTA) << nr + 1 << " Warning" << (!nr ? "" : "s")
+		   << " were issued:" << getColorEscape (ANSI_COLOR::RESET) << std::endl;
 
 		for (int i = 0; i <= nr; i++)
 		{
 			std::ostringstream name;
 			name << "warnings/#" << std::setfill ('0') << std::setw (2) << i;
 			// os << "\t" << name.str() << ": " << error.getMeta<std::string>(name.str()) << std::endl;
-			os << getColorEscape(ANSI_COLOR::BOLD) << getColorEscape(ANSI_COLOR::MAGENTA) << " Warning number: " << getColorEscape(ANSI_COLOR::RESET) << error.getMeta<std::string> (name.str () + "/number") << std::endl;
-			os << getColorEscape(ANSI_COLOR::BOLD) << "\tDescription: " << getColorEscape(ANSI_COLOR::RESET) << error.getMeta<std::string> (name.str () + "/description") << std::endl;
-			os << getColorEscape(ANSI_COLOR::BOLD) << "\tIngroup: " << getColorEscape(ANSI_COLOR::RESET) << error.getMeta<std::string> (name.str () + "/ingroup") << std::endl;
-			os << getColorEscape(ANSI_COLOR::BOLD) << "\tModule: " << getColorEscape(ANSI_COLOR::RESET) << error.getMeta<std::string> (name.str () + "/module") << std::endl;
-			os << getColorEscape(ANSI_COLOR::BOLD) << "\tAt: " << getColorEscape(ANSI_COLOR::RESET) << error.getMeta<std::string> (name.str () + "/file") << ":"
+			os << getColorEscape (ANSI_COLOR::BOLD) << getColorEscape (ANSI_COLOR::MAGENTA)
+			   << " Warning number: " << getColorEscape (ANSI_COLOR::RESET)
+			   << error.getMeta<std::string> (name.str () + "/number") << std::endl;
+			os << getColorEscape (ANSI_COLOR::BOLD) << "\tDescription: " << getColorEscape (ANSI_COLOR::RESET)
+			   << error.getMeta<std::string> (name.str () + "/description") << std::endl;
+			os << getColorEscape (ANSI_COLOR::BOLD) << "\tIngroup: " << getColorEscape (ANSI_COLOR::RESET)
+			   << error.getMeta<std::string> (name.str () + "/ingroup") << std::endl;
+			os << getColorEscape (ANSI_COLOR::BOLD) << "\tModule: " << getColorEscape (ANSI_COLOR::RESET)
+			   << error.getMeta<std::string> (name.str () + "/module") << std::endl;
+			os << getColorEscape (ANSI_COLOR::BOLD) << "\tAt: " << getColorEscape (ANSI_COLOR::RESET)
+			   << error.getMeta<std::string> (name.str () + "/file") << ":"
 			   << error.getMeta<std::string> (name.str () + "/line") << std::endl;
-			os << getColorEscape(ANSI_COLOR::BOLD) << "\tReason: " << getColorEscape(ANSI_COLOR::RESET) << error.getMeta<std::string> (name.str () + "/reason") << std::endl;
-			os << getColorEscape(ANSI_COLOR::BOLD) << "\tMountpoint: " << getColorEscape(ANSI_COLOR::RESET) << error.getMeta<std::string> (name.str () + "/mountpoint") << std::endl;
-			os << getColorEscape(ANSI_COLOR::BOLD) << "\tConfigfile: " << getColorEscape(ANSI_COLOR::RESET) << error.getMeta<std::string> (name.str () + "/configfile") << std::endl;
+			os << getColorEscape (ANSI_COLOR::BOLD) << "\tReason: " << getColorEscape (ANSI_COLOR::RESET)
+			   << error.getMeta<std::string> (name.str () + "/reason") << std::endl;
+			os << getColorEscape (ANSI_COLOR::BOLD) << "\tMountpoint: " << getColorEscape (ANSI_COLOR::RESET)
+			   << error.getMeta<std::string> (name.str () + "/mountpoint") << std::endl;
+			os << getColorEscape (ANSI_COLOR::BOLD) << "\tConfigfile: " << getColorEscape (ANSI_COLOR::RESET)
+			   << error.getMeta<std::string> (name.str () + "/configfile") << std::endl;
 		}
 	}
 	catch (kdb::KeyTypeConversion const & e)
 	{
-		os << getColorEscape(ANSI_COLOR::BOLD) << getColorEscape(ANSI_COLOR::MAGENTA) << "Warnings meta data not set correctly by a plugin: " << getColorEscape(ANSI_COLOR::RESET) << e.what () << std::endl;
+		os << getColorEscape (ANSI_COLOR::BOLD) << getColorEscape (ANSI_COLOR::MAGENTA)
+		   << "Warnings meta data not set correctly by a plugin: " << getColorEscape (ANSI_COLOR::RESET) << e.what () << std::endl;
 	}
 
 	return os;

--- a/src/tools/kdb/convert.hpp
+++ b/src/tools/kdb/convert.hpp
@@ -10,6 +10,7 @@
 #define CONVERT_HPP
 
 #include <command.hpp>
+
 #include <kdb.hpp>
 
 class ConvertCommand : public Command
@@ -22,7 +23,7 @@ public:
 
 	virtual std::string getShortOptions () override
 	{
-		return "v";
+		return "vC";
 	}
 
 	virtual std::string getSynopsis () override

--- a/src/tools/kdb/cp.hpp
+++ b/src/tools/kdb/cp.hpp
@@ -10,7 +10,7 @@
 #define CP_HPP
 
 #include <command.hpp>
-
+#include "coloredkdbio.hpp"
 #include <kdb.hpp>
 
 class CpCommand : public Command
@@ -23,7 +23,7 @@ public:
 
 	virtual std::string getShortOptions () override
 	{
-		return "rv";
+		return "rvC";
 	}
 
 	virtual std::string getSynopsis () override

--- a/src/tools/kdb/cp.hpp
+++ b/src/tools/kdb/cp.hpp
@@ -9,8 +9,8 @@
 #ifndef CP_HPP
 #define CP_HPP
 
-#include <command.hpp>
 #include "coloredkdbio.hpp"
+#include <command.hpp>
 #include <kdb.hpp>
 
 class CpCommand : public Command

--- a/src/tools/kdb/editor.hpp
+++ b/src/tools/kdb/editor.hpp
@@ -2,6 +2,7 @@
 #define EDITOR_HPP
 
 #include <command.hpp>
+#include "coloredkdbio.hpp"
 #include <kdb.hpp>
 
 using namespace std;
@@ -20,7 +21,7 @@ public:
 
 	virtual std::string getShortOptions ()
 	{
-		return "esv";
+		return "esvC";
 	}
 
 	virtual std::string getSynopsis ()

--- a/src/tools/kdb/editor.hpp
+++ b/src/tools/kdb/editor.hpp
@@ -1,8 +1,8 @@
 #ifndef EDITOR_HPP
 #define EDITOR_HPP
 
-#include <command.hpp>
 #include "coloredkdbio.hpp"
+#include <command.hpp>
 #include <kdb.hpp>
 
 using namespace std;

--- a/src/tools/kdb/export.hpp
+++ b/src/tools/kdb/export.hpp
@@ -9,8 +9,8 @@
 #ifndef EXPORT_H
 #define EXPORT_H
 
-#include <command.hpp>
 #include "coloredkdbio.hpp"
+#include <command.hpp>
 #include <kdb.hpp>
 
 class ExportCommand : public Command

--- a/src/tools/kdb/export.hpp
+++ b/src/tools/kdb/export.hpp
@@ -10,6 +10,7 @@
 #define EXPORT_H
 
 #include <command.hpp>
+#include "coloredkdbio.hpp"
 #include <kdb.hpp>
 
 class ExportCommand : public Command
@@ -23,7 +24,7 @@ public:
 
 	virtual std::string getShortOptions () override
 	{
-		return "Ec";
+		return "EcC";
 	}
 
 	virtual std::string getSynopsis () override

--- a/src/tools/kdb/file.hpp
+++ b/src/tools/kdb/file.hpp
@@ -23,7 +23,7 @@ public:
 
 	virtual std::string getShortOptions () override
 	{
-		return "nN";
+		return "nNC";
 	}
 
 	virtual std::string getSynopsis () override

--- a/src/tools/kdb/fstab.hpp
+++ b/src/tools/kdb/fstab.hpp
@@ -9,8 +9,8 @@
 #ifndef FSTAB_HPP
 #define FSTAB_HPP
 
-#include <command.hpp>
 #include "coloredkdbio.hpp"
+#include <command.hpp>
 #include <kdb.hpp>
 
 class FstabCommand : public Command

--- a/src/tools/kdb/fstab.hpp
+++ b/src/tools/kdb/fstab.hpp
@@ -10,7 +10,7 @@
 #define FSTAB_HPP
 
 #include <command.hpp>
-
+#include "coloredkdbio.hpp"
 #include <kdb.hpp>
 
 class FstabCommand : public Command
@@ -23,7 +23,7 @@ public:
 
 	virtual std::string getShortOptions () override
 	{
-		return "v";
+		return "vC";
 	}
 
 	virtual std::string getSynopsis () override

--- a/src/tools/kdb/get.hpp
+++ b/src/tools/kdb/get.hpp
@@ -9,8 +9,8 @@
 #ifndef GET_HPP
 #define GET_HPP
 
-#include <command.hpp>
 #include "coloredkdbio.hpp"
+#include <command.hpp>
 #include <kdb.hpp>
 
 class GetCommand : public Command

--- a/src/tools/kdb/get.hpp
+++ b/src/tools/kdb/get.hpp
@@ -10,7 +10,7 @@
 #define GET_HPP
 
 #include <command.hpp>
-
+#include "coloredkdbio.hpp"
 #include <kdb.hpp>
 
 class GetCommand : public Command
@@ -21,7 +21,7 @@ public:
 
 	virtual std::string getShortOptions () override
 	{
-		return "anv";
+		return "anvC";
 	}
 
 	virtual std::string getSynopsis () override

--- a/src/tools/kdb/globalmount.hpp
+++ b/src/tools/kdb/globalmount.hpp
@@ -33,7 +33,7 @@ public:
 
 	virtual std::string getShortOptions () override
 	{
-		return "W"; // TODO: c not implemented
+		return "WC"; // TODO: c not implemented
 	}
 
 	virtual std::string getSynopsis () override

--- a/src/tools/kdb/import.hpp
+++ b/src/tools/kdb/import.hpp
@@ -10,6 +10,7 @@
 #define IMPORT_HPP
 
 #include <command.hpp>
+#include "coloredkdbio.hpp"
 #include <kdb.hpp>
 
 class ImportCommand : public Command
@@ -22,7 +23,7 @@ public:
 
 	virtual std::string getShortOptions () override
 	{
-		return "svc";
+		return "svcC";
 	}
 
 	virtual std::string getSynopsis () override

--- a/src/tools/kdb/import.hpp
+++ b/src/tools/kdb/import.hpp
@@ -9,8 +9,8 @@
 #ifndef IMPORT_HPP
 #define IMPORT_HPP
 
-#include <command.hpp>
 #include "coloredkdbio.hpp"
+#include <command.hpp>
 #include <kdb.hpp>
 
 class ImportCommand : public Command

--- a/src/tools/kdb/info.cpp
+++ b/src/tools/kdb/info.cpp
@@ -119,7 +119,7 @@ int InfoCommand::execute (Cmdline const & cl)
 	{
 		while ((k = conf.next ()) && k.isBelow (root))
 		{
-			cout << getColorEscape (ANSI_COLOR::BOLD) << k.getBaseName () << ": " << getColorEscape (ANSI_COLOR::RESET)
+			cout << getStdColor (ANSI_COLOR::BOLD) << k.getBaseName () << ": " << getStdColor (ANSI_COLOR::RESET)
 			     << k.getString () << endl;
 		}
 	}

--- a/src/tools/kdb/info.cpp
+++ b/src/tools/kdb/info.cpp
@@ -15,8 +15,6 @@
 
 #include <iostream>
 
-#include "ansicolors.hpp"
-
 using namespace std;
 using namespace kdb;
 using namespace kdb::tools;
@@ -119,7 +117,8 @@ int InfoCommand::execute (Cmdline const & cl)
 	{
 		while ((k = conf.next ()) && k.isBelow (root))
 		{
-			cout << ANSI_COLOR_BOLD << k.getBaseName () << ANSI_COLOR_RESET << ": " << k.getString () << endl;
+			cout << cl.getColor (ANSI_COLOR::BOLD) << k.getBaseName () << cl.getColor (ANSI_COLOR::RESET) << ": "
+			     << k.getString () << endl;
 		}
 	}
 	else

--- a/src/tools/kdb/info.cpp
+++ b/src/tools/kdb/info.cpp
@@ -15,6 +15,8 @@
 
 #include <iostream>
 
+#include "ansicolors.hpp"
+
 using namespace std;
 using namespace kdb;
 using namespace kdb::tools;
@@ -117,7 +119,7 @@ int InfoCommand::execute (Cmdline const & cl)
 	{
 		while ((k = conf.next ()) && k.isBelow (root))
 		{
-			cout << cl.getColor (ANSI_COLOR::BOLD) << k.getBaseName () << cl.getColor (ANSI_COLOR::RESET) << ": "
+			cout << getColorEscape(ANSI_COLOR::BOLD) << k.getBaseName () << ": " << getColorEscape (ANSI_COLOR::RESET)
 			     << k.getString () << endl;
 		}
 	}

--- a/src/tools/kdb/info.cpp
+++ b/src/tools/kdb/info.cpp
@@ -15,6 +15,7 @@
 
 #include <iostream>
 
+#include "ansicolors.hpp"
 
 using namespace std;
 using namespace kdb;
@@ -118,7 +119,7 @@ int InfoCommand::execute (Cmdline const & cl)
 	{
 		while ((k = conf.next ()) && k.isBelow (root))
 		{
-			cout << k.getBaseName () << ": " << k.getString () << endl;
+			cout << ANSI_COLOR_BOLD << k.getBaseName () << ANSI_COLOR_RESET << ": " << k.getString () << endl;
 		}
 	}
 	else

--- a/src/tools/kdb/info.cpp
+++ b/src/tools/kdb/info.cpp
@@ -119,7 +119,7 @@ int InfoCommand::execute (Cmdline const & cl)
 	{
 		while ((k = conf.next ()) && k.isBelow (root))
 		{
-			cout << getColorEscape(ANSI_COLOR::BOLD) << k.getBaseName () << ": " << getColorEscape (ANSI_COLOR::RESET)
+			cout << getColorEscape (ANSI_COLOR::BOLD) << k.getBaseName () << ": " << getColorEscape (ANSI_COLOR::RESET)
 			     << k.getString () << endl;
 		}
 	}

--- a/src/tools/kdb/info.hpp
+++ b/src/tools/kdb/info.hpp
@@ -23,7 +23,7 @@ public:
 
 	virtual std::string getShortOptions () override
 	{
-		return "lc";
+		return "lcC";
 	}
 
 	virtual std::string getSynopsis () override

--- a/src/tools/kdb/list.hpp
+++ b/src/tools/kdb/list.hpp
@@ -20,7 +20,7 @@ public:
 
 	virtual std::string getShortOptions () override
 	{
-		return "0v";
+		return "0vC";
 	}
 
 	virtual std::string getSynopsis () override

--- a/src/tools/kdb/ls.hpp
+++ b/src/tools/kdb/ls.hpp
@@ -9,8 +9,8 @@
 #ifndef LS_H
 #define LS_H
 
-#include <command.hpp>
 #include "coloredkdbio.hpp"
+#include <command.hpp>
 #include <kdb.hpp>
 
 class LsCommand : public Command

--- a/src/tools/kdb/ls.hpp
+++ b/src/tools/kdb/ls.hpp
@@ -10,6 +10,7 @@
 #define LS_H
 
 #include <command.hpp>
+#include "coloredkdbio.hpp"
 #include <kdb.hpp>
 
 class LsCommand : public Command
@@ -24,7 +25,7 @@ public:
 
 	virtual std::string getShortOptions () override
 	{
-		return "v0";
+		return "v0C";
 	}
 
 	virtual std::string getSynopsis () override

--- a/src/tools/kdb/merge.hpp
+++ b/src/tools/kdb/merge.hpp
@@ -26,7 +26,7 @@ public:
 
 	virtual std::string getShortOptions () override
 	{
-		return "iHsvf";
+		return "iHsvfC";
 	}
 
 	virtual std::string getSynopsis () override

--- a/src/tools/kdb/metaget.hpp
+++ b/src/tools/kdb/metaget.hpp
@@ -9,8 +9,8 @@
 #ifndef METAGET_HPP
 #define METAGET_HPP
 
-#include <command.hpp>
 #include "coloredkdbio.hpp"
+#include <command.hpp>
 #include <kdb.hpp>
 
 class MetaGetCommand : public Command

--- a/src/tools/kdb/metaget.hpp
+++ b/src/tools/kdb/metaget.hpp
@@ -10,7 +10,7 @@
 #define METAGET_HPP
 
 #include <command.hpp>
-
+#include "coloredkdbio.hpp"
 #include <kdb.hpp>
 
 class MetaGetCommand : public Command
@@ -23,7 +23,7 @@ public:
 
 	virtual std::string getShortOptions () override
 	{
-		return "n";
+		return "nC";
 	}
 
 	virtual std::string getSynopsis () override

--- a/src/tools/kdb/metals.hpp
+++ b/src/tools/kdb/metals.hpp
@@ -23,7 +23,7 @@ public:
 
 	virtual std::string getShortOptions () override
 	{
-		return "0v";
+		return "0vC";
 	}
 
 	virtual std::string getSynopsis () override

--- a/src/tools/kdb/metaset.hpp
+++ b/src/tools/kdb/metaset.hpp
@@ -9,8 +9,8 @@
 #ifndef METASET_HPP
 #define METASET_HPP
 
-#include <command.hpp>
 #include "coloredkdbio.hpp"
+#include <command.hpp>
 #include <kdb.hpp>
 
 class MetaSetCommand : public Command

--- a/src/tools/kdb/metaset.hpp
+++ b/src/tools/kdb/metaset.hpp
@@ -10,7 +10,7 @@
 #define METASET_HPP
 
 #include <command.hpp>
-
+#include "coloredkdbio.hpp"
 #include <kdb.hpp>
 
 class MetaSetCommand : public Command
@@ -23,7 +23,7 @@ public:
 
 	virtual std::string getShortOptions () override
 	{
-		return "v";
+		return "vC";
 	}
 
 	virtual std::string getSynopsis () override

--- a/src/tools/kdb/mount.hpp
+++ b/src/tools/kdb/mount.hpp
@@ -35,7 +35,7 @@ public:
 
 	virtual std::string getShortOptions () override
 	{
-		return "idR0123cW";
+		return "idR0123cWC";
 	}
 
 	virtual std::string getSynopsis () override

--- a/src/tools/kdb/mountbase.hpp
+++ b/src/tools/kdb/mountbase.hpp
@@ -10,6 +10,7 @@
 #define MOUNTBASE_HPP_
 
 #include <command.hpp>
+#include "ansicolors.hpp"
 #include <kdb.hpp>
 
 #include <backends.hpp>

--- a/src/tools/kdb/mountbase.hpp
+++ b/src/tools/kdb/mountbase.hpp
@@ -9,8 +9,8 @@
 #ifndef MOUNTBASE_HPP_
 #define MOUNTBASE_HPP_
 
-#include <command.hpp>
 #include "ansicolors.hpp"
+#include <command.hpp>
 #include <kdb.hpp>
 
 #include <backends.hpp>

--- a/src/tools/kdb/mv.hpp
+++ b/src/tools/kdb/mv.hpp
@@ -10,7 +10,7 @@
 #define MV_HPP
 
 #include <command.hpp>
-
+#include "coloredkdbio.hpp"
 #include <kdb.hpp>
 
 class MvCommand : public Command
@@ -23,7 +23,7 @@ public:
 
 	virtual std::string getShortOptions () override
 	{
-		return "rv";
+		return "rvC";
 	}
 
 	virtual std::string getSynopsis () override

--- a/src/tools/kdb/mv.hpp
+++ b/src/tools/kdb/mv.hpp
@@ -9,8 +9,8 @@
 #ifndef MV_HPP
 #define MV_HPP
 
-#include <command.hpp>
 #include "coloredkdbio.hpp"
+#include <command.hpp>
 #include <kdb.hpp>
 
 class MvCommand : public Command

--- a/src/tools/kdb/remount.hpp
+++ b/src/tools/kdb/remount.hpp
@@ -24,7 +24,7 @@ public:
 
 	virtual std::string getShortOptions () override
 	{
-		return "id";
+		return "idC";
 	}
 
 	virtual std::string getSynopsis () override

--- a/src/tools/kdb/rm.hpp
+++ b/src/tools/kdb/rm.hpp
@@ -23,7 +23,7 @@ public:
 
 	virtual std::string getShortOptions () override
 	{
-		return "r";
+		return "rC";
 	}
 
 	virtual std::string getSynopsis () override

--- a/src/tools/kdb/set.hpp
+++ b/src/tools/kdb/set.hpp
@@ -9,8 +9,8 @@
 #ifndef SET_HPP
 #define SET_HPP
 
-#include <command.hpp>
 #include "coloredkdbio.hpp"
+#include <command.hpp>
 #include <kdb.hpp>
 
 class SetCommand : public Command

--- a/src/tools/kdb/set.hpp
+++ b/src/tools/kdb/set.hpp
@@ -10,7 +10,7 @@
 #define SET_HPP
 
 #include <command.hpp>
-
+#include "coloredkdbio.hpp"
 #include <kdb.hpp>
 
 class SetCommand : public Command
@@ -23,7 +23,7 @@ public:
 
 	virtual std::string getShortOptions () override
 	{
-		return "vN";
+		return "vNC";
 	}
 
 	virtual std::string getSynopsis () override

--- a/src/tools/kdb/sget.hpp
+++ b/src/tools/kdb/sget.hpp
@@ -22,7 +22,7 @@ public:
 
 	virtual std::string getShortOptions () override
 	{
-		return "";
+		return "C";
 	}
 
 	virtual std::string getSynopsis () override

--- a/src/tools/kdb/shell.hpp
+++ b/src/tools/kdb/shell.hpp
@@ -24,7 +24,7 @@ public:
 
 	virtual std::string getShortOptions () override
 	{
-		return "";
+		return "C";
 	}
 
 	virtual std::string getSynopsis () override

--- a/src/tools/kdb/specmount.hpp
+++ b/src/tools/kdb/specmount.hpp
@@ -33,7 +33,7 @@ public:
 
 	virtual std::string getShortOptions () override
 	{
-		return "idRcWv";
+		return "idRcWvC";
 	}
 
 	virtual std::string getSynopsis () override

--- a/src/tools/kdb/test.hpp
+++ b/src/tools/kdb/test.hpp
@@ -12,8 +12,8 @@
 #include <string>
 #include <vector>
 
-#include <command.hpp>
 #include "coloredkdbio.hpp"
+#include <command.hpp>
 #include <kdb.hpp>
 
 class TestCommand : public Command

--- a/src/tools/kdb/test.hpp
+++ b/src/tools/kdb/test.hpp
@@ -13,6 +13,7 @@
 #include <vector>
 
 #include <command.hpp>
+#include "coloredkdbio.hpp"
 #include <kdb.hpp>
 
 class TestCommand : public Command
@@ -37,7 +38,7 @@ public:
 
 	virtual std::string getShortOptions () override
 	{
-		return "";
+		return "C";
 	}
 
 	virtual std::string getSynopsis () override

--- a/src/tools/kdb/umount.hpp
+++ b/src/tools/kdb/umount.hpp
@@ -10,7 +10,7 @@
 #define UMOUNT_HPP
 
 #include <command.hpp>
-
+#include "coloredkdbio.hpp"
 #include <kdb.hpp>
 
 class UmountCommand : public Command
@@ -23,7 +23,7 @@ public:
 
 	virtual std::string getShortOptions () override
 	{
-		return "v";
+		return "vC";
 	}
 
 	virtual std::string getSynopsis () override

--- a/src/tools/kdb/umount.hpp
+++ b/src/tools/kdb/umount.hpp
@@ -9,8 +9,8 @@
 #ifndef UMOUNT_HPP
 #define UMOUNT_HPP
 
-#include <command.hpp>
 #include "coloredkdbio.hpp"
+#include <command.hpp>
 #include <kdb.hpp>
 
 class UmountCommand : public Command

--- a/src/tools/kdb/validation.hpp
+++ b/src/tools/kdb/validation.hpp
@@ -23,7 +23,7 @@ public:
 
 	virtual std::string getShortOptions () override
 	{
-		return "";
+		return "C";
 	}
 
 	virtual std::string getSynopsis () override


### PR DESCRIPTION
This is more of a suggestion. Not sure if you want colored output at all in kdb. There exist many different preferences in regard of colored terminal output.

For now the kdb info command is the only one where i found reason to add some highlights as it really can be a wall of text.
![screenshot from 2016-05-16 18-08-02](https://cloud.githubusercontent.com/assets/1131371/15295535/37f7c0b2-1b91-11e6-9c6e-91fb63fcc507.png)
