### PR TITLE
Rename intercept config

### DIFF
--- a/scripts/configure-firefox.in
+++ b/scripts/configure-firefox.in
@@ -167,35 +167,35 @@ testPreload()
     unset valTest
     unset errCount
     errCount=0
-    valTest=$(kdb sget "/preload/open/${escapedDecoy}" NA)
+    valTest=$(kdb sget "/elektra/intercept/open/${escapedDecoy}" NA)
     if [ "$valTest" == "NA" ];
     then
 	errCount=$((++errCount))
     fi
-    valTest=$(kdb sget "/preload/open/${escapedDecoy}/generate" NA)
+    valTest=$(kdb sget "/elektra/intercept/open/${escapedDecoy}/generate" NA)
     if [ "$valTest" != "$MountPoint" ];
     then
 	errCount=$((++errCount))
     fi
-    valTest=$(kdb sget "/preload/open/${escapedDecoy}/generate/plugin" NA)
+    valTest=$(kdb sget "/elektra/intercept/open/${escapedDecoy}/generate/plugin" NA)
     if [ "$valTest" != "mozprefs" ];
     then
 	errCount=$((++errCount))
     fi
     if [ $errCount -ne 0 ];
     then
-	echo "Error, failed to setup /preload/open configuration"
+	echo "Error, failed to setup /elektra/intercept/open configuration"
 	exit 1
     fi
 }
 
 setPreload()
 {
-    kdb set /preload/open 
+    kdb set /elektra/intercept/open 
     escapedDecoy=$(echo "$Decoy"|sed 's/\//\\\//g')
-    kdb set "/preload/open/${escapedDecoy}" ""
-    kdb set "/preload/open/${escapedDecoy}/generate" "$MountPoint"
-    kdb set "/preload/open/${escapedDecoy}/generate/plugin" mozprefs
+    kdb set "/elektra/intercept/open/${escapedDecoy}" ""
+    kdb set "/elektra/intercept/open/${escapedDecoy}/generate" "$MountPoint"
+    kdb set "/elektra/intercept/open/${escapedDecoy}/generate/plugin" mozprefs
 }
 
 setTestPrefs()
@@ -266,7 +266,7 @@ removePrefs()
     then
 	kdb rm "$FFInterceptKey" &>/dev/null
 	escapedDecoy=$(echo "$Decoy"|sed 's/\//\\\//g')
-	kdb rm -r "/preload/open/${espacedDecoy}" &>/dev/null
+	kdb rm -r "/elektra/intercept/open/${espacedDecoy}" &>/dev/null
 	kdb rm -r "$MountPoint" &>/dev/null
 	kdb umount "$MountPoint" &>/dev/null
 	tmpPrefsFile=$(kdb get "$FFInterceptConfig")

--- a/src/bindings/intercept/README.md
+++ b/src/bindings/intercept/README.md
@@ -10,12 +10,12 @@ Additionaly you can force files to be read-only, or even generated from elektra 
 
 ## CONFIGURATION
 
-The libraries configuration is stored under `/preload/open`.
+The libraries configuration is stored under `/elektra/intercept/open`.
 
 Syntax:
-`/preload/open/path\/to\/realfile = path/to/myfile`
-`/preload/open/path\/to\/realfile/readonly = 1`
-`/preload/open/path\/to\/realfile/generate = system/info`
+`/elektra/intercept/open/path\/to\/realfile = path/to/myfile`
+`/elektra/intercept/open/path\/to\/realfile/readonly = 1`
+`/elektra/intercept/open/path\/to\/realfile/generate = system/info`
 `/preload/opeh/path/\to\/realfile/generate/plugin = ini`
 
 ## INTERNALS
@@ -30,17 +30,17 @@ If the `/generate` and `/generate/plugin` keys are set, the library will generat
 % echo testfile > ~/testfile
 % echo testreplacement > ~/testreplacement
 
-% kdb set /preload/open
-% kdb set /preload/open/\~\\/testfile "~/testreplacement"
+% kdb set /elektra/intercept/open
+% kdb set /elektra/intercept/open/\~\\/testfile "~/testreplacement"
 
-% LD_PRELOAD=/path/to/libelektraintercept.so cat ~/testfile
+% kdb elektrify-open cat ~/testfile
 testreplacement
 
 % kdb mount-info
-% kdb set /preload/open/\~\\/testfile/generate "system/info/uname"
-% kdb set /preload/open/\~\\testfile/generate/plugin ini
+% kdb set /elektra/intercept/open/\~\\/testfile/generate "system/info/uname"
+% kdb set /elektra/intercept/open/\~\\testfile/generate/plugin ini
 
-% LD_PRELOAD=/path/to/libelektraintercept.so cat ~/testfile
+% kdb elektrify-open cat ~/testfile
 = none
 machine = x86_64
 nodename = Skipper

--- a/src/bindings/intercept/intercept.c
+++ b/src/bindings/intercept/intercept.c
@@ -19,7 +19,7 @@
 #include <kdbmodule.h>
 #include <kdbprivate.h>
 
-#define PRELOAD_PATH "/preload/open"
+#define PRELOAD_PATH "/elektra/intercept/open"
 #define TV_MAX_DIGITS 26
 #define RELEVANT_FRAME 1
 

--- a/src/libs/getenv/README.md
+++ b/src/libs/getenv/README.md
@@ -14,14 +14,14 @@ elektrify-getenv(1) -- elektrify the environment of applications
 
     kdb elektrify-getenv curl --elektra-version
     kdb elektrify-getenv curl http://www.libelektra.org
-    kdb set system/env/override/HTTP_PROXY http://proxy.hogege.com:8000/
+    kdb set system/elektra/intercept/getenv/override/HTTP_PROXY http://proxy.hogege.com:8000/
     kdb elektrify-getenv curl http://www.libelektra.org
 
 By using `elektrify-getenv` the last curl invocation will use a different http proxy.
 Or you can also reload while the application is running:
 
     ELEKTRA_RELOAD_TIMEOUT=100 kdb elektrify-getenv firefox
-    kdb set system/env/override/http_proxy http://www.example.com
+    kdb set system/elektra/intercept/getenv/override/http_proxy http://www.example.com
 
 
 ## DESCRIPTION
