### PR TITLE
super-ls

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,10 @@ Go to the [website](https://www.libelektra.org), see [News](doc/news/), and its 
 The preferred way to install Elektra is by using packages provided for
 your distribution, see [INSTALL](/doc/INSTALL.md) for available packages.
 
-If there are no packages available for your distribution, see the
+For macOS there is a homebrew tap available:
+  - [macOS](https://github.com/ElektraInitiative/homebrew-elektra)
+
+If there are no packages available for your distribution see the
 [installation document](doc/INSTALL.md).
 
 ### Download ###
@@ -203,7 +206,8 @@ following commands to compile it:
 
  * `mkdir build`
  * `cd build`
- * `cmake ..` or `ccmake ..`
+ * `cmake ..`
+ * `ccmake ..` (optional, provides a console based GUI to give an overview of the available compilation options and settings)
  * `make`
 
 Then you can use `sudo make install` to install it.

--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@ applications' configurations, leveraging easy application integration.
 
 ## Often used links ##
 
-- [build server](http://build.libelektra.org:8080/)
-- [tutorials](http://git.libelektra.org/blob/master/doc/tutorials/)
-- [API docu](http://doc.libelektra.org/api/latest/html/)
+- [build server](https://build.libelektra.org/)
+- [tutorials](/doc/tutorials/)
+- [API docu](https://doc.libelektra.org/api/latest/html/)
 
 ## Overview ##
 
@@ -58,7 +58,7 @@ implemented in C, works cross-platform, and does not need any external dependenc
 ## Contact ##
 
 Do not hesitate to ask any question on
-[GitHub issue tracker](https://github.com/ElektraInitiative/libelektra/issues),
+[GitHub issue tracker](https://issues.libelektra.org/),
 [Mailing List](https://lists.sourceforge.net/lists/listinfo/registry-list)
 or directly to one of the [authors](doc/AUTHORS.md).
 
@@ -109,7 +109,7 @@ To get an idea of Elektra, you can take a look at the
 
 The full documentation, including:
 
-- [tutorials](http://libelektra.org/blob/master/doc/tutorials/),
+- [tutorials](/doc/tutorials/),
 - [faq](/doc/help/elektra-faq.md),
 - [glossary](/doc/help/elektra-glossary.md), and
 - [concepts and man pages](/doc/help/elektra-introduction.md)
@@ -119,10 +119,10 @@ is available in the GitHub repository.
 You can read the documentation for the kdb tool, either
 
 - [on the Website](https://www.libelektra.org)
-- [in the API docu](http://doc.libelektra.org/api/latest/html/md_doc_help_kdb.html)
+- [in the API docu](https://doc.libelektra.org/api/latest/html/md_doc_help_kdb.html)
 - by using `man kdb`
 - by using `kdb --help` or `kdb help <command>`
-- [on GitHub](http://libelektra.org/blob/master/doc/help/kdb.md)
+- [on GitHub](https://master.libelektra.org/doc/help/kdb.md)
 
 
 
@@ -172,20 +172,7 @@ And in terms of quality, we want:
 
 ## News ##
 
- - [22 Nov 2016 0.8.19](http://doc.libelektra.org/news/8e05231a-4f3d-488b-8dc2-5f0d5c474c39.html) tutorials, ruby, cleanup
- - [16 Sep 2016 0.8.18](http://doc.libelektra.org/news/190576e0-9fef-486e-b8da-c4e75be08329.html) adds intercept open
- - [14 Jun 2016 0.8.17](http://doc.libelektra.org/news/e6153a39-c4bd-41c3-bc86-785d451eb6c5.html) with survey, usability improvements
- - [29 Apr 2016 0.8.16](http://doc.libelektra.org/news/9c9247ee-ee9c-4f4a-a68e-76959def9b82.html) with stability improvements
- - [16 Feb 2016 0.8.15](http://doc.libelektra.org/news/1ab4a560-c286-46d2-a058-1a8e7e208fe8.html) with lib split, improved mount
- - [19 Nov 2015 0.8.14](http://doc.libelektra.org/news/519cbfac-6db5-4594-8a38-dec4c84b134f.html) adds docu and plugins
- - [17 Sep 2015 0.8.13](http://doc.libelektra.org/news/3c00a5f1-c017-4555-92b5-a2cf6e0803e3.html) adds elektrify-getenv
- - [12 Jul 2015 0.8.12](http://doc.libelektra.org/news/98770541-32a1-486a-98a1-d02f26afc81a.html) adds dir namespace
- - [03 Apr 2015 0.8.11](http://doc.libelektra.org/news/7d4647d4-4131-411e-9c2a-2aca39446e18.html) adds spec namespace
- - [02 Dec 2014 0.8.10](http://doc.libelektra.org/news/6ce57ecf-420a-4a31-821e-1c5fe5532eb4.html) adds XDG/OpenICC compatibility
- - [04 Nov 2014 0.8.9](http://doc.libelektra.org/news/38640673-3e07-4cff-9647-f6bdd89b1b08.html) adds qt-gui
- - [02 Sep 2014 0.8.8](http://doc.libelektra.org/news/eca69e19-5ddb-438c-ac06-57c20b1a9160.html) adds 3-way merging
-
-Also see [News](doc/news/) and its [RSS feed](http://www.libelektra.org/news/feed.rss).
+Go to the [website](https://www.libelektra.org), see [News](doc/news/), and its [RSS feed](https://www.libelektra.org/news/feed.rss).
 
 
 ## Sources ##
@@ -206,7 +193,7 @@ You can clone the latest version of Elektra by running:
 
          git clone https://github.com/ElektraInitiative/libelektra.git
 
-Releases can be downloaded from [http](http://www.libelektra.org/ftp/elektra/releases/) and
+Releases can be downloaded from [http](https://www.libelektra.org/ftp/elektra/releases/) and
 `ftp://ftp.libelektra.org/elektra/releases/`
 
 ### Compiling ###

--- a/doc/COMPILE.md
+++ b/doc/COMPILE.md
@@ -10,7 +10,10 @@ some unix tools):
 Or on RPM based systems (CentOS):
 
 	sudo yum install -y cmake3 gcc-c++
+	
+Or on macOS Sierra, most of the build tools can be obtained by installing XCode (from the App Store). Other required tools may be installed using [brew](http://brew.sh/). First install brew as described on their website. Then issue the following command to get cmake to complete the basic requirements:
 
+	brew install cmake
 
 ## Optional Dependencies ##
 
@@ -24,6 +27,12 @@ To build documentation you need doxygen (we recommend 1.8.8+), graphviz and [ron
 Or on RPM based systems:
 
 	sudo yum install -y doxygen docbook-style-xsl graphviz ruby
+	gem install ronn
+	
+Or on macOS Sierra using brew:
+
+	brew install doxygen graphviz
+	brew install ruby (in case ruby is not already installed)
 	gem install ronn
 
 To build PDF documentation you need `pdflatex` with
@@ -49,7 +58,7 @@ To configure Elektra graphically (with curses) run (`..` belongs to command):
 
     mkdir build && cd build && ccmake ..
 
-and press 'c' to configure the cache (might be necessary multiple times).
+and press 'c' to configure the cache (might be necessary multiple times, and once on the first time in case you dont see any settings).
 After applying the desired settings, press 'g' to generate the make file.
 
 

--- a/doc/help/kdb-editor.md
+++ b/doc/help/kdb-editor.md
@@ -3,9 +3,9 @@ kdb-editor(1) -- Use your editor for editing KDB
 
 ## SYNOPSIS
 
-`kdb editor <key-name> [<format>]`
+`kdb editor <path> [<format>]`
 
-Where `key-name` is the destination where the user wants to edit keys and `format` is the format in which the keys should be edited.
+Where `path` is the destination where the user wants to edit keys and `format` is the format in which the keys should be edited.
 If the `format` argument is not passed, then the default format will be used as determined by the value of the `sw/kdb/current/format` key.
 By default, that key contains `storage`.
 The `storage` plugin can be configured at compile-time or changed by the link `libelektra-storage.so`.
@@ -89,3 +89,4 @@ Or set a new editor as default using:
 ## SEE ALSO
 
 - [elektra-merge-strategy(7)](elektra-merge-strategy.md)
+- [elektra-key-names(7)](elektra-key-names.md) for an explanation of key names.

--- a/doc/help/kdb-file.md
+++ b/doc/help/kdb-file.md
@@ -3,9 +3,9 @@ kdb-file(1) -- Displays which file a key is stored in
 
 ## SYNOPSIS
 
-`kdb file <path>`  
+`kdb file <key name>`  
 
-Where `path` is the path of a key.  
+Where `key name` is the name of the key to check.  
 
 ## DESCRIPTION
 
@@ -45,3 +45,4 @@ To find which file a key is stored in:
 
 - [elektra-mounting(7)](elektra-mounting.md)
 - [elektra-namespaces(7)](elektra-namespaces.md)
+- [elektra-key-names(7)](elektra-key-names.md) for an explanation of key names.

--- a/doc/help/kdb-fstab.md
+++ b/doc/help/kdb-fstab.md
@@ -3,9 +3,9 @@ kdb-fstab(1) -- Create a new fstab entry
 
 ## SYNOPSIS
 
-`kdb fstab <key-path> <fs_spec> <fs_file> <fs_vfstype> <fs_mntops>`
+`kdb fstab <path> <fs_spec> <fs_file> <fs_vfstype> <fs_mntops>`
 
-Where `key-path` is the path the where the key should be stored in the key database.
+Where `path` is the path where the created keys should be stored in the key database.
 The other arguments are as described in fstab(5).
 
 
@@ -40,3 +40,4 @@ To create an fstab entry to mount `dev/sdb1` to `/media/external` stored in the 
 ## SEE ALSO
 
 - Use `kdb info fstab` to get information about the fstab plugin.
+- [elektra-key-names(7)](elektra-key-names.md) for an explanation of key names.

--- a/doc/help/kdb-get.md
+++ b/doc/help/kdb-get.md
@@ -3,16 +3,16 @@ kdb-get(1) -- Get the value of a key stored in the key database
 
 ## SYNOPSIS
 
-`kdb get <path>`
+`kdb get <key name>`
 
-Where `path` is the full path to the key.
+Where `key name` is the name of the key.
 
 ## DESCRIPTION
 
 This command is used to retrieve the value of a key.
 
-If you enter a `path` starting with a leading `/`, then a cascading lookup will be performed in order to attempt to locate the key.
-In this case, using the `-v` option allows the user to see the full `path` of the key if it is found.
+If you enter a `key name` starting with a leading `/`, then a cascading lookup will be performed in order to attempt to locate the key.
+In this case, using the `-v` option allows the user to see the full key name of the key if it is found.
 
 Note: There is a current limitation where only keys that are mounted will be considered during a cascading lookup.
 A workaround that will lookup all keys is to pass the `-a` option.
@@ -64,3 +64,4 @@ This command will actually get `user/sw/elektra/kdb/#0/current/format` if the bo
 - [kdb(1)](kdb.md) for how to configure the kdb utility and use the bookmarks.
 - For more about cascading keys see [elektra-cascading(7)](elektra-cascading.md)
 - To get keys in shell scripts, you also can use [kdb-sget(1)](kdb-sget.md)
+- [elektra-key-names(7)](elektra-key-names.md) for an explanation of key names.

--- a/doc/help/kdb-getmeta.md
+++ b/doc/help/kdb-getmeta.md
@@ -3,9 +3,9 @@ kdb-getmeta(1) -- Get the value of a metakey stored in the key database
 
 ## SYNOPSIS
 
-`kdb getmeta <key-name> <metaname>`  
+`kdb getmeta <key name> <metaname>`  
 
-Where `key-name` is the full path to the key and
+Where `key name` is the name of the key and
 `metaname` is the name of the metakey the user would like to access.
 
 ## DESCRIPTION
@@ -13,7 +13,7 @@ Where `key-name` is the full path to the key and
 This command is used to print the value of a metakey.
 A metakey is information stored in a key which describes that key.
 
-The handling of cascading `key-name` does not differ to `kdb get`.
+The handling of cascading `key name` does not differ to `kdb get`.
 Make sure to use the namespace `spec`, if you want metadata from there.
 
 ## RETURN VALUES
@@ -53,3 +53,4 @@ To get the value of metakey called `override/#0` stored in the key `spec/example
 - How to set metadata: [kdb-setmeta(1)](kdb-setmeta.md)
 - For more about cascading keys see [elektra-cascading(7)](elektra-cascading.md)
 - For general information about metadata see [elektra-metadata(7)](elektra-metadata.md)
+- [elektra-key-names(7)](elektra-key-names.md) for an explanation of key names.

--- a/doc/help/kdb-list-commands.md
+++ b/doc/help/kdb-list-commands.md
@@ -1,5 +1,5 @@
-kdb-list(1) -- List plugins available to Elektra
-================================================
+kdb-list-commands(1) -- List commands available to Elektra
+==========================================================
 
 ## SYNOPSIS
 
@@ -32,7 +32,7 @@ tools as long as `-v` is not used.
 ## EXAMPLES
 
 To get a list of all available commands with their help text:
-`kdb list -v`
+`kdb list-commands -v`
 
 ## SEE ALSO
 

--- a/doc/help/kdb-list-commands.md
+++ b/doc/help/kdb-list-commands.md
@@ -1,0 +1,39 @@
+kdb-list(1) -- List plugins available to Elektra
+================================================
+
+## SYNOPSIS
+
+`kdb list-commands`
+
+## DESCRIPTION
+
+This command will list all internal kdb commands.
+The output is suitable to be processed from other
+tools as long as `-v` is not used.
+
+## OPTIONS
+
+- `-H`, `--help`:
+  Show the man page.
+- `-V`, `--version`:
+  Print version info.
+- `-p`, `--profile`=<profile>:
+  Use a different kdb profile.
+- `-v`, `--verbose`:
+  Also output some explanation for every
+  command. The command names are bold if
+  color is turned on. In the first line
+  it will add how many commands exist.
+- `-0`, `--null`:
+  Use binary 0 termination
+- `-C`, `--color`=[when]:
+  Print never/auto(default)/always colored output.
+
+## EXAMPLES
+
+To get a list of all available commands with their help text:
+`kdb list -v`
+
+## SEE ALSO
+
+- `kdb list-tools` for external kdb commands

--- a/doc/help/kdb-list-tools.md
+++ b/doc/help/kdb-list-tools.md
@@ -12,6 +12,10 @@ In the first line it prints where external tools are located.
 
 The tool itself is extern.
 
+## ENVIRONMENT
+
+- `KDB_EXEC_PATH`:
+  Allows to find additional external applications.
 
 ## OPTIONS
 

--- a/doc/help/kdb-list-tools.md
+++ b/doc/help/kdb-list-tools.md
@@ -15,7 +15,8 @@ The tool itself is extern.
 ## ENVIRONMENT
 
 - `KDB_EXEC_PATH`:
-  Allows to find additional external applications.
+  Path to additional external tools.
+
 
 ## OPTIONS
 
@@ -24,4 +25,4 @@ Currently no option provided.
 
 ## SEE ALSO
 
-- `kdb list-commands` for internal kdb commands
+- `kdb list-commands` to list internal kdb commands

--- a/doc/help/kdb-list-tools.md
+++ b/doc/help/kdb-list-tools.md
@@ -8,6 +8,16 @@ kdb-list-tools(1) - List all external tools available to Elektra
 ## DESCRIPTION
 
 This command lists all the externel tools that are available to Elektra.
-By default, external tools are located in the `/usr/local/lib/elektra/tool_exec` directory.
+In the first line it prints where external tools are located.
 
 The tool itself is extern.
+
+
+## OPTIONS
+
+Currently no option provided.
+
+
+## SEE ALSO
+
+- `kdb list-commands` for internal kdb commands

--- a/doc/help/kdb-ls.md
+++ b/doc/help/kdb-ls.md
@@ -3,9 +3,9 @@ kdb-ls(1) -- List keys in the key database
 
 ## SYNOPSIS
 
-`kdb ls <key-name>`  
+`kdb ls <path>`  
 
-Where `key-name` is the path in which the user would like to list keys below.
+Where `path` is the path in which the user would like to list keys below.
 
 ## DESCRIPTION
 
@@ -34,6 +34,6 @@ To list all keys below `user/example`:
 
 ## SEE ALSO
 
-If the user would also like to see the values of the keys below `path` then you should
+- If the user would also like to see the values of the keys below `path` then you should
 consider the [kdb-export(1)](kdb-export.md) command.
-
+- [elektra-key-names(7)](elektra-key-names.md) for an explanation of key names.

--- a/doc/help/kdb-lsmeta.md
+++ b/doc/help/kdb-lsmeta.md
@@ -3,11 +3,13 @@ kdb-lsmeta(1) - Print metakeys associated with a key
 
 ## SYNOPSIS
 
-`kdb lsmeta <key-name>`
+`kdb lsmeta <key name>`
+
+Where `key name` is the name of the key.
 
 ## DESCRIPTION
 
-This command prints the names of all metakeys associated with a given key.  
+This command prints the names of all metakeys associated with the key named `key name`.  
 If no metakeys are associated with the given key, nothing will be printed.  
 
 ## OPTIONS
@@ -34,3 +36,4 @@ To see which metakeys are associated with a key:
 ## SEE ALSO
 
 - [elektra-metadata(7)](elektra-metadata.md)
+- [elektra-key-names(7)](elektra-key-names.md) for an explanation of key names.

--- a/doc/help/kdb-merge.md
+++ b/doc/help/kdb-merge.md
@@ -80,3 +80,4 @@ To complete a three-way merge and overwrite all current keys in the `resultpath`
 ## SEE ALSO
 
 - [elektra-merge-strategy(7)](elektra-merge-strategy.md)
+- [elektra-key-names(7)](elektra-key-names.md) for an explanation of key names.

--- a/doc/help/kdb-rm.md
+++ b/doc/help/kdb-rm.md
@@ -6,7 +6,7 @@ kdb-rm(1) -- Remove key(s) from the key database
 `kdb rm <path>`
 
 Where `path` is the path of the key(s) you want to remove.
-Note that when using the `-r` flag, `path` as well as all of the keys below it will be removed.
+Note that when using the `-r` flag, not only the key directly at `path` will be removed, but all of the keys below the path as well.
 
 ## DESCRIPTION
 
@@ -32,3 +32,7 @@ To remove multiple keys:
 
 To remove a single key:
 `kdb rm user/example/key1`
+
+## SEE ALSO
+
+- [elektra-key-names(7)](elektra-key-names.md) for an explanation of key names.

--- a/doc/help/kdb-set.md
+++ b/doc/help/kdb-set.md
@@ -3,9 +3,9 @@ kdb-set(1) -- Set the value of a key
 
 ## SYNOPSIS
 
-`kdb set <key-name> [<value>]`
+`kdb set <key name> [<value>]`
 
-Where `key-name` is the path to the key you wish to set the value of (or create) and `value` is the value you would like to set the key to.
+Where `key name` is the name of the key you wish to set the value of (or create) and `value` is the value you would like to set the key to.
 If the `value` argument is not passed, the key will be set to a value of `null`.
 
 ## DESCRIPTION
@@ -68,4 +68,5 @@ followed by:
 ## SEE ALSO
 
 - [kdb(1)](kdb.md) for how to configure the kdb utility and use the bookmarks.
-- For difference between empty and null values, see [elektra-values(7)](elektra-values.md)
+- [elektra-key-names(7)](elektra-key-names.md) for an explanation of key names.
+- [elektra-values(7)](elektra-values.md) for the difference between empty and null values.

--- a/doc/help/kdb-setmeta.md
+++ b/doc/help/kdb-setmeta.md
@@ -3,9 +3,9 @@ kdb-setmeta(1) -- Set the value of a metakey
 
 ## SYNOPSIS
 
-`kdb setmeta <key-name> <metaname> [<metavalue>]`
+`kdb setmeta <key name> <metaname> [<metavalue>]`
 
-Where `key-name` is the path to the key that the metakey is associated with,
+Where `key name` is the name of the key that the metakey is associated with,
 `metaname` is the name of the metakey the user would like to set the value of (or create),
 and `metavalue` is the value the user wishes to set the metakey to.
 If no `metavalue` is given, the metakey will be removed.
@@ -70,3 +70,4 @@ To remove it:
 
 - How to get metadata: [kdb-getmeta(1)](kdb-getmeta.md)
 - [elektra-metadata(7)](elektra-metadata.md)
+- [elektra-key-names(7)](elektra-key-names.md) for an explanation of key names.

--- a/doc/help/kdb-sget.md
+++ b/doc/help/kdb-sget.md
@@ -3,9 +3,9 @@ kdb-sget(1) -- Get the value of a key stored in the key database from a script
 
 ## SYNOPSIS
 
-`kdb sget <path> <default-value>`
+`kdb sget <key name> <default-value>`
 
-Where `path` is the full path to the key and `default-value` is the value that should be printed if no value can be retrieved.
+Where `key name` is the name of the key to retrieve and `default-value` is the value that should be printed if no value can be retrieved.
 
 ## DESCRIPTION
 
@@ -38,3 +38,4 @@ To get the value of a key using a cascading lookup or return the value `notfound
 ## SEE ALSO
 
 - [kdb-get(1)](kdb-get.md)
+- [elektra-key-names(7)](elektra-key-names.md) for an explanation of key names.

--- a/doc/help/kdb-test.md
+++ b/doc/help/kdb-test.md
@@ -5,7 +5,7 @@ kdb-test(1) -- Run test(s) on the key database
 
 `kdb test <path> [<test-name> ...]`  
 
-Where `path` is the path to key which the user wishes to perform the test under.
+Where `path` is the path the user wishes to perform the test under.
 The option `test-name` argument is used to specify which test(s) to run. To run multiple tests, each should be named with a trailing space.  
 If no `test-name` is provided, all the tests will be run.  
 
@@ -35,5 +35,6 @@ To run all tests below the `user/example/tests` key:
 To run the `binary` and `naming` tests:  
 `kdb test user/example/tests binary naming`  
 
+## SEE ALSO
 
-
+- [elektra-key-names(7)](elektra-key-names.md) for an explanation of key names.

--- a/doc/help/kdb-vset.md
+++ b/doc/help/kdb-vset.md
@@ -3,9 +3,9 @@ kdb-vset(1) - Set the value of a key with a validation regular expression
 
 ## SYNOPSIS
 
-`kdb vset <path> <value> <regex> [<message>]`
+`kdb vset <key name> <value> <regex> [<message>]`
 
-Where `path` is the path to the key the user wishes to set, `value` is the value the user wishes to set, and `regex` is the regular expression that should be used for validation.
+Where `key name` is the name of the key the user wishes to set, `value` is the value the user wishes to set, and `regex` is the regular expression that should be used for validation.
 The optional parameter `message` is a user-defined message that will be displayed when a user tries to set the key to a value that doesn't match the regular expression.
 The expression will be matched against the whole value (`check/validation/match=LINE`).
 
@@ -41,3 +41,4 @@ To set the `user/validation/key` key to the value `a` and validate that any futu
 ## SEE ALSO
 
 - Use `kdb info validation` to get information about the validation plugin.
+- [elektra-key-names(7)](elektra-key-names.md) for an explanation of key names.

--- a/doc/help/kdb.md
+++ b/doc/help/kdb.md
@@ -96,7 +96,7 @@ because it ensures flexibility in the future (e.g. to use profiles and have a co
 path for new major versions of configuration).
 
 Long paths are, however, cumbersome to enter in the CLI.
-Thus one can define bookmarks. Bookmarks are key-names that start with `+`.
+Thus one can define bookmarks. Bookmarks are keys whose key name starts with `+`.
 They are only recognized by the `kdb` tool or tools that explicit have
 support for it. Your applications should not depend on the presence of a
 bookmark.
@@ -106,7 +106,7 @@ Bookmarks are stored below:
 
 For every key found there, a new bookmark will be introduced.
 
-Bookmarks can be used to start key-names by using `+` (plus) as first character.
+Bookmarks can be used to start key names by using `+` (plus) as first character.
 The string until the first `/` will be considered as bookmark.
 
 For example, if you set the bookmark kdb:

--- a/doc/news/2014-09-02_0.8.8.md
+++ b/doc/news/2014-09-02_0.8.8.md
@@ -102,11 +102,11 @@ destroys the order of the keyset. This is now avoided by keyLock.
 Use keyDup() to get rid of such locks.
 
 Another, even larger, change is also about ordering of keys in keysets.
-Elektra now internally has an null-terminated unescaped keyname.
+Elektra now internally has an null-terminated unescaped key name.
 Ordering of keysets will always happen on this name. The keyCmp() tool
 can be used to check this order. It works very efficiently with
 memcmp() and never gets confused by ASCII ordering of / (because / is
-0 in the unescaped keyname).
+0 in the unescaped key name).
 
 The syntax, semantics and conventions of key names is now documented in
 detail:

--- a/doc/news/2014-12-02_0.8.10.md
+++ b/doc/news/2014-12-02_0.8.10.md
@@ -283,7 +283,7 @@ We developed already
 Raffael Pancheri released the version 0.0.2 of the Qt-Gui:
 
 * added Backend Wizard for mounting
-* user can hover over TreeView items and quickly see keyname, keyvalue
+* user can hover over TreeView items and quickly see key name, key value
   and metakeys
 * it is now easily possible to create and edit arrays
 * added header to MetaArea for better clarity

--- a/doc/news/2016-02-16_0.8.15.md
+++ b/doc/news/2016-02-16_0.8.15.md
@@ -426,7 +426,7 @@ When running as root, `kdb` will now use the `system` namespace when
 writing configuration to cascading key names.
 
 Long paths are cumbersome to enter in the CLI.  Thus one can define
-bookmarks now. Bookmarks are key-names that start with `+`.  They are
+bookmarks now. Bookmarks are key names that start with `+`.  They are
 only recognized by the `kdb` tool or tools that explicitly have support
 for it. Applications should not depend on the presence of a bookmark. For
 example, if you set the bookmark kdb:
@@ -444,7 +444,7 @@ no man page viewer is present or Elektra was installed wrongly.
 
 The `--help` usage is unified and improved.
 
-The new keyname naming conventions are now used for
+The new key naming conventions are now used for
 configuration of the `kdb`-tool itself: `/sw/elektra/kdb/#0/%/`
 and `/sw/elektra/kdb/#0/current/` are additionally read.  The option
 `-p`/`--profile` is now supported for every command, it allows to fetch
@@ -490,10 +490,10 @@ did a lot of editing and fixed many places throughout the documentation
 Also thanks to Michael Zehender who added two paragraphs in the main
 README.md.
 
-Keynames of applications should be called `/sw/org/app/#0/current`,
+Key names of applications should be called `/sw/org/app/#0/current`,
 where `current` is the default profile (non given). `org` and
 `app` is supposed to not contain `/` and be completely lowercase.
-Keynames are documented [here](/doc/help/elektra-key-names.md).
+Key names are documented [here](/doc/help/elektra-key-names.md).
 [See also here](/doc/tutorials/application-integration.md). The main
 reason for long paths is the provided flexibility in the future
 (e.g. to use profiles and have a compatible path for new major versions

--- a/doc/tutorials/namespaces.md
+++ b/doc/tutorials/namespaces.md
@@ -82,7 +82,7 @@ kdb get -v /b/c
 #>  searching proc/b/c, found: <nothing>, options:
 #>  searching dir/b/c, found: <nothing>, options:
 #>  searching user/b/c, found: user/b/c, options:
-#> The resulting keyname is user/b/c
+#> The resulting key name is user/b/c
 #> Value 2
 ```
 

--- a/doc/tutorials/python-kdb.md
+++ b/doc/tutorials/python-kdb.md
@@ -32,7 +32,7 @@ with kdb.KDB() as k:
     k.get(ks, 'user')
 ```
 
-It is also possible to iterate as expected over a keyset and use `len`, `reversed` and copying. The elements of a keyset can be accessed by indexes and a keyset can be sliced. Another way of accessing a key is by the key-name (`keyset_name['/path/to/keys/key_name']`). If the key-name does not exist within the keyset, a `KeyError` exception is thrown.
+It is also possible to iterate as expected over a keyset and use `len`, `reversed` and copying. The elements of a keyset can be accessed by indexes and a keyset can be sliced. Another way of accessing a key is by the key name (`keyset_name['/path/to/keys/key_name']`). If a key with the given name does not exist within the keyset, a `KeyError` exception is thrown.
 
 An example that shows how to load an existing keyset and then access every key and value of the loaded keyset:
 
@@ -144,8 +144,8 @@ with kdb.KDB() as k:
     ks = kdb.KeySet()
     k.get(ks, 'user')
     for key in ks:
-        print("key-name:  {}".format(key.name))
-        print("{0}{1}\n{0}{2}\n".format("key-value: ", key.value,
+        print("key name:  {}".format(key.name))
+        print("{0}{1}\n{0}{2}\n".format("key value: ", key.value,
                                         ks.lookup(key).string))
 ```
 
@@ -156,7 +156,7 @@ import kdb
 
 with kdb.KDB() as k:
     # the first argument is the path to the key,
-    # the third argument is the key-value
+    # the third argument is the key's value
     new_key = kdb.Key('/user/sw/pk/key_name', kdb.KEY_VALUE, 'key_value')
     print("{}: {}".format(new_key, new_key.value))
 ```

--- a/src/bindings/README.md
+++ b/src/bindings/README.md
@@ -32,4 +32,4 @@ Deprecated bindings (not included in `ALL`):
 
 ## SEE ALSO ##
 
-- See [COMPILE](/doc/COMPILE.md#bindings) how to specify the bindings to build.
+- See [COMPILE](/doc/COMPILE.md#bindings) for how to specify the bindings to build, e.g. `ALL`.

--- a/src/tools/kdb/cmdline.cpp
+++ b/src/tools/kdb/cmdline.cpp
@@ -36,10 +36,10 @@ Cmdline::Cmdline (int argc, char ** argv, Command * command)
 : helpText (), invalidOpt (false),
 
   /*XXX: Step 2: initialise your option here.*/
-  debug (), force (), load (), humanReadable (), help (), interactive (), noNewline (), test (), recursive (), resolver (KDB_RESOLVER),
-  strategy ("preserve"), verbose (), quiet (), version (), withoutElektra (), null (), first (true), second (true), third (true),
-  withRecommends (false), all (), format (KDB_STORAGE), plugins ("sync"), globalPlugins ("spec"), pluginsConfig (""), color ("auto"),
-  ns (""), editor (), bookmarks (), profile ("current"),
+  debug (), force (), load (), humanReadable (), help (), interactive (), minDepth (0), maxDepth (1), noNewline (), test (), recursive (),
+  resolver (KDB_RESOLVER), strategy ("preserve"), verbose (), quiet (), version (), withoutElektra (), null (), first (true), second (true),
+  third (true), withRecommends (false), all (), format (KDB_STORAGE), plugins ("sync"), globalPlugins ("spec"), pluginsConfig (""),
+  color ("auto"), ns (""), editor (), bookmarks (), profile ("current"),
 
   executable (), commandName ()
 {
@@ -106,6 +106,20 @@ Cmdline::Cmdline (int argc, char ** argv, Command * command)
 		option o = { "interactive", no_argument, nullptr, 'i' };
 		long_options.push_back (o);
 		helpText += "-i --interactive         Ask the user interactively.\n";
+	}
+	if (acceptedOptions.find ('m') != string::npos)
+	{
+		option o = { "min-depth", optional_argument, nullptr, 'm' };
+		long_options.push_back (o);
+		helpText += "-m --min-depth           Specify the minimum depth of completion suggestions (0 by default), exclusive.\n";
+	}
+	if (acceptedOptions.find ('M') != string::npos)
+	{
+		option o = { "max-depth", optional_argument, nullptr, 'M' };
+		long_options.push_back (o);
+		helpText +=
+			"-M --max-depth           Specify the maximum depth of completion suggestions (1 by default, -1 to set no limit), "
+			"inclusive.\n";
 	}
 	if (acceptedOptions.find ('n') != string::npos)
 	{
@@ -371,6 +385,27 @@ Cmdline::Cmdline (int argc, char ** argv, Command * command)
 			break;
 		case 'i':
 			interactive = true;
+			break;
+		case 'm':
+			if (!optarg)
+			{
+				minDepth = 0;
+				break;
+			}
+			stringstream (optarg) >> minDepth;
+			break;
+		case 'M':
+			if (!optarg)
+			{
+				cout << " no optarg for max " << endl;
+				maxDepth = 1;
+				break;
+			}
+			stringstream (optarg) >> maxDepth;
+			if (maxDepth == -1)
+			{
+				maxDepth = numeric_limits<int>::max ();
+			}
 			break;
 		case 'n':
 			noNewline = true;

--- a/src/tools/kdb/cmdline.cpp
+++ b/src/tools/kdb/cmdline.cpp
@@ -482,7 +482,7 @@ kdb::Key Cmdline::createKey (int pos) const
 	// for (auto const & n : bookmarks) std::cout << "nks: " << n.second << std::endl;
 	if (name.empty ())
 	{
-		throw invalid_argument ("<empty string> is not a valid keyname. Please enter one.");
+		throw invalid_argument ("<empty string> is not a valid keyname. Please enter a valid one.");
 	}
 
 	if (name[0] == '+')
@@ -517,12 +517,11 @@ kdb::Key Cmdline::createKey (int pos) const
 
 	if (!root.isValid ())
 	{
-		throw invalid_argument (name + " is not a valid keyname" +
-								"\n\n" +
-                                "For absolute keys (starting without '/'), please note that only one of the predefined namespaces can be used (see 'man elektra-namespaces').\n" +
-								"Please also ensure that the path is separated by a '/'.\n" +
-                                "An example for a valid absolute key is user/a/key, and for a valid cascading key /a/key."
-			);
+		throw invalid_argument (name + " is not a valid keyname" + "\n\n" +
+					"For absolute keys (starting without '/'), please note that only one of the predefined namespaces "
+					"can be used (see 'man elektra-namespaces').\n" +
+					"Please also ensure that the path is separated by a '/'.\n" +
+					"An example for a valid absolute key is user/a/key, and for a valid cascading key /a/key.");
 	}
 
 	return root;

--- a/src/tools/kdb/cmdline.cpp
+++ b/src/tools/kdb/cmdline.cpp
@@ -482,7 +482,7 @@ kdb::Key Cmdline::createKey (int pos) const
 	// for (auto const & n : bookmarks) std::cout << "nks: " << n.second << std::endl;
 	if (name.empty ())
 	{
-		throw invalid_argument ("<empty string> is not a valid keyname");
+		throw invalid_argument ("<empty string> is not a valid keyname. Please enter one.");
 	}
 
 	if (name[0] == '+')
@@ -517,7 +517,12 @@ kdb::Key Cmdline::createKey (int pos) const
 
 	if (!root.isValid ())
 	{
-		throw invalid_argument (name + " is not a valid keyname");
+		throw invalid_argument (name + " is not a valid keyname" +
+								"\n\n" +
+                                "For absolute keys (starting without '/'), please note that only one of the predefined namespaces can be used (see 'man elektra-namespaces').\n" +
+								"Please also ensure that the path is separated by a '/'.\n" +
+                                "An example for a valid absolute key is user/a/key, and for a valid cascading key /a/key."
+			);
 	}
 
 	return root;

--- a/src/tools/kdb/cmdline.hpp
+++ b/src/tools/kdb/cmdline.hpp
@@ -62,6 +62,8 @@ public:
 	bool humanReadable; /*!< Human readable values are preferred. */
 	bool help;	  /*!< Display help instead of the normal action.. */
 	bool interactive;   /*!< Interactive mode. */
+	int minDepth;       /*!< minimum depth for completion suggestions */
+	int maxDepth;       /*!< maximum depth for completion suggestions */
 	bool noNewline;     /*!< Do not output a newline at the end. */
 	bool test;	  /*!< Run some self tests instead of the normal action. */
 	bool recursive;     /*!< Recursive mode. */

--- a/src/tools/kdb/coloredkdbio.hpp
+++ b/src/tools/kdb/coloredkdbio.hpp
@@ -15,12 +15,12 @@
  */
 #define USER_DEFINED_IO
 
+#include "ansicolors.hpp"
+
 #include <key.hpp>
 
 #include <iomanip>
 #include <ostream>
-
-#include "ansicolors.hpp"
 
 namespace kdb
 {

--- a/src/tools/kdb/complete.cpp
+++ b/src/tools/kdb/complete.cpp
@@ -6,7 +6,7 @@
  * @copyright BSD License (see doc/LICENSE.md or http://www.libelektra.org)
  */
 
-#include <complete.hpp>
+#include <superls.hpp>
 
 #include <functional>
 #include <iostream>

--- a/src/tools/kdb/complete.hpp
+++ b/src/tools/kdb/complete.hpp
@@ -1,0 +1,60 @@
+/**
+ * @file
+ *
+ * @brief
+ *
+ * @copyright BSD License (see doc/LICENSE.md or http://www.libelektra.org)
+ */
+
+#ifndef COMPLETE_H
+#define COMPLETE_H
+
+#include <functional>
+#include <map>
+
+#include "coloredkdbio.hpp"
+#include <command.hpp>
+#include <kdb.hpp>
+
+class CompleteCommand : public Command
+{
+
+public:
+	CompleteCommand ();
+	~CompleteCommand ();
+
+	virtual std::string getShortOptions () override
+	{
+		return "dmMv0";
+	}
+
+	virtual std::string getSynopsis () override
+	{
+		return "<path>";
+	}
+
+	virtual std::string getShortHelpText () override
+	{
+		return "Show suggestions how the current name could be completed.";
+	}
+
+	virtual std::string getLongHelpText () override
+	{
+		return "Suggestions will include exsting key names, path segments of existing key names and mountpoints.\n";
+	}
+
+	virtual int execute (const Cmdline & cmdline) override;
+
+private:
+	void addMountpoints (kdb::KeySet & ks, const kdb::Key root);
+	const std::map<kdb::Key, std::pair<int, int>> analyze (const kdb::KeySet & ks, const kdb::Key root, kdb::KeySet & virtualKeys,
+							       const Cmdline & cmdLine);
+	const kdb::Key getParentKey (const kdb::Key key);
+	void increaseCount (std::map<kdb::Key, std::pair<int, int>> & hierarchy, const kdb::Key key,
+			    const std::function<int(int)> depthIncreaser);
+	void printResult (const kdb::Key originalRoot, const kdb::Key root, const std::map<kdb::Key, std::pair<int, int>> & hierarchy,
+			  const kdb::KeySet & virtualKeys, const Cmdline & cmdLine);
+	const std::function<bool(std::string)> determineFilterPredicate (const kdb::Key originalRoot, const kdb::Key root);
+};
+
+#endif

--- a/src/tools/kdb/editor.cpp
+++ b/src/tools/kdb/editor.cpp
@@ -59,6 +59,8 @@ bool runAllEditors (std::string filename)
 	using namespace kdb;
 	if (runEditor ("/usr/bin/sensible-editor", filename)) return true;
 	if (runEditor ("/usr/bin/editor", filename)) return true;
+	char * editor = getenv ("EDITOR");
+	if (editor && runEditor (editor, filename)) return true;
 	if (runEditor ("/usr/bin/vi", filename)) return true;
 	if (runEditor ("/bin/vi", filename)) return true;
 	return false;

--- a/src/tools/kdb/factory.hpp
+++ b/src/tools/kdb/factory.hpp
@@ -15,7 +15,9 @@
 #include <string>
 #include <vector>
 
+#include "ansicolors.hpp"
 #include "coloredkdbio.hpp"
+
 #include <command.hpp>
 #include <external.hpp>
 
@@ -32,6 +34,7 @@
 #include <import.hpp>
 #include <info.hpp>
 #include <list.hpp>
+#include <listcommands.hpp>
 #include <ls.hpp>
 #include <merge.hpp>
 #include <metaget.hpp>
@@ -105,6 +108,7 @@ public:
 		m_factory.insert (std::make_pair ("smount", new Cnstancer<SpecMountCommand> ()));
 		m_factory.insert (std::make_pair ("global-mount", new Cnstancer<GlobalMountCommand> ()));
 		m_factory.insert (std::make_pair ("gmount", new Cnstancer<GlobalMountCommand> ()));
+		m_factory.insert (std::make_pair ("list-commands", new Cnstancer<ListCommandsCommand> ()));
 	}
 
 	~Factory ()
@@ -115,8 +119,7 @@ public:
 		}
 	}
 
-	/**Returns a list of available commands */
-	std::vector<std::string> getCommands () const
+	std::vector<std::string> getPrettyCommands () const
 	{
 		std::vector<std::string> ret;
 		for (auto & elem : m_factory)
@@ -134,6 +137,19 @@ public:
 			       "View the man page of a tool");
 		ret.push_back (getStdColor (ANSI_COLOR::BOLD) + "list-tools" + getStdColor (ANSI_COLOR::RESET) + "\t" +
 			       "List all external tool");
+		return ret;
+	}
+
+	/**Returns a list of available commands */
+	std::vector<std::string> getCommands () const
+	{
+		std::vector<std::string> ret;
+		for (auto & elem : m_factory)
+		{
+			ret.push_back (elem.first);
+		}
+		ret.push_back ("help");
+		ret.push_back ("list-tools");
 		return ret;
 	}
 

--- a/src/tools/kdb/factory.hpp
+++ b/src/tools/kdb/factory.hpp
@@ -48,6 +48,7 @@
 #include <sget.hpp>
 #include <shell.hpp>
 #include <specmount.hpp>
+#include <superls.hpp>
 #include <test.hpp>
 #include <umount.hpp>
 #include <validation.hpp>
@@ -82,6 +83,7 @@ public:
 		m_factory.insert (std::make_pair ("set", new Cnstancer<SetCommand> ()));
 		m_factory.insert (std::make_pair ("rm", new Cnstancer<RemoveCommand> ()));
 		m_factory.insert (std::make_pair ("ls", new Cnstancer<LsCommand> ()));
+		m_factory.insert (std::make_pair ("super-ls", new Cnstancer<SuperLsCommand> ()));
 		m_factory.insert (std::make_pair ("cp", new Cnstancer<CpCommand> ()));
 		m_factory.insert (std::make_pair ("mv", new Cnstancer<MvCommand> ()));
 		m_factory.insert (std::make_pair ("mount", new Cnstancer<MountCommand> ()));

--- a/src/tools/kdb/factory.hpp
+++ b/src/tools/kdb/factory.hpp
@@ -83,7 +83,7 @@ public:
 		m_factory.insert (std::make_pair ("set", new Cnstancer<SetCommand> ()));
 		m_factory.insert (std::make_pair ("rm", new Cnstancer<RemoveCommand> ()));
 		m_factory.insert (std::make_pair ("ls", new Cnstancer<LsCommand> ()));
-		m_factory.insert (std::make_pair ("super-ls", new Cnstancer<SuperLsCommand> ()));
+		m_factory.insert (std::make_pair ("complete", new Cnstancer<CompleteCommand> ()));
 		m_factory.insert (std::make_pair ("cp", new Cnstancer<CpCommand> ()));
 		m_factory.insert (std::make_pair ("mv", new Cnstancer<MvCommand> ()));
 		m_factory.insert (std::make_pair ("mount", new Cnstancer<MountCommand> ()));

--- a/src/tools/kdb/factory.hpp
+++ b/src/tools/kdb/factory.hpp
@@ -23,6 +23,7 @@
 
 // TODO: to add a new command, 1.) include your header here
 #include <check.hpp>
+#include <complete.hpp>
 #include <convert.hpp>
 #include <cp.hpp>
 #include <editor.hpp>
@@ -48,7 +49,6 @@
 #include <sget.hpp>
 #include <shell.hpp>
 #include <specmount.hpp>
-#include <superls.hpp>
 #include <test.hpp>
 #include <umount.hpp>
 #include <validation.hpp>

--- a/src/tools/kdb/listcommands.cpp
+++ b/src/tools/kdb/listcommands.cpp
@@ -1,0 +1,69 @@
+/**
+ * @file
+ *
+ * @brief
+ *
+ * @copyright BSD License (see doc/LICENSE.md or http://www.libelektra.org)
+ */
+
+#include <factory.hpp>
+#include <listcommands.hpp>
+
+#include <iostream>
+
+#include <cmdline.hpp>
+
+using namespace kdb;
+using namespace std;
+
+ListCommandsCommand::ListCommandsCommand ()
+{
+}
+
+int ListCommandsCommand::execute (Cmdline const & cl)
+{
+	Factory f;
+
+	std::vector<std::string> commands;
+	try
+	{
+		if (cl.verbose)
+		{
+			commands = f.getPrettyCommands ();
+		}
+		else
+		{
+			commands = f.getCommands ();
+		}
+	}
+	catch (kdb::KDBException const & ce)
+	{
+		std::cerr << "Sorry, I have a severe problem, it seems like I am not installed correctly!\n"
+			  << "kdbOpen() failed with the info:" << std::endl
+			  << ce.what () << std::endl
+			  << "Please report the issue on https://issues.libelektra.org/";
+		return 8;
+	}
+
+	if (cl.verbose) cout << "number of all commands: " << commands.size () << endl;
+
+	for (auto & command : commands)
+	{
+		std::cout << command;
+
+		if (cl.null)
+		{
+			cout << '\0';
+		}
+		else
+		{
+			cout << endl;
+		}
+	}
+
+	return 0;
+}
+
+ListCommandsCommand::~ListCommandsCommand ()
+{
+}

--- a/src/tools/kdb/listcommands.hpp
+++ b/src/tools/kdb/listcommands.hpp
@@ -1,0 +1,44 @@
+/**
+ * @file
+ *
+ * @brief
+ *
+ * @copyright BSD License (see doc/LICENSE.md or http://www.libelektra.org)
+ */
+
+#ifndef LIST_COMMANDS_H
+#define LIST_COMMANDS_H
+
+#include <command.hpp>
+#include <kdb.hpp>
+
+class ListCommandsCommand : public Command
+{
+public:
+	ListCommandsCommand ();
+	~ListCommandsCommand ();
+
+	virtual std::string getShortOptions () override
+	{
+		return "0vC";
+	}
+
+	virtual std::string getSynopsis () override
+	{
+		return "";
+	}
+
+	virtual std::string getShortHelpText () override
+	{
+		return "List available kdb commands.";
+	}
+
+	virtual std::string getLongHelpText () override
+	{
+		return "";
+	}
+
+	virtual int execute (Cmdline const & cmdline) override;
+};
+
+#endif

--- a/src/tools/kdb/main.cpp
+++ b/src/tools/kdb/main.cpp
@@ -17,6 +17,7 @@
 #include <command.hpp>
 #include <external.hpp>
 #include <factory.hpp>
+#include <signal.h>
 #include <toolexcept.hpp>
 
 #include <kdb.hpp>
@@ -79,8 +80,49 @@ void displayVersion ()
 	}
 }
 
+
+void catchSignal (int signum)
+{
+	cerr << endl << "Caught signal ";
+	switch (signum)
+	{
+	case SIGILL:
+		cerr << "SIGILL";
+		break;
+	case SIGABRT:
+		cerr << "SIGABRT";
+		break;
+	case SIGFPE:
+		cerr << "SIGFPE";
+		break;
+	case SIGSEGV:
+		cerr << "SIGSEGV";
+		break;
+	}
+	cerr << endl << "Please report an issue on https://issues.libelektra.org/" << std::endl;
+	signal (SIGABRT, SIG_DFL);
+	abort ();
+}
+
+void setupSignal (int signum)
+{
+	if (signal (signum, catchSignal) == SIG_ERR)
+	{
+		cerr << "Could not setup signal " << signum << " because: " << strerror (errno) << std::endl;
+	}
+}
+
+void setupSignals ()
+{
+	setupSignal (SIGILL);
+	setupSignal (SIGABRT);
+	setupSignal (SIGFPE);
+	setupSignal (SIGSEGV);
+}
+
 int main (int argc, char ** argv)
 {
+	setupSignals ();
 	Factory f;
 
 	if (argc < 2)

--- a/src/tools/kdb/main.cpp
+++ b/src/tools/kdb/main.cpp
@@ -37,7 +37,7 @@ int displayHelp (std::string app, Factory const & f)
 	std::vector<std::string> commands;
 	try
 	{
-		commands = f.getCommands ();
+		commands = f.getPrettyCommands ();
 	}
 	catch (kdb::KDBException const & ce)
 	{

--- a/src/tools/kdb/main.cpp
+++ b/src/tools/kdb/main.cpp
@@ -80,10 +80,8 @@ void displayVersion ()
 	}
 }
 
-
-void catchSignal (int signum)
+void printSignal (int signum)
 {
-	cerr << endl << "Sorry, I crashed by the signal ";
 	switch (signum)
 	{
 	case SIGILL:
@@ -99,6 +97,14 @@ void catchSignal (int signum)
 		cerr << "SIGSEGV";
 		break;
 	}
+}
+
+
+void catchSignal (int signum)
+{
+	cerr << endl << "Sorry, I crashed by the signal ";
+	printSignal (signum);
+	cerr << endl << "This should not have happened!" << endl;
 	cerr << endl << "Please report the issue on https://issues.libelektra.org/" << std::endl;
 	signal (SIGABRT, SIG_DFL);
 	abort ();
@@ -108,7 +114,9 @@ void setupSignal (int signum)
 {
 	if (signal (signum, catchSignal) == SIG_ERR)
 	{
-		cerr << "Sorry, I could not setup signal " << signum << " because: " << strerror (errno) << std::endl;
+		cerr << "Sorry, I could not setup signal ";
+		printSignal (signum);
+		cerr << " because: " << strerror (errno) << std::endl;
 		cerr << "Please report the issue on https://issues.libelektra.org/" << std::endl;
 	}
 }

--- a/src/tools/kdb/main.cpp
+++ b/src/tools/kdb/main.cpp
@@ -43,7 +43,7 @@ int displayHelp (std::string app, Factory const & f)
 		std::cerr << "Sorry, I have a severe problem, it seems like I am not installed correctly!\n"
 			  << "kdbOpen() failed with the info:" << std::endl
 			  << ce.what () << std::endl
-			  << "Please report an issue on http://git.libelektra.org/issues";
+			  << "Please report an issue on https://issues.libelektra.org/";
 		return 8;
 	}
 	for (auto & command : commands)
@@ -182,14 +182,15 @@ int main (int argc, char ** argv)
 		std::cerr << "The command " << getErrorColor (ANSI_COLOR::BOLD) << argv[0] << " " << command
 			  << getErrorColor (ANSI_COLOR::RESET) << " terminated " << getErrorColor (ANSI_COLOR::RED) << "unsuccessfully"
 			  << getErrorColor (ANSI_COLOR::RESET) << " with the info:\n"
-			  << ce.what () << std::endl;
+			  << ce.what () << "Please report an issue on https://issues.libelektra.org/" << std::endl;
 		return 6;
 	}
 	catch (...)
 	{
 		std::cerr << "The command " << getErrorColor (ANSI_COLOR::BOLD) << argv[0] << " " << command
 			  << getErrorColor (ANSI_COLOR::RESET) << " terminated with an " << getErrorColor (ANSI_COLOR::RED)
-			  << "unknown error" << getErrorColor (ANSI_COLOR::RESET) << std::endl;
+			  << "unknown error" << getErrorColor (ANSI_COLOR::RESET)
+			  << "Please report an issue on https://issues.libelektra.org/" << std::endl;
 		displayHelp (argv[0], f);
 		return 7;
 	}

--- a/src/tools/kdb/main.cpp
+++ b/src/tools/kdb/main.cpp
@@ -44,7 +44,7 @@ int displayHelp (std::string app, Factory const & f)
 		std::cerr << "Sorry, I have a severe problem, it seems like I am not installed correctly!\n"
 			  << "kdbOpen() failed with the info:" << std::endl
 			  << ce.what () << std::endl
-			  << "Please report an issue on https://issues.libelektra.org/";
+			  << "Please report the issue on https://issues.libelektra.org/";
 		return 8;
 	}
 	for (auto & command : commands)
@@ -83,7 +83,7 @@ void displayVersion ()
 
 void catchSignal (int signum)
 {
-	cerr << endl << "Caught signal ";
+	cerr << endl << "Sorry, I crashed by the signal ";
 	switch (signum)
 	{
 	case SIGILL:
@@ -99,7 +99,7 @@ void catchSignal (int signum)
 		cerr << "SIGSEGV";
 		break;
 	}
-	cerr << endl << "Please report an issue on https://issues.libelektra.org/" << std::endl;
+	cerr << endl << "Please report the issue on https://issues.libelektra.org/" << std::endl;
 	signal (SIGABRT, SIG_DFL);
 	abort ();
 }
@@ -108,7 +108,8 @@ void setupSignal (int signum)
 {
 	if (signal (signum, catchSignal) == SIG_ERR)
 	{
-		cerr << "Could not setup signal " << signum << " because: " << strerror (errno) << std::endl;
+		cerr << "Sorry, I could not setup signal " << signum << " because: " << strerror (errno) << std::endl;
+		cerr << "Please report the issue on https://issues.libelektra.org/" << std::endl;
 	}
 }
 
@@ -224,7 +225,7 @@ int main (int argc, char ** argv)
 		std::cerr << "The command " << getErrorColor (ANSI_COLOR::BOLD) << argv[0] << " " << command
 			  << getErrorColor (ANSI_COLOR::RESET) << " terminated " << getErrorColor (ANSI_COLOR::RED) << "unsuccessfully"
 			  << getErrorColor (ANSI_COLOR::RESET) << " with the info:\n"
-			  << ce.what () << "Please report an issue on https://issues.libelektra.org/" << std::endl;
+			  << ce.what () << "Please report the issue on https://issues.libelektra.org/" << std::endl;
 		return 6;
 	}
 	catch (...)
@@ -232,7 +233,7 @@ int main (int argc, char ** argv)
 		std::cerr << "The command " << getErrorColor (ANSI_COLOR::BOLD) << argv[0] << " " << command
 			  << getErrorColor (ANSI_COLOR::RESET) << " terminated with an " << getErrorColor (ANSI_COLOR::RED)
 			  << "unknown error" << getErrorColor (ANSI_COLOR::RESET)
-			  << "Please report an issue on https://issues.libelektra.org/" << std::endl;
+			  << "Please report the issue on https://issues.libelektra.org/" << std::endl;
 		displayHelp (argv[0], f);
 		return 7;
 	}

--- a/src/tools/kdb/superls.cpp
+++ b/src/tools/kdb/superls.cpp
@@ -8,9 +8,9 @@
 
 #include <superls.hpp>
 
+#include <functional>
 #include <iostream>
 #include <stack>
-#include <functional>
 
 #include <cmdline.hpp>
 #include <kdb.hpp>
@@ -19,125 +19,176 @@
 using namespace kdb;
 using namespace std;
 
-SuperLsCommand::SuperLsCommand () : kdb (root)
+SuperLsCommand::SuperLsCommand ()
 {
 }
 
-int SuperLsCommand::execute (Cmdline const & cl)
+int SuperLsCommand::execute (const Cmdline & cl)
 {
 	if (cl.arguments.size () != 1)
 	{
-		throw invalid_argument ("1 argument required");
+		throw invalid_argument ("wrong number of arguments, 1 needed");
 	}
 
-	printWarnings (cerr, root);
-	Key originalRoot = cl.createKey (0);
-	root = originalRoot;
-	kdb.get (ks, root);
-	
-	cout.setf (std::ios_base::unitbuf);
+	cout.setf (ios_base::unitbuf);
 	if (cl.null)
 	{
-		cout.unsetf (std::ios_base::skipws);
+		cout.unsetf (ios_base::skipws);
 	}
-	
-	function<bool(string)> pred = [] (string) { return true; };
-	bool isExistent = ks.lookup(root) || root.getBaseName().empty();
-	if (!isExistent) {
-		string fullName = cl.arguments[0];
-		string newKeyName = getParentKey(root).getFullName();
-		cout << "new name is " << newKeyName << endl;
-		root = Key (newKeyName, KEY_END);
-		cout << " building predicate " << root.isCascading() << " " << fullName << " " << fullName.find("/") << endl;
-		pred = [=] (string test) { 
-			return fullName.size() <= test.size() && std::equal(fullName.begin(), fullName.end(), test.begin() + (root.isCascading() ? test.find("/") : 0));
-		};
+
+	// Determine the actual root key, as for completion purpose originalRoot may not exist
+	KDB kdb;
+	const Key originalRoot = cl.createKey (0);
+	Key root = originalRoot;
+	KeySet ks;
+	printWarnings (cerr, root);
+
+	kdb.get (ks, root);
+	if (!ks.lookup (root) && !root.getBaseName ().empty ())
+	{
+		root = getParentKey (root);
 	}
-	
-	cout << "cutting at " << root << endl;
-	ks = ks.cut(root);
-	
-	map<Key, pair<int, int>> hierarchy = map<Key, pair<int, int>>();
-	
-	ks.rewind();
-	
-	KeySet hierarchialKeys;
-	Key parent;
-	Key last;
-	Key tmp;
-	
-	stack<Key> keyStack;
-	if (!(tmp = ks.next())) {
-		// return?
-		return 0;
-	}
-	
-	int curDepth = 0;
-	keyStack.push(tmp);
-	while (!keyStack.empty()) {
-		Key current = keyStack.top();
-		keyStack.pop();
-		if (current.isDirectBelow(last)) { // hierarchy change
-			parent = last;
-			curDepth++;
-		}
-		
-		cout << "Processing " << current << " vs last " << last << " at depth " << curDepth << endl;
-		
-		if (current.isDirectBelow(parent)) { // hierarchy continues
-			increaseCount(hierarchy, parent, [](int p) {return p;});
-			increaseCount(hierarchy, current, [=](int) {return curDepth;});
-		} else { // otherwise expand the current key to the stack
-			cout << "expanding at " << current << " vs root " << root << " which is belowOrSame " << current.isBelowOrSame(root) << endl;
-			while (current.isBelow(root) && !current.getBaseName().empty() && hierarchy[current].first == 0) {
-				cout << "expanding at " << current << " vs root " << root << endl;
-				keyStack.push(current);
-				hierarchialKeys.append(current);
-				current = getParentKey(current);
-			}
-			parent = getParentKey(current);
-			curDepth = hierarchy[current].second;
-		}
-		
-		// Current hierarchy processed, we can resume with the next
-		if(keyStack.empty() && (tmp = ks.next())){
-			keyStack.push(tmp);
-		}
-		
-		last = current;
-	}
-	
-	// Adjust the output offset, in case the given string exists in the hierarchy but not in the original ks
-	int offset = !isExistent && hierarchialKeys.lookup(originalRoot);
-	int minDepth = 0 + offset;
-	int maxDepth = cl.recursive ? std::numeric_limits<int>::max() : (1 + offset);
-	cout << "max is " << maxDepth << " and min is " << minDepth << endl;
-	
-	cout << "dumping all results" << endl;
-	for (auto it = hierarchy.begin(); it != hierarchy.end(); it++) {
-		cout << it->first << " " << it->second.first << " " << it->second.second << endl;
-	}
-	
-	cout << endl << "dumping filtered results" << endl;
-	for (auto it = hierarchy.begin(); it != hierarchy.end(); it++) {
-		if (pred(it->first.getFullName()) && it->second.second > minDepth && it->second.second <= maxDepth) {
-			cout << it->first << (it->second.first > 1 ? " node " + std::to_string(it->second.first - 1): " leaf") << endl;
-		}
-	}
-	
+	ks = ks.cut (root);
+
+	// Now analyze the completion possibilities and print the results
+	addMountpoints (ks);
+	KeySet virtualKeys;
+	printResult (originalRoot, root, analyze (ks, root, virtualKeys), virtualKeys);
 	printWarnings (cerr, root);
 
 	return 0;
 }
 
-Key SuperLsCommand::getParentKey(Key key) {
-	return Key (key.getFullName().erase(key.getFullName().size() - key.getBaseName().size()), KEY_END);
+void SuperLsCommand::addMountpoints (KeySet & ks)
+{
+	KDB kdb;
+	Key mountpointPath ("system/elektra/mountpoints", KEY_END);
+	KeySet mountpoints;
+
+	kdb.get (mountpoints, mountpointPath);
+	mountpoints = mountpoints.cut (mountpointPath);
+
+	for (const Key mountpoint : mountpoints)
+	{
+		if (mountpoint.isDirectBelow (mountpointPath))
+		{
+			const string actualName = mountpoints.lookup (mountpoint.getFullName () + "/mountpoint").getString ();
+			ks.append (Key (actualName, KEY_END));
+		}
+	}
+
+	printWarnings (cerr, mountpointPath);
 }
 
-void SuperLsCommand::increaseCount(map<Key, pair<int, int>> & hierarchy, Key key, function<int(int)> depthIncreaser) {
-	cout << "increasing for " << key << endl;
-	pair<int, int> prev = hierarchy[key];
-	hierarchy[key] = pair<int, int>(prev.first + 1, depthIncreaser(prev.second));
+const map<Key, pair<int, int>> SuperLsCommand::analyze (const KeySet & ks, const Key root, KeySet & virtualKeys)
+{
+	map<Key, pair<int, int>> hierarchy;
+	stack<Key> keyStack;
+	Key parent;
+	Key last;
+
+	ks.rewind ();
+	if (!(ks.next ()))
+	{
+		return hierarchy;
+	}
+
+	int curDepth = 0;
+	keyStack.push (ks.current ());
+	while (!keyStack.empty ())
+	{
+		Key current = keyStack.top ();
+		keyStack.pop ();
+		if (current.isDirectBelow (last))
+		{ // down in the hierarchy, last element is new parent
+			parent = last;
+			curDepth++;
+		}
+
+		cout << "Processing " << current << " vs last " << last << " at depth " << curDepth << endl;
+
+		if (current.isDirectBelow (parent))
+		{ // hierarchy continues at the current level
+			increaseCount (hierarchy, parent, [](int p) { return p; });
+			increaseCount (hierarchy, current, [=](int) { return curDepth; });
+		}
+		else
+		{ // hierarchy does not fit the current parent, expand the current key to the stack to find the new parent
+			cout << "expanding at " << current << " vs root " << root << " which is belowOrSame "
+			     << current.isBelowOrSame (root) << endl;
+			// Go back up in the hierarchy until we encounter a known key or are back at the namespace level
+			while (current.isBelow (root) && !current.getBaseName ().empty () && hierarchy[current].first == 0)
+			{
+				cout << "expanding at " << current << " vs root " << root << endl;
+				keyStack.push (current);
+				virtualKeys.append (current);
+				current = getParentKey (current);
+			}
+			parent = getParentKey (current);
+			curDepth = hierarchy[current].second;
+		}
+
+		// Current hierarchy processed, we can resume with the next
+		if (keyStack.empty () && (ks.next ()))
+		{
+			keyStack.push (ks.current ());
+		}
+		last = current;
+	}
+
+	return hierarchy;
+}
+
+const Key SuperLsCommand::getParentKey (const Key key)
+{
+	return Key (key.getFullName ().erase (key.getFullName ().size () - key.getBaseName ().size ()), KEY_END);
+}
+
+void SuperLsCommand::increaseCount (map<Key, pair<int, int>> & hierarchy, const Key key, const function<int(int)> depthIncreaser)
+{
+	const pair<int, int> prev = hierarchy[key];
+	hierarchy[key] = pair<int, int> (prev.first + 1, depthIncreaser (prev.second));
+}
+
+void SuperLsCommand::printResult (const Key originalRoot, const Key root, const map<Key, pair<int, int>> & hierarchy,
+				  const KeySet & virtualKeys)
+{
+	const function<bool(string)> filterPredicate = determineFilterPredicate (originalRoot, root);
+
+	// Adjust the output offset, in case the given string exists in the hierarchy but not in the original ks
+	const int offset = originalRoot != root && virtualKeys.lookup (originalRoot);
+	const int minDepth = 0 + offset;
+	const int maxDepth = false ? numeric_limits<int>::max () : (1 + offset);
+	cout << "max is " << maxDepth << " and min is " << minDepth << endl;
+
+	cout << "dumping all results" << endl;
+	for (const auto & it : hierarchy)
+	{
+		cout << it.first << " " << it.second.first << " " << it.second.second << endl;
+	}
+
+	cout << endl << "dumping filtered results" << endl;
+	for (const auto & it : hierarchy)
+	{
+		if (filterPredicate (it.first.getFullName ()) && it.second.second > minDepth && it.second.second <= maxDepth)
+		{
+			cout << it.first << (it.second.first > 1 ? " node " + to_string (it.second.first - 1) : " leaf") << endl;
+		}
+	}
+}
+
+const function<bool(string)> SuperLsCommand::determineFilterPredicate (const Key originalRoot, const Key root)
+{
+	if (root == originalRoot)
+	{
+		return [](string) { return true; };
+	}
+	const string fullName = originalRoot.getFullName ();
+	return [=](string test) {
+		// For cascading keys, we ignore the preceding namespace for filtering
+		const int cascadationOffset = (root.isCascading () ? test.find ("/") : 0);
+		return fullName.size () <= test.size () && equal (fullName.begin (), fullName.end (), test.begin () + cascadationOffset);
+	};
 }
 
 SuperLsCommand::~SuperLsCommand ()

--- a/src/tools/kdb/superls.cpp
+++ b/src/tools/kdb/superls.cpp
@@ -13,6 +13,7 @@
 #include <cmdline.hpp>
 #include <kdb.hpp>
 #include <keysetio.hpp>
+#include <functional>
 
 using namespace kdb;
 using namespace std;
@@ -29,16 +30,9 @@ int SuperLsCommand::execute (Cmdline const & cl)
 	}
 
 	printWarnings (cerr, root);
-
 	root = cl.createKey (0);
-
 	kdb.get (ks, root);
-
-	if (cl.verbose) cout << "size of all keys in mountpoint: " << ks.size () << endl;
-
-	KeySet part (ks.cut (root));
 	
-	if (cl.verbose) cout << "size of requested keys: " << part.size () << endl;
 	cout.setf (std::ios_base::unitbuf);
 	if (cl.null)
 	{
@@ -47,28 +41,114 @@ int SuperLsCommand::execute (Cmdline const & cl)
 
 	Key key;
 	Key next;
+		
+	bool isExistent = ks.size() != 0 && ks.lookup(root);
+	cout << root.getFullName() << (isExistent ? " exists!" : " nope") << " with a keyset sized " << ks.size() << " and properties isValid " << root.isValid() << " isCascading " << root.isCascading() 
+	<< " isSpec " << root.isSpec() << " isProc " << root.isProc() << " isDir " << root.isDir() << " isUser " << root.isUser() << " isSystem " << root.isSystem() << endl;
 	
-	part.rewind();
-	while ((key = part.next())) {
-		cursor_t currentCursor = part.getCursor();
-		int count = 0;
-		while ((next = part.next()) && next.isBelow(key)) {
-			if (next.isDirectBelow(key)) {
-				count++;
-			}
-		}
-		if (count == 0) {
-			cout << key << " leaf" << endl;
-		} else {
-			cout << key << " node " << count << endl;
-		}
-		// Reset it so we do the same for the next node
-		part.setCursor(currentCursor);
+	function<bool(string)> pred = [] (string test) { return true; };
+	
+	if (!isExistent) {
+		string fullName = root.getFullName();
+		string newKeyName = getParentKey(root).getFullName();
+		cout << "new name is " << newKeyName << endl;
+		root = Key (newKeyName, KEY_END);
+		pred = [=] (string test) { 
+			return fullName.size() <= test.size() && std::equal(fullName.begin(), fullName.end(), test.begin());
+		};
 	}
+	
+	ks = ks.cut (root);
+	
+	cout << "testing pred" << (pred ("user/test/this/is/ok") ? "true" : "false") << endl;
+	cout << "testing pred" << (pred ("user/toest/this/is/not/ok") ? "true" : "false") << endl;
+	cout << root.getBaseName() << " " << root.getName() << " " << root.getFullName() << " " << (root.isNull() ? "isNull" : "isNotNull") << (root.isValid() ? "isValid" : "isNotValid") << endl;
+	
+	for (NameIterator it = root.begin(); it != root.end(); it++)
+	{
+		cout << *it << endl;
+	}
+	
+	cout << "ks contains " << ks.size() << "elements" << endl;
+	
+	
+	
+	// super-ls /
+	//system/foo node 1
+	//system/foo/bla node 1
+	//system/foo/bla/something node 4
+	//system/foo/bla/something/a leaf
+	//system/foo/bla/something/b leaf
+	//system/foo/bla/something/c leaf
+	//system/foo/bla/something/d leaf
+	//system/bla node 1
+	//system/bla/xx node 0
+	
+	// also consider completion from /system/foo/b 
+	// > if the input does not end in /b, complete the parent and filter by /b
+	
+	// ok initial things:
+	
+	
+	// #1 take /system/foo
+	// #2 strip foo and take system 
+	// #3 do the analyzation function on key /System
+	// #4 
+	
+	// via map:
+	// # parent = null processed = null
+	// # system/foo -> nothing processed, no parent take system and check again
+	// # nothing, system highest, system = parent, add +1 to map for system, system/foo = processed
+	// # check system/foo/bla
+	// # case 1: cur isDirectBelow processed -> processed++; parent = processed;
+	// # case 2: cur isDirectBelow parent -> parent++;
+	// # case 4: cur isBelow parent -> back to beginning
+	// # case 3: !below parent != parent -> back to beginning for now, simple
+	
+	map<string, int> hierarchy = map<string, int>();
+	
+	ks.rewind();
+	while ((key = ks.next())) {
+		if (pred(key.getFullName())) {
+			int count = hierarchy[key.getFullName()]; // will be 0 if non existent
+			hierarchy[key.getFullName()] = ++count;
+		}
+	}
+	
+	for (auto it = hierarchy.begin(); it != hierarchy.end(); it++) {
+		cout << it->first << " is " << it->second << endl;
+	}
+	
+	// initial key
+	// ignore things behind initial key for now
+	// maxdepth
+	// curDepth
+	
+	// ks.rewind();
+	// while ((key = ks.next())) {
+		// cursor_t currentCursor = ks.getCursor();
+		// int count = 0;
+		// while ((next = ks.next()) && next.isBelow(key)) {
+			// if (next.isDirectBelow(key)) {
+				// count++;
+			// }
+		// }
+		// if (count == 0) {
+			// cout << key << " leaf" << endl;
+		// } else {
+			// cout << key << " node " << count << endl;
+		// }
+		// Reset it so we do the same for the next node
+		// ks.setCursor(currentCursor);
+	// }
 
 	printWarnings (cerr, root);
 
 	return 0;
+}
+
+Key SuperLsCommand::getParentKey(Key key) {
+	return Key (key.getFullName().erase(key.getFullName().size() - key.getBaseName().size()), KEY_END);
 }
 
 SuperLsCommand::~SuperLsCommand ()

--- a/src/tools/kdb/superls.cpp
+++ b/src/tools/kdb/superls.cpp
@@ -1,0 +1,76 @@
+/**
+ * @file
+ *
+ * @brief
+ *
+ * @copyright BSD License (see doc/LICENSE.md or http://www.libelektra.org)
+ */
+
+#include <superls.hpp>
+
+#include <iostream>
+
+#include <cmdline.hpp>
+#include <kdb.hpp>
+#include <keysetio.hpp>
+
+using namespace kdb;
+using namespace std;
+
+SuperLsCommand::SuperLsCommand () : kdb (root)
+{
+}
+
+int SuperLsCommand::execute (Cmdline const & cl)
+{
+	if (cl.arguments.size () != 1)
+	{
+		throw invalid_argument ("1 argument required");
+	}
+
+	printWarnings (cerr, root);
+
+	root = cl.createKey (0);
+
+	kdb.get (ks, root);
+
+	if (cl.verbose) cout << "size of all keys in mountpoint: " << ks.size () << endl;
+
+	KeySet part (ks.cut (root));
+	
+	if (cl.verbose) cout << "size of requested keys: " << part.size () << endl;
+	cout.setf (std::ios_base::unitbuf);
+	if (cl.null)
+	{
+		cout.unsetf (std::ios_base::skipws);
+	}
+
+	Key key;
+	Key next;
+	
+	part.rewind();
+	while ((key = part.next())) {
+		cursor_t currentCursor = part.getCursor();
+		int count = 0;
+		while ((next = part.next()) && next.isBelow(key)) {
+			if (next.isDirectBelow(key)) {
+				count++;
+			}
+		}
+		if (count == 0) {
+			cout << key << " leaf" << endl;
+		} else {
+			cout << key << " node " << count << endl;
+		}
+		// Reset it so we do the same for the next node
+		part.setCursor(currentCursor);
+	}
+
+	printWarnings (cerr, root);
+
+	return 0;
+}
+
+SuperLsCommand::~SuperLsCommand ()
+{
+}

--- a/src/tools/kdb/superls.hpp
+++ b/src/tools/kdb/superls.hpp
@@ -1,0 +1,51 @@
+/**
+ * @file
+ *
+ * @brief
+ *
+ * @copyright BSD License (see doc/LICENSE.md or http://www.libelektra.org)
+ */
+
+#ifndef SUPERLS_H
+#define SUPERLS_H
+
+#include "coloredkdbio.hpp"
+#include <command.hpp>
+#include <kdb.hpp>
+
+class SuperLsCommand : public Command
+{
+	kdb::Key root;
+	kdb::KDB kdb;
+	kdb::KeySet ks;
+
+public:
+	SuperLsCommand ();
+	~SuperLsCommand ();
+
+	virtual std::string getShortOptions () override
+	{
+		return "v0C";
+	}
+
+	virtual std::string getSynopsis () override
+	{
+		return "<name>";
+	}
+
+	virtual std::string getShortHelpText () override
+	{
+		return "List the names of keys below a given name.";
+	}
+
+	virtual std::string getLongHelpText () override
+	{
+		return "List all keys below given name.\n"
+		       "To also retrieve the value use the\n"
+		       "export command.";
+	}
+
+	virtual int execute (Cmdline const & cmdline) override;
+};
+
+#endif

--- a/src/tools/kdb/superls.hpp
+++ b/src/tools/kdb/superls.hpp
@@ -9,6 +9,9 @@
 #ifndef SUPERLS_H
 #define SUPERLS_H
 
+#include <map>
+#include <functional>
+
 #include "coloredkdbio.hpp"
 #include <command.hpp>
 #include <kdb.hpp>
@@ -49,7 +52,7 @@ public:
 
 private:
 	kdb::Key getParentKey(kdb::Key key);
-	
+	void increaseCount(std::map<kdb::Key, std::pair<int, int>> & hierarchy, kdb::Key key, std::function<int(int)> depthIncreaser);
 };
 
 #endif

--- a/src/tools/kdb/superls.hpp
+++ b/src/tools/kdb/superls.hpp
@@ -9,8 +9,8 @@
 #ifndef SUPERLS_H
 #define SUPERLS_H
 
-#include <map>
 #include <functional>
+#include <map>
 
 #include "coloredkdbio.hpp"
 #include <command.hpp>
@@ -18,10 +18,6 @@
 
 class SuperLsCommand : public Command
 {
-	kdb::Key root;
-	kdb::KDB kdb;
-	kdb::KeySet ks;
-
 public:
 	SuperLsCommand ();
 	~SuperLsCommand ();
@@ -48,11 +44,17 @@ public:
 		       "export command.";
 	}
 
-	virtual int execute (Cmdline const & cmdline) override;
+	virtual int execute (const Cmdline & cmdline) override;
 
 private:
-	kdb::Key getParentKey(kdb::Key key);
-	void increaseCount(std::map<kdb::Key, std::pair<int, int>> & hierarchy, kdb::Key key, std::function<int(int)> depthIncreaser);
+	void addMountpoints (kdb::KeySet & ks);
+	const std::map<kdb::Key, std::pair<int, int>> analyze (const kdb::KeySet & ks, const kdb::Key root, kdb::KeySet & virtualKeys);
+	const kdb::Key getParentKey (const kdb::Key key);
+	void increaseCount (std::map<kdb::Key, std::pair<int, int>> & hierarchy, const kdb::Key key,
+			    const std::function<int(int)> depthIncreaser);
+	void printResult (const kdb::Key originalRoot, const kdb::Key root, const std::map<kdb::Key, std::pair<int, int>> & hierarchy,
+			  const kdb::KeySet & virtualKeys);
+	const std::function<bool(std::string)> determineFilterPredicate (const kdb::Key originalRoot, const kdb::Key root);
 };
 
 #endif

--- a/src/tools/kdb/superls.hpp
+++ b/src/tools/kdb/superls.hpp
@@ -6,8 +6,8 @@
  * @copyright BSD License (see doc/LICENSE.md or http://www.libelektra.org)
  */
 
-#ifndef SUPERLS_H
-#define SUPERLS_H
+#ifndef COMPLETE_H
+#define COMPLETE_H
 
 #include <functional>
 #include <map>
@@ -16,44 +16,44 @@
 #include <command.hpp>
 #include <kdb.hpp>
 
-class SuperLsCommand : public Command
+class CompleteCommand : public Command
 {
+
 public:
-	SuperLsCommand ();
-	~SuperLsCommand ();
+	CompleteCommand ();
+	~CompleteCommand ();
 
 	virtual std::string getShortOptions () override
 	{
-		return "r0";
+		return "dmMv0";
 	}
 
 	virtual std::string getSynopsis () override
 	{
-		return "<name>";
+		return "<path>";
 	}
 
 	virtual std::string getShortHelpText () override
 	{
-		return "List the names of keys below a given name.";
+		return "Show suggestions how the current name could be completed.";
 	}
 
 	virtual std::string getLongHelpText () override
 	{
-		return "List all keys below given name.\n"
-		       "To also retrieve the value use the\n"
-		       "export command.";
+		return "Suggestions will include exsting key names, path segments of existing key names and mountpoints.\n";
 	}
 
 	virtual int execute (const Cmdline & cmdline) override;
 
 private:
-	void addMountpoints (kdb::KeySet & ks);
-	const std::map<kdb::Key, std::pair<int, int>> analyze (const kdb::KeySet & ks, const kdb::Key root, kdb::KeySet & virtualKeys);
+	void addMountpoints (kdb::KeySet & ks, const kdb::Key root);
+	const std::map<kdb::Key, std::pair<int, int>> analyze (const kdb::KeySet & ks, const kdb::Key root, kdb::KeySet & virtualKeys,
+							       const Cmdline & cmdLine);
 	const kdb::Key getParentKey (const kdb::Key key);
 	void increaseCount (std::map<kdb::Key, std::pair<int, int>> & hierarchy, const kdb::Key key,
 			    const std::function<int(int)> depthIncreaser);
 	void printResult (const kdb::Key originalRoot, const kdb::Key root, const std::map<kdb::Key, std::pair<int, int>> & hierarchy,
-			  const kdb::KeySet & virtualKeys);
+			  const kdb::KeySet & virtualKeys, const Cmdline & cmdLine);
 	const std::function<bool(std::string)> determineFilterPredicate (const kdb::Key originalRoot, const kdb::Key root);
 };
 

--- a/src/tools/kdb/superls.hpp
+++ b/src/tools/kdb/superls.hpp
@@ -46,6 +46,10 @@ public:
 	}
 
 	virtual int execute (Cmdline const & cmdline) override;
+
+private:
+	kdb::Key getParentKey(kdb::Key key);
+	
 };
 
 #endif

--- a/src/tools/kdb/superls.hpp
+++ b/src/tools/kdb/superls.hpp
@@ -25,7 +25,7 @@ public:
 
 	virtual std::string getShortOptions () override
 	{
-		return "v0C";
+		return "r0";
 	}
 
 	virtual std::string getSynopsis () override


### PR DESCRIPTION
# Purpose

This branch is used to develop an advantaged version of the ls tool to include further information e.g. wheter if a key is a node or a leaf, and the number of nodes/leaves inside a given node as request in #1167 .

# Checklist

Please only check relevant points.
For docu fixes, spell checking and similar nothing
needs to be checked.

- [ ] commit messages are fine (with references to issues)
- [ ] I ran all tests and everything went fine
- [ ] I added unit tests
- [ ] affected documentation is fixed
- [ ] I added code comments, logging, and assertions
- [ ] meta data is updated (e.g. README.md of plugins)

@markus2330 Please note this is heavy WIP currently. You don't seem to like the name super-ls, but i think it suits fine as a working title for now until we find a proper name. Another idea i had is that we could just add an option to the original ls tool to display node/leaf/count information instead of handling this as a new tool. In that case we could also add an option to switch between newline or NULL separators. Or lets keep it a new tool?

And consider the following case of keys:
user/test/key = "test1"
user/test/key/2 = "test2"

should the output be like
user/test node 1
user/test/key node 1
user/test/key/2 leaf

or simply (so not listing the user/test node which does not actually exist in elektra in the example)
user/test/key node 1
user/test/key/2 leaf

the latter would be easier i think as it allows me to simply iterate over the keyset i get via kdbGet like i'm doing it now.
Looking forward to some feedback as its the first actual c++ code i'm doing for elektra


