### PR TITLE
ENABLE_DEBUG: no RTLD_NODELETE for OpenBSD

### DIFF
--- a/src/libs/loader/CMakeLists.txt
+++ b/src/libs/loader/CMakeLists.txt
@@ -5,7 +5,9 @@ add_sources (elektra-full "static.c")
 if (BUILD_SHARED)
 	add_sources (elektra-shared "dl.c")
 	add_includes (elektra-shared)
-
+	if (CMAKE_SYSTEM_NAME MATCHES "kOpenBSD.*|OpenBSD.*")
+	    set(OPENBSD TRUE)
+	endif()
 	if (${CMAKE_SYSTEM_NAME} STREQUAL "Windows")
 		set(BUILD_ARGS -DCMAKE_PREFIX_PATH=${CMAKE_PREFIX_PATH}
 			-DCMAKE_INSTALL_PREFIX:PATH=<INSTALL_DIR>

--- a/src/libs/loader/dl.c
+++ b/src/libs/loader/dl.c
@@ -77,7 +77,9 @@ elektraPluginFactory elektraModulesLoad (KeySet * modules, const char * name, Ke
 	Module module;
 	module.handle = dlopen (moduleName,
 #if DEBUG
+#ifdef RTLD_NODELETE
 				RTLD_NODELETE |
+#endif
 #endif
 					RTLD_NOW);
 


### PR DESCRIPTION
# Purpose

don't set RTLD_NODELETE when building with ENABLE_DEBUG on OpenBSD
