### PR TITLE
Documentation: Fix PDF Manual

### DIFF
--- a/doc/markdownlinkconverter/elektraSpecialCharacters.sty
+++ b/doc/markdownlinkconverter/elektraSpecialCharacters.sty
@@ -1,1 +1,4 @@
+\usepackage{newunicodechar}
+
 \DeclareUnicodeCharacter{0101}{\=a}
+\newunicodechar{⏎}{$\hookleftarrow$} % \hookleftarrow ≅ ↩︎


### PR DESCRIPTION
# Purpose

Before this commit building the PDF manual would fail, since some of the included Markdown documents contain the character `⏎`. This character was not setup for use with LaTeX. We now replace the symbol `⏎` with the similar looking leftwards arrow with hook symbol (`↩︎`).

# Checklist

- [x] I ran all tests and everything went fine