### PR TITLE
lib-tools: new functions to retrieve list/map of providers

### DIFF
--- a/src/libs/tools/include/plugindatabase.hpp
+++ b/src/libs/tools/include/plugindatabase.hpp
@@ -105,6 +105,33 @@ public:
 	virtual PluginSpec lookupProvides (std::string const & provides) const = 0;
 
 	/**
+	 * @brief looks up all plugins which are a suitable provider
+	 *
+	 * @note in case a plugin name is provided, the plugin with the name will also be
+	 *	 part of the result. But if there are other plugins providing the requirement,
+	 *	 then they will also be part of the result.
+	 *
+	 * @param provides is the provider to find
+	 *
+	 * @return a map of plugins with their status offering the requirement or are named after it
+	 */
+	virtual std::map<int, PluginSpec> lookupAllProvidesWithStatus (std::string const & provides) const = 0;
+
+	/**
+	 * @brief looks up all plugins which are a suitable provider
+	 *
+	 * @note in case a plugin name is provided, the plugin with the name will also be
+	 *	 part of the result. But if there are other plugins providing the requirement,
+	 *	 then they will also be part of the result.
+	 *       The ordering of the resulting vector has no special meaning.
+	 *
+	 * @param provides is the provider to find
+	 *
+	 * @return a vector of plugins offering the requirement or are named after it
+	 */
+	virtual std::vector<PluginSpec> lookupAllProvides (std::string const & provides) const = 0;
+
+	/**
 	 * @param statusString the string encoding the status
 	 *
 	 * @return The representing number for a given status.
@@ -134,6 +161,8 @@ public:
 	func_t getSymbol (PluginSpec const & whichplugin, std::string const & which) const;
 	PluginSpec lookupMetadata (std::string const & which) const;
 	PluginSpec lookupProvides (std::string const & provides) const;
+	std::map<int, PluginSpec> lookupAllProvidesWithStatus (std::string const & provides) const;
+	std::vector<PluginSpec> lookupAllProvides (std::string const & provides) const;
 };
 
 /**

--- a/src/libs/tools/src/plugindatabase.cpp
+++ b/src/libs/tools/src/plugindatabase.cpp
@@ -286,6 +286,22 @@ PluginSpec ModulesPluginDatabase::lookupProvides (std::string const & which) con
 		return PluginSpec (which);
 	}
 
+	std::map<int, PluginSpec> foundPlugins;
+	try
+	{
+		foundPlugins = lookupAllProvidesWithStatus (which);
+	}
+	catch (kdb::tools::NoPlugin & e)
+	{
+		throw e;
+	}
+
+	// the largest element of the map contains the best-suited plugin:
+	return foundPlugins.rbegin ()->second;
+}
+
+std::map<int, PluginSpec> ModulesPluginDatabase::lookupAllProvidesWithStatus (std::string const & which) const
+{
 	std::string errors;
 	std::vector<std::string> allPlugins = listAllPlugins ();
 	std::map<int, PluginSpec> foundPlugins;
@@ -294,22 +310,26 @@ PluginSpec ModulesPluginDatabase::lookupProvides (std::string const & which) con
 		// TODO: make sure (non)-equal plugins (i.e. with same/different contract) are handled correctly
 		try
 		{
+			PluginSpec spec = PluginSpec (
+				plugin,
+				KeySet (5, *Key ("system/module", KEY_VALUE, "this plugin was loaded without a config", KEY_END), KS_END));
+
+			// lets see if there is a plugin named after the required provider
+			if (plugin == which)
+			{
+				int s = calculateStatus (lookupInfo (spec, "status"));
+				foundPlugins.insert (std::make_pair (s, PluginSpec (plugin)));
+				continue; // we are done with this plugin
+			}
+
 			// TODO: support for generic plugins with config
-			std::istringstream ss (
-				lookupInfo (PluginSpec (plugin, KeySet (5, *Key ("system/module", KEY_VALUE,
-										 "this plugin was loaded without a config", KEY_END),
-									KS_END)),
-					    "provides"));
+			std::istringstream ss (lookupInfo (spec, "provides"));
 			std::string provide;
 			while (ss >> provide)
 			{
 				if (provide == which)
 				{
-					int s = calculateStatus (lookupInfo (
-						PluginSpec (plugin, KeySet (5, *Key ("system/module", KEY_VALUE,
-										     "this plugin was loaded without a config", KEY_END),
-									    KS_END)),
-						"status"));
+					int s = calculateStatus (lookupInfo (spec, "status"));
 					foundPlugins.insert (std::make_pair (s, PluginSpec (plugin)));
 				}
 			}
@@ -330,7 +350,27 @@ PluginSpec ModulesPluginDatabase::lookupProvides (std::string const & which) con
 	}
 
 	// the largest element of the map contains the best-suited plugin:
-	return foundPlugins.rbegin ()->second;
+	return foundPlugins;
+}
+
+std::vector<PluginSpec> ModulesPluginDatabase::lookupAllProvides (std::string const & which) const
+{
+	try
+	{
+		const std::map<int, PluginSpec> foundPlugins = lookupAllProvidesWithStatus (which);
+
+		// we found some plugins, lets convert the map into a vector
+		std::vector<PluginSpec> plugins;
+		plugins.reserve (foundPlugins.size ());
+		std::for_each (foundPlugins.begin (), foundPlugins.end (),
+			       [&plugins](const std::map<int, PluginSpec>::value_type & elem) { plugins.push_back (elem.second); });
+		return plugins;
+	}
+	catch (kdb::tools::NoPlugin & e)
+	{
+		// if no plugins were found, return an empty list
+		return std::vector<PluginSpec> ();
+	}
 }
 
 

--- a/src/libs/tools/src/plugindatabase.cpp
+++ b/src/libs/tools/src/plugindatabase.cpp
@@ -280,7 +280,7 @@ PluginSpec ModulesPluginDatabase::lookupMetadata (std::string const & which) con
 
 PluginSpec ModulesPluginDatabase::lookupProvides (std::string const & which) const
 {
-	// check if plugin itself exists:
+	// check if plugin with provider name exists:
 	if (status (PluginSpec (which)) == real)
 	{
 		return PluginSpec (which);
@@ -349,7 +349,6 @@ std::map<int, PluginSpec> ModulesPluginDatabase::lookupAllProvidesWithStatus (st
 			throw NoPlugin ("No plugin that provides " + which + " could be found");
 	}
 
-	// the largest element of the map contains the best-suited plugin:
 	return foundPlugins;
 }
 
@@ -368,7 +367,7 @@ std::vector<PluginSpec> ModulesPluginDatabase::lookupAllProvides (std::string co
 	}
 	catch (kdb::tools::NoPlugin & e)
 	{
-		// if no plugins were found, return an empty list
+		// if no plugins were found, return an empty vector
 		return std::vector<PluginSpec> ();
 	}
 }


### PR DESCRIPTION
# Purpose

Two new functions for lib-tools that allow to lookup a whole bunch of suitable plugins (e.g. a list/map of all storage plugins). The new functions work basically the same as `PluginDatabase::lookupProvides`, except that they return all found plugins and not only the one with highest status rating.

I refactored the code of `ModulesPluginDatabase::lookupProvides` into the new function `ModulesPluginDatabase::lookupAllProvidesWithStatus`, which is used by the old and the new function.

# Checklist

- [X] commit messages are fine (with references to issues)
- [X] I ran all tests and everything went fine
- [X] affected documentation is fixed
- [X] I added code comments, logging, and assertions
- [X] reformat-source script was run
- [ ] I added unit tests
- [ ] meta data is updated (e.g. README.md of plugins)

@markus2330 please review my pull request

