### PR TITLE
augeas: fix crash on print error

### DIFF
--- a/src/plugins/augeas/augeas.c
+++ b/src/plugins/augeas/augeas.c
@@ -148,9 +148,10 @@ static const char * getAugeasError (augeas * augeasHandle)
 			aug_get (augeasHandle, "/augeas/text" AUGEAS_TREE_ROOT "/error/message", &message);
 
 			const char * format = "%s\n\tposition: %s:%s\n\tmessage: %s\n\tlens: %s";
-			size_t messageSize = strlen (lens) + strlen (line) + strlen (character) + strlen (message) + strlen (format);
+			size_t messageSize = strlen (augeasError) + strlen (line) + strlen (character) + strlen (message) + strlen (lens) +
+					     strlen (format);
 			char * buffer = elektraMalloc (messageSize);
-			sprintf (buffer, format, augeasError, line, character, message);
+			sprintf (buffer, format, augeasError, line, character, message, lens);
 			reason = buffer;
 		}
 		else


### PR DESCRIPTION
# Purpose

Should fix the issue with augeas crashing as described in #1187.

# Checklist

Please only check relevant points.
For docu fixes, spell checking and similar nothing
needs to be checked.

- [x] commit messages are fine (with references to issues)
- [x] I ran all tests and everything went fine

@markus2330 please review my pull request

