### PR TITLE
Base64 plugin

### DIFF
--- a/src/error/specification
+++ b/src/error/specification
@@ -944,3 +944,10 @@ severity:error
 ingroup:plugin
 module:blockresolver
 macro:BLOCKRESOLVER_NO_EOB
+
+number:157
+description:Base64 decoding error. Provided string was not Base64 encoded. The value of the Key has not been modified.
+severity:warning
+ingroup:plugin
+module:base64
+macro:BASE64_DECODING

--- a/src/plugins/README.md
+++ b/src/plugins/README.md
@@ -109,7 +109,7 @@ productive use:
 - [simpleini](simpleini/) is ini without sections
 - [csvstorage](csvstorage/) for csv files
 - [passwd](passwd/) for passwd files
-- [dpkg](dpkg/) reads /var/lib/dpkg/{available,status} 
+- [dpkg](dpkg/) reads /var/lib/dpkg/{available,status}
 - [mozprefs](mozprefs/) for Mozilla preference files
 - [c](c/) writes Elektra C-structures (`ksNew(.. keyNew(...`)
 
@@ -149,12 +149,13 @@ Rewrite unwanted characters with different techniques:
 - [ccode](ccode/) using the technique from arrays in the programming
   language C
 - [hexcode](hexcode/) using hex codes
+- [base64](base64/) using the Base64 encoding scheme (RFC4648)
 
 Transformations:
 
 - [keytometa](keytometa/) transforms keys to metadata
 - [rename](rename/) renames keys according to different rules
-- [boolean](boolean/) canonicalizes boolean keys 
+- [boolean](boolean/) canonicalizes boolean keys
 
 Doing other stuff:
 

--- a/src/plugins/base64/CMakeLists.txt
+++ b/src/plugins/base64/CMakeLists.txt
@@ -1,0 +1,13 @@
+include (LibAddPlugin)
+
+add_plugin (base64
+	SOURCES
+		base64.h
+		base64.c
+	COMPILE_DEFINITIONS
+		ELEKTRA_PLUGIN_NAME=\"base64\"
+)
+
+if (ADDTESTING_PHASE)
+	add_plugintest (base64)
+endif ()

--- a/src/plugins/base64/README.md
+++ b/src/plugins/base64/README.md
@@ -13,11 +13,26 @@
 
 ## Introduction ##
 
