### PR TITLE
Shell Recorder: use sh and disable globbing

### DIFF
--- a/tests/shell/shell_recorder/shell_recorder.sh
+++ b/tests/shell/shell_recorder/shell_recorder.sh
@@ -1,4 +1,6 @@
-#!/bin/bash
+#!/bin/sh
+
+set -f
 
 FILE=$1
 Mountpoint=
@@ -75,7 +77,7 @@ execute()
 
     printf "%s\0" "CMD: $command" >> "$OutFile"
 
-    bash -c "\"$KDBCOMMAND\" $command 2>stderr 1>stdout"
+    sh -c -f "\"$KDBCOMMAND\" $command 2>stderr 1>stdout"
 
     RETVAL="$?"
 


### PR DESCRIPTION
I can swear that I changed the shebang to the sh.
I found out that when using wildcards in testcases they get expanded.