### PR TITLE
Shell Recorder: Bugfix & Documentation Update

### DIFF
--- a/tests/shell/shell_recorder/README.md
+++ b/tests/shell/shell_recorder/README.md
@@ -9,7 +9,7 @@ e.g. `Mountpoint: user/test` tells the shell_recorder that you will be working u
 
 ### DiffType: ###
 
-Available: 
+Available:
 
 `Dump`, `Ini` exports the keys below `Mountpoint` using either the dump or ini format and diffs the changes.
 `File` does a diff on the configuration file mounted to `Mountpoint`.
@@ -24,7 +24,7 @@ If File is preset but empty a fresh database temp file will be provided for ever
 
 Posix-extended regex is used to check and validate return values and outputs.
 
-Options: 
+Options:
 
 * STDOUT:
 * STDERR:
@@ -35,7 +35,7 @@ Options:
 
 ## Commands ##
 
-A command starts with `<` followed by the usual kdb commands. 
+A command starts with `<` followed by the usual kdb commands.
 
 
 ## Examples ##

--- a/tests/shell/shell_recorder/README.md
+++ b/tests/shell/shell_recorder/README.md
@@ -24,6 +24,29 @@ If File is preset but empty a fresh database temp file will be provided for ever
 
 Posix-extended regex is used to check and validate return values and outputs.
 
+**Remark:** Shell Recorder uses the `⏎` symbol as line terminator. This means that you need to use the character `⏎`  (instead of `\n`) if you want to match a line ending in a multiline output. For example: Assume there are exactly two keys with the name `key1` and `key2` located under the path `user/test`. The output of the command `kdb ls user/test` would then be the following
+
+```
+user/test/key1
+user/test/key2
+```
+
+You can check this exact output in a shell recorder script via the following code:
+
+```
+STDOUT: user/test/key1⏎user/test/key2
+< ls user/test
+```
+
+If you only want to check that `key1` and `key2` are part of the output you can use the regex `key1.*key2` instead:
+
+```
+STDOUT: key1.*key2
+< ls user/test
+```
+
+As you can see the line ending is considered  a normal character (`.`) in the output.
+
 Options:
 
 * STDOUT:

--- a/tests/shell/shell_recorder/db_changes.esr
+++ b/tests/shell/shell_recorder/db_changes.esr
@@ -6,3 +6,6 @@ DIFF: (> keyNew.*user/test/key)
 
 DIFF: (> keyNew.*user/test/key3)
 < set user/test/key3 val2
+
+STDOUT: user/test/key⏎user/test/key3
+< ls user/test

--- a/tests/shell/shell_recorder/shell_recorder.sh
+++ b/tests/shell/shell_recorder/shell_recorder.sh
@@ -31,7 +31,7 @@ else
 fi
 
 replace_newline_return () {
-	tr '\n' '⏎'
+	awk -v RS="" '{gsub (/\n/,"⏎")}1'
 }
 
 execute()

--- a/tests/shell/shell_recorder/shell_recorder.sh
+++ b/tests/shell/shell_recorder/shell_recorder.sh
@@ -30,8 +30,8 @@ else
         KDBCOMMAND="kdb"
 fi
 
-replace_newline_null () {
-	tr '\n' '⏎' | tr '\000' '\n'
+replace_newline_return () {
+	tr '\n' '⏎'
 }
 
 execute()
@@ -125,7 +125,7 @@ execute()
     if [ ! -z "$STDERRCMP" ];
     then
         nbTest=$(( nbTest + 1 ))
-        echo "$STDERR" | replace_newline_null | grep -Eq --text "$STDERRCMP"
+        echo "$STDERR" | replace_newline_return | grep -Eq --text "$STDERRCMP"
         if [ "$?" -ne "0" ];
         then
             echo "STDERR doesn't match $STDERRCMP"
@@ -142,7 +142,7 @@ execute()
     if [ ! -z "$STDOUTCMP" ];
     then
         nbTest=$(( nbTest + 1 ))
-        echo "$STDOUT" | replace_newline_null | grep -Eq --text "$STDOUTCMP"
+        echo "$STDOUT" | replace_newline_return | grep -Eq --text "$STDOUTCMP"
         if [ "$?" -ne "0" ];
         then
             echo "STDOUT doesn't match $STDOUTCMP"
@@ -159,7 +159,7 @@ execute()
     if [ ! -z "$WARNINGSCMP" ];
     then
         nbTest=$(( nbTest + 1 ))
-        echo "$WARNINGS" | replace_newline_null | grep -Eq --text "($WARNINGSCMP)"
+        echo "$WARNINGS" | replace_newline_return | grep -Eq --text "($WARNINGSCMP)"
         if [ "$?" -ne "0" ];
         then
             echo "WARNINGS doesn't match $WARNINGSCMP"
@@ -178,7 +178,7 @@ execute()
     if [ ! -z "$ERRORSCMP" ];
     then
         nbTest=$(( nbTest + 1 ))
-        echo "$ERRORS" | replace_newline_null | grep -Eq --text "($ERRORSCMP)"
+        echo "$ERRORS" | replace_newline_return | grep -Eq --text "($ERRORSCMP)"
         if [ "$?" -ne "0" ];
         then
             echo "ERRORS doesn't match $ERRORSCMP"
@@ -193,7 +193,7 @@ execute()
     if [ ! -z "$DIFFCMP" ];
     then
         nbTest=$(( nbTest + 1 ))
-        echo "$DIFF" | replace_newline_null | grep -Eq --text "($DIFFCMP)"
+        echo "$DIFF" | replace_newline_return | grep -Eq --text "($DIFFCMP)"
         if [ "$?" -ne "0" ];
         then
             echo "Changes to $DBFile don't match $DIFFCMP"


### PR DESCRIPTION
## Bugfix

The shell recorder tests, after commit ab772e8c, worked only because all the test outputs do not contain the `NULL` symbol.

## Documentation Update

I documented the fact that you need to use the return symbol (`⏎`) to match a newline in Shell Recorder tests.

If someone wants to know the reason why I did not choose `NULL` instead of `⏎` : Something like

```sh
echo -e "bla\0blubb" | grep -Eq --text "bla\x00blubb"
```

reports a match with BSD-grep, but not with GNU-grep. It works in GNU-grep too, if we specify the `-P` flag, which is not available in BSD's version of grep.