### PR TITLE
Ruby: add missing key.del_meta test cases

### DIFF
--- a/src/bindings/swig/ruby/examples/ruby_example_keys.rb
+++ b/src/bindings/swig/ruby/examples/ruby_example_keys.rb
@@ -127,6 +127,9 @@ mv = kmeta["jet another"]
 # check if meta data exists
 kmeta.has_meta? "jet another"  # => true
 
+# delete meta data
+kmeta.del_meta "jet another"
+
 
 #
 # metadata iterator

--- a/src/bindings/swig/ruby/tests/testruby_key.rb
+++ b/src/bindings/swig/ruby/tests/testruby_key.rb
@@ -172,6 +172,34 @@ class KdbKeyTestCases < Test::Unit::TestCase
   end
 
 
+  def test_key_delete_meta
+    assert_nothing_raised do
+      k = Kdb::Key.new "user/asdf"
+
+      assert k.is_valid?
+
+      k.set_meta "comments/#0", "some value"
+      k.set_meta "comments/#1", "2nd line"
+      assert_equal "some value", k.get_meta("comments/#0")
+      assert_equal "2nd line", k.get_meta("comments/#1")
+      assert_equal 2, k.meta.size
+
+      k.del_meta "comments/#1"
+
+      assert_equal 1, k.meta.size
+      assert_equal "some value", k.get_meta("comments/#0")
+      assert_equal "", k.get_meta("comments/#1")
+
+      k["comments/#2"] = "other line"
+
+      assert_equal 2, k.meta.size
+      assert_equal "some value", k["comments/#0"]
+      assert_equal "other line", k["comments/#2"]
+
+    end
+  end
+
+
   def test_key_get_name
     assert_nothing_raised do
       k = Kdb::Key.new


### PR DESCRIPTION
# Purpose

key.del_meta was not tested by the Ruby bindings test cases
I was not really sure if this works correctly, but now it is verified.

# Checklist

Please only check relevant points.
For docu fixes, spell checking and similar nothing
needs to be checked.

- [x] commit messages are fine (with references to issues)
- [x] I ran all tests and everything went fine
- [x] I added unit tests
- [x] affected documentation is fixed
- [x] I added code comments, logging, and assertions
- [ ] meta data is updated (e.g. README.md of plugins)

@markus2330 please review my pull request

