### PR TITLE
crypto-plugin: add /usr/bin/gpg as second fallback

### DIFF
--- a/src/plugins/crypto/gpg.c
+++ b/src/plugins/crypto/gpg.c
@@ -199,33 +199,28 @@ static int getGpgBinary (char ** gpgBin, KeySet * conf, Key * errorKey)
 
 	// last resort number one - check for gpg2 at /usr/bin/gpg2
 	// NOTE this might happen if the PATH variable is empty
-	*gpgBin = elektraStrDup (ELEKTRA_CRYPTO_DEFAULT_GPG2_BIN);
-	if (!(*gpgBin))
+	if (isExecutable (ELEKTRA_CRYPTO_DEFAULT_GPG2_BIN, NULL) == 0)
 	{
-		ELEKTRA_SET_ERROR (87, errorKey, "Memory allocation failed");
-		return -1;
-	}
-
-	if (isExecutable (*gpgBin, NULL) == 0)
-	{
+		*gpgBin = elektraStrDup (ELEKTRA_CRYPTO_DEFAULT_GPG2_BIN);
+		if (!(*gpgBin))
+		{
+			ELEKTRA_SET_ERROR (87, errorKey, "Memory allocation failed");
+			return -1;
+		}
 		return 1;
 	}
-	elektraFree (*gpgBin);
 
 	// last last resort - check for /usr/bin/gpg
-	*gpgBin = elektraStrDup (ELEKTRA_CRYPTO_DEFAULT_GPG1_BIN);
-	if (!(*gpgBin))
+	if (isExecutable (ELEKTRA_CRYPTO_DEFAULT_GPG1_BIN, NULL) == 0)
 	{
-		ELEKTRA_SET_ERROR (87, errorKey, "Memory allocation failed");
-		return -1;
-	}
-
-	if (isExecutable (*gpgBin, NULL) == 0)
-	{
+		*gpgBin = elektraStrDup (ELEKTRA_CRYPTO_DEFAULT_GPG1_BIN);
+		if (!(*gpgBin))
+		{
+			ELEKTRA_SET_ERROR (87, errorKey, "Memory allocation failed");
+			return -1;
+		}
 		return 1;
 	}
-	elektraFree (*gpgBin);
-	*gpgBin = NULL;
 
 	// no GPG for us :-(
 	ELEKTRA_SET_ERROR (ELEKTRA_ERROR_CRYPTO_GPG, errorKey, "no gpg binary found. Please make sure GnuPG is installed and executable.");

--- a/src/plugins/crypto/gpg.c
+++ b/src/plugins/crypto/gpg.c
@@ -28,7 +28,7 @@ static inline void closePipe (int * pipe)
  * @brief checks whether or not a given file exists and is executable.
  * @param file holds the path to the file that should be checked
  * @param errorKey holds an error description if the file does not exist or if it is not executable. Ignored if set to NULL.
- * @retval 0 if the file exists and is executable
+ * @retval 1 if the file exists and is executable
  * @retval -1 if the file can not be found
  * @retval -2 if the file exsits but it can not be executed
 */
@@ -52,7 +52,7 @@ static int isExecutable (const char * file, Key * errorKey)
 		return -2;
 	}
 
