### PR TITLE
Add Specification as Dependency of `kdberrors.h`

### DIFF
--- a/src/error/CMakeLists.txt
+++ b/src/error/CMakeLists.txt
@@ -12,7 +12,7 @@ add_custom_command (
 		OUTPUT ${BINARY_INCLUDE_DIR}/kdberrors.h
 		DEPENDS elektra-export-errors ${CMAKE_CURRENT_SOURCE_DIR}/specification
 		COMMAND ${EXE_ERR_LOC}
-		ARGS ${EXE_ERR_ARG} ${CMAKE_SOURCE_DIR}/src/error/specification ${BINARY_INCLUDE_DIR}/kdberrors.h
+		ARGS ${EXE_ERR_ARG} ${CMAKE_CURRENT_SOURCE_DIR}/specification ${BINARY_INCLUDE_DIR}/kdberrors.h
 		)
 add_custom_target (
 	kdberrors_generated ALL

--- a/src/error/CMakeLists.txt
+++ b/src/error/CMakeLists.txt
@@ -15,9 +15,9 @@ add_custom_command (
 		ARGS ${EXE_ERR_ARG} ${CMAKE_SOURCE_DIR}/src/error/specification ${BINARY_INCLUDE_DIR}/kdberrors.h
 		)
 add_custom_target (
-    kdberrors_generated ALL
-    DEPENDS ${BINARY_INCLUDE_DIR}/kdberrors.h
-    )
+	kdberrors_generated ALL
+	DEPENDS ${BINARY_INCLUDE_DIR}/kdberrors.h
+	)
 
 add_executable(exporttranslations exporttranslations.cpp parser.hpp parser.cpp)
 

--- a/src/error/CMakeLists.txt
+++ b/src/error/CMakeLists.txt
@@ -10,7 +10,7 @@ find_util (elektra-export-errors EXE_ERR_LOC EXE_ERR_ARG)
 set (BINARY_INCLUDE_DIR "${PROJECT_BINARY_DIR}/src/include")
 add_custom_command (
 		OUTPUT ${BINARY_INCLUDE_DIR}/kdberrors.h
-		DEPENDS elektra-export-errors
+		DEPENDS elektra-export-errors ${CMAKE_CURRENT_SOURCE_DIR}/specification
 		COMMAND ${EXE_ERR_LOC}
 		ARGS ${EXE_ERR_ARG} ${CMAKE_SOURCE_DIR}/src/error/specification ${BINARY_INCLUDE_DIR}/kdberrors.h
 		)


### PR DESCRIPTION
# Purpose

This commit should fix issue #893: “kdberrors.h not regenerated”.

# Checklist

- [x] commit messages are fine (with references to issues)
- [x] I ran all tests and everything went fine

@markus2330 please review my pull request