### PR TITLE
Fix typedef for header inclusion in VS2015

### DIFF
--- a/src/include/kdbos.h
+++ b/src/include/kdbos.h
@@ -148,6 +148,11 @@
 #include <limits.h>
 #include <sys/types.h>
 
+/* If MSVC use SSIZE_T type */
+#ifdef _MSC_VER
+#undef ssize_t
+typedef SSIZE_T ssize_t;
+#endif
 // # define usleep(x) Sleep(x)
 // # define ssize_t int
 // # define snprintf _snprintf


### PR DESCRIPTION
When trying to compile a project that includes ` kdb.hpp` in a Visual Studio 2015 the ssize_t type was missing. A typedef when Visual Studio Compiler is detected should fix this.