### PR TITLE
keyRel2

### DIFF
--- a/src/include/kdbproposal.h
+++ b/src/include/kdbproposal.h
@@ -67,27 +67,24 @@ Key * ksPrev (KeySet * ks);
 Key * ksPopAtCursor (KeySet * ks, cursor_t c);
 
 
+typedef enum {
+	ELEKTRA_REL_BELOW_SAME_NS,	     // Below Same Namespace, cascading namespace matches only cascading namespace
+	ELEKTRA_REL_BELOW_IGNORE_NS,	   // Below Ignore Namespace, namespaces are ignored
+	ELEKTRA_REL_BELOW_CASCADING_NS,	// Below (allow) Cascading Namespace, cascading namespace matches all namespaces
+	ELEKTRA_REL_DIRECT_BELOW_SAME_NS,      // Direct Below Same Namespace
+	ELEKTRA_REL_DIRECT_BELOW_IGNORE_NS,    // Direct Below Ignore Namespace
+	ELEKTRA_REL_DIRECT_BELOW_CASCADING_NS, // Direct Below (allow) Cascading Namespace
+	ELEKTRA_REL_SILBLING_SAME_NS,	  // ELEKTRA_REL_SILBLING Same Namespace
+	ELEKTRA_REL_SILBLING_IGNORE_NS,	// ELEKTRA_REL_SILBLING Ignore Namespace
+	ELEKTRA_REL_SILBLING_CASCADING_NS,     // ELEKTRA_REL_SILBLING (allow) Cascading Namespace
+	ELEKTRA_REL_NEPHEW_SAME_NS,	    // Nephew Same Namespace
+	ELEKTRA_REL_NEPHEW_IGNORE_NS,	  // Nephew Ignore Namespace
+	ELEKTRA_REL_NEPHEW_CASCADING_NS,       // Nephew (allow) Cascading Namespace
+} KeyRelType;
 
-typedef enum
-{
-    BelowSameNS,        //Below Same Namespace, cascading namespace matches only cascading namespace
-    BelowIgnoreNS,        //Below Ignore Namespace, namespaces are ignored
-    BelowCascadingNS,        //Below (allow) Cascading Namespace, cascading namespace matches all namespaces
-    DirectBelowSameNS,       //Direct Below Same Namespace
-    DirectBelowIgnoreNS,       //Direct Below Ignore Namespace
-    DirectBelowCascadingNS,       //Direct Below (allow) Cascading Namespace
-    SilblingSameNS,     //Silbling Same Namespace
-    SilblingIgnoreNS,     //Silbling Ignore Namespace
-    SilblingCascadingNS,     //Silbling (allow) Cascading Namespace
-    NephewSameNS,     //Nephew Same Namespace
-    NephewIgnoreNS,     //Nephew Ignore Namespace
-    NephewCascadingNS,     //Nephew (allow) Cascading Namespace
-}KeyRelType;
-
-int keyRel2 (const Key *k1, const Key *k2, KeyRelType which);
-Key *keyAsCascading(const Key *key);
-int keyGetLevelsBelow(const Key *k1, const Key *k2);
-
+int keyRel2 (const Key * k1, const Key * k2, KeyRelType which);
+Key * keyAsCascading (const Key * key);
+int keyGetLevelsBelow (const Key * k1, const Key * k2);
 
 
 #ifdef __cplusplus

--- a/src/include/kdbproposal.h
+++ b/src/include/kdbproposal.h
@@ -66,6 +66,30 @@ KeySet * elektraKeyGetMetaKeySet (const Key * key);
 Key * ksPrev (KeySet * ks);
 Key * ksPopAtCursor (KeySet * ks, cursor_t c);
 
+
+
+typedef enum
+{
+    BelowSameNS,        //Below Same Namespace, cascading namespace matches only cascading namespace
+    BelowIgnoreNS,        //Below Ignore Namespace, namespaces are ignored
+    BelowCascadingNS,        //Below (allow) Cascading Namespace, cascading namespace matches all namespaces
+    DirectBelowSameNS,       //Direct Below Same Namespace
+    DirectBelowIgnoreNS,       //Direct Below Ignore Namespace
+    DirectBelowCascadingNS,       //Direct Below (allow) Cascading Namespace
+    SilblingSameNS,     //Silbling Same Namespace
+    SilblingIgnoreNS,     //Silbling Ignore Namespace
+    SilblingCascadingNS,     //Silbling (allow) Cascading Namespace
+    NephewSameNS,     //Nephew Same Namespace
+    NephewIgnoreNS,     //Nephew Ignore Namespace
+    NephewCascadingNS,     //Nephew (allow) Cascading Namespace
+}KeyRelType;
+
+int keyRel2 (const Key *k1, const Key *k2, KeyRelType which);
+Key *keyAsCascading(const Key *key);
+int keyGetLevelsBelow(const Key *k1, const Key *k2);
+
+
+
 #ifdef __cplusplus
 }
 }