+The Base64 Encoding (specified in [RFC4648](https://www.ietf.org/rfc/rfc4648.txt)) is used to encode arbitrary binary data to ASCII strings.
 
+This is useful for configuration files that must contain ASCII or Unicode strings only.
 
+The `base64` plugin encodes all binary values before `kdb set` writes the configuration to the file.
+The values are decoded back to its original value after `kdb get` has read from the configuration file.
+
+In order to identify the base64 encoded content, the values are marked with a prefix (see section Configuration).
 
 ## Examples ##
 
-
+    kdb mount test.ecf /test base64 /base64/prefix="encodedContent-"
 
 ## Configuration ##
+
+A custom prefix can be provided in the plugin configuration at `/base64/prefix`.
+If no such Key is provided, then `"bin:"` is used as default.
+
+Please provide a prefix that is not used otherwise within your configuration to avoid decoding mistakes.
+
+If you provide `/base64/prefix="binaryData:"` as plugin configuration all encoded values will look like
+
+    binaryData:SGVsbG8gV29ybGQhCg==

--- a/src/plugins/base64/README.md
+++ b/src/plugins/base64/README.md
@@ -1,0 +1,23 @@
+- infos = Information about base64 plugin is in keys below
+- infos/author = Peter Nirschl <peter.nirschl@gmail.com>
+- infos/licence = BSD
+- infos/provides = filefilter
+- infos/needs =
+- infos/recommends =
+- infos/placements = postgetstorage presetstorage
+- infos/status = experimental
+- infos/metadata =
+- infos/description = Base64 Encoding
+
+# base64 Plugin #
+
+## Introduction ##
+
+
+
+
+## Examples ##
+
+
+
+## Configuration ##

--- a/src/plugins/base64/README.md
+++ b/src/plugins/base64/README.md
@@ -5,7 +5,7 @@
 - infos/needs =
 - infos/recommends =
 - infos/placements = postgetstorage presetstorage
-- infos/status = experimental
+- infos/status = experimental maintained unittest nodep libc final
 - infos/metadata =
 - infos/description = Base64 Encoding
 

--- a/src/plugins/base64/README.md
+++ b/src/plugins/base64/README.md
@@ -15,7 +15,7 @@
 
 The Base64 Encoding (specified in [RFC4648](https://www.ietf.org/rfc/rfc4648.txt)) is used to encode arbitrary binary data to ASCII strings.
 
-This is useful for configuration files that must contain ASCII or Unicode strings only.
+This is useful for configuration files that must contain ASCII strings only.
 
 The `base64` plugin encodes all binary values before `kdb set` writes the configuration to the file.
 The values are decoded back to its original value after `kdb get` has read from the configuration file.

--- a/src/plugins/base64/README.md
+++ b/src/plugins/base64/README.md
@@ -20,19 +20,17 @@ This is useful for configuration files that must contain ASCII strings only.
 The `base64` plugin encodes all binary values before `kdb set` writes the configuration to the file.
 The values are decoded back to its original value after `kdb get` has read from the configuration file.
 
-In order to identify the base64 encoded content, the values are marked with a prefix (see section Configuration).
+In order to identify the base64 encoded content, the values are marked with the prefix `@BASE64`.
+To distinguish between the `@` as character and `@` as Base64 marker, all strings starting with `@` will be modified so that they begin with `@@`.
+
+See the documentation of the [null plugin](../null/), as it uses the same pattern for masking `@`.
 
 ## Examples ##
 
-    kdb mount test.ecf /test base64 /base64/prefix="encodedContent-"
+To mount a simple backend that uses the Base64 encoding, you can use:
 
-## Configuration ##
+    kdb mount test.ecf /test base64
 
-A custom prefix can be provided in the plugin configuration at `/base64/prefix`.
-If no such Key is provided, then `"bin:"` is used as default.
+All encoded binary values will look something like this:
 
-Please provide a prefix that is not used otherwise within your configuration to avoid decoding mistakes.
-
-If you provide `/base64/prefix="binaryData:"` as plugin configuration all encoded values will look like
-
-    binaryData:SGVsbG8gV29ybGQhCg==
+    @BASE64SGVsbG8gV29ybGQhCg==

--- a/src/plugins/base64/base64.c
+++ b/src/plugins/base64/base64.c
@@ -12,6 +12,7 @@
 #endif
 #include "base64.h"
 #include <kdb.h>
+#include <kdbassert.h>
 #include <kdberrors.h>
 #include <stdlib.h>
 #include <string.h>
@@ -37,6 +38,7 @@ char * ELEKTRA_PLUGIN_FUNCTION (ELEKTRA_PLUGIN_NAME, base64Encode) (const kdb_oc
 	{
 		encodedLength = ((inputLength + (3 - (inputLength % 3))) / 3 * 4) + 1;
 	}
+	ELEKTRA_ASSERT (encodedLength > 0, "Base64 output array size smaller or equal to 0.");
 
 	size_t out = 0;
 	char * encoded = elektraMalloc (encodedLength);

--- a/src/plugins/base64/base64.c
+++ b/src/plugins/base64/base64.c
@@ -1,0 +1,125 @@
+/**
+ * @file
+ *
+ * @brief filter plugin for the Base64 encoding
+ *
+ * @copyright BSD License (see doc/COPYING or http://www.libelektra.org)
+ *
+ */
+
+#ifndef HAVE_KDBCONFIG
+#include "kdbconfig.h"
+#endif
+#include "base64.h"
+#include <kdb.h>
+#include <kdberrors.h>
+#include <stdlib.h>
+#include <string.h>
+
+static const char * alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+static const char padding = '=';
+
+/**
+ * @brief encodes arbitrary binary data using the Base64 encoding scheme (RFC4648)
+ * @param input holds the data to be encoded
+ * @param inputLength tells how many bytes the input buffer is holding.
+ * @returns an allocated string holding the Base64 encoded input data or NULL if the string can not be allocated. Must be freed by the caller.
+ */
+char * ELEKTRA_PLUGIN_FUNCTION (ELEKTRA_PLUGIN_NAME, base64Encode) (kdb_octet_t * input, size_t inputLength)
+{
+	size_t out = 0;
+	char * encoded = elektraMalloc (2 * inputLength + 1);
+	if (!encoded) return NULL;
+
+	for (size_t i = 0; i < inputLength; i += 3)
+	{
+		if (inputLength - i < 3)
+		{
+			// padding required
+			kdb_octet_t padded[3] = { 0 };
+			memcpy (padded, input + i, inputLength - i);
+
+			encoded[out++] = alphabet[padded[0] >> 2];
+			encoded[out++] = alphabet[((padded[0] << 4) + (padded[1] >> 4)) & 0x3f];
+
+			if (inputLength - i == 2)
+			{
+				// 2 octets available in input
+				encoded[out++] = alphabet[((padded[1] << 2) + (padded[2] >> 6)) & 0x3f];
+				encoded[out++] = padding;
+			}
+			else
+			{
+				// 1 octet available in input
+				encoded[out++] = padding;
+				encoded[out++] = padding;
+			}
+		}
+		else
+		{
+			// no padding required
+			encoded[out++] = alphabet[input[i] >> 2];
+			encoded[out++] = alphabet[((input[i] << 4) + (input[i + 1] >> 4)) & 0x3f];
+			encoded[out++] = alphabet[((input[i + 1] << 2) + (input[i + 2] >> 6)) & 0x3f];
+			encoded[out++] = alphabet[input[i + 2] & 0x3f];
+		}
+	}
+	encoded[out++] = '\0';
+	return encoded;
+}
+
+/**
+ * @brief decodes Base64 encoded data.
+ * @param input holds the Base64 encoded data string
+ * @param output will be set to an allocated buffer holding the decoded data. Must be freed by the caller.
+ * @param outputLength will be set to the amount of decoded bytes.
+ * @retval 1 on success
+ * @retval -1 if the provided string has not been encoded with Base64
+ */
+int ELEKTRA_PLUGIN_FUNCTION (ELEKTRA_PLUGIN_NAME, base64Decode) (const char * input, kdb_octet_t ** output, size_t * outputLength)
+{
+	// TODO implement decoding
+	return 1;
+}
+
+/**
+ * @brief establish the Elektra plugin contract and decrypt the file provded at parentKey using GPG.
+ * @retval 1 on success
+ * @retval -1 on failure
+ */
+int ELEKTRA_PLUGIN_FUNCTION (ELEKTRA_PLUGIN_NAME, get) (Plugin * handle, KeySet * ks ELEKTRA_UNUSED, Key * parentKey)
+{
+	// Publish module configuration to Elektra (establish the contract)
+	if (!strcmp (keyName (parentKey), "system/elektra/modules/" ELEKTRA_PLUGIN_NAME))
+	{
+		KeySet * moduleConfig = ksNew (30,
+#include "contract.h"
+					       KS_END);
+		ksAppend (ks, moduleConfig);
+		ksDel (moduleConfig);
+		return 1;
+	}
+
+	// TODO base64 decoding
+	return 1;
+}
+
+/**
+ * @brief Encrypt the file provided at parentKey using GPG.
+ * @retval 1 on success
+ * @retval -1 on failure
+ */
+int ELEKTRA_PLUGIN_FUNCTION (ELEKTRA_PLUGIN_NAME, set) (Plugin * handle, KeySet * ks ELEKTRA_UNUSED, Key * parentKey)
+{
+	// TODO base64 encoding
+	return 1;
+}
+
+Plugin * ELEKTRA_PLUGIN_EXPORT (base64)
+{
+	// clang-format off
+	return elektraPluginExport(ELEKTRA_PLUGIN_NAME,
+			ELEKTRA_PLUGIN_GET,   &ELEKTRA_PLUGIN_FUNCTION(ELEKTRA_PLUGIN_NAME, get),
+			ELEKTRA_PLUGIN_SET,   &ELEKTRA_PLUGIN_FUNCTION(ELEKTRA_PLUGIN_NAME, set),
+			ELEKTRA_PLUGIN_END);
+}

--- a/src/plugins/base64/base64.c
+++ b/src/plugins/base64/base64.c
@@ -16,8 +16,8 @@
 #include <stdlib.h>
 #include <string.h>
 
-static const char * alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
-#define ALPHABET_LENGTH (64)
+static const char alphabet[] = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+#define ALPHABET_LENGTH (sizeof (alphabet) - 1)
 static const char padding = '=';
 
 /**
@@ -43,7 +43,7 @@ static const char * getPrefix (KeySet * config)
  */
 char * ELEKTRA_PLUGIN_FUNCTION (ELEKTRA_PLUGIN_NAME, base64Encode) (const kdb_octet_t * input, const size_t inputLength)
 {
-	size_t encodedLength;
+	size_t encodedLength = 0;
 	if (inputLength % 3 == 0)
 	{
 		encodedLength = (inputLength / 3 * 4) + 1;

--- a/src/plugins/base64/base64.c
+++ b/src/plugins/base64/base64.c
@@ -151,11 +151,11 @@ int ELEKTRA_PLUGIN_FUNCTION (ELEKTRA_PLUGIN_NAME, base64Decode) (const char * in
 		(*output)[outputIndex++] = (b0 << 2) + (b1 >> 4);
 		if (input[i + 2] != padding)
 		{
-			(*output)[outputIndex++] = ((b1 & 0x0f) << 4) + (b2 >> 2);
+			(*output)[outputIndex++] = (b1 << 4) + (b2 >> 2);
 		}
 		if (input[i + 3] != padding)
 		{
-			(*output)[outputIndex++] = ((b2 & 0x03) << 6) + b3;
+			(*output)[outputIndex++] = (b2 << 6) + b3;
 		}
 	}
 	return 1;

--- a/src/plugins/base64/base64.c
+++ b/src/plugins/base64/base64.c
@@ -28,8 +28,18 @@ static const char padding = '=';
  */
 char * ELEKTRA_PLUGIN_FUNCTION (ELEKTRA_PLUGIN_NAME, base64Encode) (kdb_octet_t * input, size_t inputLength)
 {
+	size_t encodedLength;
+	if (inputLength % 3 == 0)
+	{
+		encodedLength = (inputLength / 3 * 4) + 1;
+	}
+	else
+	{
+		encodedLength = ((inputLength + (3 - (inputLength % 3))) / 3 * 4) + 1;
+	}
+
 	size_t out = 0;
-	char * encoded = elektraMalloc (2 * inputLength + 1);
+	char * encoded = elektraMalloc (encodedLength);
 	if (!encoded) return NULL;
 
 	for (size_t i = 0; i < inputLength; i += 3)

--- a/src/plugins/base64/base64.h
+++ b/src/plugins/base64/base64.h
@@ -14,8 +14,9 @@
 #include <kdbtypes.h>
 #include <stdio.h>
 
-#define ELEKTRA_PLUGIN_BASE64_PARAM_PREFIX "/base64/prefix"
-#define ELEKTRA_PLUGIN_BASE64_DEFAULT_PREFIX "bin:"
+#define ELEKTRA_PLUGIN_BASE64_PREFIX "@BASE64"
+#define ELEKTRA_PLUGIN_BASE64_ESCAPE "@"
+#define ELEKTRA_PLUGIN_BASE64_ESCAPE_CHAR '@'
 
 // encoding functions
 char * ELEKTRA_PLUGIN_FUNCTION (ELEKTRA_PLUGIN_NAME, base64Encode) (const kdb_octet_t * input, const size_t inputLength);

--- a/src/plugins/base64/base64.h
+++ b/src/plugins/base64/base64.h
@@ -1,0 +1,27 @@
+/**
+ * @file
+ *
+ * @brief filter plugin for the Base64 encoding
+ *
+ * @copyright BSD License (see doc/COPYING or http://www.libelektra.org)
+ *
+ */
+
+#ifndef ELEKTRA_PLUGIN_BASE64_H
+#define ELEKTRA_PLUGIN_BASE64_H
+
+#include <kdbplugin.h>
+#include <kdbtypes.h>
+#include <stdio.h>
+
+// encoding functions
+char * ELEKTRA_PLUGIN_FUNCTION (ELEKTRA_PLUGIN_NAME, base64Encode) (kdb_octet_t * input, size_t inputLength);
+int ELEKTRA_PLUGIN_FUNCTION (ELEKTRA_PLUGIN_NAME, base64Decode) (const char * input, kdb_octet_t ** output, size_t * outputLength);
+
+// kdb functions
+int ELEKTRA_PLUGIN_FUNCTION (ELEKTRA_PLUGIN_NAME, get) (Plugin * handle, KeySet * ks, Key * parentKey);
+int ELEKTRA_PLUGIN_FUNCTION (ELEKTRA_PLUGIN_NAME, set) (Plugin * handle, KeySet * ks, Key * parentKey);
+
+Plugin * ELEKTRA_PLUGIN_EXPORT (base64);
+
+#endif

--- a/src/plugins/base64/base64.h
+++ b/src/plugins/base64/base64.h
@@ -14,8 +14,11 @@
 #include <kdbtypes.h>
 #include <stdio.h>
 
+#define ELEKTRA_PLUGIN_BASE64_PARAM_PREFIX "/base64/prefix"
+#define ELEKTRA_PLUGIN_BASE64_DEFAULT_PREFIX "bin:"
+
 // encoding functions
-char * ELEKTRA_PLUGIN_FUNCTION (ELEKTRA_PLUGIN_NAME, base64Encode) (kdb_octet_t * input, size_t inputLength);
+char * ELEKTRA_PLUGIN_FUNCTION (ELEKTRA_PLUGIN_NAME, base64Encode) (const kdb_octet_t * input, const size_t inputLength);
 int ELEKTRA_PLUGIN_FUNCTION (ELEKTRA_PLUGIN_NAME, base64Decode) (const char * input, kdb_octet_t ** output, size_t * outputLength);
 
 // kdb functions

--- a/src/plugins/base64/contract.h
+++ b/src/plugins/base64/contract.h
@@ -1,0 +1,16 @@
+/**
+ * @file
+ *
+ * @brief
+ *
+ * @copyright BSD License (see doc/COPYING or http://www.libelektra.org)
+ */
+
+keyNew ("system/elektra/modules/" ELEKTRA_PLUGIN_NAME, KEY_VALUE, "base64 plugin waits for your orders", KEY_END),
+	keyNew ("system/elektra/modules/" ELEKTRA_PLUGIN_NAME "/exports", KEY_END),
+	keyNew ("system/elektra/modules/" ELEKTRA_PLUGIN_NAME "/exports/get", KEY_FUNC, ELEKTRA_PLUGIN_FUNCTION (ELEKTRA_PLUGIN_NAME, get),
+		KEY_END),
+	keyNew ("system/elektra/modules/" ELEKTRA_PLUGIN_NAME "/exports/set", KEY_FUNC, ELEKTRA_PLUGIN_FUNCTION (ELEKTRA_PLUGIN_NAME, set),
+		KEY_END),
+#include ELEKTRA_README (base64)
+	keyNew ("system/elektra/modules/" ELEKTRA_PLUGIN_NAME "/infos/version", KEY_VALUE, PLUGINVERSION, KEY_END),

--- a/src/plugins/base64/testmod_base64.c
+++ b/src/plugins/base64/testmod_base64.c
@@ -1,0 +1,181 @@
+/**
+ * @file
+ *
+ * @brief test suite for the fcrypt plugin
+ *
+ * @copyright BSD License (see doc/COPYING or http://www.libelektra.org)
+ *
+ */
+
+#include <kdb.h>
+#include <kdbinternal.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <tests_internal.h>
+#include <tests_plugin.h>
+
+#include "base64.h"
+
+static KeySet * newPluginConfiguration()
+{
+	return ksNew (0, KS_END);
+}
+
+static void test_init ()
+{
+	Plugin * plugin = NULL;
+	Key * parentKey = keyNew ("system", KEY_END);
+	KeySet * modules = ksNew (0, KS_END);
+	KeySet * configKs = newPluginConfiguration ();
+	elektraModulesInit (modules, 0);
+
+	plugin = elektraPluginOpen (ELEKTRA_PLUGIN_NAME, modules, configKs, 0);
+	succeed_if (plugin != 0, "failed to open the plugin");
+	if (plugin)
+	{
+		succeed_if (!strcmp (plugin->name, ELEKTRA_PLUGIN_NAME), "got wrong name");
+
+		KeySet * config = elektraPluginGetConfig (plugin);
+		succeed_if (config != 0, "there should be a config");
+
+		succeed_if (plugin->kdbGet != 0, "no get pointer");
+		succeed_if (plugin->kdbSet != 0, "no set pointer");
+
+		elektraPluginClose (plugin, 0);
+	}
+
+	elektraModulesClose (modules, 0);
+	ksDel (modules);
+	keyDel (parentKey);
+}
+
+static void test_base64_encoding ()
+{
+	// test vectors are defined in RFC4648
+	// see https://www.ietf.org/rfc/rfc4648.txt
+	char * t1 = ELEKTRA_PLUGIN_FUNCTION (ELEKTRA_PLUGIN_NAME, base64Encode) ((kdb_octet_t*)"", 0);
+	succeed_if (t1, "can not allocate string for encoding result");
+	if (t1)
+	{
+		succeed_if (strcmp (t1, "") == 0, "encoding result from test vector 1 does not match");
+		elektraFree (t1);
+	}
+
+	char * t2 = ELEKTRA_PLUGIN_FUNCTION (ELEKTRA_PLUGIN_NAME, base64Encode) ((kdb_octet_t*)"f", 1);
+	succeed_if (t2, "can not allocate string for encoding result");
+	if (t2)
+	{
+		succeed_if (strcmp (t2, "Zg==") == 0, "encoding result from test vector 2 does not match");
+		elektraFree (t2);
+	}
+
+	char * t3 = ELEKTRA_PLUGIN_FUNCTION (ELEKTRA_PLUGIN_NAME, base64Encode) ((kdb_octet_t*)"fo", 2);
+	succeed_if (t3, "can not allocate string for encoding result");
+	if (t3)
+	{
+		succeed_if (strcmp (t3, "Zm8=") == 0, "encoding result from test vector 3 does not match");
+		elektraFree (t3);
+	}
+
+	char * t4 = ELEKTRA_PLUGIN_FUNCTION (ELEKTRA_PLUGIN_NAME, base64Encode) ((kdb_octet_t*)"foo", 3);
+	succeed_if (t4, "can not allocate string for encoding result");
+	if (t4)
+	{
+		succeed_if (strcmp (t4, "Zm9v") == 0, "encoding result from test vector 4 does not match");
+		elektraFree (t4);
+	}
+
+	char * t5 = ELEKTRA_PLUGIN_FUNCTION (ELEKTRA_PLUGIN_NAME, base64Encode) ((kdb_octet_t*)"foob", 4);
+	succeed_if (t5, "can not allocate string for encoding result");
+	if (t1)
+	{
+		succeed_if (strcmp (t5, "Zm9vYg==") == 0, "encoding result from test vector 5 does not match");
+		elektraFree (t5);
+	}
+
+	char * t6 = ELEKTRA_PLUGIN_FUNCTION (ELEKTRA_PLUGIN_NAME, base64Encode) ((kdb_octet_t*)"fooba", 5);
+	succeed_if (t6, "can not allocate string for encoding result");
+	if (t6)
+	{
+		succeed_if (strcmp (t6, "Zm9vYmE=") == 0, "encoding result from test vector 6 does not match");
+		elektraFree (t6);
+	}
+
+	char * t7 = ELEKTRA_PLUGIN_FUNCTION (ELEKTRA_PLUGIN_NAME, base64Encode) ((kdb_octet_t*)"foobar", 6);
+	succeed_if (t7, "can not allocate string for encoding result");
+	if (t7)
+	{
+		succeed_if (strcmp (t7, "Zm9vYmFy") == 0, "encoding result from test vector 7 does not match");
+		elektraFree (t7);
+	}
+}
+
+static void test_base64_decoding ()
+{
+}
+
+/*
+static void test_file_operations ()
+{
+	Plugin * plugin = NULL;
+	Key * parentKey = keyNew ("system", KEY_END);
+	KeySet * modules = ksNew (0, KS_END);
+	KeySet * config = newPluginConfiguration ();
+
+	elektraModulesInit (modules, 0);
+	plugin = elektraPluginOpen (ELEKTRA_PLUGIN_NAME, modules, config, 0);
+	succeed_if (plugin, "failed to open plugin handle");
+	if (plugin)
+	{
+		KeySet * data = ksNew (0, KS_END);
+		char * tmpFile = getTemporaryFileName ();
+		if (tmpFile)
+		{
+			// prepare test file to be encrypted
+			writeTestFile (tmpFile);
+			keySetString (parentKey, tmpFile);
+
+			// try to encrypt the file
+			succeed_if (plugin->kdbSet (plugin, data, parentKey) == 1, "kdb set failed");
+			succeed_if (isTestFileCorrect (tmpFile) == -1, "file content did not change during encryption");
+
+			// try to decrypt the file again (simulating the pregetstorage call)
+			succeed_if (plugin->kdbGet (plugin, data, parentKey) == 1, "kdb get (pregetstorage) failed");
+			succeed_if (isTestFileCorrect (tmpFile) == 1, "file content could not be restored during decryption");
+
+			// a second call to kdb get (the postgetstorage call) should re-encrypt the file again
+			succeed_if (plugin->kdbGet (plugin, data, parentKey) == 1, "kdb get (postgetstorage) failed");
+			succeed_if (isTestFileCorrect (tmpFile) == -1, "postgetstorage did not encrypt the file again");
+
+			remove (tmpFile);
+			elektraFree (tmpFile);
+		}
+
+		ksDel (data);
+		elektraPluginClose (plugin, 0);
+	}
+
+	elektraModulesClose (modules, 0);
+	ksDel (modules);
+	keyDel (parentKey);
+}
+*/
+
+int main (int argc, char ** argv)
+{
+	printf ("FCRYPT       TESTS\n");
+	printf ("==================\n\n");
+
+	init (argc, argv);
+
+	// test the encoding and decoding process
+	test_base64_encoding ();
+	test_base64_decoding ();
+
+	// test the plugin functionality
+	test_init ();
+
+	printf ("\n" ELEKTRA_PLUGIN_NAME " RESULTS: %d test(s) done. %d error(s).\n", nbTest, nbError);
+	return nbError;
+}


### PR DESCRIPTION
# Purpose

The Base64 Encoding (specified in [RFC4648](https://www.ietf.org/rfc/rfc4648.txt)) is used to encode arbitrary binary data to ASCII strings.

This is useful for configuration files that must contain ASCII or Unicode strings only.

The `base64` plugin encodes all binary values before `kdb set` writes the configuration to the file.
The values are decoded back to its original value after `kdb get` has read from the configuration file.

In order to identify the base64 encoded content, the values are marked with a prefix (see `README.md`).

See #897 for discussion.

# Checklist

Please only check relevant points.
For docu fixes, spell checking and similar nothing
needs to be checked.

- [x] commit messages are fine (with references to issues)
- [x] I ran all tests and everything went fine
- [x] I added unit tests
- [ ] affected documentation is fixed
- [x] I added code comments, logging, and assertions
- [ ] meta data is updated (e.g. README.md of plugins)

@markus2330 please review my pull request
