### PR TITLE
spec: ns fix

### DIFF
--- a/src/plugins/spec/spec.c
+++ b/src/plugins/spec/spec.c
@@ -674,6 +674,8 @@ static int doGlobbing (Key * parentKey, KeySet * returned, KeySet * specKS, Conf
 		ksRewind (returned);
 		while ((cur = ksNext (returned)) != NULL)
 		{
+			if (keyGetNamespace (cur) == KEY_NS_SPEC) continue;
+
 			cursor_t cursor = ksGetCursor (returned);
 			if (matchPatternToKey (pattern, cur))
 			{


### PR DESCRIPTION
# Purpose

in some cases spec treated spec-keys as normal keys when globbing - fixed