--- a/src/libs/proposal/proposal.c
+++ b/src/libs/proposal/proposal.c
@@ -224,7 +224,7 @@ Key * ksPopAtCursor (KeySet * ks, cursor_t pos)
  * keyRel replacement
  */
 
-//keyRel2 helper, turns key into a cascading key ( removes namespace)
+// keyRel2 helper, turns key into a cascading key ( removes namespace)
 Key * keyAsCascading (const Key * key)
 {
 	if (keyName (key)[0] == '/')
@@ -254,7 +254,7 @@ Key * keyAsCascading (const Key * key)
 	}
 }
 
-//keyRel2 helper, returns how many levels check is below key, or 0 if check isn't below
+// keyRel2 helper, returns how many levels check is below key, or 0 if check isn't below
 int keyGetLevelsBelow (const Key * key, const Key * check)
 {
 	if (!keyIsBelow (key, check)) return 0;
@@ -288,8 +288,8 @@ int keyRel2 (const Key * key, const Key * check, KeyRelType which)
 {
 	if (!key || !check) return -1;
 	if (!key->key || !check->key) return -1;
-	
-    Key * cKey = keyAsCascading (key);
+
+	Key * cKey = keyAsCascading (key);
 	Key * cCheck = keyAsCascading (check);
 	Key * cKeyParent = keyDup (cKey);
 	keySetBaseName (cKeyParent, 0);
@@ -303,46 +303,46 @@ int keyRel2 (const Key * key, const Key * check, KeyRelType which)
 	int retVal = 0;
 	switch (which)
 	{
-	case BelowSameNS:
+	case ELEKTRA_REL_BELOW_SAME_NS:
 		if (isBelow && (keyNamespace == checkNamespace)) retVal = isBelow;
 		break;
-	case BelowIgnoreNS:
+	case ELEKTRA_REL_BELOW_IGNORE_NS:
 		if (isBelow) retVal = isBelow;
 		break;
-	case BelowCascadingNS:
+	case ELEKTRA_REL_BELOW_CASCADING_NS:
 		if (isBelow && ((checkNamespace == KEY_NS_CASCADING) || (keyNamespace == KEY_NS_CASCADING))) retVal = isBelow;
 		break;
-	case DirectBelowSameNS:
+	case ELEKTRA_REL_DIRECT_BELOW_SAME_NS:
 		if ((isBelow == 1) && (keyNamespace == checkNamespace)) retVal = 1;
 		break;
-	case DirectBelowIgnoreNS:
+	case ELEKTRA_REL_DIRECT_BELOW_IGNORE_NS:
 		if (isBelow == 1) retVal = 1;
 		break;
-	case DirectBelowCascadingNS:
+	case ELEKTRA_REL_DIRECT_BELOW_CASCADING_NS:
 		if ((isBelow == 1) && ((checkNamespace == KEY_NS_CASCADING) || (keyNamespace == KEY_NS_CASCADING))) retVal = 1;
 		break;
-	case SilblingSameNS:
+	case ELEKTRA_REL_SILBLING_SAME_NS:
 		if ((isSilblingNephew == 1) && (keyNamespace == checkNamespace)) retVal = 1;
 		break;
-	case SilblingIgnoreNS:
+	case ELEKTRA_REL_SILBLING_IGNORE_NS:
 		if (isSilblingNephew == 1) retVal = 1;
 		break;
-	case SilblingCascadingNS:
+	case ELEKTRA_REL_SILBLING_CASCADING_NS:
 		if ((isSilblingNephew == 1) && ((checkNamespace == KEY_NS_CASCADING) || (keyNamespace == KEY_NS_CASCADING))) retVal = 1;
 		break;
-	case NephewSameNS:
+	case ELEKTRA_REL_NEPHEW_SAME_NS:
 		if ((isSilblingNephew > 1) && (keyNamespace == checkNamespace)) retVal = isSilblingNephew - 1;
 		break;
-	case NephewIgnoreNS:
+	case ELEKTRA_REL_NEPHEW_IGNORE_NS:
 		if (isSilblingNephew > 1) retVal = isSilblingNephew - 1;
 		break;
-	case NephewCascadingNS:
+	case ELEKTRA_REL_NEPHEW_CASCADING_NS:
 		if ((isSilblingNephew > 1) && ((checkNamespace == KEY_NS_CASCADING) || (keyNamespace == KEY_NS_CASCADING)))
 			retVal = isSilblingNephew - 1;
 		break;
-    default:
-        retVal = -1;
-        break;
+	default:
+		retVal = -1;
+		break;
 	}
 	keyDel (cKey);
 	keyDel (cCheck);

--- a/src/libs/proposal/proposal.c
+++ b/src/libs/proposal/proposal.c
@@ -219,6 +219,138 @@ Key * ksPopAtCursor (KeySet * ks, cursor_t pos)
 	return elektraKsPopAtCursor (ks, pos);
 }
 
+
+/**
+ * keyRel replacement
+ */
+
+//keyRel2 helper, turns key into a cascading key ( removes namespace)
+Key * keyAsCascading (const Key * key)
+{
+	if (keyName (key)[0] == '/')
+	{
+		return keyDup (key);
+	}
+	else
+	{
+		const char * name = keyName (key);
+		const char * ptr = strchr (name, '/');
+		if (!ptr)
+		{
+			return keyNew ("/", KEY_CASCADING_NAME, KEY_END);
+		}
+		else
+		{
+			ssize_t length = keyGetNameSize (key);
+			if ((ptr - name) == (length - 1))
+			{
+				return keyNew ("/", KEY_CASCADING_NAME, KEY_END);
+			}
+			else
+			{
+				return keyNew (ptr, KEY_CASCADING_NAME, KEY_END);
+			}
+		}
+	}
+}
+
+//keyRel2 helper, returns how many levels check is below key, or 0 if check isn't below
+int keyGetLevelsBelow (const Key * key, const Key * check)
+{
+	if (!keyIsBelow (key, check)) return 0;
+	if (keyGetNamespace (key) != keyGetNamespace (check)) return 0;
+	Key * toCheck = keyDup (check);
+	int levels = 0;
+	while (strcmp (keyName (key), keyName (toCheck)))
+	{
+		keySetBaseName (toCheck, 0);
+		if (keyName (toCheck)[0] == '\0') keySetName (toCheck, "/");
+		++levels;
+	}
+	keyDel (toCheck);
+	return levels;
+}
+
+/**
+ * @brief Replacement proposal for keyRel
+ * @return depending on relation type
+ * @retval -1 usage error
+ * @retval 0 test failed
+ * @retval >1 true for binary tests, number of levels below for other relation tests
+ *
+ * @param key the key object to work with
+ * @param check the second key object to check the relation with
+ * @param which what kind of relationship test should be done
+ */
+
+
+int keyRel2 (const Key * key, const Key * check, KeyRelType which)
+{
+	if (!key || !check) return -1;
+	if (!key->key || !check->key) return -1;
+	
+    Key * cKey = keyAsCascading (key);
+	Key * cCheck = keyAsCascading (check);
+	Key * cKeyParent = keyDup (cKey);
+	keySetBaseName (cKeyParent, 0);
+	if (keyName (cKeyParent)[0] == '\0') keySetName (cKeyParent, "/");
+	int isBelow = 0;
+	int isSilblingNephew = 0;
+	isBelow = keyGetLevelsBelow (cKey, cCheck);
+	if (!isBelow) isSilblingNephew = keyGetLevelsBelow (cKeyParent, cCheck);
+	elektraNamespace keyNamespace = keyGetNamespace (key);
+	elektraNamespace checkNamespace = keyGetNamespace (check);
+	int retVal = 0;
+	switch (which)
+	{
+	case BelowSameNS:
+		if (isBelow && (keyNamespace == checkNamespace)) retVal = isBelow;
+		break;
+	case BelowIgnoreNS:
+		if (isBelow) retVal = isBelow;
+		break;
+	case BelowCascadingNS:
+		if (isBelow && ((checkNamespace == KEY_NS_CASCADING) || (keyNamespace == KEY_NS_CASCADING))) retVal = isBelow;
+		break;
+	case DirectBelowSameNS:
+		if ((isBelow == 1) && (keyNamespace == checkNamespace)) retVal = 1;
+		break;
+	case DirectBelowIgnoreNS:
+		if (isBelow == 1) retVal = 1;
+		break;
+	case DirectBelowCascadingNS:
+		if ((isBelow == 1) && ((checkNamespace == KEY_NS_CASCADING) || (keyNamespace == KEY_NS_CASCADING))) retVal = 1;
+		break;
+	case SilblingSameNS:
+		if ((isSilblingNephew == 1) && (keyNamespace == checkNamespace)) retVal = 1;
+		break;
+	case SilblingIgnoreNS:
+		if (isSilblingNephew == 1) retVal = 1;
+		break;
+	case SilblingCascadingNS:
+		if ((isSilblingNephew == 1) && ((checkNamespace == KEY_NS_CASCADING) || (keyNamespace == KEY_NS_CASCADING))) retVal = 1;
+		break;
+	case NephewSameNS:
+		if ((isSilblingNephew > 1) && (keyNamespace == checkNamespace)) retVal = isSilblingNephew - 1;
+		break;
+	case NephewIgnoreNS:
+		if (isSilblingNephew > 1) retVal = isSilblingNephew - 1;
+		break;
+	case NephewCascadingNS:
+		if ((isSilblingNephew > 1) && ((checkNamespace == KEY_NS_CASCADING) || (keyNamespace == KEY_NS_CASCADING)))
+			retVal = isSilblingNephew - 1;
+		break;
+    default:
+        retVal = -1;
+        break;
+	}
+	keyDel (cKey);
+	keyDel (cCheck);
+	keyDel (cKeyParent);
+	return retVal;
+}
+
+
 /**
  * @}
  */

--- a/tests/ctest/test_proposal.c
+++ b/tests/ctest/test_proposal.c
@@ -54,6 +54,128 @@ static void test_ksToArray ()
 	ksDel (ks);
 }
 
