### PR TITLE
GElektra: add basic devhelp generation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,9 @@ before_install:
       brew tap caskroom/cask;
       brew install cmake;
       brew install swig;
-      brew install gobject-introspection;
+      brew install --universal gobject-introspection;
+      brew install --universal gettext;
+      brew install --universal glib;
       brew install python3;
       brew install python;
       brew install pygobject3 --with-python --with-python3;

--- a/doc/devhelp/gelektra-docs.xml
+++ b/doc/devhelp/gelektra-docs.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0"?>
+<!DOCTYPE book PUBLIC "-//OASIS//DTD DocBook XML V4.3//EN"
+               "http://www.oasis-open.org/docbook/xml/4.3/docbookx.dtd"
+[
+  <!ENTITY % local.common.attrib "xmlns:xi  CDATA  #FIXED 'http://www.w3.org/2003/XInclude'">
+  <!ENTITY % gtkdocentities SYSTEM "xml/gtkdocentities.ent">
+  %gtkdocentities;
+]>
+<book id="gelektra">
+<bookinfo>
+  <title>GElektra Reference Manual</title>
+  <releaseinfo>
+    Glib bindings for
+    <ulink role="online-location" url="http://libelektra.org">Elektra</ulink>.
+  </releaseinfo>
+</bookinfo>
+
+  <chapter>
+    <title>GElektra Classes</title>
+    <xi:include href="xml/gelektra-kdb.xml"/>
+    <xi:include href="xml/gelektra-key.xml"/>
+    <xi:include href="xml/gelektra-keyset.xml"/>
+
+  </chapter>
+  <chapter id="object-tree">
+    <title>Object Hierarchy</title>
+    <xi:include href="xml/tree_index.sgml"/>
+  </chapter>
+  <index id="api-index-full">
+    <title>API Index</title>
+    <xi:include href="xml/api-index-full.xml"><xi:fallback /></xi:include>
+  </index>
+ <!-- <index id="deprecated-api-index" role="deprecated">
+    <title>Index of deprecated API</title>
+    <xi:include href="xml/api-index-deprecated.xml"><xi:fallback /></xi:include>
+  </index>-->
+  <xi:include href="xml/annotation-glossary.xml"><xi:fallback /></xi:include>
+</book>

--- a/src/bindings/glib/CMakeLists.txt
+++ b/src/bindings/glib/CMakeLists.txt
@@ -68,7 +68,7 @@ else()
 		add_subdirectory (tests)
 	endif (BUILD_TESTING)
 
-	find_package (GtkDoc 1.25)
+	find_package (GtkDoc 1.25 QUIET)
 	if (GTKDOC_FOUND)
 		include (GNUInstallDirs)
 		gtk_doc_add_module (

--- a/src/bindings/glib/CMakeLists.txt
+++ b/src/bindings/glib/CMakeLists.txt
@@ -35,6 +35,8 @@ else()
 	target_link_libraries (${GELEKTRA_LIBRARY} PUBLIC elektra-core elektra-kdb)
 	target_link_libraries (${GELEKTRA_LIBRARY} PUBLIC ${GOBJECT_LIBRARIES})
 
+	message(WARNING "GOBJECT LIBRARIES: " ${GOBJECT_LIBRARIES})
+	message(WARNING "GOBJECT LDFLAGS: " ${GOBJECT_LDFLAGS})
 	install (
 		TARGETS ${GELEKTRA_LIBRARY}
 		LIBRARY DESTINATION lib${LIB_SUFFIX}
@@ -71,13 +73,15 @@ else()
 		include (GNUInstallDirs)
 		gtk_doc_add_module (
 			gelektra SOURCE ${CMAKE_CURRENT_SOURCE_DIR}
-			XML ${CMAKE_SOURCE_DIR}/doc/glib/gelektra-docs.xml
+			XML ${CMAKE_SOURCE_DIR}/doc/devhelp/gelektra-docs.xml
 			LIBRARIES ${GELEKTRA_LIBRARY}
 		)
 		add_custom_target (
 			gelektra-doc ALL DEPENDS doc-gelektra)
 			install (DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/gelektra/html/
-		    DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/gtk-doc/html/gelektra
-        )
+			DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/gtk-doc/html/gelektra
+		)
+	else()
+		message (STATUS "GtkDoc not found. Disabling devhalp generation.")
 	endif (GTKDOC_FOUND)
 endif()

--- a/src/bindings/glib/CMakeLists.txt
+++ b/src/bindings/glib/CMakeLists.txt
@@ -33,7 +33,7 @@ else()
 	target_compile_options (${GELEKTRA_LIBRARY} PUBLIC ${GOBJECT_CFLAGS_OTHER})
 
 	target_link_libraries (${GELEKTRA_LIBRARY} PUBLIC elektra-core elektra-kdb)
-	target_link_libraries (${GELEKTRA_LIBRARY} PUBLIC ${GOBJECT_LDFLAGS})
+	target_link_libraries (${GELEKTRA_LIBRARY} PUBLIC ${GOBJECT_LIBRARIES})
 
 	install (
 		TARGETS ${GELEKTRA_LIBRARY}
@@ -65,4 +65,19 @@ else()
 	if (BUILD_TESTING)
 		add_subdirectory (tests)
 	endif (BUILD_TESTING)
+
+	find_package (GtkDoc 1.25)
+	if (GTKDOC_FOUND)
+		include (GNUInstallDirs)
+		gtk_doc_add_module (
+			gelektra SOURCE ${CMAKE_CURRENT_SOURCE_DIR}
+			XML ${CMAKE_SOURCE_DIR}/doc/glib/gelektra-docs.xml
+			LIBRARIES ${GELEKTRA_LIBRARY}
+		)
+		add_custom_target (
+			gelektra-doc ALL DEPENDS doc-gelektra)
+			install (DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/gelektra/html/
+		    DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/gtk-doc/html/gelektra
+        )
+	endif (GTKDOC_FOUND)
 endif()


### PR DESCRIPTION
This ads devhelp generation if glib bindings are enabled and gtk-doc is found.

Currently this only contains the object hierarchy and all methods.

ref #766 
