### PR TITLE
might be a bug, typo in longestText.width

### DIFF
--- a/src/tools/qt-gui/qml/AppearanceSettingsWindow.qml
+++ b/src/tools/qt-gui/qml/AppearanceSettingsWindow.qml
@@ -47,7 +47,7 @@ BasicWindow {
 				}
 
 				Label {
-					width: longestText.widht
+					width: longestText.width
 					text: qsTr("Frame Color")
 				}
 				Rectangle {
@@ -64,7 +64,7 @@ BasicWindow {
 					}
 				}
 				Label {
-					width: longestText.widht
+					width: longestText.width
 					text: qsTr("Node with Key Color")
 				}
 				Rectangle {
@@ -128,7 +128,7 @@ BasicWindow {
 				rowSpacing: parent.parent.parent.height / 16
 				columnSpacing: parent.parent.parent.width / 16
 				Label {
-					width: longestText.widht
+					width: longestText.width
 					text: qsTr("Use system icon theme")
 				}
 				Switch {


### PR DESCRIPTION
# Purpose

while checking, I came across a potential spelling-based bug
# src/tools/qt-gui/qml/AppearanceSettingsWindow.qml
- width: longestText.widht
+ width: longestText.width
(occurs multiple times - not sure if this is )

found via bot: https://github.com/ka7/misspell_fixer

# Checklist

Please only check relevant points.
For docu fixes, spell checking and similar nothing
needs to be checked.

- [ ] commit messages are fine (with references to issues)
- [ ] I ran all tests and everything went fine
- [ ] I added unit tests
- [ ] affected documentation is fixed
- [ ] I added code comments, logging, and assertions
- [ ] meta data is updated (e.g. README.md of plugins)

@markus2330 please review my pull request
