### PR TITLE
Fix #836

### DIFF
--- a/src/plugins/crypto/CMakeLists.txt
+++ b/src/plugins/crypto/CMakeLists.txt
@@ -189,7 +189,6 @@ if (ADDTESTING_PHASE)
 		add_plugintest (crypto_gcrypt
 				MEMLEAK
 				LINK_PLUGIN "<no>")
-		set_property (TEST "testmod_crypto_gcrypt" PROPERTY LABELS memleak)
 	endif ()
 
 	if (HAS_BOTAN_4SURE)

--- a/tests/valgrind.suppression
+++ b/tests/valgrind.suppression
@@ -1,5 +1,4 @@
-
-1;4402;0c{
+{
    <insert_a_suppression_name_here>
    Memcheck:Leak
    match-leak-kinds: reachable
@@ -127,11 +126,6 @@
    obj:*/libjvm.so
    obj:*/libjvm.so
 }
-
-
-
-
-
 {
    <insert_a_suppression_name_here>
    Memcheck:Addr4


### PR DESCRIPTION
Removing redundant CMake label from `src/plugins/crypto/CMakeLists.txt` .

Shoud fix #836 .