### PR TITLE
Use cmake GNUInstallDir for script file install

### DIFF
--- a/scripts/CMakeLists.txt
+++ b/scripts/CMakeLists.txt
@@ -23,14 +23,13 @@ install (PROGRAMS upgrade-bootstrap DESTINATION ${TARGET_TOOL_EXEC_FOLDER})
 
 install (PROGRAMS umount-all DESTINATION ${TARGET_TOOL_EXEC_FOLDER})
 
-if (INSTALL_SYSTEM_FILES)
-	install (FILES kdb-bash-completion
-			DESTINATION /etc/bash_completion.d
-			RENAME kdb)
-	install (FILES elektraenv.sh
-			DESTINATION /etc/profile.d
-			RENAME kdb.sh)
-endif()
+include (GNUInstallDirs)
+install (FILES kdb-bash-completion
+		DESTINATION ${CMAKE_INSTALL_FULL_SYSCONFDIR}/bash_completion.d
+		RENAME kdb)
+install (FILES elektraenv.sh
+		DESTINATION ${CMAKE_INSTALL_FULL_SYSCONFDIR}/profile.d
+		RENAME kdb.sh)
 
 configure_file(
 	"${CMAKE_CURRENT_SOURCE_DIR}/elektrify-getenv.in"


### PR DESCRIPTION
Using the GNUInstallDir module of cmake to make the installation two
script files honor the `CMAKE_INSTALL_PREFIX` variable while staying conform
to GNU and FHS.

This is opposed to the current behavior to use `/etc` as hardcoded path.

The calculated paths for etc are as following:

|CMAKE_INSTALL_PREFIX|FULL_SYSCONFDIR|
|---|---|
|`/`|		    `/etc`|
|`/usr`|		    `/etc`|
|`/usr/local`|	    `/usr/local/etc`|
|`/opt/modulename`|  	`/etc/opt/modulename`|

The downside of the new behavior is that those files will not get
sourced automatically if the calculated FULL_SYSCONFDIR does not correspond
to one those files are expected. e.g. `/etc/profile.d`.
This folder is possibly automatically sourced by most distributions
per default for login shells.

On the other hand this implementation makes it possible to install this files as
part of a user installation. This currently is not possible without
error as the not well documented cmake variable INSTALL_SYSTEM_FILES
is set to ON per default.

There are still two cases that use the INSTALL_SYSTEM_FILES variable,
but those should be handled appart from the script files as they are
rather special cases. (GIR file for glib introspection and the gsettings
module)

The packagemanger homebrew for OS X (macOS) uses the
`/usr/local/etc/bash_completion.d` folder. With this change a brew
formula would not need to change any source files of elektra as the
correct INSTALL_PREFIX would take care of the correct path.

This change can also be helpful in situations where I use the
`CMAKE_INSTALL_PREFIX` to install into a folder that I later chroot
(or anything similar) to.