+static void test_keyAsCascading ()
+{
+	printf ("test keyAsCascading\n");
+	Key * system = keyNew ("system", KEY_END);
+	Key * user = keyNew ("user/", KEY_END);
+	Key * sysKey = keyNew ("system/test", KEY_END);
+	Key * cascadingKey = keyNew ("/test", KEY_END);
+	Key * ret;
+	ret = keyAsCascading (system);
+	succeed_if (!strcmp (keyName (ret), "/"), "Failed turning \"system\" into a cascading Key");
+	keyDel (ret);
+	ret = keyAsCascading (user);
+	succeed_if (!strcmp (keyName (ret), "/"), "Failed turning \"user/\" into a cascading Key");
+	keyDel (ret);
+	ret = keyAsCascading (sysKey);
+	succeed_if (!strcmp (keyName (ret), "/test"), "Failed turning \"system/test\" into a cascading Key");
+	keyDel (ret);
+	ret = keyAsCascading (cascadingKey);
+	succeed_if (!strcmp (keyName (ret), "/test"), "Failed turning \"/test\" into a cascading Key");
+	keyDel (ret);
+	keyDel (system);
+	keyDel (user);
+	keyDel (sysKey);
+	keyDel (cascadingKey);
+}
+
+static void test_keyGetLevelsBelow ()
+{
+	printf ("test keyGetLevelsBelow\n");
+	Key * parent = keyNew ("system/parent", KEY_END);
+	Key * user = keyNew ("user/parent", KEY_END);
+	Key * oneLvl = keyNew ("system/parent/child", KEY_END);
+	Key * threeLvl = keyNew ("system/parent/child1/child2/child3", KEY_END);
+	succeed_if (keyGetLevelsBelow (parent, oneLvl) == 1, "getLevelsBelow returned wrong value");
+	succeed_if (keyGetLevelsBelow (parent, threeLvl) == 3, "getLevelsBelow returned wrong value");
+	succeed_if (keyGetLevelsBelow (parent, parent) == 0, "getLevelsBelow returned wrong value");
+	succeed_if (keyGetLevelsBelow (parent, user) == 0, "getLevelsBelow returned wrong value");
+	keyDel (parent);
+	keyDel (user);
+	keyDel (oneLvl);
+	keyDel (threeLvl);
+}
+
+static void test_keyRel2 ()
+{
+	printf ("test keyRel2\n");
+
+	Key * systemParent = keyNew ("system/parent", KEY_END);
+	Key * userParent = keyNew ("system/parent", KEY_END);
+	Key * systemChild = keyNew ("system/parent/child", KEY_END);
+	Key * systemGrandChild = keyNew ("system/parent/child/grandchild", KEY_END);
+	Key * userChild = keyNew ("user/parent/child", KEY_END);
+	Key * userGrandChild = keyNew ("user/parent/child/grandchild", KEY_END);
+	Key * cascadingChild = keyNew ("/parent/child", KEY_CASCADING_NAME, KEY_END);
+	Key * cascadingGrandChild = keyNew ("/parent/child/grandchild", KEY_CASCADING_NAME, KEY_END);
+	Key * systemSilbling = keyNew ("system/silbling", KEY_END);
+	Key * userSilbling = keyNew ("user/silbling", KEY_END);
+	Key * cascadingSilbling = keyNew ("/silbling", KEY_END);
+	Key * systemNephew = keyNew ("system/silbling/nephew", KEY_END);
+	Key * userNephew = keyNew ("user/silbling/nephew", KEY_END);
+	Key * cascadingNephew = keyNew ("/silbling/nephew", KEY_CASCADING_NAME, KEY_END);
+	Key * systemGrandNephew = keyNew ("system/silbling/nephew/grandnephew", KEY_END);
+	Key * userGrandNephew = keyNew ("user/silbling/nephew/grandnephew", KEY_END);
+	Key * cascadingGrandNephew = keyNew ("/silbling/nephew/grandnephew", KEY_CASCADING_NAME, KEY_END);
+
+	succeed_if (keyRel2 (systemParent, systemChild, BelowSameNS) == 1, "BelowSameNS keyRel2 failed\n");
+	succeed_if (keyRel2 (systemParent, userChild, BelowSameNS) == 0, "BelowSameNS keyRel2 should have failed\n");
+	succeed_if (keyRel2 (systemParent, userChild, BelowIgnoreNS) == 1, "BelowIgnoreNS keyRel2 failed\n");
+	succeed_if (keyRel2 (systemParent, cascadingChild, BelowSameNS) == 0, "BelowSameNS keyRel2 with cascading child should have failed\n");
+	succeed_if (keyRel2 (systemParent, cascadingChild, BelowCascadingNS) == 1, "BelowSameNS keyRel2 with cascading child failed\n");
+	succeed_if (keyRel2 (systemParent, systemGrandChild, BelowSameNS) == 2, "BelowSameNS keyRel2 failed\n");
+	succeed_if (keyRel2 (systemParent, userGrandChild, BelowSameNS) == 0, "BelowSameNS keyRel2 should have failed\n");
+	succeed_if (keyRel2 (systemParent, userGrandChild, BelowIgnoreNS) == 2, "BelowIgnoreNS keyRel2 failed\n");
+	succeed_if (keyRel2 (systemParent, cascadingGrandChild, BelowSameNS) == 0, "BelowSameNS keyRel2 with cascading child should have failed\n");
+	succeed_if (keyRel2 (systemParent, cascadingGrandChild, BelowCascadingNS) == 2, "BelowSameNS keyRel2 with cascading child failed\n");
+	succeed_if (keyRel2 (systemParent, userParent, BelowIgnoreNS) == 0, "BelowIgnoreNS keyRel2 with silblings should have returned 0\n");
+	succeed_if (keyRel2 (systemParent, systemChild, DirectBelowSameNS) == 1, "DirectBelowSameNS keyRel2 failed\n");
+	succeed_if (keyRel2 (systemParent, userChild, DirectBelowSameNS) == 0, "DirectBelowSameNS keyRel2 should have failed\n");
+	succeed_if (keyRel2 (systemParent, userChild, DirectBelowIgnoreNS) == 1, "DirectBelowIgnoreNS keyRel2 failed\n");
+	succeed_if (keyRel2 (systemParent, cascadingChild, DirectBelowSameNS) == 0, "DirectBelowSameNS keyRel2 with cascading child should have failed\n");
+	succeed_if (keyRel2 (systemParent, cascadingChild, DirectBelowCascadingNS) == 1, "DirectBelowSameNS keyRel2 with cascading child failed\n");
+
+	succeed_if (keyRel2 (systemParent, systemSilbling, SilblingSameNS) == 1, "SilblingSameNS keyRel2 failed\n");
+	succeed_if (keyRel2 (systemParent, userSilbling, SilblingSameNS) == 0, "SilblingSameNS keyRel2 should have failed\n");
+	succeed_if (keyRel2 (systemParent, userSilbling, SilblingIgnoreNS) == 1, "SilblingIgnoreNS keyRel2 failed\n");
+	succeed_if (keyRel2 (systemParent, cascadingSilbling, SilblingSameNS) == 0, "SilblingSameNS keyRel2 with cascading child should have failed\n");
+	succeed_if (keyRel2 (systemParent, cascadingSilbling, SilblingCascadingNS) == 1, "SilblingSameNS keyRel2 with cascading child failed\n");
+
+	succeed_if (keyRel2 (systemParent, systemNephew, NephewSameNS) == 1, "NephewSameNS keyRel2 failed\n");
+	succeed_if (keyRel2 (systemParent, userNephew, NephewSameNS) == 0, "NephewSameNS keyRel2 should have failed\n");
+	succeed_if (keyRel2 (systemParent, userNephew, NephewIgnoreNS) == 1, "NephewIgnoreNS keyRel2 failed\n");
+	succeed_if (keyRel2 (systemParent, cascadingNephew, NephewSameNS) == 0, "NephewSameNS keyRel2 with cascading child should have failed\n");
+	succeed_if (keyRel2 (systemParent, cascadingNephew, NephewCascadingNS) == 1, "NephewSameNS keyRel2 with cascading child failed\n");
+
+	succeed_if (keyRel2 (systemParent, systemGrandNephew, NephewSameNS) == 2, "NephewSameNS keyRel2 failed\n");
+	succeed_if (keyRel2 (systemParent, userGrandNephew, NephewSameNS) == 0, "NephewSameNS keyRel2 should have failed\n");
+	succeed_if (keyRel2 (systemParent, userGrandNephew, NephewIgnoreNS) == 2, "NephewIgnoreNS keyRel2 failed\n");
+	succeed_if (keyRel2 (systemParent, cascadingGrandNephew, NephewSameNS) == 0, "NephewSameNS keyRel2 with cascading child should have failed\n");
+	succeed_if (keyRel2 (systemParent, cascadingGrandNephew, NephewCascadingNS) == 2, "NephewSameNS keyRel2 with cascading child failed\n");
+
+	succeed_if (keyRel2 (systemParent, systemGrandChild, NephewSameNS) == 0, "NephewSameNS keyRel2 should have failed\n");
+	succeed_if (keyRel2 (systemParent, systemChild, SilblingSameNS) == 0, "SilblingSameNS keyRel2 should have failed\n");
+
+	keyDel (systemParent);
+	keyDel (userParent);
+	keyDel (systemChild);
+	keyDel (systemGrandChild);
+	keyDel (userChild);
+	keyDel (userGrandChild);
+	keyDel (cascadingChild);
+	keyDel (cascadingGrandChild);
+	keyDel (systemSilbling);
+	keyDel (userSilbling);
+	keyDel (cascadingSilbling);
+	keyDel (systemNephew);
+	keyDel (userNephew);
+	keyDel (cascadingNephew);
+	keyDel (systemGrandNephew);
+	keyDel (userGrandNephew);
+	keyDel (cascadingGrandNephew);
+}
+
 int main (int argc, char ** argv)
 {
 	printf ("KEY PROPOSAL TESTS\n");
@@ -63,6 +185,10 @@ int main (int argc, char ** argv)
 
 	test_ksPopAtCursor ();
 	test_ksToArray ();
+
+    test_keyAsCascading ();
+    test_keyGetLevelsBelow ();
+    test_keyRel2 ();
 
 	printf ("\ntest_proposal RESULTS: %d test(s) done. %d error(s).\n", nbTest, nbError);
 }

