### PR TITLE
fcrypt: save timestamps of config files

### DIFF
--- a/src/error/specification
+++ b/src/error/specification
@@ -987,3 +987,10 @@ description:Hosts validation error. The hosts keyset contains unknown keys. Only
 severity:error
 ingroup:plugin
 module:storage
+
+number:163
+description:Failed to restore the timestamp when the config file was modified last.
+severity:warning
+ingroup:plugin
+module:fcrypt
+macro:FCRYPT_FUTIMENS

--- a/src/plugins/fcrypt/fcrypt.c
+++ b/src/plugins/fcrypt/fcrypt.c
@@ -140,6 +140,12 @@ static size_t getRecipientCount (KeySet * config)
  */
 static int fcryptSaveMtime (Key * parentKey, struct stat * fileStat)
 {
+	if (access (keyString (parentKey), F_OK))
+	{
+		// return failure, so no timestamp is restored later on
+		return 0;
+	}
+
 	if (stat (keyString (parentKey), fileStat) == -1)
 	{
 		ELEKTRA_ADD_WARNINGF (29, parentKey, "Failed to read file stats of %s", keyString (parentKey));

--- a/src/plugins/fcrypt/fcrypt.c
+++ b/src/plugins/fcrypt/fcrypt.c
@@ -16,12 +16,10 @@
 #include <gpg.h>
 #include <kdb.h>
 #include <kdberrors.h>
+#include <kdbstat.h>
 #include <kdbtypes.h>
 #include <stdlib.h>
 #include <string.h>
-#include <sys/stat.h>
-#include <sys/types.h>
-#include <unistd.h>
 
 enum FcryptGetState
 {
@@ -32,6 +30,8 @@ enum FcryptGetState
 struct _fcryptState
 {
 	enum FcryptGetState getState;
+	struct stat parentStat;
+	int parentStatOk;
 };
 typedef struct _fcryptState fcryptState;
 
@@ -131,6 +131,48 @@ static size_t getRecipientCount (KeySet * config)
 	return recipientCount;
 }
 
+/**
+ * @brief Determines mtime for the file given by parentKey.
+ * @param parentKey holds the path to the file as string value. Is also used for storing warnings.
+ * @param fileStat will hold the mtime on success.
+ * @retval 1 on success
+ * @retval 0 on failure. In this case a warning is appended to parentKey.
+ */
+static int fcryptSaveMtime (Key * parentKey, struct stat * fileStat)
+{
+	if (stat (keyString (parentKey), fileStat) == -1)
+	{
+		ELEKTRA_ADD_WARNINGF (29, parentKey, "Failed to read file stats of %s", keyString (parentKey));
+		return 0;
+	}
+	return 1;
+}
+
+/**
+ * @brief Sets mtime (defined by fileStat) to the file given by parentKey.
+ * @param parentKey  holds the path to the file as string value. Is also used for storing warnings.
+ * @param fileStat holds the mtime to be set on the file.
+ */
+static void fcryptRestoreMtime (Key * parentKey, struct stat * fileStat)
+{
+	struct timespec times[2];
+
+	// atime - not changing
+	times[0].tv_sec = UTIME_OMIT;
+	times[0].tv_nsec = UTIME_OMIT;
+
+	// mtime
+	times[1].tv_sec = elektraStatSeconds ((*fileStat));
+	times[1].tv_nsec = elektraStatNanoSeconds ((*fileStat));
+
+	// restore mtime on parentKeyFd
+	// if (futimens (fileDescriptor, times))
+	if (utimensat (AT_FDCWD, keyString (parentKey), times, 0))
+	{
+		ELEKTRA_ADD_WARNINGF (ELEKTRA_WARNING_FCRYPT_FUTIMENS, parentKey, "Filename: %s", keyString (parentKey));
+	}
+}
+
 static int fcryptGpgCallAndCleanup (Key * parentKey, KeySet * pluginConfig, char ** argv, int argc, int tmpFileFd, char * tmpFile)
 {
 	int parentKeyFd = -1;
@@ -140,7 +182,7 @@ static int fcryptGpgCallAndCleanup (Key * parentKey, KeySet * pluginConfig, char
 	{
 		parentKeyFd = open (keyString (parentKey), O_WRONLY);
 
-		// encryption successful, overwrite the original file with the encrypted data
+		// gpg call returned success, overwrite the original file with the gpg payload data
 		if (rename (tmpFile, keyString (parentKey)) != 0)
 		{
 			ELEKTRA_SET_ERRORF (31, parentKey, "Renaming file %s to %s failed.", tmpFile, keyString (parentKey));
@@ -314,6 +356,7 @@ int ELEKTRA_PLUGIN_FUNCTION (ELEKTRA_PLUGIN_NAME, open) (Plugin * handle, KeySet
 	}
 
 	s->getState = PREGETSTORAGE;
+	s->parentStatOk = 0;
 
 	elektraPluginSetData (handle, s);
 	return 1;
@@ -360,12 +403,24 @@ int ELEKTRA_PLUGIN_FUNCTION (ELEKTRA_PLUGIN_NAME, get) (Plugin * handle, KeySet 
 	if (s && s->getState == POSTGETSTORAGE)
 	{
 		// encrypt if this is a postgetstorage call
-		return fcryptEncrypt (pluginConfig, parentKey);
+		int encryptResult = fcryptEncrypt (pluginConfig, parentKey);
+
+		// restore "original" timestamp that has been saved in kdb get / pregetstorage
+		// NOTE if we do not restore the timestamp the resolver thinks the file has been changed externally.
+		if (encryptResult == 1 && s->parentStatOk)
+		{
+			fcryptRestoreMtime (parentKey, &(s->parentStat));
+		}
+		return encryptResult;
 	}
 
 	// now this is a pregetstorage call
 	// next time treat the kdb get call as postgetstorage call to trigger encryption after the file has been read
 	s->getState = POSTGETSTORAGE;
+
+	// save timestamp of the file
+	s->parentStatOk = fcryptSaveMtime (parentKey, &(s->parentStat));
+
 	return fcryptDecrypt (pluginConfig, parentKey);
 }
 
@@ -396,6 +451,14 @@ int ELEKTRA_PLUGIN_FUNCTION (ELEKTRA_PLUGIN_NAME, set) (Plugin * handle, KeySet 
 		return -1;
 	}
 	close (fd);
+
+	// restore "original" timestamp that has been saved in kdb get / pregetstorage
+	// NOTE if we do not restore the timestamp the resolver thinks the file has been changed externally.
+	fcryptState * s = (fcryptState *)elektraPluginGetData (handle);
+	if (s->parentStatOk)
+	{
+		fcryptRestoreMtime (parentKey, &(s->parentStat));
+	}
 	return 1;
 }
 


### PR DESCRIPTION
# Purpose

The resolver thinks that the files were modifed externally when fcrypt overwrites them.
So we restore the original timestamps after fcrypt modified the file.

See #1050 for further details.

# Checklist

Please only check relevant points.
For docu fixes, spell checking and similar nothing
needs to be checked.

- [x] commit messages are fine (with references to issues)
- [x] I ran all tests and everything went fine
- [ ] I added unit tests
- [ ] affected documentation is fixed
- [ ] I added code comments, logging, and assertions
- [ ] meta data is updated (e.g. README.md of plugins)

@markus2330 please review my pull request