### PR TITLE
macOS-reformat-source

### DIFF
--- a/scripts/cbmc
+++ b/scripts/cbmc
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-SELF=$(readlink -f "$0")
+. "$(dirname "$0")/include-common"
 
 if [ "$#" -ne 1 ] || ! [ -d "$1" ]
 then

--- a/scripts/configure-common
+++ b/scripts/configure-common
@@ -1,5 +1,29 @@
 # common configure script
 
+# load our readlink replacement for osx
+. "$(dirname "$0")/realpath"
+
+# readlink replacement, currently intented only to work with -f and the argument
+readlink() {
+        if [[ "$OSTYPE" == "darwin"* ]]; then
+                # no readlink -f on macOS
+                if [ "$(which greadlink)" ]; then
+                        # if user brewed coreutils, greadlink is like the gnu readlink
+                        greadlink "$@"
+                elif [[ "$1" == "-f" ]]; then
+                        # use our readlink replacement
+                        realpath "$2"
+                else
+                        # otherwise try to use it like it is for now
+                        $(which readlink) "$@"
+                fi
+        else
+                # on other systems, or with other parameters just execute it as it is
+                $(which readlink) "$@"
+        fi
+}
+
+
 SELF=$(readlink -f "$0")
 SCRIPTS=$(dirname "$SELF")
 SOURCE=$(dirname "$SCRIPTS")

--- a/scripts/configure-common
+++ b/scripts/configure-common
@@ -1,32 +1,6 @@
 # common configure script
+. "$(dirname "$0")/include-common"
 
-# load our readlink replacement for osx
-. "$(dirname "$0")/realpath"
-
-# readlink replacement, currently intented only to work with -f and the argument
-readlink() {
-        if [[ "$OSTYPE" == "darwin"* ]]; then
-                # no readlink -f on macOS
-                if [ "$(which greadlink)" ]; then
-                        # if user brewed coreutils, greadlink is like the gnu readlink
-                        greadlink "$@"
-                elif [[ "$1" == "-f" ]]; then
-                        # use our readlink replacement
-                        realpath "$2"
-                else
-                        # otherwise try to use it like it is for now
-                        $(which readlink) "$@"
-                fi
-        else
-                # on other systems, or with other parameters just execute it as it is
-                $(which readlink) "$@"
-        fi
-}
-
-
-SELF=$(readlink -f "$0")
-SCRIPTS=$(dirname "$SELF")
-SOURCE=$(dirname "$SCRIPTS")
 SBUILD=$(pwd)
 BUILD=$(readlink -f "$SBUILD")
 

--- a/scripts/configure-firefox.in
+++ b/scripts/configure-firefox.in
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+. "$(dirname "$0")/include-common"
+
 WorkingDir="@CMAKE_INSTALL_PREFIX@/@TARGET_TOOL_EXEC_FOLDER@/"
 TriggerPort=65432
 MountPoint="user/prefs"

--- a/scripts/draw-all-plugins
+++ b/scripts/draw-all-plugins
@@ -1,10 +1,9 @@
 #!/bin/sh
 
+. "$(dirname "$0")/include-common"
+
 set -x
 
-SELF=$(readlink -f "$0")
-SCRIPTS=$(dirname "$SELF")
-SOURCE=$(dirname "$SCRIPTS")
 OUTPUT=$SOURCE/doc/images/plugins.dot
 
 echo "strict digraph G {" > $OUTPUT
@@ -13,11 +12,11 @@ echo "strict digraph G {" > $OUTPUT
 echo "	splines = true;" >> $OUTPUT
 echo
 #echo "	plugin [shape=Mdiamond];" >> $OUTPUT
-for i in `ls src/plugins`
+for i in `ls $SOURCE/src/plugins`
 do
-	if [ -d "src/plugins/$i" ]
+	if [ -d "$SOURCE/src/plugins/$i" ]
 	then
-		r="src/plugins/$i/README.md"
+		r="$SOURCE/src/plugins/$i/README.md"
 		p=`grep "^- infos/provides" "$r" | cut -f 2 -d =`
 		if [ "$p" ]
 		then

--- a/scripts/include-common
+++ b/scripts/include-common
@@ -1,0 +1,35 @@
+# Provides common functions and variables for shellscripts:
+# fixes readlink -f on macOS
+# provides $SELF, $SCRIPTS, $SOURCE
+# include this file via '. "$(dirname "$0")/include-common"'
+
+# load our readlink replacement for osx
+. "$(dirname "$0")/realpath"
+
+# readlink replacement, currently intented only to work with -f and the 
+# argument
+readlink() {
+        if [[ "$OSTYPE" == "darwin"* ]]; then
+                # no readlink -f on macOS
+                if [ "$(which greadlink)" ]; then
+                        # if user brewed coreutils, greadlink is like 
+			#the gnu readlink
+                        greadlink "$@"
+                elif [[ "$1" == "-f" ]]; then
+                        # use our readlink replacement
+                        realpath "$2"
+                else
+                        # otherwise try to use it like it is for now
+                        $(which readlink) "$@"
+                fi
+        else
+                # on other systems, or with other parameters just 
+		# execute it as it is
+                $(which readlink) "$@"
+        fi
+}
+
+
+SELF=$(readlink -f "$0")
+SCRIPTS=$(dirname "$SELF")
+SOURCE=$(dirname "$SCRIPTS")