--- a/tests/ctest/test_proposal.c
+++ b/tests/ctest/test_proposal.c
@@ -119,43 +119,67 @@ static void test_keyRel2 ()
 	Key * userGrandNephew = keyNew ("user/silbling/nephew/grandnephew", KEY_END);
 	Key * cascadingGrandNephew = keyNew ("/silbling/nephew/grandnephew", KEY_CASCADING_NAME, KEY_END);
 
-	succeed_if (keyRel2 (systemParent, systemChild, BelowSameNS) == 1, "BelowSameNS keyRel2 failed\n");
-	succeed_if (keyRel2 (systemParent, userChild, BelowSameNS) == 0, "BelowSameNS keyRel2 should have failed\n");
-	succeed_if (keyRel2 (systemParent, userChild, BelowIgnoreNS) == 1, "BelowIgnoreNS keyRel2 failed\n");
-	succeed_if (keyRel2 (systemParent, cascadingChild, BelowSameNS) == 0, "BelowSameNS keyRel2 with cascading child should have failed\n");
-	succeed_if (keyRel2 (systemParent, cascadingChild, BelowCascadingNS) == 1, "BelowSameNS keyRel2 with cascading child failed\n");
-	succeed_if (keyRel2 (systemParent, systemGrandChild, BelowSameNS) == 2, "BelowSameNS keyRel2 failed\n");
-	succeed_if (keyRel2 (systemParent, userGrandChild, BelowSameNS) == 0, "BelowSameNS keyRel2 should have failed\n");
-	succeed_if (keyRel2 (systemParent, userGrandChild, BelowIgnoreNS) == 2, "BelowIgnoreNS keyRel2 failed\n");
-	succeed_if (keyRel2 (systemParent, cascadingGrandChild, BelowSameNS) == 0, "BelowSameNS keyRel2 with cascading child should have failed\n");
-	succeed_if (keyRel2 (systemParent, cascadingGrandChild, BelowCascadingNS) == 2, "BelowSameNS keyRel2 with cascading child failed\n");
-	succeed_if (keyRel2 (systemParent, userParent, BelowIgnoreNS) == 0, "BelowIgnoreNS keyRel2 with silblings should have returned 0\n");
-	succeed_if (keyRel2 (systemParent, systemChild, DirectBelowSameNS) == 1, "DirectBelowSameNS keyRel2 failed\n");
-	succeed_if (keyRel2 (systemParent, userChild, DirectBelowSameNS) == 0, "DirectBelowSameNS keyRel2 should have failed\n");
-	succeed_if (keyRel2 (systemParent, userChild, DirectBelowIgnoreNS) == 1, "DirectBelowIgnoreNS keyRel2 failed\n");
-	succeed_if (keyRel2 (systemParent, cascadingChild, DirectBelowSameNS) == 0, "DirectBelowSameNS keyRel2 with cascading child should have failed\n");
-	succeed_if (keyRel2 (systemParent, cascadingChild, DirectBelowCascadingNS) == 1, "DirectBelowSameNS keyRel2 with cascading child failed\n");
+	succeed_if (keyRel2 (systemParent, systemChild, ELEKTRA_REL_BELOW_SAME_NS) == 1, "ELEKTRA_REL_BELOW_SAME_NS keyRel2 failed\n");
+	succeed_if (keyRel2 (systemParent, userChild, ELEKTRA_REL_BELOW_SAME_NS) == 0,
+		    "ELEKTRA_REL_BELOW_SAME_NS keyRel2 should have failed\n");
+	succeed_if (keyRel2 (systemParent, userChild, ELEKTRA_REL_BELOW_IGNORE_NS) == 1, "ELEKTRA_REL_BELOW_IGNORE_NS keyRel2 failed\n");
+	succeed_if (keyRel2 (systemParent, cascadingChild, ELEKTRA_REL_BELOW_SAME_NS) == 0,
+		    "ELEKTRA_REL_BELOW_SAME_NS keyRel2 with cascading child should have failed\n");
+	succeed_if (keyRel2 (systemParent, cascadingChild, ELEKTRA_REL_BELOW_CASCADING_NS) == 1,
+		    "ELEKTRA_REL_BELOW_SAME_NS keyRel2 with cascading child failed\n");
+	succeed_if (keyRel2 (systemParent, systemGrandChild, ELEKTRA_REL_BELOW_SAME_NS) == 2, "ELEKTRA_REL_BELOW_SAME_NS keyRel2 failed\n");
+	succeed_if (keyRel2 (systemParent, userGrandChild, ELEKTRA_REL_BELOW_SAME_NS) == 0,
+		    "ELEKTRA_REL_BELOW_SAME_NS keyRel2 should have failed\n");
+	succeed_if (keyRel2 (systemParent, userGrandChild, ELEKTRA_REL_BELOW_IGNORE_NS) == 2,
+		    "ELEKTRA_REL_BELOW_IGNORE_NS keyRel2 failed\n");
+	succeed_if (keyRel2 (systemParent, cascadingGrandChild, ELEKTRA_REL_BELOW_SAME_NS) == 0,
+		    "ELEKTRA_REL_BELOW_SAME_NS keyRel2 with cascading child should have failed\n");
+	succeed_if (keyRel2 (systemParent, cascadingGrandChild, ELEKTRA_REL_BELOW_CASCADING_NS) == 2,
+		    "ELEKTRA_REL_BELOW_SAME_NS keyRel2 with cascading child failed\n");
+	succeed_if (keyRel2 (systemParent, userParent, ELEKTRA_REL_BELOW_IGNORE_NS) == 0,
+		    "ELEKTRA_REL_BELOW_IGNORE_NS keyRel2 with silblings should have returned 0\n");
+	succeed_if (keyRel2 (systemParent, systemChild, ELEKTRA_REL_DIRECT_BELOW_SAME_NS) == 1,
+		    "ELEKTRA_REL_DIRECT_BELOW_SAME_NS keyRel2 failed\n");
+	succeed_if (keyRel2 (systemParent, userChild, ELEKTRA_REL_DIRECT_BELOW_SAME_NS) == 0,
+		    "ELEKTRA_REL_DIRECT_BELOW_SAME_NS keyRel2 should have failed\n");
+	succeed_if (keyRel2 (systemParent, userChild, ELEKTRA_REL_DIRECT_BELOW_IGNORE_NS) == 1,
+		    "ELEKTRA_REL_DIRECT_BELOW_IGNORE_NS keyRel2 failed\n");
+	succeed_if (keyRel2 (systemParent, cascadingChild, ELEKTRA_REL_DIRECT_BELOW_SAME_NS) == 0,
+		    "ELEKTRA_REL_DIRECT_BELOW_SAME_NS keyRel2 with cascading child should have failed\n");
+	succeed_if (keyRel2 (systemParent, cascadingChild, ELEKTRA_REL_DIRECT_BELOW_CASCADING_NS) == 1,
+		    "ELEKTRA_REL_DIRECT_BELOW_SAME_NS keyRel2 with cascading child failed\n");
 
