### PR TITLE
Build: Only Generate `kdberrors.h` Once

### DIFF
--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -6,6 +6,7 @@ macro (do_benchmark source)
 	include_directories ("${CMAKE_CURRENT_SOURCE_DIR}")
 	set (SOURCES ${HDR_FILES} benchmarks.c benchmarks.h ${source}.c)
 	add_executable (${source} ${SOURCES})
+	add_dependencies (${source} kdberrors_generated)
 
 	target_link_elektra(${source} elektra-kdb elektra-meta)
 

--- a/cmake/Modules/LibAddLib.cmake
+++ b/cmake/Modules/LibAddLib.cmake
@@ -13,6 +13,7 @@ function(add_lib name)
 
 	if (BUILD_SHARED)
 		add_library (elektra-${name} SHARED ${ARG_SOURCES})
+		add_dependencies (elektra-${name} kdberrors_generated)
 
 		target_link_libraries (elektra-${name} elektra-core ${ARG_LINK_ELEKTRA})
 	endif (BUILD_SHARED)

--- a/cmake/Modules/LibAddMacros.cmake
+++ b/cmake/Modules/LibAddMacros.cmake
@@ -202,14 +202,7 @@ macro (add_headers HDR_FILES)
 	file (GLOB SRC_HDR_FILES ${SOURCE_INCLUDE_DIR}/*.h)
 	list (APPEND ${HDR_FILES} ${SRC_HDR_FILES})
 
-	find_util(elektra-export-errors EXE_ERR_LOC EXE_ERR_ARG)
-
-	add_custom_command (
-			OUTPUT ${BINARY_INCLUDE_DIR}/kdberrors.h
-			DEPENDS elektra-export-errors
-			COMMAND ${EXE_ERR_LOC}
-			ARGS ${EXE_ERR_ARG} ${CMAKE_SOURCE_DIR}/src/error/specification ${BINARY_INCLUDE_DIR}/kdberrors.h
-			)
+	set_source_files_properties (${BINARY_INCLUDE_DIR}/kdberrors.h PROPERTIES GENERATED ON)
 	list (APPEND ${HDR_FILES} "${BINARY_INCLUDE_DIR}/kdberrors.h")
 endmacro (add_headers)
 

--- a/cmake/Modules/LibAddPlugin.cmake
+++ b/cmake/Modules/LibAddPlugin.cmake
@@ -78,6 +78,7 @@ function (add_plugintest testname)
 		endif ()
 		set (testexename testmod_${testname})
 		add_executable (${testexename} ${TEST_SOURCES})
+		add_dependencies (${testexename} kdberrors_generated)
 
 		# alternative approach to restore_variable
 		#get_target_property(TARGET_COMPILE_DEFINITIONS PLUGIN_TARGET_OBJS COMPILE_DEFINITIONS)
@@ -330,6 +331,7 @@ function (add_plugin PLUGIN_SHORT_NAME)
 	endif (ARG_CPP)
 
 	add_library (${PLUGIN_OBJS} OBJECT ${ARG_SOURCES})
+	add_dependencies (${PLUGIN_OBJS} kdberrors_generated)
 
 	add_dependencies(${PLUGIN_OBJS} readme_${PLUGIN_SHORT_NAME}.c)
 
@@ -361,6 +363,7 @@ function (add_plugin PLUGIN_SHORT_NAME)
 
 	if (BUILD_SHARED)
 		add_library (${PLUGIN_NAME} MODULE ${ARG_SOURCES})
+		add_dependencies (${PLUGIN_NAME} kdberrors_generated)
 		if (ARG_LINK_ELEKTRA)
 			target_link_libraries (${PLUGIN_NAME} elektra-plugin ${ARG_LINK_ELEKTRA})
 		else()

--- a/cmake/Modules/LibAddTest.cmake
+++ b/cmake/Modules/LibAddTest.cmake
@@ -20,6 +20,7 @@ macro (add_gtest source)
 	if (BUILD_TESTING)
 	set (SOURCES ${HDR_FILES} ${source}.cpp ${ARG_SOURCES})
 	add_executable (${source} ${SOURCES})
+	add_dependencies (${source} kdberrors_generated)
 
 	if (ARG_LINK_TOOLS)
 		target_link_elektratools(${source} ${ARG_LINK_ELEKTRA})

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -7,6 +7,7 @@ macro (do_example source)
 	include_directories ("${CMAKE_CURRENT_SOURCE_DIR}")
 	set (SOURCES ${HDR_FILES} ${source}.c)
 	add_executable (${source} ${SOURCES})
+	add_dependencies (${source} kdberrors_generated)
 
 	target_link_elektra(${source} elektra-kdb)
 

--- a/src/bindings/cpp/benchmarks/CMakeLists.txt
+++ b/src/bindings/cpp/benchmarks/CMakeLists.txt
@@ -7,6 +7,7 @@ macro (do_benchmark source)
 	include_directories ("${CMAKE_CURRENT_SOURCE_DIR}")
 	set (SOURCES ${HDR_FILES} ${source}.cpp)
 	add_executable (${source} ${SOURCES})
+	add_dependencies (${source} kdberrors_generated)
 
 	target_link_elektra(${source} elektra-kdb elektra-meta)
 

--- a/src/bindings/cpp/examples/CMakeLists.txt
+++ b/src/bindings/cpp/examples/CMakeLists.txt
@@ -7,6 +7,7 @@ macro (do_example source)
 	include_directories ("${CMAKE_CURRENT_SOURCE_DIR}")
 	set (SOURCES ${HDR_FILES} ${source}.cpp)
 	add_executable (${source} ${SOURCES})
+	add_dependencies (${source} kdberrors_generated)
 
 	target_link_elektra(${source} elektra-kdb)
 

--- a/src/bindings/glib/CMakeLists.txt
+++ b/src/bindings/glib/CMakeLists.txt
@@ -27,6 +27,7 @@ else()
 	set (SOURCES ${GELEKTRA_SRC_FILES} ${GELEKTRA_HDR_FILES} ${ELEKTRA_HEADERS})
 
 	add_library (${GELEKTRA_LIBRARY} SHARED ${SOURCES})
+	add_dependencies (${GELEKTRA_LIBRARY} kdberrors_generated)
 
 	target_include_directories (${GELEKTRA_LIBRARY} PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 	target_include_directories (${GELEKTRA_LIBRARY} SYSTEM PUBLIC ${GOBJECT_INCLUDE_DIRS})

--- a/src/error/CMakeLists.txt
+++ b/src/error/CMakeLists.txt
@@ -6,6 +6,19 @@ endif (INSTALL_BUILD_TOOLS)
 
 set_source_files_properties(elektra-export-errors OBJECT_DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/specification)
 
+find_util (elektra-export-errors EXE_ERR_LOC EXE_ERR_ARG)
+set (BINARY_INCLUDE_DIR "${PROJECT_BINARY_DIR}/src/include")
+add_custom_command (
+		OUTPUT ${BINARY_INCLUDE_DIR}/kdberrors.h
+		DEPENDS elektra-export-errors
+		COMMAND ${EXE_ERR_LOC}
+		ARGS ${EXE_ERR_ARG} ${CMAKE_SOURCE_DIR}/src/error/specification ${BINARY_INCLUDE_DIR}/kdberrors.h
+		)
+add_custom_target (
+    kdberrors_generated ALL
+    DEPENDS ${BINARY_INCLUDE_DIR}/kdberrors.h
+    )
+
 add_executable(exporttranslations exporttranslations.cpp parser.hpp parser.cpp)
 
 set_source_files_properties(exporttranslations OBJECT_DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/specification)

--- a/src/libs/elektra/CMakeLists.txt
+++ b/src/libs/elektra/CMakeLists.txt
@@ -70,6 +70,7 @@ if (BUILD_SHARED)
 
 	get_property (elektra-shared_SRCS GLOBAL PROPERTY elektra-shared_SRCS)
 	add_library (elektra-core SHARED ${CORE_FILES} ${elektra-shared_SRCS})
+	add_dependencies (elektra-core kdberrors_generated)
 
 	get_property (elektra-shared_LIBRARIES GLOBAL PROPERTY elektra-shared_LIBRARIES)
 	target_link_libraries (elektra-core ${elektra-shared_LIBRARIES})
@@ -81,6 +82,7 @@ if (BUILD_SHARED)
 
 
 	add_library (elektra-kdb SHARED ${KDB_FILES})
+	add_dependencies (elektra-kdb kdberrors_generated)
 	target_link_libraries (elektra-kdb elektra-core)
 
 
@@ -89,6 +91,7 @@ if (BUILD_SHARED)
 	#message(STATUS "ignore the following ADD_LIBRARY warning")
 	#add_library (elektra INTERFACE) # no SOVERSION?
 	add_library (elektra SHARED  ${KDB_FILES} ${CORE_FILES}  ${elektra-shared_SRCS})
+	add_dependencies (elektra kdberrors_generated)
 	get_property (elektra-extension_LIBRARIES GLOBAL PROPERTY elektra-extension_LIBRARIES)
 	target_link_libraries (elektra ${elektra-shared_LIBRARIES})
 	#target_link_libraries (elektra ${elektra-extension_LIBRARIES})
@@ -144,6 +147,7 @@ endif (BUILD_FULL OR BUILD_STATIC)
 
 if (BUILD_FULL)
 	add_library (elektra-full SHARED ${SOURCES})
+	add_dependencies (elektra-full kdberrors_generated)
 
 	target_link_libraries (elektra-full ${elektra-full_LIBRARIES})
 
@@ -167,6 +171,7 @@ endif (BUILD_FULL)
 
 if (BUILD_STATIC)
 	add_library (elektra-static STATIC ${SOURCES})
+	add_dependencies (elektra-static kdberrors_generated)
 
 	target_link_libraries (elektra-static ${elektra-full_LIBRARIES})
 

--- a/src/libs/getenv/benchmarks/CMakeLists.txt
+++ b/src/libs/getenv/benchmarks/CMakeLists.txt
@@ -7,6 +7,7 @@ macro (do_benchmark source)
 	include_directories ("${CMAKE_CURRENT_SOURCE_DIR}")
 	set (SOURCES ${HDR_FILES} ${source}.cpp)
 	add_executable (${source} ${SOURCES})
+	add_dependencies (${source} kdberrors_generated)
 
 	target_link_elektra(${source})
 

--- a/src/libs/getenv/examples/CMakeLists.txt
+++ b/src/libs/getenv/examples/CMakeLists.txt
@@ -8,6 +8,7 @@ macro (do_example source)
 	include_directories ("${CMAKE_CURRENT_SOURCE_DIR}")
 	set (SOURCES ${HDR_FILES} ${source}.c)
 	add_executable (${source} ${SOURCES})
+	add_dependencies (${source} kdberrors_generated)
 	install(TARGETS ${source} DESTINATION ${TARGET_TOOL_EXEC_FOLDER})
 
 	set_target_properties (${source} PROPERTIES

--- a/src/libs/getenv/src/CMakeLists.txt
+++ b/src/libs/getenv/src/CMakeLists.txt
@@ -8,6 +8,7 @@ file (GLOB_RECURSE SRC_FILES *.cpp)
 set (SOURCES ${SRC_FILES} ${HDR_FILES})
 
 add_library (elektragetenv SHARED ${SOURCES})
+add_dependencies (elektragetenv kdberrors_generated)
 
 target_link_libraries (elektragetenv ${CMAKE_DL_LIBS})
 target_link_libraries (elektragetenv elektra-kdb elektra-meta) # must be shared!

--- a/src/libs/tools/benchmarks/CMakeLists.txt
+++ b/src/libs/tools/benchmarks/CMakeLists.txt
@@ -8,6 +8,7 @@ macro (do_benchmark source)
 	include_directories ("${CMAKE_CURRENT_SOURCE_DIR}")
 	set (SOURCES ${HDR_FILES} ${source}.cpp)
 	add_executable (${source} ${SOURCES})
+	add_dependencies (${source} kdberrors_generated)
 
 	target_link_elektratools(${source} elektra-kdb)
 

--- a/src/libs/tools/examples/CMakeLists.txt
+++ b/src/libs/tools/examples/CMakeLists.txt
@@ -8,6 +8,7 @@ macro (do_example source)
 	include_directories ("${CMAKE_CURRENT_SOURCE_DIR}")
 	set (SOURCES ${HDR_FILES} ${source}.cpp)
 	add_executable (${source} ${SOURCES})
+	add_dependencies (${source} kdberrors_generated)
 
 	target_link_elektratools(${source})
 

--- a/src/libs/tools/src/CMakeLists.txt
+++ b/src/libs/tools/src/CMakeLists.txt
@@ -12,6 +12,7 @@ set (__symbols_file ${CMAKE_CURRENT_SOURCE_DIR}/libelektratools-symbols.map)
 
 if (BUILD_SHARED)
 	add_library (elektratools SHARED ${SOURCES})
+	add_dependencies (elektratools kdberrors_generated)
 
 	target_link_libraries (elektratools elektra-core elektra-kdb elektra-plugin elektra-ease elektra-meta)
 
@@ -33,6 +34,7 @@ endif (BUILD_SHARED)
 
 if (BUILD_FULL)
 	add_library (elektratools-full SHARED ${SOURCES})
+	add_dependencies (elektratools-full kdberrors_generated)
 
 	target_link_libraries (elektratools-full elektra-full)
 
@@ -54,6 +56,7 @@ endif (BUILD_FULL)
 
 if (BUILD_STATIC)
 	add_library (elektratools-static STATIC ${SOURCES})
+	add_dependencies (elektratools-static kdberrors_generated)
 
 	target_link_libraries (elektratools-static elektra-static)
 

--- a/src/tools/kdb/CMakeLists.txt
+++ b/src/tools/kdb/CMakeLists.txt
@@ -12,6 +12,7 @@ set (SOURCES ${SRC_FILES} ${HDR_FILES})
 
 if (BUILD_SHARED)
 	add_executable (kdb ${SOURCES})
+	add_dependencies (kdb kdberrors_generated)
 
 	target_link_libraries (kdb elektra-core elektra-kdb elektratools)
 
@@ -20,6 +21,7 @@ endif (BUILD_SHARED)
 
 if (BUILD_FULL)
 	add_executable (kdb-full ${SOURCES})
+	add_dependencies (kdb-full kdberrors_generated)
 
 	target_link_libraries (kdb-full elektra-full elektratools-full)
 
@@ -28,6 +30,7 @@ endif (BUILD_FULL)
 
 if (BUILD_STATIC)
 	add_executable (kdb-static ${SOURCES})
+	add_dependencies (kdb-static kdberrors_generated)
 
 	set_target_properties (kdb-static PROPERTIES LINKER_LANGUAGE CXX)
 	set_target_properties (kdb-static PROPERTIES

--- a/src/tools/qt-gui/CMakeLists.txt
+++ b/src/tools/qt-gui/CMakeLists.txt
@@ -47,6 +47,7 @@ set(qt-gui_RSCS	resources.qrc)
 qt5_add_resources(RSCS ${qt-gui_RSCS})
 
 add_executable(qt-gui ${qt-gui_SRCS} ${qt-gui_HDRS} ${UIS} ${RSCS} ${TRS})
+add_dependencies (qt-gui kdberrors_generated)
 
 qt5_use_modules(qt-gui Quick Gui Core Qml Widgets)
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -17,6 +17,7 @@ macro (do_test source)
 	add_headers(SOURCES)
 	add_testheaders(SOURCES)
 	add_executable (${source} ${SOURCES})
+	add_dependencies (${source} kdberrors_generated)
 
 	if (INSTALL_TESTING)
 		install (TARGETS ${source}

--- a/tests/cframework/CMakeLists.txt
+++ b/tests/cframework/CMakeLists.txt
@@ -5,6 +5,7 @@ add_headers(SOURCES)
 add_testheaders(SOURCES)
 
 add_library(cframework OBJECT ${SOURCES})
+add_dependencies (cframework kdberrors_generated)
 
 set_target_properties (cframework PROPERTIES
 		COMPILE_DEFINITIONS HAVE_KDBCONFIG_H)


### PR DESCRIPTION
This commit contains the code of my second try to address issue #674:

Before this change multiple targets would generate `kdberrors.h` in parallel. Therefore it was possible that one build process would overwrite `kdberrors.h` – with exactly the same content as before – while another process was reading the file.

By the way: I think that this solution is even worse than the [first one](https://github.com/ElektraInitiative/libelektra/pull/851) I proposed 😁.