### PR TITLE
kdb-complete: fix infinite loop with escaped key names

### DIFF
--- a/src/tools/kdb/complete.cpp
+++ b/src/tools/kdb/complete.cpp
@@ -116,6 +116,8 @@ void CompleteCommand::completeNormal (const string argument, const Key parsedArg
 	const int offset = distance (root.begin (), root.end ()) - rootExists + shallShowNextLevel (argument);
 
 	const auto nameFilter = root.isCascading () ? filterCascading : filterName;
+	// Let elektra handle the escaping of the input for us
+	const string argumentEscaped = parsedArgument.getFullName ();
 	const auto filter = [&](const pair<Key, pair<int, int>> & c) {
 		return filterDepth (cl.minDepth + offset, max (cl.maxDepth, cl.maxDepth + offset), c) && nameFilter (argument, c);
 	};
@@ -227,7 +229,9 @@ void CompleteCommand::printResults (const Key root, const int minDepth, const in
 
 const Key CompleteCommand::getParentKey (const Key key)
 {
-	return Key (key.getFullName ().erase (key.getFullName ().size () - key.getBaseName ().size ()), KEY_END);
+	Key parentKey = key.dup (); // We can't set baseName on keys in keysets, so duplicate it
+	ckdb::keySetBaseName (parentKey.getKey (), NULL);
+	return parentKey;
 }
 
 KeySet CompleteCommand::getKeys (Key root, const bool cutAtRoot)
@@ -334,7 +338,6 @@ bool CompleteCommand::filterCascading (const string argument, const pair<Key, pa
 
 bool CompleteCommand::filterName (const string argument, const pair<Key, pair<int, int>> & current)
 {
-	// For a namespace completion, compare by substring
 	const string test = current.first.getFullName ();
 	return argument.size () <= test.size () && equal (argument.begin (), argument.end (), test.begin ());
 }


### PR DESCRIPTION
# Purpose

Fix the infinite loop reported in #1328 . 

# Checklist

Please only check relevant points.
For docu fixes, spell checking and similar nothing
needs to be checked.

- [X] commit messages are fine (with references to issues)
- [X] I ran all tests and everything went fine
- [ ] I added unit tests
- [X] affected documentation is fixed
- [X] I added code comments, logging, and assertions
- [X] meta data is updated (e.g. README.md of plugins)

@markus2330 this should fix your issue, let me know if there is still something else.