-	succeed_if (keyRel2 (systemParent, systemSilbling, SilblingSameNS) == 1, "SilblingSameNS keyRel2 failed\n");
-	succeed_if (keyRel2 (systemParent, userSilbling, SilblingSameNS) == 0, "SilblingSameNS keyRel2 should have failed\n");
-	succeed_if (keyRel2 (systemParent, userSilbling, SilblingIgnoreNS) == 1, "SilblingIgnoreNS keyRel2 failed\n");
-	succeed_if (keyRel2 (systemParent, cascadingSilbling, SilblingSameNS) == 0, "SilblingSameNS keyRel2 with cascading child should have failed\n");
-	succeed_if (keyRel2 (systemParent, cascadingSilbling, SilblingCascadingNS) == 1, "SilblingSameNS keyRel2 with cascading child failed\n");
+	succeed_if (keyRel2 (systemParent, systemSilbling, ELEKTRA_REL_SILBLING_SAME_NS) == 1,
+		    "ELEKTRA_REL_SILBLINGSAME_NS keyRel2 failed\n");
+	succeed_if (keyRel2 (systemParent, userSilbling, ELEKTRA_REL_SILBLING_SAME_NS) == 0,
+		    "ELEKTRA_REL_SILBLINGSAME_NS keyRel2 should have failed\n");
+	succeed_if (keyRel2 (systemParent, userSilbling, ELEKTRA_REL_SILBLING_IGNORE_NS) == 1,
+		    "ELEKTRA_REL_SILBLINGIGNORE_NS keyRel2 failed\n");
+	succeed_if (keyRel2 (systemParent, cascadingSilbling, ELEKTRA_REL_SILBLING_SAME_NS) == 0,
+		    "ELEKTRA_REL_SILBLINGSAME_NS keyRel2 with cascading child should have failed\n");
+	succeed_if (keyRel2 (systemParent, cascadingSilbling, ELEKTRA_REL_SILBLING_CASCADING_NS) == 1,
+		    "ELEKTRA_REL_SILBLINGSAME_NS keyRel2 with cascading child failed\n");
 