@@ -56,17 +56,17 @@ To do so, getenv(3) will lookup multiple sources next to searching in the enviro
 1. Given commandline parameters will always be preferred (see [OPTIONS](#OPTIONS) below).
 
    E.g. `elektrify-getenv <app> --elektra:HOME=/path/to/home`
-2. Then `/env/override/<key>` will be looked up, where <key> is the parameter to `getenv`.
+2. Then `/elektra/intercept/getenv/override/<key>` will be looked up, where <key> is the parameter to `getenv`.
    If found, the key will be returned, if it is a null keys, `getenv` will return `NULL`.
 
-   E.g. `kdb set user/env/override/HOME /path/to/home`
+   E.g. `kdb set user/elektra/intercept/getenv/override/HOME /path/to/home`
 3. Then environment will be requested.
 
    E.g. `HOME=/path/to/home elektrify-getenv <application>`
-4. Then `/env/fallback/<key>` will be looked up.
+4. Then `/elektra/intercept/getenv/fallback/<key>` will be looked up.
    If found, the key will be returned, if it is a null keys, `getenv` will return `NULL`.
 
-   E.g. `kdb set user/env/fallback/HOME /path/to/home`
+   E.g. `kdb set user/elektra/intercept/getenv/fallback/HOME /path/to/home`
 
 
 
@@ -87,16 +87,16 @@ the application will be called with `<application> -V -L`.
    Outputs this help.
  * `--elektra-version`:
    Gives version information.
- * `--elektra-debug=file`, `ELEKTRA_DEBUG` or `/env/option/debug`:
+ * `--elektra-debug=file`, `ELEKTRA_DEBUG` or `/elektra/intercept/getenv/option/debug`:
    Trace all getenv(3) calls to a file.
-   stderr if no file is given, e.g. `kdb set user/env/option/debug ""`.
+   stderr if no file is given, e.g. `kdb set user/elektra/intercept/getenv/option/debug ""`.
    Note that null values (no forth argument), will disable debug messages.
    See examples below.
- * `--elektra-clearenv`, `ELEKTRA_CLEARENV` or `/env/option/clearenv`:
+ * `--elektra-clearenv`, `ELEKTRA_CLEARENV` or `/elektra/intercept/getenv/option/clearenv`:
    Call clearenv(3) before entering main.
    This is a recommended security feature.
    Elektra itself, if configured that way, will still be able to use the environment.
- * `--elektra-reload-timeout=time_in_ms`, `ELEKTRA_RELOAD_TIMEOUT` or `/env/option/reload_timeout`:
+ * `--elektra-reload-timeout=time_in_ms`, `ELEKTRA_RELOAD_TIMEOUT` or `/elektra/intercept/getenv/option/reload_timeout`:
    Activate a timeout based feature when a time is given in ms (and is not 0).
 
 Internal Options are available in three different variants:
@@ -105,20 +105,20 @@ Internal Options are available in three different variants:
    which are *not* passed through exec(3) calls.
 2. as environment variable: `ELEKTRA_<OPTION>`.
    which might be passed through exec(3) calls, but are removed by clearenv(3) calls.
-3. as Elektra KDB entry: `/env/option/<option>`,
+3. as Elektra KDB entry: `/elektra/intercept/getenv/option/<option>`,
    which are the way to achieve an option to be enabled for every application.
 
-   E.g. `kdb set user/env/option/clearenv ""` to clear the environment for all
+   E.g. `kdb set user/elektra/intercept/getenv/option/clearenv ""` to clear the environment for all
    applications started by that user (note that at least `PATH` should to be set
-   using `kdb set user/env/fallback/PATH "/bin:/usr/bin"` then).
+   using `kdb set user/elektra/intercept/getenv/fallback/PATH "/bin:/usr/bin"` then).
 
    Note, that null keys are equal to non-set options.
-   E.g. `kdb set system/env/option/debug "/tmp/elektra.log"` and
-   `kdb set user/env/option/debug` will activate logging for the system, except
+   E.g. `kdb set system/elektra/intercept/getenv/option/debug "/tmp/elektra.log"` and
+   `kdb set user/elektra/intercept/getenv/option/debug` will activate logging for the system, except
    for the current user.
 
 ### Contextual Options
- * `--elektra%<name>%=<value>` or `/env/layer/<name>`:
+ * `--elektra%<name>%=<value>` or `/elektra/intercept/getenv/layer/<name>`:
    Add the contextual information (=layer) `%<name>%` with its value `<value>`.
    Note that `%name%` is predefined with `argv[0]` and `%basename%` with
    `basename(argv[0])`.
@@ -126,7 +126,7 @@ Internal Options are available in three different variants:
 Values can contain / to form hierarchies, e.g. `--elektra%name%=app/profile`
 
 ### Options for Applications
- * `--elektra:key=value`, `/env/override/<key>` or `/env/fallback/<key>`:
+ * `--elektra:key=value`, `/elektra/intercept/getenv/override/<key>` or `/elektra/intercept/getenv/fallback/<key>`:
    set a key/value to be preferred, i.e. the first to considered as explained in [LOOKUP](#LOOKUP).
 
 Keys can contain / to form hierarchies, e.g. `--elektra:my/HOME=/path/to/home`.
@@ -149,21 +149,21 @@ this also can be done using Elektra:
 
 The metadata `context` in the specification can be used to facilitate a context-dependent lookup.
 In its metavalue all replacements of `%<name>%` will be replaced by the
-given contextual options `--elektra%<name>%=<value>` and `/env/layer/<name>` keys.
+given contextual options `--elektra%<name>%=<value>` and `/elektra/intercept/getenv/layer/<name>` keys.
 
 E.g. to have a different home directory for any user and application:
 
-    kdb set user/env/layer/user markus
+    kdb set user/elektra/intercept/getenv/layer/user markus
     kdb set user/users/markus/konqueror/HOME /home/download
-    kdb setmeta spec/env/override/HOME context  /users/%user%/%name%/HOME
+    kdb setmeta spec/elektra/intercept/getenv/override/HOME context  /users/%user%/%name%/HOME
 
 Or to have a different lock/suspend program per computer (that all have the same config):
 
-    kdb mount-info system/env/info            # must be below /env to be available
-    kdb setmeta spec/env/layer/hostname override/#0 system/env/info/uname/nodename
-    kdb setmeta spec/env/override/lock context /env/info/lock/%hostname%
-    kdb set user/env/info/lock/computer1 "systemctl suspend -i
-    kdb set user/env/info/lock/computer2 "xset dpms force off && xtrlock"
+    kdb mount-info system/elektra/intercept/getenv/info            # must be below /elektra/intercept/getenv to be available
+    kdb setmeta spec/elektra/intercept/getenv/layer/hostname override/#0 system/elektra/intercept/getenv/info/uname/nodename
+    kdb setmeta spec/elektra/intercept/getenv/override/lock context /elektra/intercept/getenv/info/lock/%hostname%
+    kdb set user/elektra/intercept/getenv/info/lock/computer1 "systemctl suspend -i
+    kdb set user/elektra/intercept/getenv/info/lock/computer2 "xset dpms force off && xtrlock"
     `kdb getenv lock`  # call the appropriate lock method for the current computer
 
 
@@ -174,7 +174,7 @@ Some applications do not use `getenv(3)` or `secure_getenv(3)` for requesting th
 e.g. shells. This approach cannot work for them.
 
 In the startup-phase (before main is even entered), `getenv(3)` will
-not consider `/env/override/` or `/env/fallback`.
+not consider `/elektra/intercept/getenv/override/` or `/elektra/intercept/getenv/fallback`.
 
 Elektra internally tries to avoid using the environment.
 Some resolvers, however, use it to conform to some specifications, e.g. XDG.
@@ -183,7 +183,7 @@ For more information see:
 
     kdb info resolver
 
-For these parameters, `/env/override/` or `/env/fallback` will *not* be used internally, but
+For these parameters, `/elektra/intercept/getenv/override/` or `/elektra/intercept/getenv/fallback` will *not* be used internally, but
 will be used if applications request them, too.
 
 If you use the standard resolvers, the bug won't have any effect.
@@ -210,17 +210,17 @@ to set (e.g. in Makefiles).
 Debugging:
 
     # system wide to stderr (not recommended!):
-    sudo kdb set system/env/option/debug ""
+    sudo kdb set system/elektra/intercept/getenv/option/debug ""
     # system wide to /var/log/elektra.log:
-    sudo kdb set system/env/option/debug "/var/log/error.log"
+    sudo kdb set system/elektra/intercept/getenv/option/debug "/var/log/error.log"
     # but for my user to ~/.elektra.log:
-    kdb set user/env/option/debug "$HOME/.elektra.log"
+    kdb set user/elektra/intercept/getenv/option/debug "$HOME/.elektra.log"
     # or disable it for my user:
-    kdb set user/env/option/debug
+    kdb set user/elektra/intercept/getenv/option/debug
 
 Some more examples:
 
-    kdb set user/env/override/MANOPT -- "--regex -LC"
+    kdb set user/elektra/intercept/getenv/override/MANOPT -- "--regex -LC"
     elektrify-getenv getenv MANOPT   # to check if it is set as expected
     kdb getenv MANOPT   # if /etc/ld.so.preload is active
 
@@ -231,11 +231,11 @@ This feature is handy to change the default behaviour of
 applications (either system, user or directory-wide).
 
 
-    kdb set system/env/override/HTTP_PROXY http://proxy.hogege.com:8000/
+    kdb set system/elektra/intercept/getenv/override/HTTP_PROXY http://proxy.hogege.com:8000/
 
 Will permanently and system-wide change the proxy for all applications
 that honor HTTP_PROXY, e.g. w3m.
 We can also link `http_proxy` to the value of `HTTP_PROXY`:
 
-    kdb setmeta spec/env/override/http_proxy "override/#0" /env/override/HTTP_PROXY
-    kdb get /env/override/http_proxy
+    kdb setmeta spec/elektra/intercept/getenv/override/http_proxy "override/#0" /elektra/intercept/getenv/override/HTTP_PROXY
+    kdb get /elektra/intercept/getenv/override/http_proxy

--- a/src/libs/getenv/src/getenv.cpp
+++ b/src/libs/getenv/src/getenv.cpp
@@ -332,7 +332,7 @@ void addLayers ()
 	Key * c;
 	KeySet * lookupConfig = ksDup (elektraConfig);
 	ksRewind (elektraConfig);
-	std::string fallbackPrefix = "/env";
+	std::string fallbackPrefix = "/env/layer/";
 	while ((c = ksNext (elektraConfig)))
 	{
 		std::string fullName = keyName (c);

--- a/src/libs/getenv/tests/test_context.cpp
+++ b/src/libs/getenv/tests/test_context.cpp
@@ -21,8 +21,8 @@ TEST (Context, Exist)
 {
 	Key * k;
 	elektraOpen (nullptr, nullptr);
-	ksAppendKey (elektraConfig, k = keyNew ("user/env/override/does-exist", KEY_VALUE, "hello", KEY_END));
-	Key * f = elektraLookupWithContext ("user/env/override/does-exist");
+	ksAppendKey (elektraConfig, k = keyNew ("user/elektra/intercept/getenv/override/does-exist", KEY_VALUE, "hello", KEY_END));
+	Key * f = elektraLookupWithContext ("user/elektra/intercept/getenv/override/does-exist");
 	EXPECT_EQ (k, f);
 }
 
@@ -31,10 +31,10 @@ TEST (Context, ExistWithContext)
 {
 	Key * k;
 	elektraOpen (nullptr, nullptr);
-	ksAppendKey (elektraConfig, k = keyNew ("user/env/override/does-exist", KEY_VALUE, "hello", KEY_END));
-	ksAppendKey (elektraConfig, keyNew ("spec/env/override/does-exist", KEY_META, "context", "user/env/override/does-exist", KEY_VALUE,
+	ksAppendKey (elektraConfig, k = keyNew ("user/elektra/intercept/getenv/override/does-exist", KEY_VALUE, "hello", KEY_END));
+	ksAppendKey (elektraConfig, keyNew ("spec/elektra/intercept/getenv/override/does-exist", KEY_META, "context", "user/elektra/intercept/getenv/override/does-exist", KEY_VALUE,
 					    "hello", KEY_END));
-	Key * f = elektraLookupWithContext ("/env/override/does-exist");
+	Key * f = elektraLookupWithContext ("/elektra/intercept/getenv/override/does-exist");
 	EXPECT_EQ (k, f);
 }
 
@@ -43,10 +43,10 @@ TEST (Context, ExistWithContextCascading)
 {
 	Key * k;
 	elektraOpen (nullptr, nullptr);
-	ksAppendKey (elektraConfig, k = keyNew ("user/env/override/does-exist-too", KEY_VALUE, "hello", KEY_END));
-	ksAppendKey (elektraConfig, keyNew ("spec/env/override/does-exist", KEY_META, "context", "/env/override/does-exist-too", KEY_VALUE,
+	ksAppendKey (elektraConfig, k = keyNew ("user/elektra/intercept/getenv/override/does-exist-too", KEY_VALUE, "hello", KEY_END));
+	ksAppendKey (elektraConfig, keyNew ("spec/elektra/intercept/getenv/override/does-exist", KEY_META, "context", "/elektra/intercept/getenv/override/does-exist-too", KEY_VALUE,
 					    "hello", KEY_END));
-	Key * f = elektraLookupWithContext ("/env/override/does-exist");
+	Key * f = elektraLookupWithContext ("/elektra/intercept/getenv/override/does-exist");
 	EXPECT_EQ (k, f);
 }
 
@@ -59,14 +59,14 @@ TEST (Context, ExistWithContextOverrideCascading)
 {
 	Key * k;
 	elektraOpen (nullptr, nullptr);
-	ksAppendKey (elektraConfig, keyNew ("user/env/layer/layer", KEY_VALUE, "layer", KEY_END));
+	ksAppendKey (elektraConfig, keyNew ("user/elektra/intercept/getenv/layer/layer", KEY_VALUE, "layer", KEY_END));
 	addLayers ();
 
-	ksAppendKey (elektraConfig, keyNew ("user/env/override/does-exist-too", KEY_VALUE, "wrong", KEY_END));
-	ksAppendKey (elektraConfig, k = keyNew ("user/env/override/layer/does-exist-too", KEY_VALUE, "correct", KEY_END));
-	ksAppendKey (elektraConfig, keyNew ("spec/env/override/does-exist", KEY_META, "context", "/env/override/%layer%/does-exist-too",
-					    KEY_META, "override/#0", "/env/override/does-exist-too", KEY_VALUE, "hello", KEY_END));
-	Key * f = elektraLookupWithContext ("/env/override/does-exist");
+	ksAppendKey (elektraConfig, keyNew ("user/elektra/intercept/getenv/override/does-exist-too", KEY_VALUE, "wrong", KEY_END));
+	ksAppendKey (elektraConfig, k = keyNew ("user/elektra/intercept/getenv/override/layer/does-exist-too", KEY_VALUE, "correct", KEY_END));
+	ksAppendKey (elektraConfig, keyNew ("spec/elektra/intercept/getenv/override/does-exist", KEY_META, "context", "/elektra/intercept/getenv/override/%layer%/does-exist-too",
+					    KEY_META, "override/#0", "/elektra/intercept/getenv/override/does-exist-too", KEY_VALUE, "hello", KEY_END));
+	Key * f = elektraLookupWithContext ("/elektra/intercept/getenv/override/does-exist");
 	EXPECT_EQ (k, f);
 }
 
@@ -74,15 +74,15 @@ TEST (Context, ExistWithContextOverrideCascadingSystem)
 {
 	Key * k;
 	elektraOpen (nullptr, nullptr);
-	ksAppendKey (elektraConfig, keyNew ("user/env/layer/layer", KEY_VALUE, "layer", KEY_END));
-	ksAppendKey (elektraConfig, keyNew ("system/env/layer/layer", KEY_VALUE, "systemlayer", KEY_END));
+	ksAppendKey (elektraConfig, keyNew ("user/elektra/intercept/getenv/layer/layer", KEY_VALUE, "layer", KEY_END));
+	ksAppendKey (elektraConfig, keyNew ("system/elektra/intercept/getenv/layer/layer", KEY_VALUE, "systemlayer", KEY_END));
 	addLayers ();
 
-	ksAppendKey (elektraConfig, keyNew ("user/env/override/does-exist-too", KEY_VALUE, "wrong", KEY_END));
-	ksAppendKey (elektraConfig, k = keyNew ("user/env/override/layer/does-exist-too", KEY_VALUE, "correct", KEY_END));
-	ksAppendKey (elektraConfig, keyNew ("spec/env/override/does-exist", KEY_META, "context", "/env/override/%layer%/does-exist-too",
-					    KEY_META, "override/#0", "/env/override/does-exist-too", KEY_VALUE, "hello", KEY_END));
-	Key * f = elektraLookupWithContext ("/env/override/does-exist");
+	ksAppendKey (elektraConfig, keyNew ("user/elektra/intercept/getenv/override/does-exist-too", KEY_VALUE, "wrong", KEY_END));
+	ksAppendKey (elektraConfig, k = keyNew ("user/elektra/intercept/getenv/override/layer/does-exist-too", KEY_VALUE, "correct", KEY_END));
+	ksAppendKey (elektraConfig, keyNew ("spec/elektra/intercept/getenv/override/does-exist", KEY_META, "context", "/elektra/intercept/getenv/override/%layer%/does-exist-too",
+					    KEY_META, "override/#0", "/elektra/intercept/getenv/override/does-exist-too", KEY_VALUE, "hello", KEY_END));
+	Key * f = elektraLookupWithContext ("/elektra/intercept/getenv/override/does-exist");
 	EXPECT_EQ (k, f);
 }
 
@@ -91,15 +91,15 @@ TEST (Context, ExistWithContextOverrideCascadingDir)
 {
 	Key * k;
 	elektraOpen (nullptr, nullptr);
-	ksAppendKey (elektraConfig, keyNew ("dir/env/layer/layer", KEY_VALUE, "layer", KEY_END));
-	ksAppendKey (elektraConfig, keyNew ("user/env/layer/layer", KEY_VALUE, "userlayer", KEY_END));
+	ksAppendKey (elektraConfig, keyNew ("dir/elektra/intercept/getenv/layer/layer", KEY_VALUE, "layer", KEY_END));
+	ksAppendKey (elektraConfig, keyNew ("user/elektra/intercept/getenv/layer/layer", KEY_VALUE, "userlayer", KEY_END));
 	addLayers ();
 
-	ksAppendKey (elektraConfig, keyNew ("user/env/override/does-exist-too", KEY_VALUE, "wrong", KEY_END));
-	ksAppendKey (elektraConfig, k = keyNew ("user/env/override/layer/does-exist-too", KEY_VALUE, "correct", KEY_END));
-	ksAppendKey (elektraConfig, keyNew ("spec/env/override/does-exist", KEY_META, "context", "/env/override/%layer%/does-exist-too",
-					    KEY_META, "override/#0", "/env/override/does-exist-too", KEY_VALUE, "hello", KEY_END));
-	Key * f = elektraLookupWithContext ("/env/override/does-exist");
+	ksAppendKey (elektraConfig, keyNew ("user/elektra/intercept/getenv/override/does-exist-too", KEY_VALUE, "wrong", KEY_END));
+	ksAppendKey (elektraConfig, k = keyNew ("user/elektra/intercept/getenv/override/layer/does-exist-too", KEY_VALUE, "correct", KEY_END));
+	ksAppendKey (elektraConfig, keyNew ("spec/elektra/intercept/getenv/override/does-exist", KEY_META, "context", "/elektra/intercept/getenv/override/%layer%/does-exist-too",
+					    KEY_META, "override/#0", "/elektra/intercept/getenv/override/does-exist-too", KEY_VALUE, "hello", KEY_END));
+	Key * f = elektraLookupWithContext ("/elektra/intercept/getenv/override/does-exist");
 	EXPECT_EQ (k, f);
 }
 
@@ -107,15 +107,15 @@ TEST (Context, ExistWithContextOverrideCascadingProc)
 {
 	Key * k;
 	elektraOpen (nullptr, nullptr);
-	ksAppendKey (elektraConfig, keyNew ("proc/env/layer/layer", KEY_VALUE, "layer", KEY_END));
-	ksAppendKey (elektraConfig, keyNew ("user/env/layer/layer", KEY_VALUE, "userlayer", KEY_END));
+	ksAppendKey (elektraConfig, keyNew ("proc/elektra/intercept/getenv/layer/layer", KEY_VALUE, "layer", KEY_END));
+	ksAppendKey (elektraConfig, keyNew ("user/elektra/intercept/getenv/layer/layer", KEY_VALUE, "userlayer", KEY_END));
 	addLayers ();
 
-	ksAppendKey (elektraConfig, keyNew ("user/env/override/does-exist-too", KEY_VALUE, "wrong", KEY_END));
-	ksAppendKey (elektraConfig, k = keyNew ("user/env/override/layer/does-exist-too", KEY_VALUE, "correct", KEY_END));
-	ksAppendKey (elektraConfig, keyNew ("spec/env/override/does-exist", KEY_META, "context", "/env/override/%layer%/does-exist-too",
-					    KEY_META, "override/#0", "/env/override/does-exist-too", KEY_VALUE, "hello", KEY_END));
-	Key * f = elektraLookupWithContext ("/env/override/does-exist");
+	ksAppendKey (elektraConfig, keyNew ("user/elektra/intercept/getenv/override/does-exist-too", KEY_VALUE, "wrong", KEY_END));
+	ksAppendKey (elektraConfig, k = keyNew ("user/elektra/intercept/getenv/override/layer/does-exist-too", KEY_VALUE, "correct", KEY_END));
+	ksAppendKey (elektraConfig, keyNew ("spec/elektra/intercept/getenv/override/does-exist", KEY_META, "context", "/elektra/intercept/getenv/override/%layer%/does-exist-too",
+					    KEY_META, "override/#0", "/elektra/intercept/getenv/override/does-exist-too", KEY_VALUE, "hello", KEY_END));
+	Key * f = elektraLookupWithContext ("/elektra/intercept/getenv/override/does-exist");
 	EXPECT_EQ (k, f);
 }
 
@@ -123,15 +123,15 @@ TEST (Context, ExistWithContextOverrideCascadingWithSlash)
 {
 	Key * k;
 	elektraOpen (nullptr, nullptr);
-	ksAppendKey (elektraConfig, keyNew ("proc/env/layer/layer/name", KEY_VALUE, "layer/value", KEY_END));
+	ksAppendKey (elektraConfig, keyNew ("proc/elektra/intercept/getenv/layer/layer/name", KEY_VALUE, "layer/value", KEY_END));
 	addLayers ();
 
-	ksAppendKey (elektraConfig, keyNew ("user/env/override/does-exist-too", KEY_VALUE, "wrong", KEY_END));
-	ksAppendKey (elektraConfig, k = keyNew ("user/env/override/layer/value/does-exist-too", KEY_VALUE, "correct", KEY_END));
+	ksAppendKey (elektraConfig, keyNew ("user/elektra/intercept/getenv/override/does-exist-too", KEY_VALUE, "wrong", KEY_END));
+	ksAppendKey (elektraConfig, k = keyNew ("user/elektra/intercept/getenv/override/layer/value/does-exist-too", KEY_VALUE, "correct", KEY_END));
 	ksAppendKey (elektraConfig,
-		     keyNew ("spec/env/override/does-exist", KEY_META, "context", "/env/override/%layer/name%/does-exist-too", KEY_META,
-			     "override/#0", "/env/override/does-exist-too", KEY_VALUE, "hello", KEY_END));
-	Key * f = elektraLookupWithContext ("/env/override/does-exist");
+		     keyNew ("spec/elektra/intercept/getenv/override/does-exist", KEY_META, "context", "/elektra/intercept/getenv/override/%layer/name%/does-exist-too", KEY_META,
+			     "override/#0", "/elektra/intercept/getenv/override/does-exist-too", KEY_VALUE, "hello", KEY_END));
+	Key * f = elektraLookupWithContext ("/elektra/intercept/getenv/override/does-exist");
 	EXPECT_EQ (k, f);
 }
 
@@ -146,7 +146,7 @@ TEST (Context, NameExplicit)
 	elektraOpen (&argc, argv);
 	ksAppendKey (elektraConfig, keyNew ("system/somewhere/other-name/layer/does-exist", KEY_VALUE, "hello", KEY_END));
 	ksAppendKey (elektraConfig,
-		     keyNew ("system/env/override/akey", KEY_META, "context", "/somewhere/%name%/%layer%/does-exist", KEY_END));
+		     keyNew ("system/elektra/intercept/getenv/override/akey", KEY_META, "context", "/somewhere/%name%/%layer%/does-exist", KEY_END));
 	elektraClose ();
 }
 
@@ -154,16 +154,16 @@ TEST (Context, ExistWithContextOverrideCascadingOverrideUser)
 {
 	Key * k;
 	elektraOpen (nullptr, nullptr);
-	ksAppendKey (elektraConfig, keyNew ("user/env/layer/hostname", KEY_VALUE, "wrongname", KEY_END));
-	ksAppendKey (elektraConfig, keyNew ("spec/env/layer/hostname", KEY_META, "override/#0", "system/syscall/uname/hostname", KEY_END));
+	ksAppendKey (elektraConfig, keyNew ("user/elektra/intercept/getenv/layer/hostname", KEY_VALUE, "wrongname", KEY_END));
+	ksAppendKey (elektraConfig, keyNew ("spec/elektra/intercept/getenv/layer/hostname", KEY_META, "override/#0", "system/syscall/uname/hostname", KEY_END));
 	ksAppendKey (elektraConfig, keyNew ("system/syscall/uname/hostname", KEY_VALUE, "localhost", KEY_END));
 	addLayers ();
 
-	ksAppendKey (elektraConfig, keyNew ("user/env/override/does-exist-too", KEY_VALUE, "wrong", KEY_END));
-	ksAppendKey (elektraConfig, k = keyNew ("user/env/override/localhost/does-exist-too", KEY_VALUE, "correct", KEY_END));
-	ksAppendKey (elektraConfig, keyNew ("spec/env/override/does-exist", KEY_META, "context", "/env/override/%hostname%/does-exist-too",
+	ksAppendKey (elektraConfig, keyNew ("user/elektra/intercept/getenv/override/does-exist-too", KEY_VALUE, "wrong", KEY_END));
+	ksAppendKey (elektraConfig, k = keyNew ("user/elektra/intercept/getenv/override/localhost/does-exist-too", KEY_VALUE, "correct", KEY_END));
+	ksAppendKey (elektraConfig, keyNew ("spec/elektra/intercept/getenv/override/does-exist", KEY_META, "context", "/elektra/intercept/getenv/override/%hostname%/does-exist-too",
 					    KEY_VALUE, "hello", KEY_END));
-	Key * f = elektraLookupWithContext ("/env/override/does-exist");
+	Key * f = elektraLookupWithContext ("/elektra/intercept/getenv/override/does-exist");
 	EXPECT_EQ (k, f);
 }
 
@@ -171,16 +171,16 @@ TEST (Context, ExistWithContextOverrideCascadingOverrideSystem)
 {
 	Key * k;
 	elektraOpen (nullptr, nullptr);
-	ksAppendKey (elektraConfig, keyNew ("system/env/layer/hostname", KEY_VALUE, "wrongname", KEY_END));
-	ksAppendKey (elektraConfig, keyNew ("spec/env/layer/hostname", KEY_META, "override/#0", "system/syscall/uname/hostname", KEY_END));
+	ksAppendKey (elektraConfig, keyNew ("system/elektra/intercept/getenv/layer/hostname", KEY_VALUE, "wrongname", KEY_END));
+	ksAppendKey (elektraConfig, keyNew ("spec/elektra/intercept/getenv/layer/hostname", KEY_META, "override/#0", "system/syscall/uname/hostname", KEY_END));
 	ksAppendKey (elektraConfig, keyNew ("system/syscall/uname/hostname", KEY_VALUE, "localhost", KEY_END));
 	addLayers ();
 
-	ksAppendKey (elektraConfig, keyNew ("user/env/override/does-exist-too", KEY_VALUE, "wrong", KEY_END));
-	ksAppendKey (elektraConfig, k = keyNew ("user/env/override/localhost/does-exist-too", KEY_VALUE, "correct", KEY_END));
-	ksAppendKey (elektraConfig, keyNew ("spec/env/override/does-exist", KEY_META, "context", "/env/override/%hostname%/does-exist-too",
+	ksAppendKey (elektraConfig, keyNew ("user/elektra/intercept/getenv/override/does-exist-too", KEY_VALUE, "wrong", KEY_END));
+	ksAppendKey (elektraConfig, k = keyNew ("user/elektra/intercept/getenv/override/localhost/does-exist-too", KEY_VALUE, "correct", KEY_END));
+	ksAppendKey (elektraConfig, keyNew ("spec/elektra/intercept/getenv/override/does-exist", KEY_META, "context", "/elektra/intercept/getenv/override/%hostname%/does-exist-too",
 					    KEY_VALUE, "hello", KEY_END));
-	Key * f = elektraLookupWithContext ("/env/override/does-exist");
+	Key * f = elektraLookupWithContext ("/elektra/intercept/getenv/override/does-exist");
 	EXPECT_EQ (k, f);
 }
 
@@ -188,15 +188,15 @@ TEST (Context, ExistWithContextOverrideCascadingOverride)
 {
 	Key * k;
 	elektraOpen (nullptr, nullptr);
-	ksAppendKey (elektraConfig, keyNew ("spec/env/layer/hostname", KEY_META, "override/#0", "system/syscall/uname/hostname", KEY_END));
+	ksAppendKey (elektraConfig, keyNew ("spec/elektra/intercept/getenv/layer/hostname", KEY_META, "override/#0", "system/syscall/uname/hostname", KEY_END));
 	ksAppendKey (elektraConfig, keyNew ("system/syscall/uname/hostname", KEY_VALUE, "localhost", KEY_END));
 	addLayers ();
 
-	ksAppendKey (elektraConfig, keyNew ("user/env/override/does-exist-too", KEY_VALUE, "wrong", KEY_END));
-	ksAppendKey (elektraConfig, k = keyNew ("user/env/override/localhost/does-exist-too", KEY_VALUE, "correct", KEY_END));
-	ksAppendKey (elektraConfig, keyNew ("spec/env/override/does-exist", KEY_META, "context", "/env/override/%hostname%/does-exist-too",
+	ksAppendKey (elektraConfig, keyNew ("user/elektra/intercept/getenv/override/does-exist-too", KEY_VALUE, "wrong", KEY_END));
+	ksAppendKey (elektraConfig, k = keyNew ("user/elektra/intercept/getenv/override/localhost/does-exist-too", KEY_VALUE, "correct", KEY_END));
+	ksAppendKey (elektraConfig, keyNew ("spec/elektra/intercept/getenv/override/does-exist", KEY_META, "context", "/elektra/intercept/getenv/override/%hostname%/does-exist-too",
 					    KEY_VALUE, "hello", KEY_END));
-	Key * f = elektraLookupWithContext ("/env/override/does-exist");
+	Key * f = elektraLookupWithContext ("/elektra/intercept/getenv/override/does-exist");
 	EXPECT_EQ (k, f);
 }
 

--- a/src/libs/getenv/tests/test_context.cpp
+++ b/src/libs/getenv/tests/test_context.cpp
@@ -32,8 +32,8 @@ TEST (Context, ExistWithContext)
 	Key * k;
 	elektraOpen (nullptr, nullptr);
 	ksAppendKey (elektraConfig, k = keyNew ("user/elektra/intercept/getenv/override/does-exist", KEY_VALUE, "hello", KEY_END));
-	ksAppendKey (elektraConfig, keyNew ("spec/elektra/intercept/getenv/override/does-exist", KEY_META, "context", "user/elektra/intercept/getenv/override/does-exist", KEY_VALUE,
-					    "hello", KEY_END));
+	ksAppendKey (elektraConfig, keyNew ("spec/elektra/intercept/getenv/override/does-exist", KEY_META, "context",
+					    "user/elektra/intercept/getenv/override/does-exist", KEY_VALUE, "hello", KEY_END));
 	Key * f = elektraLookupWithContext ("/elektra/intercept/getenv/override/does-exist");
 	EXPECT_EQ (k, f);
 }
@@ -44,8 +44,8 @@ TEST (Context, ExistWithContextCascading)
 	Key * k;
 	elektraOpen (nullptr, nullptr);
 	ksAppendKey (elektraConfig, k = keyNew ("user/elektra/intercept/getenv/override/does-exist-too", KEY_VALUE, "hello", KEY_END));
-	ksAppendKey (elektraConfig, keyNew ("spec/elektra/intercept/getenv/override/does-exist", KEY_META, "context", "/elektra/intercept/getenv/override/does-exist-too", KEY_VALUE,
-					    "hello", KEY_END));
+	ksAppendKey (elektraConfig, keyNew ("spec/elektra/intercept/getenv/override/does-exist", KEY_META, "context",
+					    "/elektra/intercept/getenv/override/does-exist-too", KEY_VALUE, "hello", KEY_END));
 	Key * f = elektraLookupWithContext ("/elektra/intercept/getenv/override/does-exist");
 	EXPECT_EQ (k, f);
 }
@@ -63,9 +63,11 @@ TEST (Context, ExistWithContextOverrideCascading)
 	addLayers ();
 
 	ksAppendKey (elektraConfig, keyNew ("user/elektra/intercept/getenv/override/does-exist-too", KEY_VALUE, "wrong", KEY_END));
-	ksAppendKey (elektraConfig, k = keyNew ("user/elektra/intercept/getenv/override/layer/does-exist-too", KEY_VALUE, "correct", KEY_END));
-	ksAppendKey (elektraConfig, keyNew ("spec/elektra/intercept/getenv/override/does-exist", KEY_META, "context", "/elektra/intercept/getenv/override/%layer%/does-exist-too",
-					    KEY_META, "override/#0", "/elektra/intercept/getenv/override/does-exist-too", KEY_VALUE, "hello", KEY_END));
+	ksAppendKey (elektraConfig,
+		     k = keyNew ("user/elektra/intercept/getenv/override/layer/does-exist-too", KEY_VALUE, "correct", KEY_END));
+	ksAppendKey (elektraConfig, keyNew ("spec/elektra/intercept/getenv/override/does-exist", KEY_META, "context",
+					    "/elektra/intercept/getenv/override/%layer%/does-exist-too", KEY_META, "override/#0",
+					    "/elektra/intercept/getenv/override/does-exist-too", KEY_VALUE, "hello", KEY_END));
 	Key * f = elektraLookupWithContext ("/elektra/intercept/getenv/override/does-exist");
 	EXPECT_EQ (k, f);
 }
@@ -79,9 +81,11 @@ TEST (Context, ExistWithContextOverrideCascadingSystem)
 	addLayers ();
 
 	ksAppendKey (elektraConfig, keyNew ("user/elektra/intercept/getenv/override/does-exist-too", KEY_VALUE, "wrong", KEY_END));
-	ksAppendKey (elektraConfig, k = keyNew ("user/elektra/intercept/getenv/override/layer/does-exist-too", KEY_VALUE, "correct", KEY_END));
-	ksAppendKey (elektraConfig, keyNew ("spec/elektra/intercept/getenv/override/does-exist", KEY_META, "context", "/elektra/intercept/getenv/override/%layer%/does-exist-too",
-					    KEY_META, "override/#0", "/elektra/intercept/getenv/override/does-exist-too", KEY_VALUE, "hello", KEY_END));
+	ksAppendKey (elektraConfig,
+		     k = keyNew ("user/elektra/intercept/getenv/override/layer/does-exist-too", KEY_VALUE, "correct", KEY_END));
+	ksAppendKey (elektraConfig, keyNew ("spec/elektra/intercept/getenv/override/does-exist", KEY_META, "context",
+					    "/elektra/intercept/getenv/override/%layer%/does-exist-too", KEY_META, "override/#0",
+					    "/elektra/intercept/getenv/override/does-exist-too", KEY_VALUE, "hello", KEY_END));
 	Key * f = elektraLookupWithContext ("/elektra/intercept/getenv/override/does-exist");
 	EXPECT_EQ (k, f);
 }
@@ -96,9 +100,11 @@ TEST (Context, ExistWithContextOverrideCascadingDir)
 	addLayers ();
 
 	ksAppendKey (elektraConfig, keyNew ("user/elektra/intercept/getenv/override/does-exist-too", KEY_VALUE, "wrong", KEY_END));
-	ksAppendKey (elektraConfig, k = keyNew ("user/elektra/intercept/getenv/override/layer/does-exist-too", KEY_VALUE, "correct", KEY_END));
-	ksAppendKey (elektraConfig, keyNew ("spec/elektra/intercept/getenv/override/does-exist", KEY_META, "context", "/elektra/intercept/getenv/override/%layer%/does-exist-too",
-					    KEY_META, "override/#0", "/elektra/intercept/getenv/override/does-exist-too", KEY_VALUE, "hello", KEY_END));
+	ksAppendKey (elektraConfig,
+		     k = keyNew ("user/elektra/intercept/getenv/override/layer/does-exist-too", KEY_VALUE, "correct", KEY_END));
+	ksAppendKey (elektraConfig, keyNew ("spec/elektra/intercept/getenv/override/does-exist", KEY_META, "context",
+					    "/elektra/intercept/getenv/override/%layer%/does-exist-too", KEY_META, "override/#0",
+					    "/elektra/intercept/getenv/override/does-exist-too", KEY_VALUE, "hello", KEY_END));
 	Key * f = elektraLookupWithContext ("/elektra/intercept/getenv/override/does-exist");
 	EXPECT_EQ (k, f);
 }
@@ -112,9 +118,11 @@ TEST (Context, ExistWithContextOverrideCascadingProc)
 	addLayers ();
 
 	ksAppendKey (elektraConfig, keyNew ("user/elektra/intercept/getenv/override/does-exist-too", KEY_VALUE, "wrong", KEY_END));
-	ksAppendKey (elektraConfig, k = keyNew ("user/elektra/intercept/getenv/override/layer/does-exist-too", KEY_VALUE, "correct", KEY_END));
-	ksAppendKey (elektraConfig, keyNew ("spec/elektra/intercept/getenv/override/does-exist", KEY_META, "context", "/elektra/intercept/getenv/override/%layer%/does-exist-too",
-					    KEY_META, "override/#0", "/elektra/intercept/getenv/override/does-exist-too", KEY_VALUE, "hello", KEY_END));
+	ksAppendKey (elektraConfig,
+		     k = keyNew ("user/elektra/intercept/getenv/override/layer/does-exist-too", KEY_VALUE, "correct", KEY_END));
+	ksAppendKey (elektraConfig, keyNew ("spec/elektra/intercept/getenv/override/does-exist", KEY_META, "context",
+					    "/elektra/intercept/getenv/override/%layer%/does-exist-too", KEY_META, "override/#0",
+					    "/elektra/intercept/getenv/override/does-exist-too", KEY_VALUE, "hello", KEY_END));
 	Key * f = elektraLookupWithContext ("/elektra/intercept/getenv/override/does-exist");
 	EXPECT_EQ (k, f);
 }
@@ -127,10 +135,11 @@ TEST (Context, ExistWithContextOverrideCascadingWithSlash)
 	addLayers ();
 
 	ksAppendKey (elektraConfig, keyNew ("user/elektra/intercept/getenv/override/does-exist-too", KEY_VALUE, "wrong", KEY_END));
-	ksAppendKey (elektraConfig, k = keyNew ("user/elektra/intercept/getenv/override/layer/value/does-exist-too", KEY_VALUE, "correct", KEY_END));
 	ksAppendKey (elektraConfig,
-		     keyNew ("spec/elektra/intercept/getenv/override/does-exist", KEY_META, "context", "/elektra/intercept/getenv/override/%layer/name%/does-exist-too", KEY_META,
-			     "override/#0", "/elektra/intercept/getenv/override/does-exist-too", KEY_VALUE, "hello", KEY_END));
+		     k = keyNew ("user/elektra/intercept/getenv/override/layer/value/does-exist-too", KEY_VALUE, "correct", KEY_END));
+	ksAppendKey (elektraConfig, keyNew ("spec/elektra/intercept/getenv/override/does-exist", KEY_META, "context",
+					    "/elektra/intercept/getenv/override/%layer/name%/does-exist-too", KEY_META, "override/#0",
+					    "/elektra/intercept/getenv/override/does-exist-too", KEY_VALUE, "hello", KEY_END));
 	Key * f = elektraLookupWithContext ("/elektra/intercept/getenv/override/does-exist");
 	EXPECT_EQ (k, f);
 }
@@ -145,8 +154,8 @@ TEST (Context, NameExplicit)
 
 	elektraOpen (&argc, argv);
 	ksAppendKey (elektraConfig, keyNew ("system/somewhere/other-name/layer/does-exist", KEY_VALUE, "hello", KEY_END));
-	ksAppendKey (elektraConfig,
-		     keyNew ("system/elektra/intercept/getenv/override/akey", KEY_META, "context", "/somewhere/%name%/%layer%/does-exist", KEY_END));
+	ksAppendKey (elektraConfig, keyNew ("system/elektra/intercept/getenv/override/akey", KEY_META, "context",
+					    "/somewhere/%name%/%layer%/does-exist", KEY_END));
 	elektraClose ();
 }
 
@@ -155,14 +164,16 @@ TEST (Context, ExistWithContextOverrideCascadingOverrideUser)
 	Key * k;
 	elektraOpen (nullptr, nullptr);
 	ksAppendKey (elektraConfig, keyNew ("user/elektra/intercept/getenv/layer/hostname", KEY_VALUE, "wrongname", KEY_END));
-	ksAppendKey (elektraConfig, keyNew ("spec/elektra/intercept/getenv/layer/hostname", KEY_META, "override/#0", "system/syscall/uname/hostname", KEY_END));
+	ksAppendKey (elektraConfig, keyNew ("spec/elektra/intercept/getenv/layer/hostname", KEY_META, "override/#0",
+					    "system/syscall/uname/hostname", KEY_END));
 	ksAppendKey (elektraConfig, keyNew ("system/syscall/uname/hostname", KEY_VALUE, "localhost", KEY_END));
 	addLayers ();
 
 	ksAppendKey (elektraConfig, keyNew ("user/elektra/intercept/getenv/override/does-exist-too", KEY_VALUE, "wrong", KEY_END));
-	ksAppendKey (elektraConfig, k = keyNew ("user/elektra/intercept/getenv/override/localhost/does-exist-too", KEY_VALUE, "correct", KEY_END));
-	ksAppendKey (elektraConfig, keyNew ("spec/elektra/intercept/getenv/override/does-exist", KEY_META, "context", "/elektra/intercept/getenv/override/%hostname%/does-exist-too",
-					    KEY_VALUE, "hello", KEY_END));
+	ksAppendKey (elektraConfig,
+		     k = keyNew ("user/elektra/intercept/getenv/override/localhost/does-exist-too", KEY_VALUE, "correct", KEY_END));
+	ksAppendKey (elektraConfig, keyNew ("spec/elektra/intercept/getenv/override/does-exist", KEY_META, "context",
+					    "/elektra/intercept/getenv/override/%hostname%/does-exist-too", KEY_VALUE, "hello", KEY_END));
 	Key * f = elektraLookupWithContext ("/elektra/intercept/getenv/override/does-exist");
 	EXPECT_EQ (k, f);
 }
