### PR TITLE
Checkconf (#559)

### DIFF
--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -7,7 +7,7 @@ macro (do_benchmark source)
 	set (SOURCES ${HDR_FILES} benchmarks.c benchmarks.h ${source}.c)
 	add_executable (${source} ${SOURCES})
 
-	target_link_elektra(${source} elektra-kdb)
+	target_link_elektra(${source} elektra-kdb elektra-meta)
 
 	set_target_properties (${source} PROPERTIES
 			COMPILE_DEFINITIONS HAVE_KDBCONFIG_H)

--- a/cmake/ElektraCache.cmake
+++ b/cmake/ElektraCache.cmake
@@ -218,8 +218,8 @@ set (CMAKE_STATIC_FLAGS ""
 
 
 option (BUILD_SHARED "Build the shared version of elektra." ON)
-option (BUILD_FULL "Build the full version of elektra (shared with all selected backends included)." ON)
-option (BUILD_STATIC "Build the static version of elektra (all selected backends included statically)." ON)
+option (BUILD_FULL "Build the full version of elektra (shared with all selected backends included)." OFF)
+option (BUILD_STATIC "Build the static version of elektra (all selected backends included statically)." OFF)
 
 option (BUILD_DOCUMENTATION "Build the documentation (API, man pages)" ON)
 if (BUILD_DOCUMENTATION)
@@ -398,4 +398,22 @@ MARK_AS_ADVANCED(FORCE
 	SWIG_DIR SWIG_EXECUTABLE SWIG_VERSION
 	gtest_build_samples gtest_build_tests gtest_disable_pthreads
 	gtest_force_shared_crt BUILD_SHARED_LIBS
+
+	ADDED_DIRECTORIES
+	ADDED_PLUGINS
+	REMOVED_PLUGINS
+
+	LIBGCRYPTCONFIG_EXECUTABLE
+	RONN_LOC
+
+	jna
+
+	Qt5Core_DIR
+	Qt5Gui_DIR
+	Qt5Network_DIR
+	Qt5Qml_DIR
+	Qt5Quick_DIR
+	Qt5Test_DIR
+	Qt5Widgets_DIR
+	Qt5_DIR
 	)

--- a/cmake/Modules/LibAddPlugin.cmake
+++ b/cmake/Modules/LibAddPlugin.cmake
@@ -1,5 +1,126 @@
 include(LibAddMacros)
 
+# Add a test for a plugin
+#
+# Will include the common tests.h file + its source file
+# additional source files can be added as additional arguments.
+# They need to be absolute or relative to the plugin dir.
+#
+# The testname must be the pluginname.
+# By convention the source file needs to be called testmod_${pluginname}.c
+#
+# Prefer to use ADD_TEST of add_plugin which takes care
+# of properly set all arguments so that the test is built
+# in the same way as the plugin.
+#
+# LINK_PLUGIN:
+#  Link against a different plugin (not the test name itself).
+#  If you want to avoid linking against a plugin, use the string <no>.
+#
+# links the executable (only if build_static or build_full)
+# and adds a test
+function (add_plugintest testname)
+	if (NOT ADDTESTING_PHASE)
+		return ()
+	endif ()
+
+	if (BUILD_TESTING)
+		cmake_parse_arguments (ARG
+			"MEMLEAK;INSTALL_TEST_DATA" # optional keywords
+			""        # one value keywords
+			"COMPILE_DEFINITIONS;INCLUDE_DIRECTORIES;LINK_LIBRARIES;LINK_ELEKTRA;LINK_PLUGIN;WORKING_DIRECTORY" # multi value keywords
+			${ARGN}
+		)
+
+		list (FIND ADDED_PLUGINS "${testname}" FOUND_NAME)
+		if (FOUND_NAME EQUAL -1)
+			if (NOT ARG_LINK_PLUGIN)
+				message (FATAL_ERROR "Trying to add plugintest ${testname} but no such plugin was added (try to use LINK_PLUGIN)")
+			endif ()
+		endif ()
+
+
+		set (PLUGIN_NAME elektra-${testname})
+		restore_variable (${PLUGIN_NAME} ARG_LINK_LIBRARIES)
+		restore_variable (${PLUGIN_NAME} ARG_COMPILE_DEFINITIONS)
+		restore_variable (${PLUGIN_NAME} ARG_INCLUDE_DIRECTORIES)
+		restore_variable (${PLUGIN_NAME} ARG_LINK_ELEKTRA)
+		restore_variable (${PLUGIN_NAME} ARG_ADD_TEST)
+		restore_variable (${PLUGIN_NAME} ARG_INSTALL_TEST_DATA)
+
+		set (TEST_SOURCES
+				$<TARGET_OBJECTS:cframework>
+				)
+
+		foreach (A ${ARG_UNPARSED_ARGUMENTS})
+			if (EXISTS "${A}")
+				list (APPEND TEST_SOURCES "${A}")
+			else ()
+				list (APPEND TEST_SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/${A}")
+			endif ()
+		endforeach ()
+
+		add_headers(TEST_SOURCES)
+		add_testheaders(TEST_SOURCES)
+		include_directories ("${CMAKE_SOURCE_DIR}/tests/cframework")
+		list (APPEND TEST_SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/testmod_${testname}.c")
+		if (BUILD_SHARED)
+			set (PLUGIN_TARGET_OBJS "")
+			if (ARG_LINK_PLUGIN)
+				if (NOT ARG_LINK_PLUGIN STREQUAL "<no>")
+					set (PLUGIN_TARGET_OBJS "$<TARGET_OBJECTS:elektra-${ARG_LINK_PLUGIN}-objects>")
+				endif ()
+			else ()
+				#assume that testcase+plugin to be tested have same name:
+				set (PLUGIN_TARGET_OBJS "$<TARGET_OBJECTS:elektra-${testname}-objects>")
+			endif ()
+			list (APPEND TEST_SOURCES "${PLUGIN_TARGET_OBJS}")
+		endif ()
+		set (testexename testmod_${testname})
+		add_executable (${testexename} ${TEST_SOURCES})
+
+		# alternative approach to restore_variable
+		#get_target_property(TARGET_COMPILE_DEFINITIONS PLUGIN_TARGET_OBJS COMPILE_DEFINITIONS)
+
+		if (INSTALL_TESTING)
+			install (TARGETS ${testexename}
+				DESTINATION "${TARGET_TOOL_EXEC_FOLDER}")
+			if (ARG_INSTALL_TEST_DATA)
+				install (DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/${testname}" DESTINATION "${TARGET_TEST_DATA_FOLDER}")
+			endif ()
+		endif (INSTALL_TESTING)
+
+		if (BUILD_SHARED)
+			if (ARG_LINK_ELEKTRA)
+				target_link_libraries (${testexename} elektra-kdb elektra-plugin ${ARG_LINK_ELEKTRA})
+			else()
+				target_link_libraries (${testexename} elektra-kdb elektra-plugin)
+			endif ()
+		endif ()
+		target_link_libraries (${testexename} ${ARG_LINK_LIBRARIES})
+		set_target_properties (${testexename} PROPERTIES
+				COMPILE_DEFINITIONS "HAVE_KDBCONFIG_H;ELEKTRA_PLUGIN_TEST;${ARG_COMPILE_DEFINITIONS}")
+		set_property(TARGET ${testexename}
+				APPEND PROPERTY INCLUDE_DIRECTORIES
+				${ARG_INCLUDE_DIRECTORIES})
+
+		if (ARG_WORKING_DIRECTORY)
+			set (WORKING_DIRECTORY "${ARG_WORKING_DIRECTORY}")
+		else ()
+			set (WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}")
+		endif ()
+
+		add_test (NAME ${testexename}
+				COMMAND "${CMAKE_BINARY_DIR}/bin/${testexename}" "${CMAKE_CURRENT_SOURCE_DIR}"
+				WORKING_DIRECTORY "${WORKING_DIRECTORY}"
+				)
+		if (ARG_MEMLEAK)
+			set_property(TEST ${testexename} PROPERTY
+				LABELS memleak)
+		endif (ARG_MEMLEAK)
+	endif ()
+endfunction (add_plugintest)
+
 
 function (plugin_check_if_included PLUGIN_SHORT_NAME)
 	list (FIND PLUGINS "-${PLUGIN_SHORT_NAME}" FOUND_EXCLUDE_NAME)
@@ -18,7 +139,7 @@ function (plugin_check_if_included PLUGIN_SHORT_NAME)
 		return ()
 	endif ()
 
-	FILE(READ ${CMAKE_CURRENT_SOURCE_DIR}/${PLUGIN_DIRECTORY_NAME}/README.md contents)
+	FILE(READ ${CMAKE_CURRENT_SOURCE_DIR}/README.md contents)
 	STRING (REGEX MATCH "- +infos/status *= *([-a-zA-Z0-9 ]*)" CATEGORIES "${contents}")
 	STRING (REGEX REPLACE "- +infos/status *= *([-a-zA-Z0-9 ]*)" "\\1" CATEGORIES "${CATEGORIES}")
 	STRING (REGEX REPLACE " " ";" CATEGORIES "${CATEGORIES}")
@@ -46,15 +167,33 @@ function (plugin_check_if_included PLUGIN_SHORT_NAME)
 	endforeach ()
 endfunction ()
 
+function (restore_variable PLUGIN_NAME VARIABLE)
+	set (PROP_NAME "${PLUGIN_NAME}_${VARIABLE}")
+	get_property (VAR GLOBAL PROPERTY "${PROP_NAME}")
+	if (VAR)
+		if (DEFINED ${VARIABLE})
+			# both stored and given by user: do consistency check
+			#message (STATUS "consistency check, plugin ${PLUGIN_NAME} got ${VARIABLE} reset to ${VAR}")
+			if (NOT "${VARIABLE}" STREQUAL "${VAR}")
+				message (FATAL_ERROR "Internally inconsistency, plugin ${PLUGIN_NAME} got different values for variable ${VARIABLE}: '${${VARIABLE}}' != '${VAR}'")
+			endif ()
+		else ()
+			# stored, but not given by user, use what was stored
+			set (${VARIABLE} ${VAR} PARENT_SCOPE)
+		endif ()
+	else ()
+		if (DEFINED ${VARIABLE})
+			# given by user, but not stored: store it
+			set_property (GLOBAL PROPERTY "${PROP_NAME}" "${${VARIABLE}}")
+		endif ()
+	endif ()
+endfunction ()
 
-# add_plugin: add a plugin to Elektra
+
+# add_plugin: register and potentially add a plugin
 #
 # SOURCES:
 #  The sources of the plugin
-#
-# SHARED_SOURCES:
-#  Will be added only once without any per-variant macros nor
-#  COMPILE_DEFINITIONS.
 #
 # LINK_LIBRARIES:
 #  add here only add libraries found by cmake
@@ -68,18 +207,64 @@ endfunction ()
 #
 # INCLUDE_DIRECTORIES:
 #  Append to include path (globally+plugin specific).
+#
+# ADD_TEST:
+#  Add a plugin test case written in C (alternatively you can use add_gtest)
+#
+# INSTALL_TEST_DATA:
+#  Install a directory with test data which has the same name as the plugin.
+#
 function (add_plugin PLUGIN_SHORT_NAME)
 	cmake_parse_arguments (ARG
-		"CPP" # optional keywords
+		"CPP;ADD_TEST;INSTALL_TEST_DATA" # optional keywords
 		"" # one value keywords
-		"SOURCES;SHARED_SOURCES;LINK_LIBRARIES;COMPILE_DEFINITIONS;INCLUDE_DIRECTORIES;LINK_ELEKTRA" # multi value keywords
+		"SOURCES;LINK_LIBRARIES;COMPILE_DEFINITIONS;INCLUDE_DIRECTORIES;LINK_ELEKTRA" # multi value keywords
 		${ARGN}
 	)
 
 	set (PLUGIN_NAME elektra-${PLUGIN_SHORT_NAME})
 	set (PLUGIN_OBJS ${PLUGIN_NAME}-objects)
 	set (PLUGIN_TARGET_OBJS "$<TARGET_OBJECTS:${PLUGIN_OBJS}>")
-	file(GLOB PLUGIN_SHARED_SOURCES ${ARG_SHARED_SOURCES})
+
+	restore_variable (${PLUGIN_NAME} ARG_LINK_LIBRARIES)
+	restore_variable (${PLUGIN_NAME} ARG_SOURCES)
+	restore_variable (${PLUGIN_NAME} ARG_COMPILE_DEFINITIONS)
+	restore_variable (${PLUGIN_NAME} ARG_INCLUDE_DIRECTORIES)
+	restore_variable (${PLUGIN_NAME} ARG_LINK_ELEKTRA)
+	restore_variable (${PLUGIN_NAME} ARG_ADD_TEST)
+	restore_variable (${PLUGIN_NAME} ARG_INSTALL_TEST_DATA)
+
+	if (ADDTESTING_PHASE)
+		if (ARG_INSTALL_TEST_DATA AND NOT ARG_ADD_TEST)
+			if (INSTALL_TESTING)
+				install (DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/${PLUGIN_SHORT_NAME}" DESTINATION "${TARGET_TEST_DATA_FOLDER}")
+			endif (INSTALL_TESTING)
+		endif ()
+
+		if (ARG_ADD_TEST)
+			set (HAS_CPP "")
+			if (ARG_CPP)
+				set (HAS_CPP "CPP")
+			endif (ARG_CPP)
+
+			set (HAS_INSTALL_TEST_DATA "")
+			if (ARG_INSTALL_TEST_DATA)
+				set (HAS_INSTALL_TEST_DATA "INSTALL_TEST_DATA")
+			endif (ARG_INSTALL_TEST_DATA)
+
+			add_plugintest ("${PLUGIN_SHORT_NAME}"
+					LINK_LIBRARIES "${ARG_LINK_LIBRARIES}"
+					LINK_PLUGIN "${PLUGIN_SHORT_NAME}"
+					COMPILE_DEFINITIONS "${ARG_COMPILE_DEFINITIONS}"
+					INCLUDE_DIRECTORIES "${ARG_INCLUDE_DIRECTORIES}"
+					LINK_ELEKTRA "${ARG_LINK_ELEKTRA}"
+					"${HAS_CPP}"
+					"${HAS_INSTALL_TEST_DATA}"
+					)
+		endif ()
+		return ()
+	endif ()
+
 
 	#message (STATUS "enter add_plugin ${PLUGIN_SHORT_NAME}")
 
@@ -110,6 +295,7 @@ function (add_plugin PLUGIN_SHORT_NAME)
 			set (ADDED_DIRECTORIES "${VAR}" CACHE STRING "${ADDED_DIRECTORIES_DOC}" FORCE)
 		endif ()
 
+		message (STATUS "Include Plugin ${PLUGIN_SHORT_NAME}")
 		return()
 	endif ()
 
@@ -123,7 +309,7 @@ function (add_plugin PLUGIN_SHORT_NAME)
 		return ()
 	endif ()
 
-	message (STATUS "Include Plugin ${PLUGIN_SHORT_NAME}")
+	#message (STATUS "Include Plugin ${PLUGIN_SHORT_NAME}")
 
 	#message (STATUS "name: ${PLUGIN_NAME}")
 	#message (STATUS "srcs are: ${ARG_SOURCES}")
@@ -168,8 +354,7 @@ function (add_plugin PLUGIN_SHORT_NAME)
 	#	PROPERTY CMAKE_POSITION_INDEPENDENT_CODE ON)
 
 	if (BUILD_SHARED)
-		add_library (${PLUGIN_NAME} MODULE ${ARG_SOURCES}
-			${PLUGIN_SHARED_SOURCES})
+		add_library (${PLUGIN_NAME} MODULE ${ARG_SOURCES})
 		if (ARG_LINK_ELEKTRA)
 			target_link_libraries (${PLUGIN_NAME} elektra-plugin ${ARG_LINK_ELEKTRA})
 		else()
@@ -200,12 +385,12 @@ function (add_plugin PLUGIN_SHORT_NAME)
 		endif ()
 	endif()
 
+	#message (STATUS "added ${PLUGIN_TARGET_OBJS}")
 	set_property (GLOBAL APPEND PROPERTY "elektra-full_SRCS"
 		${PLUGIN_TARGET_OBJS}
-		${PLUGIN_SHARED_SOURCES}
 		)
 
 	set_property (GLOBAL APPEND PROPERTY "elektra-full_LIBRARIES"
 		"${ARG_LINK_LIBRARIES}"
 		)
-endfunction()
+endfunction(add_plugin)

--- a/doc/todo/FRONT_END
+++ b/doc/todo/FRONT_END
@@ -1,8 +1,14 @@
 ## register
 
-elektraRegisterOpen(kdb, ..)
+elektraRegisterOpen(kdb, ..) // register as global plugin
 elektraRegisterClose // not needed
-elektraRegisterInt()
+
+int a;
+elektraRegisterInt(&a, "/app/a");
+char *;
+elektraRegisterString(&c, "/app/c");
+
+elektraRegisterCallback(f, "/app/f");
 
 ## array support ##
 

--- a/doc/todo/PLUGINS
+++ b/doc/todo/PLUGINS
@@ -417,7 +417,11 @@ If you want in the filename that contains $, you need to double it. So:
     abc$$USER$$ -> file name called abc$USER$
     abc$USER -> error: used invalid unquoted $; checkFile should return -1
 
+Block resolver:
+	only take care of a block within the configuration file, leave the rest untouched
 
+Multi-file resolver:
+	resolve a directory of conf files with a backend each
 
 curl resolver:
 	a resolver that downloads file from http/ftp/ssh/sftp/etc and uses them

--- a/doc/tutorials/plugins.md
+++ b/doc/tutorials/plugins.md
@@ -23,6 +23,7 @@ Additionally, there is one more function called
 [ELEKTRA_PLUGIN_EXPORT](http://doc.libelektra.org/api/current/html/group__plugin.html#gabe78724d2d477eef39997fd9b85bff16),
 where once again `Plugin` should be replaced with the name of the plug-in, this time in lower-case. So for my line plugin this function would be
 `ELEKTRA_PLUGIN_EXPORT(line)`.
+The developer may define elektraPluginCheckConf() if configuration validation at mount time is desired.
 
 The KDB relies on the first five functions for interacting with configuration files stored in the key database.
 Calls for kdbGet() and kdbClose() will call the functions elektraPluginGet() and elektraPluginClose() respectively for the
@@ -321,6 +322,14 @@ parentKey is available.
 The `elektraPluginOpen` and `elektraPluginClose` functions are not commonly used for storage plug-ins, but they can be useful and are worth
 reviewing. `elektraPluginOpen` function runs before `elektraPluginGet` and is useful to do initialization if necessary for the plug-in. On the other
 hand `elektraPluginClose` is run after other functions of the plug-in and can be useful for freeing up resources.
+
+### elektraPluginCheckConf ###
+
+The `elektraPluginCheckConf` function may be used for validation of the plugin configuration during mount time. The signature of the function is:
+
+	int elektraLineCheckConfig (Key * errorKey, KeySet * conf)
+
+The configuration of the plugin is provided as `conf`. The function may report errors using the `errorKey` and the return value.
 
 ### ELEKTRA_PLUGIN_EXPORT ###
 

--- a/doc/tutorials/plugins.md
+++ b/doc/tutorials/plugins.md
@@ -331,6 +331,12 @@ The `elektraPluginCheckConf` function may be used for validation of the plugin c
 
 The configuration of the plugin is provided as `conf`. The function may report errors using the `errorKey` and the return value.
 
+The following convention was established for the return value of `elektraPluginCheckConf`:
+
+- 0: config was not changed (was ok)
+- 1: config is changed (now ok)
+- -1: config not ok, could not fix it
+
 ### ELEKTRA_PLUGIN_EXPORT ###
 
 The last function, one that is always needed in a plug-in, is `ELEKTRA_PLUGIN_EXPORT`. This functions is responsible for letting Elektra know that

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,5 +1,7 @@
 add_subdirectory (error)
 
+
+set (ADDTESTING_PHASE OFF)
 add_subdirectory (plugins)
 
 add_subdirectory (libs)
@@ -9,3 +11,6 @@ add_subdirectory (bindings)
 add_subdirectory (tools)
 
 add_subdirectory (include)
+
+set (ADDTESTING_PHASE ON)
+add_subdirectory (plugins plugins_tests)

--- a/src/bindings/cpp/benchmarks/CMakeLists.txt
+++ b/src/bindings/cpp/benchmarks/CMakeLists.txt
@@ -8,7 +8,7 @@ macro (do_benchmark source)
 	set (SOURCES ${HDR_FILES} ${source}.cpp)
 	add_executable (${source} ${SOURCES})
 
-	target_link_elektra(${source})
+	target_link_elektra(${source} elektra-kdb elektra-meta)
 
 	set_target_properties (${source} PROPERTIES
 			COMPILE_DEFINITIONS HAVE_KDBCONFIG_H)

--- a/src/bindings/cpp/examples/CMakeLists.txt
+++ b/src/bindings/cpp/examples/CMakeLists.txt
@@ -8,7 +8,7 @@ macro (do_example source)
 	set (SOURCES ${HDR_FILES} ${source}.cpp)
 	add_executable (${source} ${SOURCES})
 
-	target_link_elektra(${source})
+	target_link_elektra(${source} elektra-kdb)
 
 	set_target_properties (${source} PROPERTIES
 			COMPILE_DEFINITIONS HAVE_KDBCONFIG_H)

--- a/src/bindings/cpp/tests/CMakeLists.txt
+++ b/src/bindings/cpp/tests/CMakeLists.txt
@@ -4,31 +4,10 @@ include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 add_headers (HDR_FILES)
 add_cppheaders (HDR_FILES)
 
-#macro (do_cpp_test source)
-#	include_directories ("${CMAKE_CURRENT_SOURCE_DIR}")
-#	set (SOURCES ${HDR_FILES} ${source}.cpp tests.cpp tests.hpp)
-#	add_executable (${source} ${SOURCES})
-#
-#	target_link_elektra(${source})
-#
-#	if (INSTALL_TESTING)
-#		install (TARGETS ${source}
-#			DESTINATION ${TARGET_TOOL_EXEC_FOLDER})
-#	endif (INSTALL_TESTING)
-#
-#	set_target_properties (${source} PROPERTIES
-#			COMPILE_DEFINITIONS HAVE_KDBCONFIG_H)
-#	add_test (${source}
-#			"${CMAKE_BINARY_DIR}/bin/${source}"
-#			"${CMAKE_CURRENT_BINARY_DIR}/"
-#			)
-#endmacro (do_cpp_test)
-#
-
 file (GLOB TESTS testcpp_*.cpp)
 foreach (file ${TESTS})
 	get_filename_component (name ${file} NAME_WE)
-	add_gtest (${name})
+	add_gtest (${name} LINK_LIBRARIES elektra-kdb elektra-meta)
 endforeach (file ${TESTS})
 
 set_property(TEST testcpp_kdb

--- a/src/libs/tools/include/plugindatabase.hpp
+++ b/src/libs/tools/include/plugindatabase.hpp
@@ -30,6 +30,9 @@ namespace tools
  */
 class PluginDatabase
 {
+protected:
+	typedef void (*func_t) ();
+
 public:
 	/**
 	 * @brief list all plugins
@@ -67,6 +70,16 @@ public:
 	 * @return the clause of the contract
 	 */
 	virtual std::string lookupInfo (PluginSpec const & whichplugin, std::string const & which) const = 0;
+
+	/**
+	 * @brief get exported plugin symbol
+	 *
+	 * @param whichplugin from which plugin?
+	 * @param which which symbol would you like to look up?
+	 *
+	 * @return the function pointer to the exported symbol
+	 */
+	virtual func_t getSymbol (PluginSpec const & whichplugin, std::string const & which) const = 0;
 
 	/**
 	 * @brief lookup which plugin handles meta data
@@ -118,6 +131,7 @@ public:
 	std::vector<std::string> listAllPlugins () const;
 	PluginDatabase::Status status (PluginSpec const & whichplugin) const;
 	std::string lookupInfo (PluginSpec const & spec, std::string const & which) const;
+	func_t getSymbol (PluginSpec const & whichplugin, std::string const & which) const;
 	PluginSpec lookupMetadata (std::string const & which) const;
 	PluginSpec lookupProvides (std::string const & provides) const;
 };
@@ -135,6 +149,7 @@ public:
 	std::vector<std::string> listAllPlugins () const;
 	PluginDatabase::Status status (PluginSpec const & whichplugin) const;
 	std::string lookupInfo (PluginSpec const & spec, std::string const & which) const;
+	func_t getSymbol (PluginSpec const & whichplugin, std::string const & which) const;
 };
 }
 }

--- a/src/libs/tools/include/toolexcept.hpp
+++ b/src/libs/tools/include/toolexcept.hpp
@@ -157,6 +157,35 @@ struct PluginAlreadyInserted : public PluginCheckException
 	std::string m_str;
 };
 
+struct PluginConfigInvalid : public PluginCheckException
+{
+	explicit PluginConfigInvalid (Key key) : m_key (key), m_str ()
+	{
+	}
+
+	explicit PluginConfigInvalid (std::string const & message) : m_str (message)
+	{
+	}
+
+	virtual const char * what () const throw () override
+	{
+		if (m_str.empty ())
+		{
+			std::stringstream ss;
+			ss << "The provided plugin configuration is not valid!\n";
+			ss << "Errors/Warnings during the check were:\n";
+			printError (ss, m_key);
+			printWarnings (ss, m_key);
+			m_str = ss.str ();
+		}
+		return m_str.c_str ();
+	}
+
+private:
+	Key m_key;
+	mutable std::string m_str;
+};
+
 struct BadPluginName : public PluginCheckException
 {
 	explicit BadPluginName (std::string name)

--- a/src/libs/tools/src/backendbuilder.cpp
+++ b/src/libs/tools/src/backendbuilder.cpp
@@ -431,7 +431,7 @@ void BackendBuilder::addPlugin (PluginSpec const & plugin)
 	{
 		ckdb::Key * errorKey = ckdb::keyNew (0);
 		int checkResult = checkConfFunction (errorKey, newPlugin.getConfig ().getKeySet ());
-		if (checkResult != 1)
+		if (checkResult == -1)
 		{
 			throw PluginConfigInvalid (errorKey);
 		}

--- a/src/libs/tools/src/backendbuilder.cpp
+++ b/src/libs/tools/src/backendbuilder.cpp
@@ -431,7 +431,7 @@ void BackendBuilder::addPlugin (PluginSpec const & plugin)
 	{
 		ckdb::Key * errorKey = ckdb::keyNew (0);
 		int checkResult = checkConfFunction (errorKey, newPlugin.getConfig ().getKeySet ());
-		if (checkResult != 0)
+		if (checkResult != 1)
 		{
 			throw PluginConfigInvalid (errorKey);
 		}

--- a/src/libs/tools/src/plugindatabase.cpp
+++ b/src/libs/tools/src/plugindatabase.cpp
@@ -223,6 +223,21 @@ std::string ModulesPluginDatabase::lookupInfo (PluginSpec const & spec, std::str
 	return plugin->lookupInfo (which);
 }
 
+PluginDatabase::func_t ModulesPluginDatabase::getSymbol (PluginSpec const & spec, std::string const & which) const
+{
+	PluginPtr plugin;
+	try
+	{
+		plugin = impl->modules.load (spec.getName (), spec.getConfig ());
+	}
+	catch (...)
+	{
+		throw;
+	}
+
+	return plugin->getSymbol (which);
+}
+
 PluginSpec ModulesPluginDatabase::lookupMetadata (std::string const & which) const
 {
 	std::vector<std::string> allPlugins = listAllPlugins ();
@@ -366,6 +381,13 @@ std::string MockPluginDatabase::lookupInfo (PluginSpec const & spec, std::string
 	}
 
 	return "";
+}
+
+PluginDatabase::func_t MockPluginDatabase::getSymbol (PluginSpec const & spec ELEKTRA_UNUSED,
+						      std::string const & which ELEKTRA_UNUSED) const
+{
+	// TODO implement mockup
+	return NULL;
 }
 }
 }

--- a/src/plugins/CMakeLists.txt
+++ b/src/plugins/CMakeLists.txt
@@ -1,5 +1,24 @@
 include (LibAddPlugin)
 
+if (ADDTESTING_PHASE)
+	list (REMOVE_DUPLICATES ADDED_DIRECTORIES)
+
+	set (COLLECTION_PHASE OFF)
+	set (DEPENDENCY_PHASE OFF)
+	foreach (plugin ${ADDED_DIRECTORIES})
+		set (CMAKE_CURRENT_SOURCE_DIR_TOPSAFE ${CMAKE_CURRENT_SOURCE_DIR})
+		set (CMAKE_CURRENT_BINARY_DIR_TOPSAFE ${CMAKE_CURRENT_BINARY_DIR})
+		set (PLUGIN_DIRECTORY_NAME ${plugin})
+		set (CMAKE_CURRENT_SOURCE_DIR "${CMAKE_SOURCE_DIR}/src/plugins/${plugin}")
+		set (CMAKE_CURRENT_BINARY_DIR "${CMAKE_BINARY_DIR}/src/plugins/${plugin}")
+		include ("${plugin}/CMakeLists.txt")
+		set (CMAKE_CURRENT_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR_TOPSAFE})
+		set (CMAKE_CURRENT_BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR_TOPSAFE})
+	endforeach(plugin)
+	return ()
+endif ()
+
+
 generate_manpage (elektra-plugins FILENAME ${CMAKE_CURRENT_SOURCE_DIR}/README.md SECTION 7)
 
 set (COLLECTION_PHASE ON)
@@ -11,8 +30,14 @@ file (GLOB DIRECTORIES RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_SOUR
 foreach (plugin ${DIRECTORIES})
 	#message (STATUS ${plugin})
 	if (IS_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/${plugin} AND NOT ${plugin} STREQUAL CMakeFiles)
+		set (CMAKE_CURRENT_SOURCE_DIR_TOPSAFE ${CMAKE_CURRENT_SOURCE_DIR})
+		set (CMAKE_CURRENT_BINARY_DIR_TOPSAFE ${CMAKE_CURRENT_BINARY_DIR})
 		set (PLUGIN_DIRECTORY_NAME ${plugin})
+		set (CMAKE_CURRENT_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/${plugin}")
+		set (CMAKE_CURRENT_BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}/${plugin}")
 		include ("${plugin}/CMakeLists.txt")
+		set (CMAKE_CURRENT_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR_TOPSAFE})
+		set (CMAKE_CURRENT_BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR_TOPSAFE})
 	endif ()
 endforeach(plugin)
 
@@ -20,7 +45,6 @@ endforeach(plugin)
 # Now ADDED_DIRECTORIES and ADDED_PLUGINS is modified accordingly
 #
 
-list (SORT ADDED_DIRECTORIES)
 list (REMOVE_DUPLICATES ADDED_DIRECTORIES)
 
 
@@ -37,8 +61,6 @@ foreach (plugin ${ADDED_DIRECTORIES})
 	endif ()
 endforeach(plugin)
 
-
-
 list (FIND ADDED_PLUGINS ${KDB_DEFAULT_STORAGE} output)
 if (output EQUAL -1)
 	message(SEND_ERROR "selected default storage (${KDB_DEFAULT_STORAGE})  is not selected in PLUGINS, please change KDB_DEFAULT_STORAGE or PLUGINS")
@@ -48,6 +70,7 @@ list (FIND ADDED_PLUGINS ${KDB_DEFAULT_RESOLVER} output)
 if (output EQUAL -1)
 	message(SEND_ERROR "selected default resolver (${KDB_DEFAULT_RESOLVER}) is not selected in PLUGINS, please change KDB_DEFAULT_RESOLVER or PLUGINS")
 endif()
+
 
 if (BUILD_SHARED)
 	mkdir (${CMAKE_LIBRARY_OUTPUT_DIRECTORY})
@@ -61,3 +84,4 @@ if (BUILD_SHARED)
 			libelektra-resolver.so
 			)
 endif (BUILD_SHARED)
+

--- a/src/plugins/augeas/CMakeLists.txt
+++ b/src/plugins/augeas/CMakeLists.txt
@@ -11,15 +11,9 @@ if (DEPENDENCY_PHASE)
 				-DLINK_LIBRARIES:PATH=${LIBAUGEAS_LIBRARIES}\;${LIBXML2_LIBRARIES}
 			)
 
-		if (HAS_LIBAUGEAS16)
-			include (LibAddMacros)
-
-			install(DIRECTORY augeas DESTINATION ${TARGET_TEST_DATA_FOLDER})
-
-			add_plugintest(augeas)
-		else (HAS_LIBAUGEAS16)
+		if (NOT HAS_LIBAUGEAS16)
 			remove_plugin (augeas "symbols aug_text_store and aug_text_retrieve not found. Make sure you have libaugeas 0.16 or higher. This library version is included in Augeas 1.0 or higher")
-		endif (HAS_LIBAUGEAS16)
+		endif (NOT HAS_LIBAUGEAS16)
 	else (LIBAUGEAS_FOUND AND LIBXML2_FOUND AND)
 		remove_plugin (augeas "augeas not found")
 	endif (LIBAUGEAS_FOUND AND LIBXML2_FOUND )
@@ -29,6 +23,8 @@ add_plugin(augeas
 	SOURCES
 		aug.h
 		augeas.c
+	ADD_TEST
+	INSTALL_TEST_DATA
 	INCLUDE_DIRECTORIES
 		${LIBAUGEAS_INCLUDE_DIR}
 		${LIBXML2_INCLUDE_DIR}
@@ -39,3 +35,7 @@ add_plugin(augeas
 		${LIBAUGEAS_LIBRARIES}
 		${LIBXML2_LIBRARIES}
 	)
+
+if (ADDTESTING_PHASE)
+	include (LibAddMacros)
+endif ()

--- a/src/plugins/ccode/CMakeLists.txt
+++ b/src/plugins/ccode/CMakeLists.txt
@@ -4,6 +4,5 @@ add_plugin (ccode
 	SOURCES
 		ccode.h
 		ccode.c
+	ADD_TEST
 	)
-
-add_plugintest (ccode)

--- a/src/plugins/conditionals/CMakeLists.txt
+++ b/src/plugins/conditionals/CMakeLists.txt
@@ -4,6 +4,5 @@ add_plugin (conditionals
 	SOURCES
 		conditionals.h
 		conditionals.c
+	ADD_TEST
 	)
-
-add_plugintest (conditionals)

--- a/src/plugins/crypto/CMakeLists.txt
+++ b/src/plugins/crypto/CMakeLists.txt
@@ -83,10 +83,6 @@ if (DEPENDENCY_PHASE)
 	unset (OPENSSL_MANUAL_OSX_HACK)
 	unset (LIBGCRYPT_MANUAL_OSX_HACK)
 	unset (plugin)
-
-	if (HAS_OPENSSL_4SURE OR HAS_GCRYPT_4SURE)
-		add_plugintest (crypto)
-	endif ()
 endif ()
 
 #
@@ -126,3 +122,9 @@ add_plugin (crypto_openssl
 		ELEKTRA_VARIANT=openssl
 		ELEKTRA_CRYPTO_API_OPENSSL
 )
+
+if (ADDTESTING_PHASE)
+	if (HAS_OPENSSL_4SURE OR HAS_GCRYPT_4SURE)
+		add_plugintest (crypto LINK_PLUGIN "<no>")
+	endif ()
+endif ()

--- a/src/plugins/crypto/CMakeLists.txt
+++ b/src/plugins/crypto/CMakeLists.txt
@@ -125,6 +125,8 @@ add_plugin (crypto_openssl
 
 if (ADDTESTING_PHASE)
 	if (HAS_OPENSSL_4SURE OR HAS_GCRYPT_4SURE)
-		add_plugintest (crypto LINK_PLUGIN "<no>")
+		add_plugintest (crypto
+				MEMLEAK
+				LINK_PLUGIN "<no>")
 	endif ()
 endif ()

--- a/src/plugins/csvstorage/CMakeLists.txt
+++ b/src/plugins/csvstorage/CMakeLists.txt
@@ -1,15 +1,11 @@
 include (LibAddMacros)
 
-if (DEPENDENCY_PHASE)
-	install (DIRECTORY csvstorage DESTINATION ${TARGET_TEST_DATA_FOLDER})
-	add_plugintest (csvstorage)
-endif ()
-
 add_plugin (csvstorage
 	SOURCES
 		csvstorage.h
 		csvstorage.c
 	LINK_ELEKTRA
 		elektra-ease
+	ADD_TEST
+	INSTALL_TEST_DATA
 	)
-

--- a/src/plugins/curlget/CMakeLists.txt
+++ b/src/plugins/curlget/CMakeLists.txt
@@ -1,7 +1,7 @@
 if (DEPENDENCY_PHASE)
 	find_package(CURL)
 
-	if(NOT (CURL_FOUND))
+	if(NOT CURL_FOUND)
 		remove_plugin(curlget "Curl-dev not found")
 	endif ()
 endif ()
@@ -14,6 +14,5 @@ add_plugin (curlget
 		${CURL_INCLUDE_DIR}
 	LINK_LIBRARIES
 		${CURL_LIBRARIES}
+	ADD_TEST
 	)
-
-add_plugintest (curlget)

--- a/src/plugins/dbus/CMakeLists.txt
+++ b/src/plugins/dbus/CMakeLists.txt
@@ -1,16 +1,9 @@
 if (DEPENDENCY_PHASE)
 	find_package (DBus)
 
-	if (DBUS_FOUND)
-
-		include_directories (${DBUS_INCLUDE_DIR})
-		include_directories (${DBUS_ARCH_INCLUDE_DIR})
-		add_plugintest (dbus
-				sendmessage.c receivemessage.c
-				)
-	else (DBUS_FOUND)
+	if (NOT DBUS_FOUND)
 		remove_plugin (dbus "dbus not found")
-	endif (DBUS_FOUND)
+	endif ()
 endif ()
 
 add_plugin (dbus
@@ -22,4 +15,10 @@ add_plugin (dbus
 		${DBUS_ARCH_INCLUDE_DIR}
 	LINK_LIBRARIES
 		${DBUS_LIBRARIES}
+	)
+
+add_plugintest (dbus
+	INCLUDE_DIRECTORIES
+		${DBUS_INCLUDE_DIR}
+		${DBUS_ARCH_INCLUDE_DIR}
 	)

--- a/src/plugins/doc/doc.c
+++ b/src/plugins/doc/doc.c
@@ -107,6 +107,7 @@ int elektraDocGet (Plugin * plugin ELEKTRA_UNUSED, KeySet * returned, Key * pare
 			       keyNew ("system/elektra/modules/doc/exports/get", KEY_FUNC, elektraDocGet, KEY_END),
 			       keyNew ("system/elektra/modules/doc/exports/set", KEY_FUNC, elektraDocSet, KEY_END),
 			       keyNew ("system/elektra/modules/doc/exports/error", KEY_FUNC, elektraDocError, KEY_END),
+			       keyNew ("system/elektra/modules/doc/exports/checkconf", KEY_FUNC, elektraDocCheckConf, KEY_END),
 #include ELEKTRA_README (doc)
 			       keyNew ("system/elektra/modules/doc/infos/version", KEY_VALUE, PLUGINVERSION, KEY_END), KS_END);
 		ksAppend (returned, contract);
@@ -182,6 +183,19 @@ static Plugin * findPlugin (KDB * handle ELEKTRA_UNUSED)
 static void saveToDisc (Key * k ELEKTRA_UNUSED)
 {
 }
+
+//![validate configuration]
+int elektraDocCheckConf (Key * errorKey ELEKTRA_UNUSED, KeySet * conf ELEKTRA_UNUSED)
+{
+	/* validate plugin configuration */
+
+	// the return codes have the following meaning:
+	// 0: config was not changed (was ok)
+	// 1: config is changed (now ok)
+	// -1: config not ok, could not fix
+	return 0;
+}
+//![validate configuration]
 
 //![set full]
 static void usercode (KDB * handle, KeySet * keyset, Key * key)

--- a/src/plugins/doc/doc.h
+++ b/src/plugins/doc/doc.h
@@ -494,6 +494,28 @@ int elektraDocSet (Plugin * handle, KeySet * returned, Key * parentKey);
  */
 int elektraDocError (Plugin * handle, KeySet * returned, Key * parentKey);
 
+/**
+ * @brief Validate plugin configuration at mount time.
+ * 
+ * During the mount phase the BackendBuilder calls this method,
+ * if it is provided by the plugin.
+ * 
+ * In this method the plugin configuration can be checked for validity or 
+ * integrity. Missing items can be added to complete the configuration.
+ * 
+ * @param errorKey is used to propagate error messages to the caller
+ * @param conf contains the plugin configuration to be validated
+ * 
+ * @retval 1 on success: config is changed (now ok)
+ * @retval 0 on success: config was not changed (was ok)
+ * @retval -1 on failure: config not ok, could not be fixed
+ *   Set an error using #ELEKTRA_SET_ERROR to inform the user what went wrong.
+ *   Additionally you can add any number of warnings with
+ *   #ELEKTRA_ADD_WARNING.
+ * 
+ * @ingroup plugin
+ */
+int elektraDocCheckConf (Key * errorKey, KeySet * conf);
 
 /**
  * @}

--- a/src/plugins/dpkg/CMakeLists.txt
+++ b/src/plugins/dpkg/CMakeLists.txt
@@ -4,6 +4,5 @@ add_plugin (dpkg
 	SOURCES
 		dpkg.h
 		dpkg.c
+	ADD_TEST
 	)
-
-add_plugintest (dpkg)

--- a/src/plugins/dump/CMakeLists.txt
+++ b/src/plugins/dump/CMakeLists.txt
@@ -4,6 +4,5 @@ add_plugin (dump
 	SOURCES
 		dump.hpp
 		dump.cpp
+	ADD_TEST
 	)
-
-add_plugintest (dump)

--- a/src/plugins/enum/CMakeLists.txt
+++ b/src/plugins/enum/CMakeLists.txt
@@ -4,6 +4,5 @@ add_plugin (enum
 	SOURCES
 		enum.h
 		enum.c
+	ADD_TEST
 	)
-
-add_plugintest (enum)

--- a/src/plugins/filecheck/CMakeLists.txt
+++ b/src/plugins/filecheck/CMakeLists.txt
@@ -2,11 +2,8 @@ include (LibAddMacros)
 if (DEPENDENCY_PHASE)
 	find_package (Iconv)
 
-	if (ICONV_FOUND)
-		install(DIRECTORY filecheck DESTINATION ${TARGET_TEST_DATA_FOLDER})
-		add_plugintest (filecheck)
-	else ()
-		remove_plugin(filecheck "Can't find iconv library")
+	if (NOT ICONV_FOUND)
+		remove_plugin(filecheck "Cannot find iconv library")
 	endif ()
 endif ()
 
@@ -18,4 +15,6 @@ add_plugin (filecheck
 		${ICONV_INCLUDE_DIR}	
 	LINK_LIBRARIES
 		${ICONV_LIBRARIES}
+	ADD_TEST
+	INSTALL_TESTING
 )

--- a/src/plugins/fstab/CMakeLists.txt
+++ b/src/plugins/fstab/CMakeLists.txt
@@ -4,14 +4,9 @@ if (DEPENDENCY_PHASE)
 			"${PROJECT_SOURCE_DIR}/src/plugins/fstab/testmntent.c"
 			)
 
-	if (HAS_MNTENT)
-
-		install(DIRECTORY fstab DESTINATION ${TARGET_TEST_DATA_FOLDER})
-
-		add_plugintest (fstab)
-	else (HAS_MNTENT)
-		remove_plugin (fstab "mntent is missing")
-	endif (HAS_MNTENT)
+	if (NOT HAS_MNTENT)
+		remove_plugin (fstab "function mntent is missing")
+	endif ()
 endif ()
 
 add_plugin (fstab
@@ -20,4 +15,6 @@ add_plugin (fstab
 		fstab.h
 	LINK_ELEKTRA
 		elektra-meta
+	ADD_TEST
+	INSTALL_TEST_DATA
 	)

--- a/src/plugins/glob/CMakeLists.txt
+++ b/src/plugins/glob/CMakeLists.txt
@@ -4,6 +4,5 @@ add_plugin (glob
 	SOURCES
 		glob.h
 		glob.c
-	)	
-
-add_plugintest (glob)
+	ADD_TEST
+	)

--- a/src/plugins/hexcode/CMakeLists.txt
+++ b/src/plugins/hexcode/CMakeLists.txt
@@ -4,6 +4,5 @@ add_plugin (hexcode
 	SOURCES
 		hexcode.h
 		hexcode.c
+	ADD_TEST
 	)
-
-add_plugintest (hexcode)

--- a/src/plugins/hosts/CMakeLists.txt
+++ b/src/plugins/hosts/CMakeLists.txt
@@ -11,9 +11,6 @@ add_plugin (hosts
 		elektra-ease
 		elektra-proposal
 		elektra-meta
+	ADD_TEST
+	INSTALL_TEST_DATA
 	)
-
-
-install (DIRECTORY hosts DESTINATION ${TARGET_TEST_DATA_FOLDER})
-
-add_plugintest(hosts)

--- a/src/plugins/iconv/CMakeLists.txt
+++ b/src/plugins/iconv/CMakeLists.txt
@@ -1,10 +1,8 @@
 if (DEPENDENCY_PHASE)
 	find_package(Iconv)
 
-	if (ICONV_FOUND)
-		add_plugintest (iconv)
-	else ()
-		remove_plugin (iconv "Can't find iconv library")
+	if (NOT ICONV_FOUND)
+		remove_plugin (iconv "Cannot find iconv library")
 	endif ()
 endif ()
 
@@ -16,4 +14,5 @@ add_plugin (iconv
 		${ICONV_INCLUDE_DIR}	
 	LINK_LIBRARIES
 		${ICONV_LIBRARIES}
+	ADD_TEST
 )

--- a/src/plugins/ini/CMakeLists.txt
+++ b/src/plugins/ini/CMakeLists.txt
@@ -1,8 +1,6 @@
 include (LibAddMacros)
 
 file (GLOB INIH_FILES ${CMAKE_CURRENT_SOURCE_DIR}/inih-r29/*)
-set (INIH_INCLUDE ${CMAKE_CURRENT_SOURCE_DIR}/inih-r29)
-add_definitions( -DINI_ALLOW_MULTILINE=0 )
 
 add_plugin(ini
 	SOURCES
@@ -10,13 +8,13 @@ add_plugin(ini
 		ini.c
 		${INIH_FILES}
 	INCLUDE_DIRECTORIES
-		${INIH_INCLUDE}
+		${CMAKE_CURRENT_SOURCE_DIR}/inih-r29
 	LINK_ELEKTRA
 		elektra-ease
 		elektra-meta
 		elektra-proposal
+	COMPILE_DEFINITIONS
+		INI_ALLOW_MULTILINE=0
+	ADD_TEST
+	INSTALL_TEST_DATA
 	)
-
-install (DIRECTORY ini DESTINATION ${TARGET_TEST_DATA_FOLDER})
-
-add_plugintest (ini)

--- a/src/plugins/iterate/CMakeLists.txt
+++ b/src/plugins/iterate/CMakeLists.txt
@@ -4,6 +4,5 @@ add_plugin (iterate
 	SOURCES
 		iterate.h
 		iterate.c
+	ADD_TEST
 	)
-
-add_plugintest (iterate)

--- a/src/plugins/jni/CMakeLists.txt
+++ b/src/plugins/jni/CMakeLists.txt
@@ -3,31 +3,27 @@ if (DEPENDENCY_PHASE)
 	find_package (JNI)
 
 	if (JNI_FOUND)
-		set (CMAKE_REQUIRED_INCLUDES
-					${JNI_INCLUDE_DIRS}
-					${JAVA_INCLUDE_PATH}
-					${JAVA_INCLUDE_PATH2}
-					${JAVA_AWT_INCLUDE_PATH}
-				)
 		include (CheckSymbolExists)
+		set (DIRS
+			${JNI_INCLUDE_DIRS}
+			${JAVA_INCLUDE_PATH}
+			${JAVA_INCLUDE_PATH2}
+			${JAVA_AWT_INCLUDE_PATH}
+		    )
+		set (LIBS
+			${JAVA_MAWT_LIBRARY}
+			${JNI_LIBRARIES}
+			${JAVA_AWT_LIBRARY}
+			${JAVA_JVM_LIBRARY}
+		    )
+		# for check_symbol_exists
+		set (CMAKE_REQUIRED_INCLUDES
+			${DIRS}
+		    )
 		check_symbol_exists (JNI_VERSION_1_8 jni.h JNI_CORRECT_VERSION)
-		if (JNI_CORRECT_VERSION)
+		unset (CMAKE_REQUIRED_INCLUDES)
 
-			list (FIND BINDINGS "jna" FINDEX)
-			if (BUILD_TESTING AND FINDEX GREATER -1)
-				set (libelektra_jar ${CMAKE_BINARY_DIR}/src/bindings/jna/libelektra.jar)
-
-				configure_file (
-					"${CMAKE_CURRENT_SOURCE_DIR}/testmod_jni.h.in"
-					"${CMAKE_CURRENT_BINARY_DIR}/testmod_jni.h"
-					)
-
-				include_directories (${CMAKE_CURRENT_BINARY_DIR})
-				add_plugintest(jni MEMLEAK)
-			else ()
-				message (WARNING "jna bindings are required for testing, test deactivated")
-			endif ()
-		else ()
+		if (NOT JNI_CORRECT_VERSION)
 			remove_plugin (jni "jni.h does not define JNI_VERSION_1_8")
 		endif ()
 	else ()
@@ -39,12 +35,24 @@ add_plugin(jni
 	SOURCES
 		jni.c
 	INCLUDE_DIRECTORIES
-		${CMAKE_REQUIRED_INCLUDES}
+		${DIRS}
 	LINK_LIBRARIES
-		${JAVA_MAWT_LIBRARY}
-		${JNI_LIBRARIES}
-		${JAVA_AWT_LIBRARY}
-		${JAVA_JVM_LIBRARY}
+		${LIBS}
 	)
 
-unset (CMAKE_REQUIRED_INCLUDES)
+if (ADDTESTING_PHASE)
+	list (FIND BINDINGS "jna" FINDEX)
+	if (BUILD_TESTING AND FINDEX GREATER -1)
+		set (libelektra_jar ${CMAKE_BINARY_DIR}/src/bindings/jna/libelektra.jar)
+
+		configure_file (
+			"${CMAKE_CURRENT_SOURCE_DIR}/testmod_jni.h.in"
+			"${CMAKE_CURRENT_BINARY_DIR}/testmod_jni.h"
+			)
+
+		include_directories (${CMAKE_CURRENT_BINARY_DIR})
+		add_plugintest(jni MEMLEAK)
+	else ()
+		message (WARNING "jna bindings are required for testing, test deactivated")
+	endif ()
+endif ()

--- a/src/plugins/jni/testmod_jni.h.in
+++ b/src/plugins/jni/testmod_jni.h.in
@@ -9,6 +9,6 @@
 #ifndef TESTMOD_JNI_H_IN
 #define TESTMOD_JNI_H_IN
 
-#define CLASSPATH "@jna@:@libelektra_jar@:/usr/share/java"
+#define CLASSPATH "@jna@:@libelektra_jar@"
 
 #endif

--- a/src/plugins/journald/CMakeLists.txt
+++ b/src/plugins/journald/CMakeLists.txt
@@ -1,17 +1,11 @@
 if (DEPENDENCY_PHASE)
 	find_package(SystemdJournal)
 
-	if (LIBSYSTEMD_JOURNAL_FOUND)
-
-		include (LibAddMacros)
-
-		#add_plugintest (journald)
-
-	else (LIBSYSTEMD_JOURNAL_FOUND)
+	if (NOT LIBSYSTEMD_JOURNAL_FOUND)
 
 		remove_plugin (journald "systemd-journal not found")
 
-	endif (LIBSYSTEMD_JOURNAL_FOUND)
+	endif ()
 endif ()
 
 add_plugin(journald

--- a/src/plugins/keytometa/CMakeLists.txt
+++ b/src/plugins/keytometa/CMakeLists.txt
@@ -7,6 +7,5 @@ add_plugin (keytometa
 	LINK_ELEKTRA
 		elektra-proposal
 		elektra-meta
+	ADD_TEST
 	)
-
-add_plugintest (keytometa)

--- a/src/plugins/line/CMakeLists.txt
+++ b/src/plugins/line/CMakeLists.txt
@@ -4,14 +4,9 @@ if (DEPENDENCY_PHASE)
 		"${PROJECT_SOURCE_DIR}/src/plugins/line/testgetline.c"
 		)
 
-	if (COMPAT_GETLINE)
-		install(DIRECTORY line DESTINATION ${TARGET_TEST_DATA_FOLDER})
-
-		add_plugintest (line)
-	else (COMPAT_GETLINE)
+	if (NOT COMPAT_GETLINE)
 		remove_plugin (line "Unable to use getline function. Check libc version, should be higher than 4.6.27.")
-
-	endif (COMPAT_GETLINE)
+	endif ()
 endif ()
 
 add_plugin (line
@@ -20,4 +15,11 @@ add_plugin (line
 		line.c
 	LINK_ELEKTRA
 		elektra-ease
+	INSTALL_TEST_DATA
 	)
+
+if (ADDTESTING_PHASE)
+	add_plugintest (line
+		INSTALL_TEST_DATA
+			)
+endif ()

--- a/src/plugins/lineendings/CMakeLists.txt
+++ b/src/plugins/lineendings/CMakeLists.txt
@@ -4,6 +4,6 @@ add_plugin (lineendings
 	SOURCES
 		lineendings.h
 		lineendings.c
+	ADD_TEST
+	INSTALL_TEST_DATA
 	)
-install (DIRECTORY lineendings DESTINATION ${TARGET_TEST_DATA_FOLDER})
-add_plugintest (lineendings)

--- a/src/plugins/list/CMakeLists.txt
+++ b/src/plugins/list/CMakeLists.txt
@@ -6,6 +6,5 @@ add_plugin (list
 		list.c
 	LINK_ELEKTRA
 		elektra-kdb
+	ADD_TEST
 	)
-
-add_plugintest (list)

--- a/src/plugins/lua/CMakeLists.txt
+++ b/src/plugins/lua/CMakeLists.txt
@@ -35,7 +35,7 @@ add_plugin (lua
 if (ADDTESTING_PHASE)
 	# bindings are required for tests
 	list (FIND BINDINGS "swig_lua" FINDEX)
-	if (BUILD_TESTING AND FINDEX GREATER -1)
+	if (NOT BUILD_SHARED AND BUILD_TESTING AND FINDEX GREATER -1)
 		# test environment clears env so setting LUA_CPATH is no option
 		# we workaround this by changing the current directory to our bindings
 		# output directory + per default lua loads modules from current directory

--- a/src/plugins/lua/CMakeLists.txt
+++ b/src/plugins/lua/CMakeLists.txt
@@ -12,23 +12,6 @@ if (DEPENDENCY_PHASE)
 		# we call this SWIG_COMPILE_FLAGS because we have the same variable in our swig bindings
 		set (SWIG_COMPILE_FLAGS "-Wno-shadow -Wno-old-style-cast -Wno-unused-variable")
 		set_source_files_properties (lua.cpp PROPERTIES COMPILE_FLAGS "${SWIG_COMPILE_FLAGS}")
-
-		# bindings are required for tests
-		list (FIND BINDINGS "swig_lua" FINDEX)
-		if (BUILD_TESTING AND FINDEX GREATER -1)
-			# test environment clears env so setting LUA_CPATH is no option
-			# we workaround this by changing the current directory to our bindings
-			# output directory + per default lua loads modules from current directory
-			add_plugintest (lua
-				MEMLEAK
-				WORKING_DIRECTORY
-					${CMAKE_CURRENT_BINARY_DIR}/../../bindings/swig/lua/
-			)
-
-			install (DIRECTORY lua DESTINATION ${TARGET_TEST_DATA_FOLDER})
-		else ()
-			message (WARNING "swig_lua bindings are required for testing, test deactivated")
-		endif ()
 	elseif (NOT LUA_FOUND)
 		remove_plugin (lua "Lua libs >= 5.2 not found")
 	else ()
@@ -46,4 +29,23 @@ add_plugin (lua
 		${LUA_LIBRARIES}
 	COMPILE_DEFINITIONS
 		SWIG_TYPE_TABLE=kdb
+	INSTALL_TEST_DATA
 )
+
+if (ADDTESTING_PHASE)
+	# bindings are required for tests
+	list (FIND BINDINGS "swig_lua" FINDEX)
+	if (BUILD_TESTING AND FINDEX GREATER -1)
+		# test environment clears env so setting LUA_CPATH is no option
+		# we workaround this by changing the current directory to our bindings
+		# output directory + per default lua loads modules from current directory
+		add_plugintest (lua
+			MEMLEAK
+			WORKING_DIRECTORY
+				${CMAKE_CURRENT_BINARY_DIR}/../../bindings/swig/lua/
+			INSTALL_TEST_DATA
+		)
+	else ()
+		message (WARNING "swig_lua bindings are required for testing, test deactivated")
+	endif ()
+endif ()

--- a/src/plugins/mathcheck/CMakeLists.txt
+++ b/src/plugins/mathcheck/CMakeLists.txt
@@ -8,6 +8,6 @@ if (NOT CMAKE_CXX_COMPILER_ID STREQUAL "Intel")
 			floathelper.h
 			floathelper.c
 		)
-endif ()
 
-add_plugintest (mathcheck)
+	add_plugintest (mathcheck)
+endif ()

--- a/src/plugins/ni/CMakeLists.txt
+++ b/src/plugins/ni/CMakeLists.txt
@@ -17,17 +17,12 @@ add_plugin(ni
 		${NI}/src/include
 	LINK_ELEKTRA
 		elektra-ease
+	ADD_TEST
 	)
 
-include_directories (${NI}/include)
-file (GLOB NI_INI_FILES ${NI}/src/tests/*.ini)
-foreach (NI_INI_FILE ${NI_INI_FILES})
-	copy_file (${NI_INI_FILE} "${CMAKE_CURRENT_BINARY_DIR}")
-endforeach ()
-
-# testmod_ni mainly tests nickel functions so we need to
-# link against nickel objects
-add_plugintest (ni ${NI_FILES}
-	INCLUDE_DIRECTORIES
-		${NI}/include
-		${NI}/src/include)
+if (ADDTESTING_PHASE)
+	file (GLOB NI_INI_FILES ${NI}/src/tests/*.ini)
+	foreach (NI_INI_FILE ${NI_INI_FILES})
+		copy_file (${NI_INI_FILE} "${CMAKE_CURRENT_BINARY_DIR}")
+	endforeach ()
+endif ()

--- a/src/plugins/noresolver/CMakeLists.txt
+++ b/src/plugins/noresolver/CMakeLists.txt
@@ -5,5 +5,3 @@ add_plugin (noresolver
 		noresolver.h
 		noresolver.c
 	)
-
-#add_plugintest (noresolver)

--- a/src/plugins/null/CMakeLists.txt
+++ b/src/plugins/null/CMakeLists.txt
@@ -5,5 +5,3 @@ add_plugin (null
 		null.h
 		null.c
 	)
-
-#add_plugintest (null)

--- a/src/plugins/path/CMakeLists.txt
+++ b/src/plugins/path/CMakeLists.txt
@@ -5,5 +5,3 @@ add_plugin (path
 		path.h
 		path.c
 	)
-
-#add_plugintest (path)

--- a/src/plugins/profile/CMakeLists.txt
+++ b/src/plugins/profile/CMakeLists.txt
@@ -6,6 +6,5 @@ add_plugin (profile
 		profile.c
 	LINK_ELEKTRA
 		elektra-ease
+	ADD_TEST
 	)
-
-add_plugintest (profile)

--- a/src/plugins/python/CMakeLists.txt
+++ b/src/plugins/python/CMakeLists.txt
@@ -11,26 +11,7 @@ if (DEPENDENCY_PHASE)
 
 		# we call this SWIG_COMPILE_FLAGS because we have the same variable in our swig bindings
 		set (SWIG_COMPILE_FLAGS "-Wno-shadow -Wno-old-style-cast -Wno-unused-variable")
-		set_source_files_properties (python.cpp PROPERTIES COMPILE_FLAGS "${SWIG_COMPILE_FLAGS}")
-
-		# bindings are required for tests
-		list (FIND BINDINGS "swig_python" FINDEX)
-		if (BUILD_TESTING AND FINDEX GREATER -1)
-			# test environment clears env so setting PYTHONPATH is no option
-			# we workaround this by changing the current directory to our bindings
-			# output directory + our test adds the current directory to pythons sys.path
-			add_plugintest (python
-				MEMLEAK
-				WORKING_DIRECTORY
-					${CMAKE_CURRENT_BINARY_DIR}/../../bindings/swig/python/
-				COMPILE_DEFINITIONS
-					PYTHON_PLUGIN_NAME=\"python\"
-			)
-
-			install (DIRECTORY python DESTINATION ${TARGET_TEST_DATA_FOLDER})
-		else ()
-			message (WARNING "swig_python bindings are required for testing, test deactivated")
-		endif ()
+		set_source_files_properties ("python.cpp" PROPERTIES COMPILE_FLAGS "${SWIG_COMPILE_FLAGS}")
 	elseif (NOT PYTHONLIBS_FOUND)
 		remove_plugin (python "python 3 libs not found")
 	else ()
@@ -53,3 +34,23 @@ add_plugin(python
 		PYTHON_PLUGIN_SYMBOL_NAME=Python
 )
 
+if (ADDTESTING_PHASE)
+	# bindings are required for tests
+	list (FIND BINDINGS "swig_python" FINDEX)
+	if (BUILD_TESTING AND FINDEX GREATER -1)
+		# test environment clears env so setting PYTHONPATH is no option
+		# we workaround this by changing the current directory to our bindings
+		# output directory + our test adds the current directory to pythons sys.path
+		add_plugintest (python
+			MEMLEAK
+			WORKING_DIRECTORY
+				${CMAKE_CURRENT_BINARY_DIR}/../../bindings/swig/python/
+		)
+
+		if (INSTALL_TESTING)
+			install (DIRECTORY python DESTINATION ${TARGET_TEST_DATA_FOLDER})
+		endif ()
+	else ()
+		message (WARNING "swig_python bindings are required for testing, test deactivated")
+	endif ()
+endif ()

--- a/src/plugins/python/CMakeLists.txt
+++ b/src/plugins/python/CMakeLists.txt
@@ -37,7 +37,7 @@ add_plugin(python
 if (ADDTESTING_PHASE)
 	# bindings are required for tests
 	list (FIND BINDINGS "swig_python" FINDEX)
-	if (BUILD_TESTING AND FINDEX GREATER -1)
+	if (NOT BUILD_SHARED AND BUILD_TESTING AND FINDEX GREATER -1)
 		# test environment clears env so setting PYTHONPATH is no option
 		# we workaround this by changing the current directory to our bindings
 		# output directory + our test adds the current directory to pythons sys.path

--- a/src/plugins/python/testmod_python.c
+++ b/src/plugins/python/testmod_python.c
@@ -12,6 +12,9 @@
 #include "kdbconfig.h"
 #endif
 
+#define STRINGIFY(x) STRINGIFY2 (x)
+#define STRINGIFY2(x) #x
+
 #include <tests_plugin.h>
 
 static void init_env ()
@@ -27,7 +30,7 @@ static char * python_file (const char * filename)
 	if (!srcdir_rewrite)
 	{
 		/* no rewrite. just append our plugin name */
-		strcpy (filebuf, PYTHON_PLUGIN_NAME);
+		strcpy (filebuf, STRINGIFY (PYTHON_PLUGIN_NAME));
 		strcat (strcat (filebuf, "/"), filename);
 		return srcdir_file (filebuf);
 	}
@@ -36,7 +39,7 @@ static char * python_file (const char * filename)
 	*srcdir_rewrite = '\0';
 
 	/* append plugin name and delete last character */
-	strcat (strcat (filebuf, "/"), PYTHON_PLUGIN_NAME);
+	strcat (strcat (filebuf, "/"), STRINGIFY (PYTHON_PLUGIN_NAME));
 	*(filebuf + strlen (filebuf) - 1) = '\0';
 
 	strcat (strcat (filebuf, "/"), filename);
@@ -50,7 +53,7 @@ static void test_variable_passing ()
 
 	KeySet * conf = ksNew (1, keyNew ("user/script", KEY_VALUE, python_file ("python_plugin.py"), KEY_END),
 			       keyNew ("user/shutdown", KEY_VALUE, "1", KEY_END), keyNew ("user/print", KEY_END), KS_END);
-	PLUGIN_OPEN (PYTHON_PLUGIN_NAME);
+	PLUGIN_OPEN (STRINGIFY (PYTHON_PLUGIN_NAME));
 
 	Key * parentKey = keyNew ("user/from_c", KEY_END);
 	KeySet * ks = ksNew (0, KS_END);
@@ -79,14 +82,14 @@ static void test_two_scripts ()
 				keyNew ("user/shutdown", KEY_VALUE, "1", KEY_END), keyNew ("user/print", KEY_END), KS_END);
 
 	Key * errorKey = keyNew ("", KEY_END);
-	Plugin * plugin = elektraPluginOpen (PYTHON_PLUGIN_NAME, modules, conf, errorKey);
+	Plugin * plugin = elektraPluginOpen (STRINGIFY (PYTHON_PLUGIN_NAME), modules, conf, errorKey);
 	succeed_if (output_warnings (errorKey), "warnings in kdbOpen");
 	succeed_if (output_error (errorKey), "errors in kdbOpen");
 	exit_if_fail (plugin != NULL, "unable to load python plugin");
 	keyDel (errorKey);
 
 	Key * errorKey2 = keyNew ("", KEY_END);
-	Plugin * plugin2 = elektraPluginOpen (PYTHON_PLUGIN_NAME, modules, conf2, errorKey2);
+	Plugin * plugin2 = elektraPluginOpen (STRINGIFY (PYTHON_PLUGIN_NAME), modules, conf2, errorKey2);
 	succeed_if (output_warnings (errorKey2), "warnings in kdbOpen");
 	succeed_if (output_error (errorKey2), "errors in kdbOpen");
 	exit_if_fail (plugin2 != NULL, "unable to load python plugin again");
@@ -105,7 +108,7 @@ static void test_fail ()
 
 	KeySet * conf = ksNew (2, keyNew ("user/script", KEY_VALUE, python_file ("python_plugin_fail.py"), KEY_END),
 			       keyNew ("user/shutdown", KEY_VALUE, "1", KEY_END), keyNew ("user/print", KEY_END), KS_END);
-	PLUGIN_OPEN (PYTHON_PLUGIN_NAME);
+	PLUGIN_OPEN (STRINGIFY (PYTHON_PLUGIN_NAME));
 
 	Key * parentKey = keyNew ("user/tests/from_c", KEY_END);
 	KeySet * ks = ksNew (0, KS_END);
@@ -132,7 +135,7 @@ static void test_wrong ()
 			       keyNew ("user/shutdown", KEY_VALUE, "1", KEY_END), keyNew ("user/print", KEY_END), KS_END);
 
 	Key * errorKey = keyNew ("", KEY_END);
-	Plugin * plugin = elektraPluginOpen (PYTHON_PLUGIN_NAME, modules, conf, errorKey);
+	Plugin * plugin = elektraPluginOpen (STRINGIFY (PYTHON_PLUGIN_NAME), modules, conf, errorKey);
 	succeed_if (!output_warnings (errorKey), "we expect some warnings");
 	succeed_if (!output_error (errorKey), "we expect some errors");
 	succeed_if (plugin == NULL, "python plugin shouldn't be loadable");

--- a/src/plugins/python2/CMakeLists.txt
+++ b/src/plugins/python2/CMakeLists.txt
@@ -1,6 +1,4 @@
 if (DEPENDENCY_PHASE)
-	message(DEPRECATION "Python 2.7 plugin has been deprecated")
-
 	find_package(Python2Libs 2.7)
 	find_swig()
 
@@ -15,30 +13,7 @@ if (DEPENDENCY_PHASE)
 
 		# we call this SWIG_COMPILE_FLAGS because we have the same variable in our swig bindings
 		set (SWIG_COMPILE_FLAGS "-Wno-shadow -Wno-old-style-cast -Wno-unused-variable")
-		set_source_files_properties (python.cpp PROPERTIES COMPILE_FLAGS "${SWIG_COMPILE_FLAGS}")
-
-		# bindings are required for tests
-		list (FIND BINDINGS "swig_python2" FINDEX)
-		if (BUILD_TESTING AND FINDEX GREATER -1)
-			# test environment clears env so setting PYTHONPATH is no option
-			# we workaround this by changing the current directory to our bindings
-			# output directory + our test adds the current directory to pythons sys.path
-			add_plugintest (python2
-				MEMLEAK
-				INCLUDE_DIRECTORIES
-					${PYTHON2_INCLUDE_DIR}
-				LINK_LIBRARIES
-					${PYTHON2_LIBRARIES}
-				WORKING_DIRECTORY
-					${CMAKE_CURRENT_BINARY_DIR}/../../bindings/swig/python2/
-				COMPILE_DEFINITIONS
-					PYTHON_PLUGIN_NAME=\"python2\"
-			)
-
-			install (DIRECTORY ../python/python/ DESTINATION "${TARGET_TEST_DATA_FOLDER}/python2")
-		else ()
-			message (WARNING "swig_python2 bindings are required for testing, test deactivated")
-		endif ()
+		set_source_files_properties ("python.cpp" PROPERTIES COMPILE_FLAGS "${SWIG_COMPILE_FLAGS}")
 	elseif (NOT PYTHON2LIBS_FOUND)
 		remove_plugin (python2 "python 2 libs not found")
 	else ()
@@ -62,10 +37,33 @@ add_plugin (python2
 )
 
 if (DEPENDENCY_PHASE)
+	message(DEPRECATION "Python 2.7 plugin has been deprecated")
+
 	# generate readme from pythons3 README.md
 	# it will overwrite previously generated file of add_plugin directly above
 	set (CMAKE_CURRENT_SOURCE_DIR_SAFE ${CMAKE_CURRENT_SOURCE_DIR})
 	set (CMAKE_CURRENT_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../python")
 	generate_readme (python2)
 	set (CMAKE_CURRENT_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR_SAFE})
+endif ()
+
+if (ADDTESTING_PHASE)
+	# bindings are required for tests
+	list (FIND BINDINGS "swig_python2" FINDEX)
+	if (BUILD_TESTING AND FINDEX GREATER -1)
+		# test environment clears env so setting PYTHONPATH is no option
+		# we workaround this by changing the current directory to our bindings
+		# output directory + our test adds the current directory to pythons sys.path
+		add_plugintest (python2
+			MEMLEAK
+			WORKING_DIRECTORY
+				${CMAKE_CURRENT_BINARY_DIR}/../../bindings/swig/python2/
+		)
+
+		if (INSTALL_TESTING)
+			install (DIRECTORY ${CMAKE_SOURCE_DIR}/src/plugins/python/python/ DESTINATION "${TARGET_TEST_DATA_FOLDER}/python2")
+		endif ()
+	else ()
+		message (WARNING "swig_python bindings are required for testing, test deactivated")
+	endif ()
 endif ()

--- a/src/plugins/python2/CMakeLists.txt
+++ b/src/plugins/python2/CMakeLists.txt
@@ -50,7 +50,7 @@ endif ()
 if (ADDTESTING_PHASE)
 	# bindings are required for tests
 	list (FIND BINDINGS "swig_python2" FINDEX)
-	if (BUILD_TESTING AND FINDEX GREATER -1)
+	if (NOT BUILD_SHARED AND BUILD_TESTING AND FINDEX GREATER -1)
 		# test environment clears env so setting PYTHONPATH is no option
 		# we workaround this by changing the current directory to our bindings
 		# output directory + our test adds the current directory to pythons sys.path

--- a/src/plugins/rename/CMakeLists.txt
+++ b/src/plugins/rename/CMakeLists.txt
@@ -1,9 +1,6 @@
-include (LibAddMacros)
-
 add_plugin (rename
 	SOURCES
 		rename.h
 		rename.c
+	ADD_TEST
 	)
-
-add_plugintest (rename)

--- a/src/plugins/resolver/CMakeLists.txt
+++ b/src/plugins/resolver/CMakeLists.txt
@@ -1,11 +1,6 @@
 include (LibAddPlugin)
 
-if (DEPENDENCY_PHASE)
-	find_package (Threads)
-	add_plugintest (resolver)
-endif ()
-
-set (SOURCES resolver.h resolver.c filename.c)
+find_package (Threads)
 
 if (KDB_DEFAULT_RESOLVER MATCHES "resolver_.*")
 	set (RESOLVERS "${KDB_DEFAULT_RESOLVER}") # default resolver
@@ -60,10 +55,12 @@ foreach (plugin ${RESOLVERS})
 		string(FIND "${variant_base}" "m" out_var_n)
 		if (NOT "${out_var_n}" EQUAL "-1")
 			set (FURTHER_DEFINITIONS ${FURTHER_DEFINITIONS} "ELEKTRA_LOCK_MUTEX")
-			set(FURTHER_LIBRARIES ${FURTHER_LIBRARIES}
+			set (FURTHER_LIBRARIES ${FURTHER_LIBRARIES}
 				${CMAKE_THREAD_LIBS_INIT}
 				${CMAKE_REALTIME_LIBS_INIT})
 		endif ()
+
+		set (SOURCES resolver.h resolver.c filename.c)
 
 		add_plugin(${plugin}
 			SOURCES
@@ -78,6 +75,14 @@ foreach (plugin ${RESOLVERS})
 				ELEKTRA_PLUGIN_NAME=\"${plugin}\"
 				${FURTHER_DEFINITIONS}
 			)
+
+		if (variant MATCHES "fm_hpu_b")
+			add_plugintest (resolver
+				LINK_LIBRARIES
+					${FURTHER_LIBRARIES}
+				LINK_PLUGIN
+					resolver_fm_hpu_b
+				)
+		endif ()
 	endif()
 endforeach(plugin)
-

--- a/src/plugins/semlock/CMakeLists.txt
+++ b/src/plugins/semlock/CMakeLists.txt
@@ -7,6 +7,5 @@ add_plugin (semlock
 		semlock.c
 	LINK_LIBRARIES
 		${CMAKE_THREAD_LIBS_INIT}
+	ADD_TEST
 	)
-
-add_plugintest (semlock)

--- a/src/plugins/shell/CMakeLists.txt
+++ b/src/plugins/shell/CMakeLists.txt
@@ -4,6 +4,5 @@ add_plugin (shell
 	SOURCES
 		shell.h
 		shell.c
+	ADD_TEST
 	)
-
-add_plugintest (shell)

--- a/src/plugins/simpleini/CMakeLists.txt
+++ b/src/plugins/simpleini/CMakeLists.txt
@@ -11,5 +11,3 @@ if (HAVE_GLIBC)
 			simpleini.c
 		)
 endif()
-
-#add_plugintest (simpleini)

--- a/src/plugins/spec/CMakeLists.txt
+++ b/src/plugins/spec/CMakeLists.txt
@@ -7,6 +7,5 @@ add_plugin (spec
 	LINK_ELEKTRA
 		elektra-ease
 		elektra-meta
+	ADD_TEST
 	   )
-
-add_plugintest (spec)

--- a/src/plugins/template/CMakeLists.txt
+++ b/src/plugins/template/CMakeLists.txt
@@ -4,6 +4,5 @@ add_plugin (template
 	SOURCES
 		template.h
 		template.c
+	ADD_TEST
 	)
-
-add_plugintest (template)

--- a/src/plugins/template/template.c
+++ b/src/plugins/template/template.c
@@ -74,7 +74,11 @@ int elektraTemplateCheckConfig (Key * errorKey ELEKTRA_UNUSED, KeySet * conf ELE
 	// validate plugin configuration
 	// this function is optional
 
-	return 1; // success
+	// the return codes have the following meaning:
+	// 0: config was not changed (was ok)
+	// 1: config is changed (now ok)
+	// -1: config not ok, could not fix
+	return 0;
 }
 
 Plugin * ELEKTRA_PLUGIN_EXPORT (template)

--- a/src/plugins/template/template.c
+++ b/src/plugins/template/template.c
@@ -15,6 +15,7 @@
 int elektraTemplateOpen (Plugin * handle ELEKTRA_UNUSED, Key * errorKey ELEKTRA_UNUSED)
 {
 	// plugin initialization logic
+	// this function is optional
 
 	return 1; // success
 }
@@ -22,6 +23,7 @@ int elektraTemplateOpen (Plugin * handle ELEKTRA_UNUSED, Key * errorKey ELEKTRA_
 int elektraTemplateClose (Plugin * handle ELEKTRA_UNUSED, Key * errorKey ELEKTRA_UNUSED)
 {
 	// free all plugin resources and shut it down
+	// this function is optional
 
 	return 1; // success
 }
@@ -54,6 +56,7 @@ int elektraTemplateGet (Plugin * handle ELEKTRA_UNUSED, KeySet * returned ELEKTR
 int elektraTemplateSet (Plugin * handle ELEKTRA_UNUSED, KeySet * returned ELEKTRA_UNUSED, Key * parentKey ELEKTRA_UNUSED)
 {
 	// get all keys
+	// this function is optional
 
 	return 1; // success
 }
@@ -61,6 +64,7 @@ int elektraTemplateSet (Plugin * handle ELEKTRA_UNUSED, KeySet * returned ELEKTR
 int elektraTemplateError (Plugin * handle ELEKTRA_UNUSED, KeySet * returned ELEKTRA_UNUSED, Key * parentKey ELEKTRA_UNUSED)
 {
 	// set all keys
+	// this function is optional
 
 	return 1; // success
 }
@@ -69,7 +73,6 @@ int elektraTemplateCheckConfig (Key * errorKey, KeySet * conf)
 {
 	// validate plugin configuration
 	// this function is optional
-	// if the export symbol "exports/checkconf" is provided, the function will be called during the mount phase
 
 	return 1; // success
 }

--- a/src/plugins/template/template.c
+++ b/src/plugins/template/template.c
@@ -69,7 +69,7 @@ int elektraTemplateError (Plugin * handle ELEKTRA_UNUSED, KeySet * returned ELEK
 	return 1; // success
 }
 
-int elektraTemplateCheckConfig (Key * errorKey, KeySet * conf)
+int elektraTemplateCheckConfig (Key * errorKey ELEKTRA_UNUSED, KeySet * conf ELEKTRA_UNUSED)
 {
 	// validate plugin configuration
 	// this function is optional

--- a/src/plugins/template/template.c
+++ b/src/plugins/template/template.c
@@ -38,6 +38,7 @@ int elektraTemplateGet (Plugin * handle ELEKTRA_UNUSED, KeySet * returned ELEKTR
 			       keyNew ("system/elektra/modules/template/exports/get", KEY_FUNC, elektraTemplateGet, KEY_END),
 			       keyNew ("system/elektra/modules/template/exports/set", KEY_FUNC, elektraTemplateSet, KEY_END),
 			       keyNew ("system/elektra/modules/template/exports/error", KEY_FUNC, elektraTemplateError, KEY_END),
+			       keyNew ("system/elektra/modules/template/exports/checkconf", KEY_FUNC, elektraTemplateCheckConfig, KEY_END),
 #include ELEKTRA_README (template)
 			       keyNew ("system/elektra/modules/template/infos/version", KEY_VALUE, PLUGINVERSION, KEY_END), KS_END);
 		ksAppend (returned, contract);
@@ -60,6 +61,15 @@ int elektraTemplateSet (Plugin * handle ELEKTRA_UNUSED, KeySet * returned ELEKTR
 int elektraTemplateError (Plugin * handle ELEKTRA_UNUSED, KeySet * returned ELEKTRA_UNUSED, Key * parentKey ELEKTRA_UNUSED)
 {
 	// set all keys
+
+	return 1; // success
+}
+
+int elektraTemplateCheckConfig (Key * errorKey, KeySet * conf)
+{
+	// validate plugin configuration
+	// this function is optional
+	// if the export symbol "exports/checkconf" is provided, the function will be called during the mount phase
 
 	return 1; // success
 }

--- a/src/plugins/template/template.h
+++ b/src/plugins/template/template.h
@@ -18,6 +18,7 @@ int elektraTemplateClose (Plugin * handle, Key * errorKey);
 int elektraTemplateGet (Plugin * handle, KeySet * ks, Key * parentKey);
 int elektraTemplateSet (Plugin * handle, KeySet * ks, Key * parentKey);
 int elektraTemplateError (Plugin * handle, KeySet * ks, Key * parentKey);
+int elektraTemplateCheckConfig (Key * errorKey, KeySet * conf);
 
 Plugin * ELEKTRA_PLUGIN_EXPORT (template);
 

--- a/src/plugins/uname/CMakeLists.txt
+++ b/src/plugins/uname/CMakeLists.txt
@@ -6,9 +6,7 @@ if (DEPENDENCY_PHASE)
 
 	include(LibAddMacros)
 
-	if (HAS_UNAME)
-		add_plugintest (uname)
-	else()
+	if (NOT HAS_UNAME)
 		remove_plugin (uname "uname is missing")
 	endif()
 endif ()
@@ -17,4 +15,5 @@ add_plugin (uname
 	SOURCES
 		uname.h
 		uname.c
+	ADD_TEST
 )

--- a/src/plugins/validation/CMakeLists.txt
+++ b/src/plugins/validation/CMakeLists.txt
@@ -5,6 +5,5 @@ add_plugin (validation
 		validation.h
 		validation.c
 		lookupre.c
+	ADD_TEST
 	)
-
-add_plugintest (validation)

--- a/src/plugins/xmltool/CMakeLists.txt
+++ b/src/plugins/xmltool/CMakeLists.txt
@@ -1,17 +1,9 @@
 if (DEPENDENCY_PHASE)
 	find_package (LibXml2)
 
-	if (LIBXML2_FOUND)
-		include (LibAddMacros)
-
-		add_plugintest (xmltool
-			MEMLEAK)
-
-		install(DIRECTORY xmltool DESTINATION ${TARGET_TEST_DATA_FOLDER})
-
-	else (LIBXML2_FOUND)
+	if (NOT LIBXML2_FOUND)
 		remove_plugin (xmltool "libxml2 not found")
-	endif (LIBXML2_FOUND)
+	endif ()
 endif ()
 
 add_plugin (xmltool
@@ -21,6 +13,7 @@ add_plugin (xmltool
 		stream.c
 		kdbtools.c
 		kscompare.c
+	INSTALL_TEST_DATA
 	INCLUDE_DIRECTORIES
 		${LIBXML2_INCLUDE_DIR}
 	LINK_ELEKTRA
@@ -28,3 +21,11 @@ add_plugin (xmltool
 	LINK_LIBRARIES
 		${LIBXML2_LIBRARIES}
 	)
+
+if (ADDTESTING_PHASE)
+	include (LibAddMacros)
+
+#add_plugintest (xmltool
+#	INSTALL_TEST_DATA
+#	MEMLEAK)
+endif ()

--- a/src/plugins/yajl/CMakeLists.txt
+++ b/src/plugins/yajl/CMakeLists.txt
@@ -1,22 +1,14 @@
 if (DEPENDENCY_PHASE)
 	find_package(Yajl)
 
-	if (YAJL_FOUND)
-		configure_file (
-			"${CMAKE_CURRENT_SOURCE_DIR}/yajl.h.in"
-			"${CMAKE_CURRENT_BINARY_DIR}/yajl.h"
-			)
+	set (INCL
+		${YAJL_INCLUDE_DIR}
+		${CMAKE_CURRENT_BINARY_DIR}
+	    )
 
-		install(DIRECTORY yajl DESTINATION ${TARGET_TEST_DATA_FOLDER})
-
-		include_directories(${CMAKE_CURRENT_BINARY_DIR})
-		add_plugintest (yajl
-			INCLUDE_DIRECTORIES
-				${YAJL_INCLUDE_DIR}
-			)
-	else (YAJL_FOUND)
+	if (NOT YAJL_FOUND)
 		remove_plugin (yajl "yajl not found")
-	endif (YAJL_FOUND)
+	endif (NOT YAJL_FOUND)
 endif ()
 
 add_plugin(yajl
@@ -25,11 +17,19 @@ add_plugin(yajl
 		yajl_gen_open.c  yajl_gen_close.c
 		yajl_parse.c name.c
 		"${CMAKE_CURRENT_BINARY_DIR}/yajl.h"
+	ADD_TEST
+	INSTALL_TEST_DATA
 	INCLUDE_DIRECTORIES
-		${YAJL_INCLUDE_DIR}
-		${CMAKE_CURRENT_BINARY_DIR}
+		"${INCL}"
 	LINK_ELEKTRA
 		elektra-ease
 	LINK_LIBRARIES
 		${YAJL_LIBRARIES}
 	)
+
+if (ADDTESTING_PHASE)
+	configure_file (
+		"${CMAKE_CURRENT_SOURCE_DIR}/yajl.h.in"
+		"${CMAKE_CURRENT_BINARY_DIR}/yajl.h"
+		)
+endif ()


### PR DESCRIPTION
Add `checkconf` interface for plugins. Enables plugin configuration validation at mount time.

See #559 .