### PR TITLE
travis: bump to most recent macOS / Xcode version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ language: generic
 matrix:
   include:
     - os: osx
-      osx_image: xcode8
+      osx_image: xcode8.2
     - os: osx
       osx_image: xcode7.3
     - os: osx


### PR DESCRIPTION
Enable travis-ci builds for the most recent macOS version.