### PR TITLE
cachefilter plugin update

### DIFF
--- a/src/libs/elektra/kdb.c
+++ b/src/libs/elektra/kdb.c
@@ -753,6 +753,10 @@ int kdbGet (KDB * handle, KeySet * ks, Key * parentKey)
 	{
 	case 0: // We don't need an update so let's do nothing
 		keySetName (parentKey, keyName (initialParent));
+		if (handle && handle->globalPlugins[POSTGETSTORAGE])
+		{
+			handle->globalPlugins[POSTGETSTORAGE]->kdbGet (handle->globalPlugins[POSTGETSTORAGE], ks, parentKey);
+		}
 		splitUpdateFileName (split, handle, parentKey);
 		keyDel (initialParent);
 		splitDel (split);

--- a/src/plugins/cachefilter/testmod_cachefilter.c
+++ b/src/plugins/cachefilter/testmod_cachefilter.c
@@ -45,6 +45,22 @@ static KeySet * createTestKeysToNotCache ()
 		      keyNew ("user/tests/cachefilter/will/not/be/cached", KEY_VALUE, "not-cached", KEY_END), KS_END);
 }
 
+static KeySet * createTestKeysToNotCacheCascading ()
+{
+	return ksNew (3, 
+			keyNew ("user/tests/cachefilter/will/not/be/cached/with/directory/key1", KEY_END),
+			keyNew ("user/tests/cachefilter/will/not/be/cached/with/directory/key2", KEY_END),
+			keyNew ("user/tests/cachefilter/will/not/be/cached/with/directory/key3", KEY_END));
+}
+
+static KeySet * createTestKeysToNotCacheSiblings ()
+{
+	return ksNew (3,
+			keyNew ("user/tests/cachefilter/will/not/be/cached/for/whatever/key1", KEY_END),
+			keyNew ("user/tests/cachefilter/will/not/be/cached/for/whatever/key2", KEY_END),
+			keyNew ("user/tests/cachefilter/will/not/be/cached/for/whatever/key3", KEY_END));
+}
+
 static void test_successfulCache ()
 {
 	Key * parentKey = keyNew ("user/tests/cachefilter/will/not/be/cached", KEY_END);
@@ -233,6 +249,154 @@ static void test_successfulGetSetGetSet ()
 	PLUGIN_CLOSE ();
 }
 
