### PR TITLE
Ini fixes

### DIFF
--- a/src/plugins/ini/ini.c
+++ b/src/plugins/ini/ini.c
@@ -128,11 +128,16 @@ static void keyAddUnescapedBasePath (Key * key, const char * path)
 		int ret = keyAddName (key, buffer);
 		if (ret == -1)
 		{
-			char * tmp = elektraMalloc (keyGetFullNameSize (key) + strlen (buffer));
+			char * tmp = elektraMalloc (keyGetFullNameSize (key) + strlen (buffer) + 2);
 			keyGetFullName (key, tmp, keyGetFullNameSize (key));
 			strcat (tmp, "/");
 			strcat (tmp, buffer);
-			keySetName (key, tmp);
+			ssize_t rc = keySetName (key, tmp);
+			if (rc == -1 && tmp[strlen (tmp) - 1] == '\\')
+			{
+				tmp[strlen (tmp) - 1] = '\0';
+				keySetName (key, tmp);
+			}
 			elektraFree (tmp);
 		}
 		elektraFree (buffer);

--- a/src/plugins/ini/inih-r29/inih.c
+++ b/src/plugins/ini/inih-r29/inih.c
@@ -449,7 +449,25 @@ int ini_parse_file (FILE * file, const struct IniConfig * config, void * user)
 				{
 					rstrip (start);
 					name = start;
-					value = NULL;
+					end = strchr (start, delim);
+					if (!end)
+					{
+						value = NULL;
+					}
+					else
+					{
+						if (*end == delim) *end = '\0';
+						rstrip (end - 1);
+						value = lskip (end + 1);
+						rstrip (value);
+						if (*value == '"')
+						{
+							*(value++) = '\0';
+							while ((*end != '"') && !isprint (*end) && end > value)
+								--end;
+							if (*end == '"') *end = '\0';
+						}
+					}
 				}
 				strncpy0 (prev_name, name, sizeof (prev_name));
 

--- a/src/plugins/ini/inih-r29/inih.c
+++ b/src/plugins/ini/inih-r29/inih.c
@@ -144,6 +144,11 @@ int ini_parse_file (FILE * file, const struct IniConfig * config, void * user)
 			continue;
 		}
 		start = lskip (line);
+		if (*start == '\0')
+		{
+			if (!config->commentHandler (user, "") && !error) error = lineno;
+			continue;
+		}
 		if (isContinuation (line, config) && config->supportMultiline && *prev_name)
 		{
 			start = line + strlen (config->continuationString);


### PR DESCRIPTION
# Purpose

fix for valueless keynames ending with a '\' and parser to use first delimiter when everything else fails