@@ -172,14 +183,16 @@ TEST (Context, ExistWithContextOverrideCascadingOverrideSystem)
 	Key * k;
 	elektraOpen (nullptr, nullptr);
 	ksAppendKey (elektraConfig, keyNew ("system/elektra/intercept/getenv/layer/hostname", KEY_VALUE, "wrongname", KEY_END));
-	ksAppendKey (elektraConfig, keyNew ("spec/elektra/intercept/getenv/layer/hostname", KEY_META, "override/#0", "system/syscall/uname/hostname", KEY_END));
+	ksAppendKey (elektraConfig, keyNew ("spec/elektra/intercept/getenv/layer/hostname", KEY_META, "override/#0",
+					    "system/syscall/uname/hostname", KEY_END));
 	ksAppendKey (elektraConfig, keyNew ("system/syscall/uname/hostname", KEY_VALUE, "localhost", KEY_END));
 	addLayers ();
 
 	ksAppendKey (elektraConfig, keyNew ("user/elektra/intercept/getenv/override/does-exist-too", KEY_VALUE, "wrong", KEY_END));
-	ksAppendKey (elektraConfig, k = keyNew ("user/elektra/intercept/getenv/override/localhost/does-exist-too", KEY_VALUE, "correct", KEY_END));
-	ksAppendKey (elektraConfig, keyNew ("spec/elektra/intercept/getenv/override/does-exist", KEY_META, "context", "/elektra/intercept/getenv/override/%hostname%/does-exist-too",
-					    KEY_VALUE, "hello", KEY_END));
+	ksAppendKey (elektraConfig,
+		     k = keyNew ("user/elektra/intercept/getenv/override/localhost/does-exist-too", KEY_VALUE, "correct", KEY_END));
+	ksAppendKey (elektraConfig, keyNew ("spec/elektra/intercept/getenv/override/does-exist", KEY_META, "context",
+					    "/elektra/intercept/getenv/override/%hostname%/does-exist-too", KEY_VALUE, "hello", KEY_END));
 	Key * f = elektraLookupWithContext ("/elektra/intercept/getenv/override/does-exist");
 	EXPECT_EQ (k, f);
 }
