### PR TITLE
add shutdown option to crypto plugin config

### DIFF
--- a/src/plugins/crypto/README.md
+++ b/src/plugins/crypto/README.md
@@ -126,6 +126,16 @@ The following example configuration illustrates this concept:
 
 Only keys marked with a certain meta-key will be considered for encryption/decryption.
 
+## Configuration ##
+
+The following key must be set to `"true"` within the plugin configuration,
+if the plugin should shut down the crypto library:
+
+	/crypto/shutdown
+
+Per default shutdown is disabled to prevent applications like the qt-gui from crashing.
+Shutdown is enabled in the unit tests to prevent memory leaks.
+
 ## Examples ##
 
 ### Metadata based encyption ###

--- a/src/plugins/crypto/README.md
+++ b/src/plugins/crypto/README.md
@@ -131,7 +131,7 @@ Only keys marked with a certain meta-key will be considered for encryption/decry
 The following key must be set to `"1"` within the plugin configuration,
 if the plugin should shut down the crypto library:
 
-	/crypto/shutdown
+	/shutdown
 
 Per default shutdown is disabled to prevent applications like the qt-gui from crashing.
 Shutdown is enabled in the unit tests to prevent memory leaks.

--- a/src/plugins/crypto/README.md
+++ b/src/plugins/crypto/README.md
@@ -128,7 +128,7 @@ Only keys marked with a certain meta-key will be considered for encryption/decry
 
 ## Configuration ##
 
-The following key must be set to `"true"` within the plugin configuration,
+The following key must be set to `"1"` within the plugin configuration,
 if the plugin should shut down the crypto library:
 
 	/crypto/shutdown

