### PR TITLE
macOS-reformat-source: fix include-common on dash and fix test for mac

### DIFF
--- a/scripts/include-common
+++ b/scripts/include-common
@@ -6,16 +6,19 @@
 # load our readlink replacement for osx
 . "$(dirname "$0")/realpath"
 
+# substring emulation which should work in dash and other shells too
+stringContain() { [ -z "${2##*$1*}" ] && [ -z "$1" -o -n "$2" ]; }
+
 # readlink replacement, currently intented only to work with -f and the 
 # argument
 readlink() {
-        if [[ "$OSTYPE" == "darwin"* ]]; then
+        if stringContain "Darwin" "$(uname)"; then
                 # no readlink -f on macOS
                 if [ "$(which greadlink)" ]; then
                         # if user brewed coreutils, greadlink is like 
-			#the gnu readlink
+			# the gnu readlink
                         greadlink "$@"
-                elif [[ "$1" == "-f" ]]; then
+                elif [ "$1" = "-f" ]; then
                         # use our readlink replacement
                         realpath "$2"
                 else

--- a/tests/shell/check_formatting.sh
+++ b/tests/shell/check_formatting.sh
@@ -5,7 +5,7 @@ echo ELEKTRA CHECK FORMATTING
 echo
 
 command -v git >/dev/null 2>&1 || { echo "git command needed for this test, aborting" >&2; exit 0; }
-command -v clang-format-3.8 >/dev/null 2>&1 || { echo "clang-format-3.8 command needed for this test, aborting" >&2; exit 0; }
+command -v clang-format-3.8 >/dev/null 2>&1 || command -v clang-format >/dev/null 2>&1 || { echo "clang-format command needed for this test, aborting" >&2; exit 0; }
 
 cd "@CMAKE_SOURCE_DIR@"
 


### PR DESCRIPTION
# Purpose

fix the include-common script for dash (it used some bash specific extensions while it should use posix sh instead)

# Checklist

- [X] commit messages are fine (with references to issues)
- [X] I ran all tests and everything went fine
- [X] I added unit tests

@markus2330 here is the fix for #1323 . There was already a test in tests/shell/check_formatting.sh which calls the reformat-source script and thus also checks the include-common, i only fixed it to support clang-format instead of clang-format-3.8 too.