@@ -188,14 +201,16 @@ TEST (Context, ExistWithContextOverrideCascadingOverride)
 {
 	Key * k;
 	elektraOpen (nullptr, nullptr);
-	ksAppendKey (elektraConfig, keyNew ("spec/elektra/intercept/getenv/layer/hostname", KEY_META, "override/#0", "system/syscall/uname/hostname", KEY_END));
+	ksAppendKey (elektraConfig, keyNew ("spec/elektra/intercept/getenv/layer/hostname", KEY_META, "override/#0",
+					    "system/syscall/uname/hostname", KEY_END));
 	ksAppendKey (elektraConfig, keyNew ("system/syscall/uname/hostname", KEY_VALUE, "localhost", KEY_END));
 	addLayers ();
 
 	ksAppendKey (elektraConfig, keyNew ("user/elektra/intercept/getenv/override/does-exist-too", KEY_VALUE, "wrong", KEY_END));
-	ksAppendKey (elektraConfig, k = keyNew ("user/elektra/intercept/getenv/override/localhost/does-exist-too", KEY_VALUE, "correct", KEY_END));
-	ksAppendKey (elektraConfig, keyNew ("spec/elektra/intercept/getenv/override/does-exist", KEY_META, "context", "/elektra/intercept/getenv/override/%hostname%/does-exist-too",
-					    KEY_VALUE, "hello", KEY_END));
+	ksAppendKey (elektraConfig,
+		     k = keyNew ("user/elektra/intercept/getenv/override/localhost/does-exist-too", KEY_VALUE, "correct", KEY_END));
+	ksAppendKey (elektraConfig, keyNew ("spec/elektra/intercept/getenv/override/does-exist", KEY_META, "context",
+					    "/elektra/intercept/getenv/override/%hostname%/does-exist-too", KEY_VALUE, "hello", KEY_END));
 	Key * f = elektraLookupWithContext ("/elektra/intercept/getenv/override/does-exist");
 	EXPECT_EQ (k, f);
 }