--- a/scripts/realpath
+++ b/scripts/realpath
@@ -1,0 +1,71 @@
+#!/bin/sh
+# readlink -f replacement for macOS
+# taken from https://github.com/mkropat/sh-realpath (MIT licenced)
+
+realpath() {
+    canonicalize_path "$(resolve_symlinks "$1")"
+}
+
+resolve_symlinks() {
+    _resolve_symlinks "$1"
+}
+
+_resolve_symlinks() {
+    _assert_no_path_cycles "$@" || return
+
+    local dir_context path
+    path=$(readlink -- "$1")
+    if [ $? -eq 0 ]; then
+        dir_context=$(dirname -- "$1")
+        _resolve_symlinks "$(_prepend_dir_context_if_necessary "$dir_context" "$path")" "$@"
+    else
+        printf '%s\n' "$1"
+    fi
+}
+
+_prepend_dir_context_if_necessary() {
+    if [ "$1" = . ]; then
+        printf '%s\n' "$2"
+    else
+        _prepend_path_if_relative "$1" "$2"
+    fi
+}
+
+_prepend_path_if_relative() {
+    case "$2" in
+        /* ) printf '%s\n' "$2" ;;
+         * ) printf '%s\n' "$1/$2" ;;
+    esac
+}
+
+_assert_no_path_cycles() {
+    local target path
+
+    target=$1
+    shift
+
+    for path in "$@"; do
+        if [ "$path" = "$target" ]; then
+            return 1
+        fi
+    done
+}
+
+canonicalize_path() {
+    if [ -d "$1" ]; then
+        _canonicalize_dir_path "$1"
+    else
+        _canonicalize_file_path "$1"
+    fi
+}
+
+_canonicalize_dir_path() {
+    (cd "$1" 2>/dev/null && pwd -P)
+}
+
+_canonicalize_file_path() {
+    local dir file
+    dir=$(dirname -- "$1")
+    file=$(basename -- "$1")
+    (cd "$dir" 2>/dev/null && printf '%s/%s\n' "$(pwd -P)" "$file")
+}

--- a/scripts/realpath
+++ b/scripts/realpath
@@ -2,6 +2,28 @@
 # readlink -f replacement for macOS
 # taken from https://github.com/mkropat/sh-realpath (MIT licenced)
 
+# The MIT License (MIT)
+
+# Copyright (c) 2014 Michael Kropat
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
 realpath() {
     canonicalize_path "$(resolve_symlinks "$1")"
 }

--- a/scripts/reformat-source
+++ b/scripts/reformat-source
@@ -5,7 +5,7 @@
 # @date 18.02.2016
 # @tags reformat
 
-. "$(dirname "$0")/configure-common"
+. "$(dirname "$0")/include-common"
 
 CLANG_FORMAT=$(which clang-format-3.8)
 if [ -z "${CLANG_FORMAT}" ]; then

--- a/scripts/reformat-source
+++ b/scripts/reformat-source
@@ -5,10 +5,13 @@
 # @date 18.02.2016
 # @tags reformat
 
-SELF=$(readlink -f "$0")
-SCRIPTS=$(dirname "$SELF")
-SOURCE=$(dirname "$SCRIPTS")
+. "$(dirname "$0")/configure-common"
+
+CLANG_FORMAT=$(which clang-format-3.8)
+if [ -z "${CLANG_FORMAT}" ]; then
+	CLANG_FORMAT=$(which clang-format)
+fi
 
 cd $SOURCE
 
-clang-format-3.8 -style=file -i `find . -name '*.[ch]' -or -name '*.[ch]pp' -or -name '*.[ch].in' | egrep -v "^(./src/tools/gen|./tests/gtest-1.7.0)"`
+$($CLANG_FORMAT -style=file -i `find . -name '*.[ch]' -or -name '*.[ch]pp' -or -name '*.[ch].in' | egrep -v "^(./src/tools/gen|./tests/gtest-1.7.0)"`)

--- a/scripts/untidy-source
+++ b/scripts/untidy-source
@@ -1,9 +1,12 @@
 #!/bin/sh
 
-SELF=$(readlink -f "$0")
-SCRIPTS=$(dirname "$SELF")
-SOURCE=$(dirname "$SCRIPTS")
+. "$(dirname "$0")/include-common"
+
+CLANG_TIDY=$(which clang-tidy-3.8)
+if [ -z "${CLANG_TIDY}" ]; then
+        CLANG_TIDY=$(which clang-tidy)
+fi
 
 cd $SOURCE
 
-clang-tidy-3.8 -fix-errors -checks="readability-braces-around-statements"  `find . -name '*.[ch]' -or -name '*.[ch]pp' -or -name '*.[ch].in' | egrep -v "^(./src/tools/gen|./tests/gtest-1.7.0)"`
+$($CLANG_TIDY -fix-errors -checks="readability-braces-around-statements"  `find . -name '*.[ch]' -or -name '*.[ch]pp' -or -name '*.[ch].in' | egrep -v "^(./src/tools/gen|./tests/gtest-1.7.0)"`)


### PR DESCRIPTION
# Purpose

fix the issue with reformat-source not working on macOS (#1286) by detecting clang-format via which, and by providing a common include file "include-common" which provides an adjusted readlink function, as readlink -f is not available on macOS.

On macOS it tries to use greadlink, which is the same as readlink on linux given the user installed coreutils via homebrew. Otherwise i've found a shellscript which provides the required functionality to emulate at least readlink -f (we only use that at the moment, no other arguments for readlink in our scripts anywhere, so it should be good for now and avoids enforcing brewing coreutils).

# Checklist

- [X] commit messages are fine (with references to issues)
- [X] I ran all tests and everything went fine
- [ ] I added unit tests
- [X] affected documentation is fixed
- [X] I added code comments, logging, and assertions
- [ ] meta data is updated (e.g. README.md of plugins)

@markus2330 what do you think about this approach? It fixes the issue with the script on my mac, both with coreutils brewed and without. If its okay that way, i'd include it in all other scripts using readlink -f.