-	return 0;
+	return 1;
 }
 
 /**
@@ -199,7 +199,7 @@ static int getGpgBinary (char ** gpgBin, KeySet * conf, Key * errorKey)
 
 	// last resort number one - check for gpg2 at /usr/bin/gpg2
 	// NOTE this might happen if the PATH variable is empty
-	if (isExecutable (ELEKTRA_CRYPTO_DEFAULT_GPG2_BIN, NULL) == 0)
+	if (isExecutable (ELEKTRA_CRYPTO_DEFAULT_GPG2_BIN, NULL) == 1)
 	{
 		*gpgBin = elektraStrDup (ELEKTRA_CRYPTO_DEFAULT_GPG2_BIN);
 		if (!(*gpgBin))
@@ -211,7 +211,7 @@ static int getGpgBinary (char ** gpgBin, KeySet * conf, Key * errorKey)
 	}
 
 	// last last resort - check for /usr/bin/gpg
-	if (isExecutable (ELEKTRA_CRYPTO_DEFAULT_GPG1_BIN, NULL) == 0)
+	if (isExecutable (ELEKTRA_CRYPTO_DEFAULT_GPG1_BIN, NULL) == 1)
 	{
 		*gpgBin = elektraStrDup (ELEKTRA_CRYPTO_DEFAULT_GPG1_BIN);
 		if (!(*gpgBin))
@@ -376,7 +376,7 @@ int elektraCryptoGpgCall (KeySet * conf, Key * errorKey, Key * msgKey, char * ar
 	argv[argc - 1] = NULL;
 
 	// check that the gpg binary exists and that it is executable
-	if (isExecutable (argv[0], errorKey) < 0)
+	if (isExecutable (argv[0], errorKey) != 1)
 	{
 		elektraFree (argv[0]);
 		return -1; // error set by isExecutable()

--- a/src/plugins/crypto/gpg.c
+++ b/src/plugins/crypto/gpg.c
@@ -199,7 +199,7 @@ static int getGpgBinary (char ** gpgBin, KeySet * conf, Key * errorKey)
 
 	// last resort number one - check for gpg2 at /usr/bin/gpg2
 	// NOTE this might happen if the PATH variable is empty
-	*gpgBin = strdup (ELEKTRA_CRYPTO_DEFAULT_GPG2_BIN);
+	*gpgBin = elektraStrDup (ELEKTRA_CRYPTO_DEFAULT_GPG2_BIN);
 	if (!(*gpgBin))
 	{
 		ELEKTRA_SET_ERROR (87, errorKey, "Memory allocation failed");
@@ -213,7 +213,7 @@ static int getGpgBinary (char ** gpgBin, KeySet * conf, Key * errorKey)
 	elektraFree (*gpgBin);
 
 	// last last resort - check for /usr/bin/gpg
-	*gpgBin = strdup (ELEKTRA_CRYPTO_DEFAULT_GPG1_BIN);
+	*gpgBin = elektraStrDup (ELEKTRA_CRYPTO_DEFAULT_GPG1_BIN);
 	if (!(*gpgBin))
 	{
 		ELEKTRA_SET_ERROR (87, errorKey, "Memory allocation failed");

--- a/src/plugins/crypto/gpg.h
+++ b/src/plugins/crypto/gpg.h
@@ -16,7 +16,8 @@
 #define ELEKTRA_CRYPTO_PARAM_GPG_BIN "/gpg/bin"
 #define ELEKTRA_CRYPTO_PARAM_GPG_KEY "/gpg/key"
 #define ELEKTRA_CRYPTO_PARAM_GPG_UNIT_TEST "/gpg/unit_test"
-#define ELEKTRA_CRYPTO_DEFAULT_GPG_BIN "/usr/bin/gpg2"
+#define ELEKTRA_CRYPTO_DEFAULT_GPG2_BIN "/usr/bin/gpg2"
+#define ELEKTRA_CRYPTO_DEFAULT_GPG1_BIN "/usr/bin/gpg"
 
 int elektraCryptoGpgEncryptMasterPassword (KeySet * conf, Key * errorKey, Key * msgKey);
 int elektraCryptoGpgDecryptMasterPassword (KeySet * conf, Key * errorKey, Key * msgKey);


### PR DESCRIPTION
# Purpose

If the PATH environment variable is empty we check if `/usr/bin/gpg2` or `/usr/bin/gpg` is available as a fallback.

Fixes #940.

# Checklist

Please only check relevant points.
For docu fixes, spell checking and similar nothing
needs to be checked.

- [x] commit messages are fine (with references to issues)
- [x] I ran all tests and everything went fine
- [ ] I added unit tests
- [ ] affected documentation is fixed
- [ ] I added code comments, logging, and assertions
- [ ] meta data is updated (e.g. README.md of plugins)

@markus2330 please review my pull request
