### PR TITLE
csvstorage: fixed tests overwriting testfiles + bogus testcase

### DIFF
--- a/src/plugins/csvstorage/testmod_csvstorage.c
+++ b/src/plugins/csvstorage/testmod_csvstorage.c
@@ -59,6 +59,7 @@ static void testreadwriteinvalid (const char * file)
 	PLUGIN_OPEN ("csvstorage");
 	succeed_if (plugin->kdbGet (plugin, ks, parentKey) > 0, "call to kdbGet was not successful");
 	succeed_if (!output_warnings (parentKey), "no warnings in kdbGet");
+	keySetString (parentKey, elektraFilename ());
 	succeed_if (plugin->kdbSet (plugin, ks, parentKey) == (-1), "error: wrote invalid data");
 	ksDel (ks);
 	keyDel (parentKey);
@@ -77,22 +78,24 @@ static void testwriteinvalidheader (const char * file)
 	PLUGIN_OPEN ("csvstorage");
 	succeed_if (plugin->kdbGet (plugin, ks, parentKey) > 0, "call to kdbGet was not successful");
 	succeed_if (!output_warnings (parentKey), "no warnings in kdbGet");
+	keySetString (parentKey, elektraFilename ());
 	succeed_if (plugin->kdbSet (plugin, ks, parentKey) == (-1), "error: wrote invalid data");
 	ksDel (ks);
 	keyDel (parentKey);
 	PLUGIN_CLOSE ();
 }
 
-static void testwritevalidemptycol (const char * file ELEKTRA_UNUSED)
+static void testwritevalidemptycol (const char * file)
 {
 
-	Key * parentKey = keyNew ("user/tests/csvstorage", KEY_VALUE, elektraFilename (), KEY_END);
+	Key * parentKey = keyNew ("user/tests/csvstorage", KEY_VALUE, srcdir_file (file), KEY_END);
 	KeySet * conf = ksNew (20, keyNew ("system/delimiter", KEY_VALUE, ";", KEY_END),
 			       keyNew ("system/header", KEY_VALUE, "colname", KEY_END), KS_END);
 
 	KeySet * ks = ksNew (0, KS_END);
 	PLUGIN_OPEN ("csvstorage");
 	succeed_if (plugin->kdbGet (plugin, ks, parentKey) > 0, "call to kdbGet was not successful");
+	keySetString (parentKey, elektraFilename ());
 	succeed_if (plugin->kdbSet (plugin, ks, parentKey) >= 0, "error: couldn't write data");
 	ksDel (ks);
 	keyDel (parentKey);


### PR DESCRIPTION
forgot to change the parent key value after reading the file, before calling kdbSet 