### PR TITLE
fix Ruby test cases for Ruby < 2.3.0

### DIFF
--- a/src/bindings/swig/ruby/tests/CMakeLists.txt
+++ b/src/bindings/swig/ruby/tests/CMakeLists.txt
@@ -1,4 +1,4 @@
-file (GLOB TESTS *.rb)
+file (GLOB TESTS testruby_*.rb)
 foreach (file ${TESTS})
 	get_filename_component (name ${file} NAME_WE)
 	add_test (

--- a/src/bindings/swig/ruby/tests/test_helper.rb
+++ b/src/bindings/swig/ruby/tests/test_helper.rb
@@ -1,0 +1,23 @@
+#!/usr/bin/env ruby
+#encoding: UTF-8
+##
+# @file
+#
+# @brief helper class for unit test cases
+#
+# @copyright BSD License (see doc/COPYING or http://www.libelektra.org)
+#
+
+require 'test/unit'
+
+# Ruby 2.3.0 renamed caption_io to capture_output
+# we generally use capture_output and define an alias
+# if it is missing
+#
+if !Test::Unit::TestCase.public_instance_methods.include? :capture_output
+  module Test::Unit
+    class TestCase
+      alias capture_output capture_io
+    end
+  end
+end

--- a/src/bindings/swig/ruby/tests/testruby_kdb.rb
+++ b/src/bindings/swig/ruby/tests/testruby_kdb.rb
@@ -11,7 +11,11 @@ require 'kdb'
 require 'test/unit'
 require_relative 'test_helper.rb'
 
-RB_TEST_NS = "user/tests/swig_ruby"
+# basename for all keys written to a configuration used in the following
+# test cases
+RB_TEST_NS = "/tests/ruby"
+# key namespace use when creating new keys
+NAMESPACE  = "user"
 
 class KdbTestCases < Test::Unit::TestCase
 
@@ -45,8 +49,9 @@ class KdbTestCases < Test::Unit::TestCase
 
       assert ret >= 0
 
-      ks << Kdb::Key.new("#{RB_TEST_NS}/kdbgetset/c1", value: "v1")
-      ks << Kdb::Key.new("#{RB_TEST_NS}/kdbgetset/c2", value: "v2", meta: "m2")
+      ks << Kdb::Key.new("#{NAMESPACE}#{RB_TEST_NS}/kdbgetset/c1", value: "v1")
+      ks << Kdb::Key.new("#{NAMESPACE}#{RB_TEST_NS}/kdbgetset/c2",
+                         value: "v2", meta: "m2")
 
       ret = h.set ks, RB_TEST_NS
 
@@ -66,12 +71,12 @@ class KdbTestCases < Test::Unit::TestCase
       # use KDB_O_POP to remove the keys from the KeySet
       k = ks.lookup "#{RB_TEST_NS}/kdbgetset/c1", Kdb::KDB_O_POP
       assert_not_nil k
-      assert_equal "#{RB_TEST_NS}/kdbgetset/c1", k.name
+      assert_equal "#{NAMESPACE}#{RB_TEST_NS}/kdbgetset/c1", k.name
       assert_equal "v1", k.value
 
       k = ks.lookup "#{RB_TEST_NS}/kdbgetset/c2", Kdb::KDB_O_POP
       assert_not_nil k
-      assert_equal "#{RB_TEST_NS}/kdbgetset/c2", k.name
+      assert_equal "#{NAMESPACE}#{RB_TEST_NS}/kdbgetset/c2", k.name
       assert_equal "v2", k.value
       assert_equal "m2", k["meta"]
 
@@ -159,7 +164,8 @@ class KdbTestCases < Test::Unit::TestCase
       assert_raise Kdb::KDBException do
         Kdb.open do |db|
           db_access = db
-          ks = Kdb::KeySet.new Kdb::Key.new("#{RB_TEST_NS}/key1", value: "v1")
+          ks = Kdb::KeySet.new Kdb::Key.new("#{NAMESPACE}#{RB_TEST_NS}/key1",
+                                            value: "v1")
           # raises an exception
           db.set ks, RB_TEST_NS
         end

--- a/src/bindings/swig/ruby/tests/testruby_kdb.rb
+++ b/src/bindings/swig/ruby/tests/testruby_kdb.rb
@@ -9,6 +9,7 @@
 
 require 'kdb'
 require 'test/unit'
+require_relative 'test_helper.rb'
 
 RB_TEST_NS = "user/tests/swig_ruby"
 

--- a/src/bindings/swig/ruby/tests/testruby_key.rb
+++ b/src/bindings/swig/ruby/tests/testruby_key.rb
@@ -10,6 +10,7 @@
 
 require 'kdb'
 require 'test/unit'
+require_relative 'test_helper'
 
 
 class KdbKeyTestCases < Test::Unit::TestCase

--- a/src/bindings/swig/ruby/tests/testruby_keyset.rb
+++ b/src/bindings/swig/ruby/tests/testruby_keyset.rb
@@ -9,6 +9,7 @@
 
 require 'kdb'
 require 'test/unit'
+require_relative 'test_helper'
 
 
 class KdbKeySetTestCases < Test::Unit::TestCase


### PR DESCRIPTION
# Purpose

Fixes #1070 
`Test::Unit::TestCase.capture_output` was called `Test::Unit::TestCase.capture_io` for versions < Ruby 2.3.0. To stay backward compatible, add an method alias when it is necessary.

# Checklist

Please only check relevant points.
For docu fixes, spell checking and similar nothing
needs to be checked.

- [x] commit messages are fine (with references to issues)
- [x] I ran all tests and everything went fine
- [x] I added code comments, logging, and assertions

@markus2330 please review my pull request
