### PR TITLE
Only Generate `kdberrors.h` Once

### DIFF
--- a/cmake/Modules/LibAddMacros.cmake
+++ b/cmake/Modules/LibAddMacros.cmake
@@ -204,12 +204,20 @@ macro (add_headers HDR_FILES)
 
 	find_util(elektra-export-errors EXE_ERR_LOC EXE_ERR_ARG)
 
-	add_custom_command (
-			OUTPUT ${BINARY_INCLUDE_DIR}/kdberrors.h
-			DEPENDS elektra-export-errors
-			COMMAND ${EXE_ERR_LOC}
-			ARGS ${EXE_ERR_ARG} ${CMAKE_SOURCE_DIR}/src/error/specification ${BINARY_INCLUDE_DIR}/kdberrors.h
-			)
+	GET_PROPERTY(KDB_ERRORS_GENERATED GLOBAL PROPERTY KDB_ERRORS_COMMAND_ADDED)
+	IF(NOT KDB_ERRORS_GENERATED)
+		add_custom_command (
+				OUTPUT ${BINARY_INCLUDE_DIR}/kdberrors.h
+				DEPENDS elektra-export-errors
+				COMMAND ${EXE_ERR_LOC}
+				ARGS ${EXE_ERR_ARG} ${CMAKE_SOURCE_DIR}/src/error/specification ${BINARY_INCLUDE_DIR}/kdberrors.h
+				)
+		SET_PROPERTY(GLOBAL PROPERTY KDB_ERRORS_COMMAND_ADDED
+			"Command to generate `kdberrors.h` already added")
+	ENDIF()
+	set_source_files_properties(${BINARY_INCLUDE_DIR}/kdberrors.h PROPERTIES
+		GENERATED ON)
+
 	list (APPEND ${HDR_FILES} "${BINARY_INCLUDE_DIR}/kdberrors.h")
 endmacro (add_headers)
 


### PR DESCRIPTION
This commit adresses issue #674:

Before this change multiple targets would generate `kdberrors.h` in parallel. Therefore it was possible that one build process would overwrite `kdberrors.h` – with exactly the same content as before – while another process was reading the file.

By the way: I do no think that the attached code is the ideal solution to the problem. However, since it looks like the commit fixes the problem,  it is – in my opinion – better than nothing 😁.