--- a/src/libs/getenv/tests/test_getenv.cpp
+++ b/src/libs/getenv/tests/test_getenv.cpp
@@ -69,7 +69,7 @@ TEST (GetEnv, ExistFallbackFallback)
 {
 	using namespace ckdb;
 	elektraOpen (nullptr, nullptr);
-	ksAppendKey (elektraConfig, keyNew ("user/elektra/intercept/getenv/fallback/does-exist-fb", KEY_VALUE, "hello", KEY_END));
+	ksAppendKey (elektraConfig, keyNew ("user/env/fallback/does-exist-fb", KEY_VALUE, "hello", KEY_END));
 	ASSERT_NE (getenv ("does-exist-fb"), static_cast<char *> (nullptr));
 	EXPECT_EQ (getenv ("does-exist-fb"), std::string ("hello"));
 	elektraClose ();

--- a/src/libs/getenv/tests/test_getenv.cpp
+++ b/src/libs/getenv/tests/test_getenv.cpp
@@ -19,7 +19,7 @@ TEST (GetEnv, ExistOverride)
 {
 	using namespace ckdb;
 	elektraOpen (nullptr, nullptr);
-	ksAppendKey (elektraConfig, keyNew ("user/env/override/does-exist", KEY_VALUE, "hello", KEY_END));
+	ksAppendKey (elektraConfig, keyNew ("user/elektra/intercept/getenv/override/does-exist", KEY_VALUE, "hello", KEY_END));
 	ASSERT_NE (getenv ("does-exist"), static_cast<char *> (nullptr));
 	EXPECT_EQ (getenv ("does-exist"), std::string ("hello"));
 	elektraClose ();
@@ -39,7 +39,7 @@ TEST (GetEnv, ExistFallback)
 {
 	using namespace ckdb;
 	elektraOpen (nullptr, nullptr);
-	ksAppendKey (elektraConfig, keyNew ("user/env/fallback/does-exist", KEY_VALUE, "hello", KEY_END));
+	ksAppendKey (elektraConfig, keyNew ("user/elektra/intercept/getenv/fallback/does-exist", KEY_VALUE, "hello", KEY_END));
 	ASSERT_NE (getenv ("does-exist"), static_cast<char *> (nullptr));
 	EXPECT_EQ (getenv ("does-exist"), std::string ("hello"));
 	elektraClose ();
@@ -53,7 +53,7 @@ TEST (GetEnv, OpenClose)
 	elektraOpen (nullptr, nullptr);
 	// EXPECT_NE(elektraConfig, oldElektraConfig); // even its a new object, it might point to same address
 	EXPECT_EQ (getenv ("du4Maiwi/does-not-exist"), static_cast<char *> (nullptr));
-	ksAppendKey (elektraConfig, keyNew ("user/env/override/does-exist", KEY_VALUE, "hello", KEY_END));
+	ksAppendKey (elektraConfig, keyNew ("user/elektra/intercept/getenv/override/does-exist", KEY_VALUE, "hello", KEY_END));
 
 	ASSERT_NE (getenv ("does-exist"), static_cast<char *> (nullptr));
 	EXPECT_EQ (getenv ("does-exist"), std::string ("hello"));
@@ -83,7 +83,7 @@ TEST (GetEnv, ArgvParam)
 	EXPECT_EQ (argv[0], std::string ("name"));
 	EXPECT_EQ (argv[1], static_cast<char *> (nullptr));
 
-	ckdb::Key * k = ksLookupByName (elektraConfig, "proc/env/override/does-exist", 0);
+	ckdb::Key * k = ksLookupByName (elektraConfig, "proc/elektra/intercept/getenv/override/does-exist", 0);
 
 	ASSERT_NE (k, static_cast<ckdb::Key *> (nullptr));
 	EXPECT_EQ (keyString (k), std::string ("hello"));
@@ -111,7 +111,7 @@ TEST (GetEnv, ArgvParamUninvolved)
 	EXPECT_EQ (argv[6], std::string ("-L"));
 	EXPECT_EQ (argv[7], static_cast<char *> (nullptr));
 
-	ckdb::Key * k = ksLookupByName (elektraConfig, "proc/env/override/does-exist", 0);
+	ckdb::Key * k = ksLookupByName (elektraConfig, "proc/elektra/intercept/getenv/override/does-exist", 0);
 
 	ASSERT_NE (k, static_cast<ckdb::Key *> (nullptr));
 	EXPECT_EQ (keyString (k), std::string ("hello"));
@@ -129,11 +129,11 @@ TEST (GetEnv, NameArgv0)
 	char ** argv = const_cast<char **> (cargv);
 
 	elektraOpen (&argc, argv);
-	ckdb::Key * k = ksLookupByName (elektraConfig, "proc/env/layer/name", 0);
+	ckdb::Key * k = ksLookupByName (elektraConfig, "proc/elektra/intercept/getenv/layer/name", 0);
 	ASSERT_NE (k, static_cast<ckdb::Key *> (nullptr));
 	EXPECT_EQ (keyString (k), std::string ("path/to/any-name"));
 
-	k = ksLookupByName (elektraConfig, "proc/env/layer/basename", 0);
+	k = ksLookupByName (elektraConfig, "proc/elektra/intercept/getenv/layer/basename", 0);
 	ASSERT_NE (k, static_cast<ckdb::Key *> (nullptr));
 	EXPECT_EQ (keyString (k), std::string ("any-name"));
 	elektraClose ();
@@ -148,7 +148,7 @@ TEST (GetEnv, NameExplicit)
 	char ** argv = const_cast<char **> (cargv);
 
 	elektraOpen (&argc, argv);
-	ckdb::Key * k = ksLookupByName (elektraConfig, "proc/env/layer/name", 0);
+	ckdb::Key * k = ksLookupByName (elektraConfig, "proc/elektra/intercept/getenv/layer/name", 0);
 	ASSERT_NE (k, static_cast<ckdb::Key *> (nullptr));
 	EXPECT_EQ (keyString (k), std::string ("other-name"));
 	elektraClose ();

--- a/src/libs/getenv/tests/test_getenv.cpp
+++ b/src/libs/getenv/tests/test_getenv.cpp
@@ -25,6 +25,16 @@ TEST (GetEnv, ExistOverride)
 	elektraClose ();
 }
 
+TEST (GetEnv, ExistOverrideFallback)
+{
+	using namespace ckdb;
+	elektraOpen (nullptr, nullptr);
+	ksAppendKey (elektraConfig, keyNew ("user/env/override/does-exist-fb", KEY_VALUE, "hello", KEY_END));
+	ASSERT_NE (getenv ("does-exist-fb"), static_cast<char *> (nullptr));
+	EXPECT_EQ (getenv ("does-exist-fb"), std::string ("hello"));
+	elektraClose ();
+}
+
 TEST (GetEnv, ExistEnv)
 {
 	using namespace ckdb;
@@ -32,6 +42,16 @@ TEST (GetEnv, ExistEnv)
 	setenv ("does-exist", "hello", 1);
 	ASSERT_NE (getenv ("does-exist"), static_cast<char *> (nullptr));
 	EXPECT_EQ (getenv ("does-exist"), std::string ("hello"));
+	elektraClose ();
+}
+
+TEST (GetEnv, ExistEnvFallback)
+{
+	using namespace ckdb;
+	elektraOpen (nullptr, nullptr);
+	setenv ("does-exist-fb", "hello", 1);
+	ASSERT_NE (getenv ("does-exist-fb"), static_cast<char *> (nullptr));
+	EXPECT_EQ (getenv ("does-exist-fb"), std::string ("hello"));
 	elektraClose ();
 }
 
@@ -45,6 +65,15 @@ TEST (GetEnv, ExistFallback)
 	elektraClose ();
 }
 
+TEST (GetEnv, ExistFallbackFallback)
+{
+	using namespace ckdb;
+	elektraOpen (nullptr, nullptr);
+	ksAppendKey (elektraConfig, keyNew ("user/elektra/intercept/getenv/fallback/does-exist-fb", KEY_VALUE, "hello", KEY_END));
+	ASSERT_NE (getenv ("does-exist-fb"), static_cast<char *> (nullptr));
+	EXPECT_EQ (getenv ("does-exist-fb"), std::string ("hello"));
+	elektraClose ();
+}
 
 TEST (GetEnv, OpenClose)
 {
@@ -58,6 +87,21 @@ TEST (GetEnv, OpenClose)
 	ASSERT_NE (getenv ("does-exist"), static_cast<char *> (nullptr));
 	EXPECT_EQ (getenv ("does-exist"), std::string ("hello"));
 	EXPECT_EQ (getenv ("du4Maiwi/does-not-exist"), static_cast<char *> (nullptr));
+	elektraClose ();
+}
+
+TEST (GetEnv, OpenCloseFallback)
+{
+	using namespace ckdb;
+	// KeySet *oldElektraConfig = elektraConfig;
+	elektraOpen (nullptr, nullptr);
+	// EXPECT_NE(elektraConfig, oldElektraConfig); // even its a new object, it might point to same address
+	EXPECT_EQ (getenv ("du4Maiwi/does-not-exist-fb"), static_cast<char *> (nullptr));
+	ksAppendKey (elektraConfig, keyNew ("user/env/override/does-exist-fb", KEY_VALUE, "hello", KEY_END));
+
+	ASSERT_NE (getenv ("does-exist-fb"), static_cast<char *> (nullptr));
+	EXPECT_EQ (getenv ("does-exist-fb"), std::string ("hello"));
+	EXPECT_EQ (getenv ("du4Maiwi/does-not-exist-fb"), static_cast<char *> (nullptr));
 	elektraClose ();
 }
 


### PR DESCRIPTION
# Purpose

moved `open` and `getenv` configuration to `/elektra/intercept/...` (+ keep `/env` as fallback for `getenv`)

getenv: looks up `/elektra/intercept/getenv` configs first, if not found, try `/env` configs. `/elektra/intercept/getenv` is always preferred over `/env` 

# Checklist

- [x] commit messages are fine (with references to issues)
- [x] I ran all tests and everything went fine
- [x] I added unit tests
- [ ] affected documentation is fixed
- [ ] I added code comments, logging, and assertions
- [ ] meta data is updated (e.g. README.md of plugins)

@markus2330 please review my pull request