-	succeed_if (keyRel2 (systemParent, systemNephew, NephewSameNS) == 1, "NephewSameNS keyRel2 failed\n");
-	succeed_if (keyRel2 (systemParent, userNephew, NephewSameNS) == 0, "NephewSameNS keyRel2 should have failed\n");
-	succeed_if (keyRel2 (systemParent, userNephew, NephewIgnoreNS) == 1, "NephewIgnoreNS keyRel2 failed\n");
-	succeed_if (keyRel2 (systemParent, cascadingNephew, NephewSameNS) == 0, "NephewSameNS keyRel2 with cascading child should have failed\n");
-	succeed_if (keyRel2 (systemParent, cascadingNephew, NephewCascadingNS) == 1, "NephewSameNS keyRel2 with cascading child failed\n");
+	succeed_if (keyRel2 (systemParent, systemNephew, ELEKTRA_REL_NEPHEW_SAME_NS) == 1, "NephewSAME_NS keyRel2 failed\n");
+	succeed_if (keyRel2 (systemParent, userNephew, ELEKTRA_REL_NEPHEW_SAME_NS) == 0, "NephewSAME_NS keyRel2 should have failed\n");
+	succeed_if (keyRel2 (systemParent, userNephew, ELEKTRA_REL_NEPHEW_IGNORE_NS) == 1, "NephewIGNORE_NS keyRel2 failed\n");
+	succeed_if (keyRel2 (systemParent, cascadingNephew, ELEKTRA_REL_NEPHEW_SAME_NS) == 0,
+		    "NephewSAME_NS keyRel2 with cascading child should have failed\n");
+	succeed_if (keyRel2 (systemParent, cascadingNephew, ELEKTRA_REL_NEPHEW_CASCADING_NS) == 1,
+		    "NephewSAME_NS keyRel2 with cascading child failed\n");
 
