### PR TITLE
Improve Coding Style in crypto_botan

### DIFF
--- a/src/plugins/crypto/botan_operations.cpp
+++ b/src/plugins/crypto/botan_operations.cpp
@@ -15,9 +15,11 @@
 #include <botan/pipe.h>
 #include <botan/symkey.h>
 #include <kdbplugin.h>
+#include <memory>
 
 using namespace ckdb;
 using namespace Botan;
+using std::unique_ptr;
 
 extern "C" {
 
@@ -33,12 +35,13 @@ extern "C" {
  * @param config KeySet holding the plugin/backend configuration
  * @param errorKey holds an error description in case of failure
  * @param k the (Elektra)-Key to be encrypted
- * @param cKey holds a pointer to an allocated SymmetricKey. Must be freed by the caller.
- * @param cIv holds a pointer to an allocated InitializationVector. Must be freed by the caller.
+ * @param cKey holds a unique pointer to an allocated SymmetricKey.
+ * @param cIv holds a unique pointer to an allocated InitializationVector.
  * @retval -1 on failure. errorKey holds the error description.
  * @retval 1 on success
  */
-static int getKeyIvForEncryption (KeySet * config, Key * errorKey, Key * k, SymmetricKey ** cKey, InitializationVector ** cIv)
+static int getKeyIvForEncryption (KeySet * config, Key * errorKey, Key * k, unique_ptr<SymmetricKey> & cKey,
+				  unique_ptr<InitializationVector> & cIv)
 {
 	byte salt[ELEKTRA_CRYPTO_DEFAULT_SALT_LEN];
 	char * saltHexString = NULL;
@@ -68,8 +71,9 @@ static int getKeyIvForEncryption (KeySet * config, Key * errorKey, Key * k, Symm
 			requiredKeyBytes, std::string (reinterpret_cast<const char *> (keyValue (msg)), keyGetValueSize (msg)), salt,
 			sizeof (salt), iterations);
 
-		*cKey = new SymmetricKey (derived.begin (), ELEKTRA_CRYPTO_BOTAN_KEYSIZE);
-		*cIv = new InitializationVector (derived.begin () + ELEKTRA_CRYPTO_BOTAN_KEYSIZE, ELEKTRA_CRYPTO_BOTAN_BLOCKSIZE);
+		cKey = unique_ptr<SymmetricKey> (new SymmetricKey (derived.begin (), ELEKTRA_CRYPTO_BOTAN_KEYSIZE));
+		cIv = unique_ptr<InitializationVector> (
+			new InitializationVector (derived.begin () + ELEKTRA_CRYPTO_BOTAN_KEYSIZE, ELEKTRA_CRYPTO_BOTAN_BLOCKSIZE));
 
 		delete pbkdf;
 		keyDel (msg);
@@ -89,12 +93,13 @@ static int getKeyIvForEncryption (KeySet * config, Key * errorKey, Key * k, Symm
  * @param config KeySet holding the plugin/backend configuration
  * @param errorKey holds an error description in case of failure
  * @param k the (Elektra)-Key to be encrypted
- * @param cKey holds a pointer to an allocated SymmetricKey. Must be freed by the caller.
- * @param cIv holds a pointer to an allocated InitializationVector. Must be freed by the caller.
+ * @param cKey holds a unique pointer to an allocated SymmetricKey.
+ * @param cIv holds a unique pointer to an allocated InitializationVector.
  * @retval -1 on failure. errorKey holds the error description.
  * @retval 1 on success
  */
-static int getKeyIvForDecryption (KeySet * config, Key * errorKey, Key * k, SymmetricKey ** cKey, InitializationVector ** cIv)
+static int getKeyIvForDecryption (KeySet * config, Key * errorKey, Key * k, unique_ptr<SymmetricKey> & cKey,
+				  unique_ptr<InitializationVector> & cIv)
 {
 	const size_t requiredKeyBytes = ELEKTRA_CRYPTO_BOTAN_KEYSIZE + ELEKTRA_CRYPTO_BOTAN_BLOCKSIZE;
 	kdb_octet_t * saltBuffer;
@@ -125,8 +130,9 @@ static int getKeyIvForDecryption (KeySet * config, Key * errorKey, Key * k, Symm
 			requiredKeyBytes, std::string (reinterpret_cast<const char *> (keyValue (msg)), keyGetValueSize (msg)), saltBuffer,
 			saltBufferLen, iterations);
 
-		*cKey = new SymmetricKey (derived.begin (), ELEKTRA_CRYPTO_BOTAN_KEYSIZE);
-		*cIv = new InitializationVector (derived.begin () + ELEKTRA_CRYPTO_BOTAN_KEYSIZE, ELEKTRA_CRYPTO_BOTAN_BLOCKSIZE);
+		cKey = unique_ptr<SymmetricKey> (new SymmetricKey (derived.begin (), ELEKTRA_CRYPTO_BOTAN_KEYSIZE));
+		cIv = unique_ptr<InitializationVector> (
+			new InitializationVector (derived.begin () + ELEKTRA_CRYPTO_BOTAN_KEYSIZE, ELEKTRA_CRYPTO_BOTAN_BLOCKSIZE));
 
 		delete pbkdf;
 		keyDel (msg);
@@ -158,12 +164,10 @@ int elektraCryptoBotanInit (Key * errorKey)
 int elektraCryptoBotanEncrypt (KeySet * pluginConfig, Key * k, Key * errorKey)
 {
 	// get cryptographic material
-	SymmetricKey * cryptoKey = NULL;
-	InitializationVector * cryptoIv = NULL;
-	if (getKeyIvForEncryption (pluginConfig, errorKey, k, &cryptoKey, &cryptoIv) != 1)
+	unique_ptr<SymmetricKey> cryptoKey;
+	unique_ptr<InitializationVector> cryptoIv;
+	if (getKeyIvForEncryption (pluginConfig, errorKey, k, cryptoKey, cryptoIv) != 1)
 	{
-		if (cryptoKey) delete cryptoKey;
-		if (cryptoIv) delete cryptoIv;
 		return -1;
 	}
 
@@ -234,14 +238,10 @@ int elektraCryptoBotanEncrypt (KeySet * pluginConfig, Key * k, Key * errorKey)
 	catch (std::exception & e)
 	{
 		ELEKTRA_SET_ERRORF (ELEKTRA_ERROR_CRYPTO_ENCRYPT_FAIL, errorKey, "Encryption failed because: %s", e.what ());
-		delete cryptoIv;
-		delete cryptoKey;
 		elektraFree (salt);
 		return -1; // failure
 	}
 
-	delete cryptoIv;
-	delete cryptoKey;
 	elektraFree (salt);
 	return 1; // success
 }
@@ -249,12 +249,10 @@ int elektraCryptoBotanEncrypt (KeySet * pluginConfig, Key * k, Key * errorKey)
 int elektraCryptoBotanDecrypt (KeySet * pluginConfig, Key * k, Key * errorKey)
 {
 	// get cryptographic material
-	SymmetricKey * cryptoKey = NULL;
-	InitializationVector * cryptoIv = NULL;
-	if (getKeyIvForDecryption (pluginConfig, errorKey, k, &cryptoKey, &cryptoIv) != 1)
+	unique_ptr<SymmetricKey> cryptoKey;
+	unique_ptr<InitializationVector> cryptoIv;
+	if (getKeyIvForDecryption (pluginConfig, errorKey, k, cryptoKey, cryptoIv) != 1)
 	{
-		if (cryptoKey) delete cryptoKey;
-		if (cryptoIv) delete cryptoIv;
 		return -1;
 	}
 
@@ -262,8 +260,6 @@ int elektraCryptoBotanDecrypt (KeySet * pluginConfig, Key * k, Key * errorKey)
 	kdb_unsigned_long_t saltLen = 0;
 	if (CRYPTO_PLUGIN_FUNCTION (getSaltFromPayload) (errorKey, k, NULL, &saltLen) != 1)
 	{
-		if (cryptoKey) delete cryptoKey;
-		if (cryptoIv) delete cryptoIv;
 		return -1; // error set by CRYPTO_PLUGIN_FUNCTION(getSaltFromPayload)()
 	}
 	saltLen += sizeof (kdb_unsigned_long_t);
@@ -315,13 +311,9 @@ int elektraCryptoBotanDecrypt (KeySet * pluginConfig, Key * k, Key * errorKey)
 	catch (std::exception & e)
 	{
 		ELEKTRA_SET_ERRORF (ELEKTRA_ERROR_CRYPTO_DECRYPT_FAIL, errorKey, "Decryption failed because: %s", e.what ());
-		delete cryptoIv;
-		delete cryptoKey;
 		return -1; // failure
 	}
 
-	delete cryptoIv;
-	delete cryptoKey;
 	return 1; // success
 }
 

--- a/src/plugins/crypto/botan_operations.cpp
+++ b/src/plugins/crypto/botan_operations.cpp
@@ -66,7 +66,7 @@ static int getKeyIvForEncryption (KeySet * config, Key * errorKey, Key * k, uniq
 		if (!msg) return -1; // error set by CRYPTO_PLUGIN_FUNCTION(getMasterPassword)()
 
 		// generate/derive the cryptographic key and the IV
-		PBKDF * pbkdf = get_pbkdf ("PBKDF2(SHA-256)");
+		unique_ptr<PBKDF> pbkdf = unique_ptr<PBKDF> (get_pbkdf ("PBKDF2(SHA-256)"));
 		OctetString derived = pbkdf->derive_key (
 			requiredKeyBytes, std::string (reinterpret_cast<const char *> (keyValue (msg)), keyGetValueSize (msg)), salt,
 			sizeof (salt), iterations);
@@ -75,7 +75,6 @@ static int getKeyIvForEncryption (KeySet * config, Key * errorKey, Key * k, uniq
 		cIv = unique_ptr<InitializationVector> (
 			new InitializationVector (derived.begin () + ELEKTRA_CRYPTO_BOTAN_KEYSIZE, ELEKTRA_CRYPTO_BOTAN_BLOCKSIZE));
 
-		delete pbkdf;
 		keyDel (msg);
 		return 1;
 	}
@@ -125,7 +124,7 @@ static int getKeyIvForDecryption (KeySet * config, Key * errorKey, Key * k, uniq
 	try
 	{
 		// derive the cryptographic key and the IV
-		PBKDF * pbkdf = get_pbkdf ("PBKDF2(SHA-256)");
+		unique_ptr<PBKDF> pbkdf = unique_ptr<PBKDF> (get_pbkdf ("PBKDF2(SHA-256)"));
 		OctetString derived = pbkdf->derive_key (
 			requiredKeyBytes, std::string (reinterpret_cast<const char *> (keyValue (msg)), keyGetValueSize (msg)), saltBuffer,
 			saltBufferLen, iterations);
@@ -134,7 +133,6 @@ static int getKeyIvForDecryption (KeySet * config, Key * errorKey, Key * k, uniq
 		cIv = unique_ptr<InitializationVector> (
 			new InitializationVector (derived.begin () + ELEKTRA_CRYPTO_BOTAN_KEYSIZE, ELEKTRA_CRYPTO_BOTAN_BLOCKSIZE));
 
-		delete pbkdf;
 		keyDel (msg);
 		return 1;
 	}

--- a/tests/valgrind.suppression
+++ b/tests/valgrind.suppression
@@ -11,24 +11,6 @@
    Memcheck:Leak
    match-leak-kinds: all
    ...
-   fun:_ZN5Botan18LibraryInitializer10initializeERKSs
-   ...
-}
-{
-   <insert_a_suppression_name_here>
-   Memcheck:Leak
-   match-leak-kinds: all
-   ...
-   fun:_ZNSs4_Rep9_S_createEmmRKSaIcE
-   fun:_ZNSs12_S_constructIPKcEEPcT_S3_RKSaIcESt20forward_iterator_tag
-   fun:_ZNSsC1EPKcRKSaIcE
-   ...
-}
-{
-   <insert_a_suppression_name_here>
-   Memcheck:Leak
-   match-leak-kinds: all
-   ...
    obj:*libgcrypt*
    ...
 }


### PR DESCRIPTION
# Purpose

Guard references to `Botan::SymmetricKey` and `Botan::InitializationVector` by `unique_ptr`.

This change made two valgrind suppressions obsolete. They have been removed.

# Checklist

Please only check relevant points.
For docu fixes, spell checking and similar nothing
needs to be checked.

- [x] commit messages are fine (with references to issues)
- [x] I ran all tests and everything went fine
- [ ] I added unit tests
- [ ] affected documentation is fixed
- [ ] I added code comments, logging, and assertions
- [ ] meta data is updated (e.g. README.md of plugins)

@markus2330 please review my pull request
