### PR TITLE
fcrypt: clean up CMakeLists.txt

### DIFF
--- a/src/plugins/fcrypt/CMakeLists.txt
+++ b/src/plugins/fcrypt/CMakeLists.txt
@@ -2,17 +2,12 @@ include (LibAddPlugin)
 
 add_plugin (fcrypt
 	SOURCES
-		../base64/base64_functions.h
-		../base64/base64_functions.c
-		../crypto/helper.h
-		../crypto/helper.c
 		../crypto/gpg.h
 		../crypto/gpg.c
 		fcrypt.h
 		fcrypt.c
 	INCLUDE_DIRECTORIES
 		${CMAKE_SOURCE_DIR}/src/plugins/crypto/
-		${CMAKE_SOURCE_DIR}/src/plugins/base64/
 	COMPILE_DEFINITIONS
 		ELEKTRA_PLUGIN_NAME=\"fcrypt\"
 		ELEKTRA_PLUGIN_NAME_C=fcrypt


### PR DESCRIPTION
# Purpose

Remove unnecessary sources from fcrypt plugin.

Hopefully fixes all compiler and linker warnings (see #1043 ).

# Checklist

Please only check relevant points.
For docu fixes, spell checking and similar nothing
needs to be checked.

- [x] commit messages are fine (with references to issues)
- [ ] I ran all tests and everything went fine
- [ ] I added unit tests
- [ ] affected documentation is fixed
- [ ] I added code comments, logging, and assertions
- [ ] meta data is updated (e.g. README.md of plugins)

@markus2330 please review my pull request

Remove unnesseccary dependencies (See #1043 ).