-	succeed_if (keyRel2 (systemParent, systemGrandNephew, NephewSameNS) == 2, "NephewSameNS keyRel2 failed\n");
-	succeed_if (keyRel2 (systemParent, userGrandNephew, NephewSameNS) == 0, "NephewSameNS keyRel2 should have failed\n");
-	succeed_if (keyRel2 (systemParent, userGrandNephew, NephewIgnoreNS) == 2, "NephewIgnoreNS keyRel2 failed\n");
-	succeed_if (keyRel2 (systemParent, cascadingGrandNephew, NephewSameNS) == 0, "NephewSameNS keyRel2 with cascading child should have failed\n");
-	succeed_if (keyRel2 (systemParent, cascadingGrandNephew, NephewCascadingNS) == 2, "NephewSameNS keyRel2 with cascading child failed\n");
+	succeed_if (keyRel2 (systemParent, systemGrandNephew, ELEKTRA_REL_NEPHEW_SAME_NS) == 2, "NephewSAME_NS keyRel2 failed\n");
+	succeed_if (keyRel2 (systemParent, userGrandNephew, ELEKTRA_REL_NEPHEW_SAME_NS) == 0, "NephewSAME_NS keyRel2 should have failed\n");
+	succeed_if (keyRel2 (systemParent, userGrandNephew, ELEKTRA_REL_NEPHEW_IGNORE_NS) == 2, "NephewIGNORE_NS keyRel2 failed\n");
+	succeed_if (keyRel2 (systemParent, cascadingGrandNephew, ELEKTRA_REL_NEPHEW_SAME_NS) == 0,
+		    "NephewSAME_NS keyRel2 with cascading child should have failed\n");
+	succeed_if (keyRel2 (systemParent, cascadingGrandNephew, ELEKTRA_REL_NEPHEW_CASCADING_NS) == 2,
+		    "NephewSAME_NS keyRel2 with cascading child failed\n");
 