--- a/src/plugins/crypto/crypto.c
+++ b/src/plugins/crypto/crypto.c
@@ -221,7 +221,7 @@ int CRYPTO_PLUGIN_FUNCTION (close) (Plugin * handle, Key * errorKey ELEKTRA_UNUS
 	}
 	else
 	{
-		if (strcmp (keyString (shutdown), "true") != 0)
+		if (!strcmp (keyString (shutdown), "1"))
 		{
 			return 1; // applying default behaviour -> success
 		}

--- a/src/plugins/crypto/crypto.c
+++ b/src/plugins/crypto/crypto.c
@@ -221,7 +221,7 @@ int CRYPTO_PLUGIN_FUNCTION (close) (Plugin * handle, Key * errorKey ELEKTRA_UNUS
 	}
 	else
 	{
-		if (!strcmp (keyString (shutdown), "1"))
+		if (strcmp (keyString (shutdown), "1") != 0)
 		{
 			return 1; // applying default behaviour -> success
 		}

--- a/src/plugins/crypto/crypto.c
+++ b/src/plugins/crypto/crypto.c
@@ -205,15 +205,35 @@ int CRYPTO_PLUGIN_FUNCTION (open) (Plugin * handle ELEKTRA_UNUSED, Key * errorKe
  * @retval 1 on success
  * @retval -1 on failure
  */
-int CRYPTO_PLUGIN_FUNCTION (close) (Plugin * handle ELEKTRA_UNUSED, Key * errorKey ELEKTRA_UNUSED)
+int CRYPTO_PLUGIN_FUNCTION (close) (Plugin * handle, Key * errorKey ELEKTRA_UNUSED)
 {
+	/* default behaviour: no teardown except the user/system requests it */
+	KeySet * pluginConfig = elektraPluginGetConfig (handle);
+	if (!pluginConfig)
+	{
+		return -1; // failure because of missing plugin config
+	}
+
+	Key * shutdown = ksLookupByName (pluginConfig, ELEKTRA_CRYPTO_PARAM_SHUTDOWN, 0);
+	if (!shutdown)
+	{
+		return 1; // applying default behaviour -> success
+	}
+	else
+	{
+		if (strcmp (keyString (shutdown), "true") != 0)
+		{
+			return 1; // applying default behaviour -> success
+		}
+	}
+
 	pthread_mutex_lock (&mutex_ref_cnt);
 	if (--ref_cnt == 0)
 	{
 		elektraCryptoTeardown ();
 	}
 	pthread_mutex_unlock (&mutex_ref_cnt);
-	return 1;
+	return 1; // success
 }
 
 /**

--- a/src/plugins/crypto/crypto.h
+++ b/src/plugins/crypto/crypto.h
@@ -22,6 +22,7 @@ enum ElektraCryptoHeaderFlags
 
 #define ELEKTRA_CRYPTO_PARAM_KEY_PATH ("/crypto/key")
 #define ELEKTRA_CRYPTO_PARAM_IV_PATH ("/crypto/iv")
+#define ELEKTRA_CRYPTO_PARAM_SHUTDOWN ("/crypto/shutdown")
 #define ELEKTRA_CRYPTO_META_ENCRYPT ("crypto/encrypt")
 
 #if defined(ELEKTRA_CRYPTO_API_GCRYPT)

--- a/src/plugins/crypto/crypto.h
+++ b/src/plugins/crypto/crypto.h
@@ -22,7 +22,7 @@ enum ElektraCryptoHeaderFlags
 
 #define ELEKTRA_CRYPTO_PARAM_KEY_PATH ("/crypto/key")
 #define ELEKTRA_CRYPTO_PARAM_IV_PATH ("/crypto/iv")
-#define ELEKTRA_CRYPTO_PARAM_SHUTDOWN ("/crypto/shutdown")
+#define ELEKTRA_CRYPTO_PARAM_SHUTDOWN ("/shutdown")
 #define ELEKTRA_CRYPTO_META_ENCRYPT ("crypto/encrypt")
 
 #if defined(ELEKTRA_CRYPTO_API_GCRYPT)

--- a/src/plugins/crypto/openssl_operations.c
+++ b/src/plugins/crypto/openssl_operations.c
@@ -78,6 +78,7 @@ int elektraCryptoOpenSSLInit (Key * errorKey)
 	// check if libcrypto has already been initialized (possibly by the application)
 	if (CRYPTO_get_locking_callback ())
 	{
+		cryptoSetup = 1;
 		return 1;
 	}
 

--- a/src/plugins/crypto/testmod_crypto.c
+++ b/src/plugins/crypto/testmod_crypto.c
@@ -44,7 +44,7 @@ static KeySet * newWorkingConfiguration (int shutdown)
 
 	if (shutdown)
 	{
-		Key * configShutdown = keyNew ("user/crypto/shutdown", KEY_END);
+		Key * configShutdown = keyNew ("user/shutdown", KEY_END);
 		keySetString (configShutdown, "1");
 		return ksNew (3, configKey, configIv, configShutdown, KS_END);
 	}

--- a/src/plugins/crypto/testmod_crypto.c
+++ b/src/plugins/crypto/testmod_crypto.c
@@ -31,14 +31,23 @@ static const kdb_octet_t binVal[] = { 0x01, 0x02, 0x03, 0x04 };
 
 /**
  * @brief create new KeySet and add a working configuration to it.
+ * @param shutdown set to 1 if the shutdown key should be appended.
+ *                 If this key is set, the crypto library will be de cleaned up.
  */
-static KeySet * newWorkingConfiguration ()
+static KeySet * newWorkingConfiguration (int shutdown)
 {
 	Key * configKey = keyNew ("user/crypto/key", KEY_END);
 	keySetBinary (configKey, key, sizeof (key));
 
 	Key * configIv = keyNew ("user/crypto/iv", KEY_END);
 	keySetBinary (configIv, iv, sizeof (iv));
+
+	if (shutdown)
+	{
+		Key * configShutdown = keyNew ("user/crypto/shutdown", KEY_END);
+		keySetString (configShutdown, "true");
+		return ksNew (3, configKey, configIv, configShutdown, KS_END);
+	}
 
 	return ksNew (2, configKey, configIv, KS_END);
 }
@@ -124,7 +133,7 @@ static void test_init ()
 	elektraModulesInit (modules, 0);
 
 	// gcrypt tests
-	plugin = elektraPluginOpen ("crypto_gcrypt", modules, newWorkingConfiguration (), 0);
+	plugin = elektraPluginOpen ("crypto_gcrypt", modules, newWorkingConfiguration (0), 0);
 	if (plugin)
 	{
 		succeed_if (!strcmp (plugin->name, "crypto_gcrypt"), "got wrong name");
@@ -133,7 +142,7 @@ static void test_init ()
 	}
 
 	// OpenSSL tests
-	plugin = elektraPluginOpen ("crypto_openssl", modules, newWorkingConfiguration (), 0);
+	plugin = elektraPluginOpen ("crypto_openssl", modules, newWorkingConfiguration (0), 0);
 	if (plugin)
 	{
 		succeed_if (!strcmp (plugin->name, "crypto_openssl"), "got wrong name");
@@ -170,12 +179,12 @@ static void test_config_errors_internal (const char * pluginName, KeySet * plugi
 static void test_config_errors ()
 {
 	// gcrypt tests
-	test_config_errors_internal ("crypto_gcrypt", newWorkingConfiguration (), 1, "kdbSet failed with valid config");
+	test_config_errors_internal ("crypto_gcrypt", newWorkingConfiguration (0), 1, "kdbSet failed with valid config");
 	test_config_errors_internal ("crypto_gcrypt", newInvalidConfiguration (), -1, "kdbSet succeeded with invalid config");
 	test_config_errors_internal ("crypto_gcrypt", newIncompleteConfiguration (), -1, "kdbSet succeeded with incomplete config");
 
 	// OpenSSL tests
-	test_config_errors_internal ("crypto_openssl", newWorkingConfiguration (), 1, "kdbSet failed with valid config");
+	test_config_errors_internal ("crypto_openssl", newWorkingConfiguration (0), 1, "kdbSet failed with valid config");
 	test_config_errors_internal ("crypto_openssl", newInvalidConfiguration (), -1, "kdbSet succeeded with invalid config");
 	test_config_errors_internal ("crypto_openssl", newIncompleteConfiguration (), -1, "kdbSet succeeded with incomplete config");
 }
@@ -220,7 +229,7 @@ static void test_crypto_operations ()
 	elektraModulesInit (modules, 0);
 
 	// gcrypt tests
-	plugin = elektraPluginOpen ("crypto_gcrypt", modules, newWorkingConfiguration (), 0);
+	plugin = elektraPluginOpen ("crypto_gcrypt", modules, newWorkingConfiguration (0), 0);
 	if (plugin)
 	{
 		test_crypto_operations_internal (plugin, parentKey);
@@ -228,7 +237,8 @@ static void test_crypto_operations ()
 	}
 
 	// OpenSSL tests
-	plugin = elektraPluginOpen ("crypto_openssl", modules, newWorkingConfiguration (), 0);
+	// FINAL unit test -> call crypto cleanup code
+	plugin = elektraPluginOpen ("crypto_openssl", modules, newWorkingConfiguration (1), 0);
 	if (plugin)
 	{
 		test_crypto_operations_internal (plugin, parentKey);

--- a/src/plugins/crypto/testmod_crypto.c
+++ b/src/plugins/crypto/testmod_crypto.c
@@ -45,7 +45,7 @@ static KeySet * newWorkingConfiguration (int shutdown)
 	if (shutdown)
 	{
 		Key * configShutdown = keyNew ("user/crypto/shutdown", KEY_END);
-		keySetString (configShutdown, "true");
+		keySetString (configShutdown, "1");
 		return ksNew (3, configKey, configIv, configShutdown, KS_END);
 	}
 


### PR DESCRIPTION
In order to prevent the qt-gui from crashing (see #675 ) we disable the crypto library teardown in kdbClose() by default. In order to enable it, the key /crypto/shutdown must be set to true within the plugin configuration.

See #675 and #731 for full discussion.

@markus2330 wrote in #731 :
> Ok, then we should not cleanup by default. (Use a plugin config as done in python plugin). In the unit tests you should use cleanup to make valgrind happy.

What do you think about this solution? At least `qt-gui` should be running now, altough the memory leaks in `testmod_crypto` still occur.