### PR TITLE
Doxygen: Properly Escape Location of Markdown Link Converter

### DIFF
--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -54,6 +54,9 @@ if (DOXYGEN_FOUND)
 	# fix usage with wine
 	# https://github.com/ElektraInitiative/libelektra/pull/340#discussion_r44044444
 	find_util (markdownlinkconverter MARKDOWN_LINK_CONVERTER "")
+	if (DOXYGEN_VERSION VERSION_GREATER "1.8.11")
+		set (MARKDOWN_LINK_CONVERTER "\\\"${MARKDOWN_LINK_CONVERTER}\\\"")
+	endif ()
 
 	configure_file (
 		"${CMAKE_CURRENT_SOURCE_DIR}/Doxyfile"

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -97,8 +97,6 @@ if (DOXYGEN_FOUND)
 
 	endif (WITH_LATEX)
 
-	list(APPEND outputs "${CMAKE_BINARY_DIR}/external-links.txt")
-
 	add_custom_command (
 		OUTPUT ${outputs}
 		COMMAND ${DOXYGEN_EXECUTABLE}

--- a/doc/Doxyfile
+++ b/doc/Doxyfile
@@ -921,7 +921,7 @@ INPUT_FILTER           =
 # filters are used. If the FILTER_PATTERNS tag is empty or if none of the
 # patterns match the file name, INPUT_FILTER is applied.
 
-FILTER_PATTERNS        = "*.md"="@MARKDOWN_LINK_CONVERTER@"
+FILTER_PATTERNS        = *.md="@MARKDOWN_LINK_CONVERTER@"
 
 # If the FILTER_SOURCE_FILES tag is set to YES, the input filter (if set using
 # INPUT_FILTER ) will also be used to filter the input files that are used for


### PR DESCRIPTION
# Purpose

This pull request should address the problem mentioned in commit 5f62893 **properly**.

# Checklist

- [x] Commit messages are fine. (The references mentioned in the commit messages are correct.)
- [x] I ran all tests and everything went fine

👋 @markus2330: Please review my pull request.