### PR TITLE
Build: Support Older Versions of CMake

### DIFF
--- a/src/plugins/python2/CMakeLists.txt
+++ b/src/plugins/python2/CMakeLists.txt
@@ -40,7 +40,11 @@ if (DEPENDENCY_PHASE)
 	# generate readme from pythons3 README.md
 	# it will overwrite previously generated file of add_plugin directly above
 	set (CMAKE_CURRENT_SOURCE_DIR_SAFE ${CMAKE_CURRENT_SOURCE_DIR})
-	get_filename_component(CMAKE_CURRENT_SOURCE_PARENT_DIR ${CMAKE_CURRENT_SOURCE_DIR} DIRECTORY)
+	if (CMAKE_VERSION VERSION_LESS "2.8.12")
+		get_filename_component(CMAKE_CURRENT_SOURCE_PARENT_DIR ${CMAKE_CURRENT_SOURCE_DIR} PATH)
+	else ()
+		get_filename_component(CMAKE_CURRENT_SOURCE_PARENT_DIR ${CMAKE_CURRENT_SOURCE_DIR} DIRECTORY)
+	endif ()
 	set (CMAKE_CURRENT_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_PARENT_DIR}/python")
 	generate_readme (python2)
 	set (CMAKE_CURRENT_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR_SAFE})


### PR DESCRIPTION
# Purpose

- Support old versions of CMake again

# Checklist

- [x] The issue reference in the commit message is correct.
- [x] I ran all tests and “only”:
  - `testtool_plugindatabase`
  - `testpy2_kdb.py`
  - `testpy2_key.py`
  - `testpy2_keyset.py`
  - `test_kdb.py`
  - `test_key.py`
  - `test_keyset.py`
  - `testruby_kdb`
  - `testruby_key`
  - `testruby_keyset`

  failed.

@markus2330 👋 Please review my pull request.