### PR TITLE
INI: default character for comments (fix #1091)

### DIFF
--- a/src/plugins/ini/README.md
+++ b/src/plugins/ini/README.md
@@ -38,9 +38,13 @@ Find out which file you modified:
 ## Comments ##
 
 The ini plugin supports the use of comments. Comment lines start with
-a ';' or a '#'. Adjacent comments are merged together (separated by
-"\n") and are put into the comment metadata of the key following the
-comment. This can be either a section key or a normal key.
+a ';' or a '#'. Comments are put into the comment metadata of the key 
+following the comment. This can be either a section key or a normal key.
+When creating new comments (e.g. via `kdb setmeta`) you can prefix 
+your comment with the comment indicator for your choice (';' or '#') 
+which will be used when writing the comment to the file. If the comment
+is not prefixed with a comment indicator, the ini plugin will use the
+character defined by the `comment` option, or default to '#'.  
 
 ## Multi-Line Support ##
 

--- a/src/plugins/ini/testmod_ini.c
+++ b/src/plugins/ini/testmod_ini.c
@@ -516,6 +516,33 @@ static void test_dontquotebracketvalues (char * fileName)
 	PLUGIN_CLOSE ();
 }
 
+static void test_commentDefaultChar (char * fileName)
+{
+	Key * parentKey = keyNew ("user/tests/ini-write", KEY_VALUE, elektraFilename (), KEY_END);
+	KeySet * conf = ksNew (10, keyNew ("system/comment", KEY_VALUE, ";", KEY_END), KS_END);
+	PLUGIN_OPEN ("ini");
+
+	KeySet * ks =
+		ksNew (30, keyNew ("user/tests/ini-write/nosectionkey", KEY_VALUE, "nosectionvalue", KEY_META, "comments", "#1", KEY_META,
+				   "comments/#0", "nosection comment1", KEY_META, "comments/#1", "nosection comment2", KEY_END),
+		       keyNew ("user/tests/ini-write/section1", KEY_BINARY, KEY_META, "comments", "#1", KEY_META, "comments/#0",
+			       "section comment1", KEY_META, "comments/#1", "section comment2", KEY_END),
+		       keyNew ("user/tests/ini-write/section1/key1", KEY_VALUE, "value1", KEY_META, "comments", "#1", KEY_META,
+			       "comments/#0", "key comment1", KEY_META, "comments/#1", "key comment2", KEY_END),
+		       KS_END);
+
+	succeed_if (plugin->kdbSet (plugin, ks, parentKey) >= 1, "call to kdbSet was not successful");
+	succeed_if (output_error (parentKey), "error in kdbSet");
+	succeed_if (output_warnings (parentKey), "warnings in kdbSet");
+
+	succeed_if (compare_line_files (srcdir_file (fileName), keyString (parentKey)), "files do not match as expected");
+
+	ksDel (ks);
+	keyDel (parentKey);
+
+	PLUGIN_CLOSE ();
+}
+
 int main (int argc, char ** argv)
 {
 	printf ("INI         TESTS\n");
@@ -542,6 +569,7 @@ int main (int argc, char ** argv)
 	test_complexInsert ("ini/complexIn.ini", "ini/complexOut.ini");
 	test_arrayInsert ("ini/arrayInsertIn.ini", "ini/arrayInsertOut.ini");
 	test_dontquotebracketvalues ("ini/bracketQuoteOut.ini");
+	test_commentDefaultChar ("ini/commentini");
 	printf ("\ntest_ini RESULTS: %d test(s) done. %d error(s).\n", nbTest, nbError);
 
 	return nbError;


### PR DESCRIPTION
# Purpose

add default character for comments

# Checklist

- [x] commit messages are fine (with references to issues)
- [x] I ran all tests and everything went fine
- [x] I added unit tests
- [x] affected documentation is fixed
- [ ] I added code comments, logging, and assertions
- [ ] meta data is updated (e.g. README.md of plugins)