### PR TITLE
CI: workaround for augeas failing on OS X with homebrew

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ before_install:
       brew install pygobject3 --with-python --with-python3;
       brew install lua;
       brew install yajl;
-      brew install augeas;
+      brew install augeas --HEAD;
       brew install dbus;
       brew install Caskroom/cask/java;
       brew outdated libffi || brew install libffi;


### PR DESCRIPTION
Tests currently fail with version 1.5 of augeas from homebrew.
Using homebrews --HEAD version works as a temporary fix so PRs do not
show up broken.

ref #812 