-	succeed_if (keyRel2 (systemParent, systemGrandChild, NephewSameNS) == 0, "NephewSameNS keyRel2 should have failed\n");
-	succeed_if (keyRel2 (systemParent, systemChild, SilblingSameNS) == 0, "SilblingSameNS keyRel2 should have failed\n");
+	succeed_if (keyRel2 (systemParent, systemGrandChild, ELEKTRA_REL_NEPHEW_SAME_NS) == 0,
+		    "NephewSAME_NS keyRel2 should have failed\n");
+	succeed_if (keyRel2 (systemParent, systemChild, ELEKTRA_REL_SILBLING_SAME_NS) == 0,
+		    "ELEKTRA_REL_SILBLINGSAME_NS keyRel2 should have failed\n");
 
 	keyDel (systemParent);
 	keyDel (userParent);
@@ -186,9 +210,9 @@ int main (int argc, char ** argv)
 	test_ksPopAtCursor ();
 	test_ksToArray ();
 
-    test_keyAsCascading ();
-    test_keyGetLevelsBelow ();
-    test_keyRel2 ();
+	test_keyAsCascading ();
+	test_keyGetLevelsBelow ();
+	test_keyRel2 ();
 
 	printf ("\ntest_proposal RESULTS: %d test(s) done. %d error(s).\n", nbTest, nbError);
 }


### PR DESCRIPTION
Key relation types: Below, DirectBelow, Silbling, and Nephew
DirectBelow and Silbling are boolean tests
relation suffixes:
SN: the namespaces have to match
IN: ignoring namespaces completely
CN: cascading namespace matches all namespaces

currently returns: 
-1 for invalid keys / usage error
0 for failed tests
1 if a boolean relation test succeeded
>0 if non-boolean relation tests succeeded - the value is the number of levels the check key is below