### PR TITLE
Use cmake GNUInstallDir for /etc/*.d files

### DIFF
--- a/scripts/CMakeLists.txt
+++ b/scripts/CMakeLists.txt
@@ -23,12 +23,13 @@ install (PROGRAMS upgrade-bootstrap DESTINATION ${TARGET_TOOL_EXEC_FOLDER})
 
 install (PROGRAMS umount-all DESTINATION ${TARGET_TOOL_EXEC_FOLDER})
 
+include (GNUInstallDirs)
 if (INSTALL_SYSTEM_FILES)
 	install (FILES kdb-bash-completion
-			DESTINATION /etc/bash_completion.d
+			DESTINATION ${CMAKE_INSTALL_FULL_SYSCONFDIR}/bash_completion.d
 			RENAME kdb)
 	install (FILES elektraenv.sh
-			DESTINATION /etc/profile.d
+			DESTINATION ${CMAKE_INSTALL_FULL_SYSCONFDIR}/profile.d
 			RENAME kdb.sh)
 endif()
 


### PR DESCRIPTION
Using the GNUInstallDir module of cmake to make the installation of this
two files honor the CMAKE_INSTALL_PREFIX variable while staying conform
to GNU and FHS.

> It does not make it more standard and as you already noted the files
> would not be used anyway, so the out-of-the-box behavior is
> identical to not installing the files at all.

That is untrue. It makes it more standard. It is correct to install to `/usr/local/etc` if it is not a package manager installation. Further it is my responsibility as user to source them then. This makes it work with other software installed the same way.

> Something that would improve usability is a script that installs and
> setups the bash completion for the specific user.

That in my opinion is wrong and overcomplicated. If i install things to `/usr/local` i should be aware of the installed files. As they are manually installed files.

> I dont know where you get this from, in the link above (FHS 3.0 and
2.3) it says "/usr/local/etc may be a symbolic link to /etc/local",
not that it is a directory that should be used for installation.

>Also I do not find your `/opt/etc`, I only find references to
`/etc/opt`.

If you read my source reference you see that i made a and switched `/opt/etc` for `/etc/opt` as a mistake.
The GNUInstallDirs variable should behave as expected from FHS. If not we should create a ticket to resolve the issue.

>And /usr/local today is basically identical to /opt, the original
usage of /usr as NFS mounted and /usr/local as locally mounted
partitions is mostly historically. In my opinion correctly packaged
software should be installed to /usr. But this discussion is not
leading to anything.

let as take a look at the stackexchange page with 121 votes for the correct answer:
___
> While both designed to contain files not belonging to the Operating System, /opt and /usr/local are not designed to contain the same set of files.

> /usr/local is a place to install files built by the administrator usually by using the make command (eg: ./configure; make; make install). The idea is to avoid clashes with files that are part of the operating systems which would either be overwritten or overwrite the local ones otherwise. eg. /usr/bin/foo is part of the OS while /usr/local/bin/foo is a local alternative.

> All files under /usr are shareable between OS instances although this is rarely done with Linux. This is a part where the FHS is weak, or at least self-contraditory, as /usr is defined to be read-only but /usr/local/bin needs to be read-write for local installation of software to succeed. The SVR4 file system standard which was the FHS main source of inspiration is recommending to avoid /usr/local and use /opt/local instead to avoid this issue.

> /usr/local is a legacy from the original BSD. At that time, the source code of /usr/bin OS commands were in /usr/src/bin and /usr/src/usr.bin while the source of commands developed locally was in /usr/local/src and their binaries in /usr/local/bin. There was no notion of packaging (outside tarballs).

> On the other hand, /opt is a directory where to install unbundled packages, each in its own subdirectory. They are already built whole packages provided by an independent third party software distributor. Unlike /usr/local stuff, these package follow the directory conventions. For example someapp would be installed in /opt/someapp with one of its command being /opt/someapp/bin/foo, its configuration file would be in /etc/opt/someapp/foo.conf, and its log files in /var/opt/someapp/logs/foo.access.

___

But anyway GNUInstallDirs should handle both `usr/local` and `opt` correctly according to the documentation.

> I am not talking about complete introduction at once, but to
completely think it through. And finding someone who is willing to
do it the full way. But I *really* think we should concentrate on
Elektra's goals, not on some beautification of the build system.

Just because you do not share the value in resolving this issue  does not mean it does not have a value to be solved. Maybe just not from your perspective. And it is not a beautification but a valid patch to solve to issues.

> Maintainers are much more pragmatic on such things. Their needs are
satisfied, so we should really listen to them.

I am the maintainer (homebrew package) in this case and I am not happy with the current solution.

> It is a major change interfering with most parts of the build
> system:
> 
> 1. You get conflicts with KDB_DB_SYSTEM

please elaborate?

> 2. configure and INSTALL documents get more complex

No they do not. This variable is neither shown in the cmake gui or documentation by default. We just honor the CMAKE_INSTALL_PREFIX.

> 3. Users have to deal with more options to set

One optional option which is set to a sane default for GNU and FHS and not visible in the cmake gui by default.

> 4. Confused users why some GNUInstallDirs work, and others not (or
> many other conflicts with the current way libraries and modules are
> installed if we fully go for GNUInstallDirs)

If someone wants to override it he must explicitly know that it is used at that location. The main reason to introduce this change is to get correct behaviour for the CMAKE_INSTALL_PREFIX.

> So you introduce a lot of complexity without eliminating the need to
still manually move files.

Honestly I still can not see all this complexity you are talking about.


> And it actually does not solve an issue, it only installs files at
> places where they are not used instead of not installing them at
> all.

It actually does, by installing it to the correct place. It is then up to the user to source it. Again when installed to with `/usr/local` as prefix you should never install something to `/etc as everything in `etc`should be only installed by the package manager…


And just to make it clear and we are not misunderstanding:

``` shell
CMAKE_INSTALL_PREFIX=/            => CMAKE_INSTALL_FULL_SYSCONFDIR=/etc
CMAKE_INSTALL_PREFIX=/opt/bla/blu => CMAKE_INSTALL_FULL_SYSCONFDIR=/etc/opt/bla/blu
CMAKE_INSTALL_PREFIX=/usr         => CMAKE_INSTALL_FULL_SYSCONFDIR=/etc
CMAKE_INSTALL_PREFIX=/usr/local   => CMAKE_INSTALL_FULL_SYSCONFDIR=/usr/local/etc
```