### PR TITLE
Fix missing include in keyset.c

### DIFF
--- a/src/libs/elektra/keyset.c
+++ b/src/libs/elektra/keyset.c
@@ -10,7 +10,7 @@
 #include "kdbconfig.h"
 #endif
 
-#if DEBUG && defined(HAVE_STDIO_H)
+#if defined(HAVE_STDIO_H)
 #include <stdio.h>
 #endif
 


### PR DESCRIPTION
# Purpose

`snprintf()` was implicitly used at line 1531. 
Fixes clang compiler warning.

# Checklist

Please only check relevant points.
For docu fixes, spell checking and similar nothing
needs to be checked.

- [x] commit messages are fine (with references to issues)
- [ ] I ran all tests and everything went fine
- [ ] I added unit tests
- [ ] affected documentation is fixed
- [ ] I added code comments, logging, and assertions
- [ ] meta data is updated (e.g. README.md of plugins)

@markus2330 please review my pull request