+static void test_successfulGetGetGet ()
+{
+	Key * parentKey = keyNew ("user/tests/cachefilter/will/not/be/cached", KEY_END);
+	Key * parentKey2 = keyNew ("user/tests/cachefilter/will/not/be/cached/with", KEY_END);
+	Key * parentKey3 = keyNew ("user/tests/cachefilter/will/not/be/cached/with/directory", KEY_END);
+	KeySet * conf = ksNew (0, KS_END);
+	PLUGIN_OPEN ("cachefilter");
+
+	KeySet * ks;
+	KeySet * expected;
+	KeySet * testKeysCache = createTestKeysToCache ();
+	KeySet * testKeysNoCache = createTestKeysToNotCache ();
+	KeySet * testKeysNoCacheCascading = createTestKeysToNotCacheCascading ();
+	
+	// first kdbGet()
+	ks = ksNew (0, KS_END);
+	ksAppend (ks, testKeysCache);
+	ksAppend (ks, testKeysNoCache);
+	ksAppend (ks, testKeysNoCacheCascading);
+
+	succeed_if (plugin->kdbGet (plugin, ks, parentKey) >= 1, "call to kdbGet was not successful");
+	succeed_if (output_error (parentKey), "error in kdbGet");
+	succeed_if (output_warnings (parentKey), "warnings in kdbGet");
+	succeed_if (ksGetSize (ks) == 6, "wrong number of keys in result, expected 6");
+
+	expected = ksNew (0, KS_END);
+	ksAppend (expected, testKeysNoCache);
+	ksAppend (expected, testKeysNoCacheCascading);
+	compare_keyset (ks, expected);
+	ksDel (expected);
+	ksDel (ks);
+	
+	// second kdbGet(), this keys do now all come from cache
+	ks = ksNew (0, KS_END);
+
+	succeed_if (plugin->kdbGet (plugin, ks, parentKey2) >= 1, "call to kdbGet was not successful");
+	succeed_if (output_error (parentKey2), "error in kdbGet");
+	succeed_if (output_warnings (parentKey2), "warnings in kdbGet");
+	succeed_if (ksGetSize (ks) == 3, "wrong number of keys in result, expected 3");
+
+	expected = ksNew (0, KS_END);
+	ksAppend (expected, testKeysNoCacheCascading);
+	compare_keyset (ks, expected);
+	ksDel (expected);
+	ksDel (ks);
+	
+	// third kdbGet(), this keys do also all come from cache
+	ks = ksNew (0, KS_END);
+
+	succeed_if (plugin->kdbGet (plugin, ks, parentKey3) >= 1, "call to kdbGet was not successful");
+	succeed_if (output_error (parentKey3), "error in kdbGet");
+	succeed_if (output_warnings (parentKey3), "warnings in kdbGet");
+	succeed_if (ksGetSize (ks) == 3, "wrong number of keys in result, expected 3");
+
+	expected = ksNew (0, KS_END);
+	ksAppend (expected, testKeysNoCacheCascading);
+	compare_keyset (ks, expected);
+	ksDel (expected);
+	ksDel (ks);
+
+	keyDel (parentKey);
+	keyDel (parentKey2);
+	keyDel (parentKey3);
+	ksDel (testKeysCache);
+	ksDel (testKeysNoCache);
+	ksDel (testKeysNoCacheCascading);
+	
+	PLUGIN_CLOSE ();
+}
+
+static void test_successfulSiblingGets ()
+{
+	Key * parentKey = keyNew ("user/tests/cachefilter/will/not/be/cached/with", KEY_END);
+	Key * parentKey2 = keyNew ("user/tests/cachefilter/will/not/be/cached/for", KEY_END);
+	KeySet * conf = ksNew (0, KS_END);
+	PLUGIN_OPEN ("cachefilter");
+
+	KeySet * ks;
+	KeySet * expected;
+	KeySet * testKeysNoCacheCascading = createTestKeysToNotCacheCascading ();
+	KeySet * testKeysNoCacheSiblings = createTestKeysToNotCacheSiblings ();
+	
+	// first kdbGet()
+	ks = ksNew (0, KS_END);
+	ksAppend (ks, testKeysNoCacheCascading);
+
+	succeed_if (plugin->kdbGet (plugin, ks, parentKey) >= 1, "call to kdbGet was not successful");
+	succeed_if (output_error (parentKey), "error in kdbGet");
+	succeed_if (output_warnings (parentKey), "warnings in kdbGet");
+	succeed_if (ksGetSize (ks) == 3, "wrong number of keys in result, expected 3");
+
+	expected = ksNew (0, KS_END);
+	ksAppend (expected, testKeysNoCacheCascading);
+	compare_keyset (ks, expected);
+	ksDel (expected);
+	ksDel (ks);
+	
+	// second kdbGet()
+	ks = ksNew (0, KS_END);
+	ksAppend (ks, testKeysNoCacheSiblings);
+	
+	succeed_if (plugin->kdbGet (plugin, ks, parentKey2) >= 1, "call to kdbGet was not successful");
+	succeed_if (output_error (parentKey2), "error in kdbGet");
+	succeed_if (output_warnings (parentKey2), "warnings in kdbGet");
+	succeed_if (ksGetSize (ks) == 3, "wrong number of keys in result, expected 3");
+
+	expected = ksNew (0, KS_END);
+	ksAppend (expected, testKeysNoCacheSiblings);
+	compare_keyset (ks, expected);
+	ksDel (expected);
+	ksDel (ks);
+	
+	// third kdbGet()
+	ks = ksNew (0, KS_END);
+	
+	succeed_if (plugin->kdbGet (plugin, ks, parentKey) >= 1, "call to kdbGet was not successful");
+	succeed_if (output_error (parentKey), "error in kdbGet");
+	succeed_if (output_warnings (parentKey), "warnings in kdbGet");
+	succeed_if (ksGetSize (ks) == 3, "wrong number of keys in result, expected 3");
+
+	expected = ksNew (0, KS_END);
+	ksAppend (expected, testKeysNoCacheCascading);
+	compare_keyset (ks, expected);
+	ksDel (expected);
+	ksDel (ks);
+	
+	// fourth kdbGet()
+	ks = ksNew (0, KS_END);
+	
+	succeed_if (plugin->kdbGet (plugin, ks, parentKey2) >= 1, "call to kdbGet was not successful");
+	succeed_if (output_error (parentKey2), "error in kdbGet");
+	succeed_if (output_warnings (parentKey2), "warnings in kdbGet");
+	succeed_if (ksGetSize (ks) == 3, "wrong number of keys in result, expected 3");
+
+	expected = ksNew (0, KS_END);
+	ksAppend (expected, testKeysNoCacheSiblings);
+	compare_keyset (ks, expected);
+	ksDel (expected);
+	ksDel (ks);
+
+	keyDel (parentKey);
+	keyDel (parentKey2);
+	ksDel (testKeysNoCacheCascading);
+	ksDel (testKeysNoCacheSiblings);
+	
+	PLUGIN_CLOSE ();
+}
+
 int main (int argc, char ** argv)
 {
 	printf ("CACHEFILTER     TESTS\n");
@@ -243,6 +407,8 @@ int main (int argc, char ** argv)
 	test_successfulCache ();
 	test_successfulCacheLong ();
 	test_successfulGetSetGetSet ();
+	test_successfulGetGetGet ();
+	test_successfulSiblingGets ();
 
 	printf ("\ntestmod_cachefilter RESULTS: %d test(s) done. %d error(s).\n", nbTest, nbError);
 


### PR DESCRIPTION
# Purpose

Show problems with cachefilter plugin.

# Test Case

```
$> kdb mount users.dump dir/users dump
$> kdb mount configs.dump dir/configs dump
$> kdb global-mount cachefilter

$> kdb shell
> kdbGet dir/users
return value: 0
> kdbGet dir/configs
return value: 0
> ksOutput
> keySetName dir/users/Namoshek
> keySetString password
> ksAppendKey 
> ksOutput
dir/users/Namoshek string: password
> kdbSet dir/users/Namoshek
return value: 1
> ksOutput
dir/users/Namoshek string: password
> ksCut dir/users
> ksOutput
> keySetName dir/configs/some/test/config/path
> keySetString some-conf-value
> ksAppendKey
> ksOutput
dir/configs/some/test/config/path string: some-conf-value
> kdbSet dir/configs/some/test/config/path
return value: 1
> ksCut dir/configs
> ksOutput
> kdbGet dir/users
return value: 0
> ksOutput
dir/users/Namoshek string: password
> ksCut dir/users
> kdbGet dir/configs
return value: 0
> ksOutput
dir/configs/some/test/config/path string: some-conf-value
> ksCut dir/configs
> ksOutput

$> kdb ls dir
dir/configs/some/test/config/path
dir/users/Namoshek
1 Warning was issued:
 Warning number: 79
	Description: Postcondition of backend was violated
	Ingroup: kdb
	Module: 
	At: /home/marvin/Schreibtisch/libelektra-improvements/src/libs/elektra/split.c:501
	Reason: drop key dir/users/Namoshek not belonging to "dir/users" with name "dir/users" but instead to "dir/configs" with name "dir/configs" because it is hidden by other mountpoint
	Mountpoint: dir
	Configfile: /home/marvin/Schreibtisch/libelektra-improvements/build/.dir/users.dump
```

The test case basically reflects what my REST service is doing, with the difference that successive kdbGet calls do not return anything in the latter (probably because the plugin is not called... for whatever reason).

As you can see above, keys are also written to the wrong mountpoint when the whole cache is appended during kdbSet. I also noticed that my global plugin list gets always reset when working with mount commands (maybe a side-effect of my plugin?).