### PR TITLE
fcrypt: write test files to TMPDIR

### DIFF
--- a/src/plugins/fcrypt/testmod_fcrypt.c
+++ b/src/plugins/fcrypt/testmod_fcrypt.c
@@ -30,10 +30,16 @@ static const kdb_octet_t testContent[] = { 0x01, 0x02, 0xCA, 0xFE, 0xBA, 0xBE, 0
  */
 static char * getTemporaryFileName ()
 {
-	const size_t newFileAllocated = strlen (TEST_FILE) + 7;
+	const char * tmpvar = getenv ("TMPDIR");
+	if (!tmpvar)
+	{
+		tmpvar = "/tmp";
+	}
+
+	const size_t newFileAllocated = strlen (tmpvar) + 1 + strlen (TEST_FILE) + 7;
 	char * newFile = elektraMalloc (newFileAllocated);
 	if (!newFile) return NULL;
-	snprintf (newFile, newFileAllocated, "%sXXXXXX", TEST_FILE);
+	snprintf (newFile, newFileAllocated, "%s/%sXXXXXX", tmpvar, TEST_FILE);
 	mkstemp (newFile);
 	return newFile;
 }


### PR DESCRIPTION
# Purpose

As discussed in #1113 the unit tests store their test files in the TMPDIR folder if set, otherwise the files are stored in /tmp.

Closes #1113 .

# Checklist

Please only check relevant points.
For docu fixes, spell checking and similar nothing
needs to be checked.

- [x] commit messages are fine (with references to issues)
- [x] I ran all tests and everything went fine
- [ ] I added unit tests
- [ ] affected documentation is fixed
- [ ] I added code comments, logging, and assertions
- [ ] meta data is updated (e.g. README.md of plugins)

@markus2330 please review my pull request