### PR TITLE
crypto / fcrypt: add gpg error output to test cases

### DIFF
--- a/src/plugins/crypto/test_internals.h
+++ b/src/plugins/crypto/test_internals.h
@@ -264,7 +264,7 @@ static void test_gpg (void)
 	int result = CRYPTO_PLUGIN_FUNCTION (gpgCall) (conf, errorKey, msg, argv, argc);
 	if (result != 1)
 	{
-		fprintf (stderr, "GPG error: %s\n", keyString (keyGetMeta (errorKey, "error/description")));
+		fprintf (stderr, "GPG error: %s\n", keyString (keyGetMeta (errorKey, "error/reason")));
 	}
 	succeed_if (result == 1, "failed to install the GPG test key");
 

--- a/src/plugins/crypto/test_internals.h
+++ b/src/plugins/crypto/test_internals.h
@@ -260,7 +260,13 @@ static void test_gpg (void)
 	Key * msg = keyNew (0);
 	keySetBinary (msg, test_key_asc, test_key_asc_len);
 
-	succeed_if (CRYPTO_PLUGIN_FUNCTION (gpgCall) (conf, errorKey, msg, argv, argc) == 1, "failed to install the GPG test key");
+	// gpg call
+	int result = CRYPTO_PLUGIN_FUNCTION (gpgCall) (conf, errorKey, msg, argv, argc);
+	if (result != 1)
+	{
+		fprintf (stderr, "GPG error: %s\n", keyString (keyGetMeta (errorKey, "error/description")));
+	}
+	succeed_if (result == 1, "failed to install the GPG test key");
 
 	keyDel (msg);
 	keyDel (errorKey);

--- a/src/plugins/fcrypt/testmod_fcrypt.c
+++ b/src/plugins/fcrypt/testmod_fcrypt.c
@@ -111,7 +111,13 @@ static void test_gpg ()
 	Key * msg = keyNew (0);
 	keySetBinary (msg, test_key_asc, test_key_asc_len);
 
-	succeed_if (CRYPTO_PLUGIN_FUNCTION (gpgCall) (conf, errorKey, msg, argv, argc) == 1, "failed to install the GPG test key");
+	// gpg call
+	int result = CRYPTO_PLUGIN_FUNCTION (gpgCall) (conf, errorKey, msg, argv, argc);
+	if (result != 1)
+	{
+		fprintf (stderr, "GPG error: %s\n", keyString (keyGetMeta (errorKey, "error/description")));
+	}
+	succeed_if (result == 1, "failed to install the GPG test key");
 
 	keyDel (msg);
 	keyDel (errorKey);

--- a/src/plugins/fcrypt/testmod_fcrypt.c
+++ b/src/plugins/fcrypt/testmod_fcrypt.c
@@ -115,7 +115,7 @@ static void test_gpg ()
 	int result = CRYPTO_PLUGIN_FUNCTION (gpgCall) (conf, errorKey, msg, argv, argc);
 	if (result != 1)
 	{
-		fprintf (stderr, "GPG error: %s\n", keyString (keyGetMeta (errorKey, "error/description")));
+		fprintf (stderr, "GPG error: %s\n", keyString (keyGetMeta (errorKey, "error/reason")));
 	}
 	succeed_if (result == 1, "failed to install the GPG test key");
 


### PR DESCRIPTION
# Purpose

The unit tests of `fcrypt` and `crypto_*` write the gpg output to `stderr` in case of error.
With the additional output we can hopefully fix #1230 .

# Checklist

Please only check relevant points.
For docu fixes, spell checking and similar nothing
needs to be checked.

- [x] commit messages are fine (with references to issues)
- [x] I ran all tests and everything went fine
- [ ] I added unit tests
- [ ] affected documentation is fixed
- [ ] I added code comments, logging, and assertions
- [ ] meta data is updated (e.g. README.md of plugins)

@markus2330 please review my pull request
