### PR TITLE
XMLTool: Fix Compiler Warning

### DIFF
--- a/src/plugins/xmltool/kdbtools.c
+++ b/src/plugins/xmltool/kdbtools.c
@@ -297,7 +297,7 @@ static int consumeKeySetNode (KeySet * ks, const char * context, xmlTextReaderPt
 		privateContext = xmlTextReaderGetAttribute (reader, (const xmlChar *)"parent");
 		if (context && privateContext)
 		{
-			xmlStrPrintf (fullContext, sizeof (fullContext), (const xmlChar *)"%s/%s", context, privateContext);
+			xmlStrPrintf (fullContext, sizeof (fullContext), "%s/%s", context, privateContext);
 		}
 
 		/* Parse everything else */


### PR DESCRIPTION
# Purpose

This pull request fixes a compiler warning in the XMLTool plugin.

# Checklist

- [x] Commit messages are fine
- [x] I ran all tests and everything went fine

@markus2330 Please review my pull request