### PR TITLE
Fix global hook keyset / ksCut

### DIFF
--- a/src/libs/elektra/kdb.c
+++ b/src/libs/elektra/kdb.c
@@ -594,11 +594,26 @@ static int elektraGetDoUpdateWithGlobalHooks (KDB * handle, Split * split, KeySe
 					Key * cutKey = keyNew ("/", KEY_CASCADING_NAME, KEY_END);
 					keyAddName (cutKey, strchr (keyName (parentKey), '/'));
 					KeySet * cutKS = ksCut (ks, cutKey);
+					Key * specCutKey = keyNew ("spec", KEY_END);
+					KeySet * specCut = ksCut (cutKS, specCutKey);
+					ksRewind (specCut);
+					Key * cur;
+					while ((cur = ksNext (specCut)) != NULL)
+					{
+						if (keyGetNamespace (cur) == KEY_NS_CASCADING)
+						{
+							ksAppendKey (cutKS, cur);
+							keyDel (ksLookup (specCut, cur, KDB_O_POP));
+						}
+					}
 					ksRewind (cutKS);
 					ret = backend->getplugins[p]->kdbGet (backend->getplugins[p], cutKS, parentKey);
+					ksAppend (cutKS, specCut);
+					ksDel (specCut);
 					ksAppend (ks, cutKS);
 					ksDel (cutKS);
 					keyDel (cutKey);
+					keyDel (specCutKey);
 				}
 			}
 

--- a/src/libs/elektra/kdb.c
+++ b/src/libs/elektra/kdb.c
@@ -533,6 +533,32 @@ static int elektraGetDoUpdate (Split * split, Key * parentKey)
 
 typedef enum { FIRST, LAST } UpdatePass;
 
+static KeySet * prepareGlobalKS (KeySet * ks, Key * parentKey)
+{
+	ksRewind (ks);
+	Key * cutKey = keyNew ("/", KEY_CASCADING_NAME, KEY_END);
+	keyAddName (cutKey, strchr (keyName (parentKey), '/'));
+	KeySet * cutKS = ksCut (ks, cutKey);
+	Key * specCutKey = keyNew ("spec", KEY_END);
+	KeySet * specCut = ksCut (cutKS, specCutKey);
+	ksRewind (specCut);
+	Key * cur;
+	while ((cur = ksNext (specCut)) != NULL)
+	{
+		if (keyGetNamespace (cur) == KEY_NS_CASCADING)
+		{
+			ksAppendKey (cutKS, cur);
+			keyDel (ksLookup (specCut, cur, KDB_O_POP));
+		}
+	}
+	ksAppend (ks, specCut);
+	ksDel (specCut);
+	keyDel (specCutKey);
+	keyDel (cutKey);
+	ksRewind (cutKS);
+	return cutKS;
+}
+
 static int elektraGetDoUpdateWithGlobalHooks (KDB * handle, Split * split, KeySet * ks, Key * parentKey, Key * initialParent,
 					      UpdatePass run)
 {
@@ -590,30 +616,10 @@ static int elektraGetDoUpdateWithGlobalHooks (KDB * handle, Split * split, KeySe
 				}
 				else
 				{
-					ksRewind (ks);
-					Key * cutKey = keyNew ("/", KEY_CASCADING_NAME, KEY_END);
-					keyAddName (cutKey, strchr (keyName (parentKey), '/'));
-					KeySet * cutKS = ksCut (ks, cutKey);
-					Key * specCutKey = keyNew ("spec", KEY_END);
-					KeySet * specCut = ksCut (cutKS, specCutKey);
-					ksRewind (specCut);
-					Key * cur;
-					while ((cur = ksNext (specCut)) != NULL)
-					{
-						if (keyGetNamespace (cur) == KEY_NS_CASCADING)
-						{
-							ksAppendKey (cutKS, cur);
-							keyDel (ksLookup (specCut, cur, KDB_O_POP));
-						}
-					}
-					ksRewind (cutKS);
+					KeySet * cutKS = prepareGlobalKS (ks, parentKey);
 					ret = backend->getplugins[p]->kdbGet (backend->getplugins[p], cutKS, parentKey);
-					ksAppend (cutKS, specCut);
-					ksDel (specCut);
 					ksAppend (ks, cutKS);
 					ksDel (cutKS);
-					keyDel (cutKey);
-					keyDel (specCutKey);
 				}
 			}
 

--- a/src/plugins/conditionals/conditionals.c
+++ b/src/plugins/conditionals/conditionals.c
@@ -806,7 +806,6 @@ int elektraConditionalsGet (Plugin * handle ELEKTRA_UNUSED, KeySet * returned EL
 	CondResult ret = FALSE;
 	while ((cur = ksNext (returned)) != NULL)
 	{
-		if (keyGetNamespace (cur) == KEY_NS_SPEC) continue;
 		Key * conditionMeta = (Key *)keyGetMeta (cur, "check/condition");
 		Key * assignMeta = (Key *)keyGetMeta (cur, "assign/condition");
 		Key * suffixList = (Key *)keyGetMeta (cur, "condition/validsuffix");
@@ -840,7 +839,6 @@ int elektraConditionalsSet (Plugin * handle ELEKTRA_UNUSED, KeySet * returned EL
 	CondResult ret = FALSE;
 	while ((cur = ksNext (returned)) != NULL)
 	{
-		if (keyGetNamespace (cur) == KEY_NS_SPEC) continue;
 		Key * conditionMeta = (Key *)keyGetMeta (cur, "check/condition");
 		Key * assignMeta = (Key *)keyGetMeta (cur, "assign/condition");
 		Key * suffixList = (Key *)keyGetMeta (cur, "condition/validsuffix");

--- a/src/plugins/mathcheck/mathcheck.c
+++ b/src/plugins/mathcheck/mathcheck.c
@@ -360,7 +360,6 @@ int elektraMathcheckSet (Plugin * handle ELEKTRA_UNUSED, KeySet * returned, Key 
 	PNElem result;
 	while ((cur = ksNext (returned)) != NULL)
 	{
-		if (keyGetNamespace (cur) == KEY_NS_SPEC) continue;
 		meta = keyGetMeta (cur, "check/math");
 		if (!meta) continue;
 		result = parsePrefixString (keyString (meta), cur, ksDup (returned), parentKey);


### PR DESCRIPTION
Workaround for removing spec keys from the keyset passed to global plugins while keeping cascading/default keys. spec keys have to be removed because otherwise validation plugins might try to validate them and will most likely fail. 

currently there is no way to exclude cascading/default keys when using ksCut which causes problems with default keys created by plugins like `conditionals`. this workaround moves the removed keys back to the original keyset before passing it to the global plugins.

Edited!