### PR TITLE
Ruby Libtool bindings

### DIFF
--- a/src/bindings/swig/ruby/CMakeLists.txt
+++ b/src/bindings/swig/ruby/CMakeLists.txt
@@ -73,7 +73,7 @@ else()
 	
 	set_source_files_properties (
 		${swig_generated_file_fullname} PROPERTIES
-		COMPILE_FLAGS "${SWIG_COMPILE_FLAGS} -Wno-unused-parameter -Wno-unused-but-set-variable -DSWIG_TYPE_TABLE=kdb"
+		COMPILE_FLAGS "${SWIG_COMPILE_FLAGS} -Wno-unused-parameter -Wno-unused-but-set-variable -DSWIG_TYPE_TABLE=kdb -Wno-sign-compare -Wno-old-style-cast"
 	)
 
 

--- a/src/bindings/swig/ruby/CMakeLists.txt
+++ b/src/bindings/swig/ruby/CMakeLists.txt
@@ -17,6 +17,7 @@ else()
 
 	add_headers (HDR_FILES)
 	add_cppheaders (HDR_FILES)
+	add_toolheaders (HDR_FILES)
 
 	include_directories (${CMAKE_CURRENT_SOURCE_DIR})
 
@@ -47,19 +48,29 @@ else()
 	#message (STATUS "Ruby version: ${RUBY_VERSION}")
 	# to print RUBY_* variables for debugging build run cmake with -D_RUBY_DEBUG_OUTPUT=1
 
-	set_source_files_properties (kdb.i PROPERTIES CPLUSPLUS ON)
+	set_source_files_properties (kdb.i kdbtools.i PROPERTIES CPLUSPLUS ON)
+
+	set_source_files_properties (kdb.i PROPERTIES SWIG_FLAGS "-initname;_kdb")
+	set_source_files_properties (kdbtools.i PROPERTIES SWIG_FLAGS "-initname;_kdbtools")
 
 	set (CMAKE_SWIG_OUTDIR "${CMAKE_CURRENT_BINARY_DIR}")
 	set (CMAKE_LIBRARY_OUTPUT_DIRECTORY "${CMAKE_SWIG_OUTDIR}")
-	set (CMAKE_SWIG_FLAGS "-initname;_kdb;-O;-autorename;-DSWIG_NO_EXPORT_ITERATOR_METHODS")
+	set (CMAKE_SWIG_FLAGS "-O;-autorename;-DSWIG_NO_EXPORT_ITERATOR_METHODS")
 
 	swig_add_module (swig-ruby ruby kdb.i)
+	swig_add_module (swig-ruby-tools ruby kdbtools.i)
 	swig_link_libraries (swig-ruby ${RUBY_LIBRARY} elektra-core elektra-kdb)
 	set_target_properties (swig-ruby PROPERTIES
 		OUTPUT_NAME _kdb
 		PREFIX ""
 	)
 
+	swig_link_libraries (swig-ruby-tools ${RUBY_LIBRARY} elektra-core elektra-kdb elektratools)
+	set_target_properties (swig-ruby-tools PROPERTIES
+		OUTPUT_NAME _kdbtools
+		PREFIX ""
+	)
+	
 	set_source_files_properties (
 		${swig_generated_file_fullname} PROPERTIES
 		COMPILE_FLAGS "${SWIG_COMPILE_FLAGS} -Wno-unused-parameter -Wno-unused-but-set-variable -DSWIG_TYPE_TABLE=kdb"

--- a/src/bindings/swig/ruby/CMakeLists.txt
+++ b/src/bindings/swig/ruby/CMakeLists.txt
@@ -57,8 +57,29 @@ else()
 	set (CMAKE_LIBRARY_OUTPUT_DIRECTORY "${CMAKE_SWIG_OUTDIR}")
 	set (CMAKE_SWIG_FLAGS "-O;-autorename;-DSWIG_NO_EXPORT_ITERATOR_METHODS;-DSWIG_WITHOUT_OVERRIDE")
 
+	# specify the SWIG_TYPE_TABLE to use (has to be in sync with the ruby plugin)
+	set (SWIG_COMPILE_FLAGS "${SWIG_COMPILE_FLAGS} -DSWIG_TYPE_TABLE=kdb")
+
+	# disable certain compiler warnings for SWIG generated files
+	set (SWIG_COMPILE_FLAGS "${SWIG_COMPILE_FLAGS} -Wno-unused-parameter -Wno-unused-but-set-variable")
+	set (SWIG_COMPILE_FLAGS "${SWIG_COMPILE_FLAGS} -Wno-sign-compare")
+
+	# add 'kdb' module
 	swig_add_module (swig-ruby ruby kdb.i)
+	# set the compiler settings for the generated file
+	# (has to be done for each module separately)
+	set_source_files_properties (
+		${swig_generated_sources} PROPERTIES
+		COMPILE_FLAGS "${SWIG_COMPILE_FLAGS}"
+	)
+
+	# add the 'kdbtools' module
 	swig_add_module (swig-ruby-tools ruby kdbtools.i)
+	set_source_files_properties (
+		${swig_generated_sources} PROPERTIES
+		COMPILE_FLAGS "${SWIG_COMPILE_FLAGS}"
+	)
+
 	swig_link_libraries (swig-ruby ${RUBY_LIBRARY} elektra-core elektra-kdb)
 	set_target_properties (swig-ruby PROPERTIES
 		OUTPUT_NAME _kdb
@@ -71,11 +92,6 @@ else()
 		PREFIX ""
 	)
 	
-	set_source_files_properties (
-		${swig_generated_file_fullname} PROPERTIES
-		COMPILE_FLAGS "${SWIG_COMPILE_FLAGS} -Wno-unused-parameter -Wno-unused-but-set-variable -DSWIG_TYPE_TABLE=kdb -Wno-sign-compare -Wno-old-style-cast"
-	)
-
 
 	# CMAKE_INSTALL_PREFIX dependent install location
 	# if we hit one of the usual cases (/usr/local or /usr) install the lib
@@ -100,11 +116,11 @@ else()
 	endif()
 
 	install (
-		TARGETS swig-ruby
+		TARGETS swig-ruby swig-ruby-tools
 		LIBRARY DESTINATION ${RUBY_LIB_INSTALL_DIR}
 	)
 	install (
-		FILES ${CMAKE_CURRENT_SOURCE_DIR}/kdb.rb
+		FILES ${CMAKE_CURRENT_SOURCE_DIR}/kdb.rb ${CMAKE_CURRENT_SOURCE_DIR}/kdbtools.rb
 		DESTINATION ${RUBY_MODULE_INSTALL_DIR}
 	)
 

--- a/src/bindings/swig/ruby/CMakeLists.txt
+++ b/src/bindings/swig/ruby/CMakeLists.txt
@@ -11,6 +11,8 @@ find_package(Ruby)
 
 if (NOT RUBY_FOUND)
 	remove_binding(swig_ruby "ruby interpreter or ruby header files not found (package ruby-dev/ruby-devel installed?)")
+elseif (SWIG_VERSION MATCHES "^[12]\\.")
+	remove_binding(swig_ruby "found SWIG version (${SWIG_VERSION}) is not suitable. SWIG version >= 3.x required")
 else()
 
 	message(STATUS "Include Binding swig_ruby")

--- a/src/bindings/swig/ruby/CMakeLists.txt
+++ b/src/bindings/swig/ruby/CMakeLists.txt
@@ -51,7 +51,7 @@ else()
 	set_source_files_properties (kdb.i kdbtools.i PROPERTIES CPLUSPLUS ON)
 
 	set_source_files_properties (kdb.i PROPERTIES SWIG_FLAGS "-initname;_kdb")
-	set_source_files_properties (kdbtools.i PROPERTIES SWIG_FLAGS "-initname;_kdbtools")
+	set_source_files_properties (kdbtools.i PROPERTIES SWIG_FLAGS "-initname;_kdbtools;-minherit")
 
 	set (CMAKE_SWIG_OUTDIR "${CMAKE_CURRENT_BINARY_DIR}")
 	set (CMAKE_LIBRARY_OUTPUT_DIRECTORY "${CMAKE_SWIG_OUTDIR}")

--- a/src/bindings/swig/ruby/CMakeLists.txt
+++ b/src/bindings/swig/ruby/CMakeLists.txt
@@ -55,7 +55,7 @@ else()
 
 	set (CMAKE_SWIG_OUTDIR "${CMAKE_CURRENT_BINARY_DIR}")
 	set (CMAKE_LIBRARY_OUTPUT_DIRECTORY "${CMAKE_SWIG_OUTDIR}")
-	set (CMAKE_SWIG_FLAGS "-O;-autorename;-DSWIG_NO_EXPORT_ITERATOR_METHODS")
+	set (CMAKE_SWIG_FLAGS "-O;-autorename;-DSWIG_NO_EXPORT_ITERATOR_METHODS;-DSWIG_WITHOUT_OVERRIDE")
 
 	swig_add_module (swig-ruby ruby kdb.i)
 	swig_add_module (swig-ruby-tools ruby kdbtools.i)

--- a/src/bindings/swig/ruby/README.md
+++ b/src/bindings/swig/ruby/README.md
@@ -1,19 +1,51 @@
 # Ruby bindings
 
-This module is a SWIG generated binding for KDB (http://www.libelektra.org),
-therefore the module provides wrapper classes to KDBs C++ interface and is
-mainly a 1 to 1 relation. However, to provide a more Ruby-style API to KDB,
-this module differs to the C++ API in the following way:
- * C++ iterators for Key/KeySet are excluded. Instead KeySet implements
-   a 'each' method and includes 'Enumerable'. Therefore it is very similar to
-   a Ruby-Array. However, the KeySet cursor methods are still available.
- * Access to native C-level KDB structures (such as ckdb::Key) is not
-   possible, as this does not make much sense within Ruby.
+This module is a SWIG generated Ruby binding for Elektra Core API - KDB
+(http://www.libelektra.org) and its libtools library. So it consists of the two
+Ruby modules:
+ * `Kdb` wrapping Elektra's core API
+ * `Kdbtools` wrapping Elektra's libtools API
+
+The two modules provides wrapper classes the C++ interface and are
+mainly a 1 to 1 mapping. However, to provide a more Ruby-style API,
+the modules differs to the C++ API in the following way:
+
+## Ruby `Kdb` differences to C++ API
+
+ * C++ iterators for `Key`/`KeySet` are excluded. Instead `KeySet` implements
+   an `each` method and includes `Enumerable`. Therefore it is very similar to
+   a Ruby-Array. However, the `KeySet` cursor methods are still available.
  * Method names are renamed to follow Ruby naming conventions
- * Key and KeySet methods directly modify the underlying Key/KeySet
+ * Access to native C-level `KDB` structures (such as `ckdb::Key`) is not
+   possible, as this does not make much sense within Ruby.
+ * Key and `KeySet` implement a `pretty_print` method very suitable for debugging
+ * The `Kdb` module has a static `open` method taking a block, which can be
+   used to access the opened KDB handle within a block, whereas the handle is
+   closed afterwards (similar to `File.open`).
+ * `Key.new` accepts an Hash-like argument list, imitating the C++ variable
+   arguments feature. However, we do not relay on the `KEY_END` flat to
+   indicate the end of a list.
+ * Additional to `Key`s and `KeySet`s, the `KeySet`.new method also accepts a
+   Ruby-Array of `Key`s for `KeySet` creation. This allows a very short
+   KeySet creation.
+ * `KeySet` implements the usual `<<` operator for appending `Key`s and
+   `KeySet`s.
+ * `Key` and `KeySet` methods directly modify the underlying `Key`/`KeySet`
  * The `Key.setCallback` and `Key.getFunc` methods are not supported
 
-Below, we show some specifics of the Ruby binding.
+## Ruby `Kdbtools` differences to C++ API
+
+These bindings do not really change anything to the API and are basically a
+direct 1:1 mapping. However the usual renaming from C++ camelcase to Rubys
+naming conventions also was done here.
+
+ * methods for fetching library symbol function pointers are excluded
+
+## Examples
+
+Example and demo applications which a lot of documentation in it can be found
+in the Ruby-bindings source tree under 'examples'. Also the test cases (under
+'tests') can be a good point to look if you need more information.
 
 ## Quick start guide
 

--- a/src/bindings/swig/ruby/examples/tools/kdb_simple.rb
+++ b/src/bindings/swig/ruby/examples/tools/kdb_simple.rb
@@ -1,0 +1,313 @@
+#!/usr/bin/ruby
+##
+# @file
+#
+# @brief minimal kdb tool written Rub
+#
+# @copyright BSD License (see doc/LICENSE.md or http://www.libelektra.org)
+#
+#
+# This example is a simple 'kdb' replacement to show some function of the
+# Elektra tools API
+#
+# use kdb_simple.rb --help to see some examples
+
+require 'kdbtools'
+
+
+class Cmdline
+  @@commands = Hash.new
+
+  def self.define(name, &block)
+    @@commands[name] = block
+  end
+end
+
+
+#
+# list all plugins
+#
+# fetches all avalible plugins and prints them on stdout
+#
+Cmdline.define :list do
+
+  # create a new PluginDatabase instance
+  db = Kdbtools::ModulesPluginDatabase.new
+
+  # get the list of plugins
+  plugins = db.list_all_plugins
+
+  puts "all available plugins:"
+  plugins.each do |p|
+    puts "  #{p}"
+  end
+end
+
+
+#
+# print info about a specific plugin
+#
+# similar to $> kdb info <plugin>
+#
+# fetches plugin info from system/elektra/modules path
+# if plugin is not loaded yet, load it and fetch info
+# directly from plugin
+#
+Cmdline.define :info do
+  # get the plugin name from the command line (just the last one ;)
+  plugin_name = ARGV.pop
+  if plugin_name.nil?
+    raise ArgmentError.new "missing plugin name"
+  end
+
+  # open the kdb
+  Kdb.open do |kdb|
+    # this is the path where plugin info can be found
+    plugin_key_path = "system/elektra/modules/#{plugin_name}"
+
+    # fetch the info from the database
+    conf = Kdb::KeySet.new
+    kdb.get conf, plugin_key_path
+
+    # check if it is already there
+    if conf.lookup(plugin_key_path).nil?
+      # plugin info is missing, so we have to load the plugin
+      # first
+
+      # load plugin
+      modules = Kdbtools::Modules.new
+      begin
+        plugin = modules.load plugin_name
+
+        # get info and append it to the central conf
+        conf << plugin.get_info
+      rescue Kdbtools::NoPlugin
+        # modules.load will raise an exception if the plugin
+        # can not be loaded
+        puts $!
+      end
+    end
+
+    # plugin infos path
+    infos_key = Kdb::Key.new plugin_key_path + "/infos"
+    # filter all keys we are interested in
+    # -> all below infos_key path
+    infos = conf.find_all { |k| k.is_below? infos_key }
+    # print each key
+    infos.each do |i|
+      puts "#{i.basename}: #{i.value}"
+    end
+  end
+end
+
+
+#
+# fetch all configured mountpoints and print it on stdout
+# (same as '$> kdb mount'
+#
+Cmdline.define :showmounts do
+
+  # open the KDB
+  Kdb.open do |kdb|
+
+    mountconf = Kdb::KeySet.new
+
+    # fetch mountpoints from db
+    kdb.get mountconf, Kdbtools::MOUNTPOINTS_PATH
+
+    # parse the info from the retrieved keyset
+    mtab = Kdbtools::Backends.get_backend_info mountconf
+
+    puts "currently configured mountpoints:"
+    puts
+
+    mtab.each do |b|
+      puts "#{b.path} on #{b.mountpoint}"
+    end
+
+    puts
+    puts "number of mounts: #{mtab.size}"
+
+  end
+end
+
+
+
+#
+# add a new mountpoint
+#
+# this is a minimal for for '$> kdb mount <file> <mountpoint> <plugin> ...'
+#
+Cmdline.define :mount do
+  args = ARGV.reverse
+  args.pop  # remove the command 'mount'
+
+  if args.size < 3
+    Cmdline.usage
+    exit
+  end
+
+  FILE_PATH = args.pop
+  MOUNTPOINT = args.pop
+
+  # open KDB
+  #
+  kdb = Kdb.open
+
+  begin
+    # create a new backend builder
+    backend = Kdbtools::MountBackendBuilder.new
+
+    # elektra mountpoint to mount to
+    mpk = Kdb::Key.new MOUNTPOINT
+
+    if ! mpk.is_valid?
+      raise ArgumentError.new "invalid mountpoint given: #{MOUNTPOINT}"
+    end
+
+    # KeySet to collect all mounting settings
+    mountconf = Kdb::KeySet.new
+
+    kdb.get mountconf, Kdbtools::MOUNTPOINTS_PATH
+
+    # set mountpoint
+    # raises a MountpointAlreadyInUseException if mount point is invalid
+    # or already used
+    backend.set_mountpoint mpk, mountconf
+
+    # config settings for all plugins
+    #config = Kdbtools.parse_plugin_arguments "", "system/"
+    #backend.set_backend_config config
+
+    # add the resolver plugin
+    backend.add_plugin Kdbtools::PluginSpec.new "resolver"
+
+    # file to mount at mountpoint
+    backend.use_config_file FILE_PATH
+
+    # specify that we require a storage plugin
+    backend.need_plugin "storage"
+
+    # define recommended plugins
+    backend.recommend_plugin "sync"
+
+    # the rest of our command line args are can be passed to 
+    # Kdbtools.parse_arguments
+    plugin_config_args = args.reverse.join " "
+
+    # add specific plugins
+    backend.add_plugins Kdbtools.parse_arguments plugin_config_args
+
+    # resolve needed and recommended plugins
+    # returns Array of missing recommended plugin name
+    # throws NoPlugin exception if a needed or 
+    backend.resolve_needs true
+
+    # generate the mount specifications
+    backend.serialize mountconf
+
+    # to check
+    #mountconf.pretty_print
+    kdb.set mountconf, Kdbtools::MOUNTPOINTS_PATH
+
+  rescue Kdbtools::NoPlugin
+    # thrown if one of the specifed plugins was not found
+    # or a needed plugin is missing
+    puts $!
+
+  rescue Kdbtools::TooManyPlugins
+    # thrown by serialize, if a plugin can't be placed
+    # e.g. adding two storage plugins
+    puts $!
+
+  rescue
+    puts $!
+
+  ensure
+    # do not forget to close it again
+    kdb.close
+  end
+end
+
+
+
+#
+# unmout a backend
+#
+# simply do an unmout
+#
+Cmdline.define :umount do
+  if ARGV.size < 2
+    raise ArgmentError.new "missing mountpoint"
+  end
+
+  # get the mountpoint
+  mountpoint = ARGV.pop
+
+  Kdb.open do |db|
+    # fetch the mount info from the db
+    conf = Kdb::KeySet.new
+    db.get conf, Kdbtools::MOUNTPOINTS_PATH
+
+    # do the umount
+    Kdbtools::Backends.umount mountpoint, conf
+
+    db.set conf, Kdbtools::MOUNTPOINTS_PATH
+  end
+end
+
+
+
+
+# command line helper
+#
+class Cmdline
+  def self.usage
+    puts "Demo app to show some libtools functionallity"
+    puts "usage: #{__FILE__} <command>"
+    puts
+    puts "available commands:"
+    @@commands.keys.each do |c|
+      puts "   #{c}"
+    end
+    puts
+    puts <<EOF
+examples:
+    #{__FILE__} info dump
+
+    #{__FILE__} mount /tmp/myconfig.ini /myconfig/file ini conf1=a,conf2=b
+
+    #{__FILE__} mount /tmp/file system/file ini sync
+
+    #{__FILE__} umount system/file
+
+EOF
+  end
+
+  def self.run
+    command = :showmounts
+    if ARGV.size > 0
+      if ["-h", "--help"].include? ARGV[0]
+        usage
+        exit
+      end
+
+      command = ARGV[0].to_sym
+    end
+
+    if ! @@commands.include? command
+      puts "unknown command: #{command}"
+      usage
+      exit
+    end
+
+    begin
+      @@commands[command].call
+    rescue
+      puts $!
+    end
+  end
+
+end
+
+Cmdline.run

--- a/src/bindings/swig/ruby/kdbtools.i
+++ b/src/bindings/swig/ruby/kdbtools.i
@@ -55,6 +55,7 @@ namespace std {
   #include "plugins.hpp"
   #include "plugindatabase.hpp"
   #include "modules.hpp"
+  #include "backendparser.hpp"
 
   #include "toolexcept.hpp"
 
@@ -248,6 +249,9 @@ namespace std {
          kdb::tools::PluginCheckException,
          kdb::tools::ToolException
 ) kdb::tools::PluginSpec::validate;
+
+
+%template(PluginSpecVector) std::vector<kdb::tools::PluginSpec>;
 
 %include "pluginspec.hpp"
 
@@ -474,3 +478,19 @@ namespace std {
 %include "modules.hpp"
 
 
+
+
+/*************************************************************************
+ *
+ * kdb::tools::parse(Plugin)Arguments
+ *
+ ************************************************************************/
+
+%ignore kdb::tools::parseArguments(std::initializer_list<std::string>);
+%ignore kdb::tools::detail::processArgument;
+%ignore kdb::tools::detail::fixArguments;
+
+%catches (kdb::tools::ParseException) kdb::tools::parsePluginArguments;
+%catches (kdb::tools::ParseException) kdb::tools::parseArguments;
+
+%include "backendparser.hpp"

--- a/src/bindings/swig/ruby/kdbtools.i
+++ b/src/bindings/swig/ruby/kdbtools.i
@@ -57,6 +57,7 @@ namespace std {
   #include "modules.hpp"
   #include "backendparser.hpp"
   #include "backend.hpp"
+  #include "backends.hpp"
 
   #include "toolexcept.hpp"
 
@@ -589,3 +590,24 @@ STATUS_OSTREAM_TO_STRING(kdb::tools::ImportExportBackend)
 %include "backend.hpp"
 
 
+
+
+/*************************************************************************
+ *
+ * backends.hpp
+ *
+ ************************************************************************/
+
+%template(BackendInfoVector) std::vector<kdb::tools::BackendInfo>;
+
+/* ignore this constant, since SWIG treats it as static member variable
+ * and defines a setter method for it */
+%ignore kdb::tools::Backends::mountpointsPath;
+
+/* is there no way to define a class constant? 
+ * so this will become Kdbtools::MOUNTPOINTS_PATH
+*/
+%constant const char * mountpoints_path = 
+        kdb::tools::Backends::mountpointsPath;
+
+%include "backends.hpp"

--- a/src/bindings/swig/ruby/kdbtools.i
+++ b/src/bindings/swig/ruby/kdbtools.i
@@ -39,6 +39,16 @@ Please note, this documentation will show C++ types too (e.g. std::string).
 %include <stdint.i>
 %include <exception.i>
 %include <std_except.i>
+%include <std_shared_ptr.i>
+
+/* shared pointer definitions have to be before the first include
+ * statements (have to be defined before its types */
+#define SWIG_SHARED_PTR_NAMESPACE std
+%shared_ptr(kdb::tools::PluginDatabase)
+/* MUST be done for all sub-types too !!! */
+%shared_ptr(kdb::tools::ModulesPluginDatabase)
+%shared_ptr(kdb::tools::PluginVariantDatabase)
+%shared_ptr(kdb::tools::MockPluginDatabase)
 
 
 namespace std {
@@ -58,6 +68,7 @@ namespace std {
   #include "backendparser.hpp"
   #include "backend.hpp"
   #include "backends.hpp"
+  #include "backendbuilder.hpp"
 
   #include "toolexcept.hpp"
 
@@ -474,6 +485,7 @@ UNIQUE_PTR_VALUE_WRAPPER(
 
 
 
+
 /*************************************************************************
  *
  * kdb::tools::Modules
@@ -607,7 +619,33 @@ STATUS_OSTREAM_TO_STRING(kdb::tools::ImportExportBackend)
 /* is there no way to define a class constant? 
  * so this will become Kdbtools::MOUNTPOINTS_PATH
 */
-%constant const char * mountpoints_path = 
+%constant const char * mountpoints_path =
         kdb::tools::Backends::mountpointsPath;
 
 %include "backends.hpp"
+
+
+
+
+/*************************************************************************
+ *
+ * backendbuilder.hpp
+ *
+ ************************************************************************/
+
+/* this is just a local helper class */
+%ignore kdb::tools::BackendBuilderInit;
+
+%ignore kdb::tools::BackendBuilder::begin;
+%ignore kdb::tools::BackendBuilder::end;
+%ignore kdb::tools::BackendBuilder::cbegin;
+%ignore kdb::tools::BackendBuilder::cend;
+
+%rename("backend_config") kdb::tools::BackendBuilder::getBackendConfig;
+%rename("backend_config=") kdb::tools::BackendBuilder::setBackendConfig;
+
+%ignore kdb::tools::GlobalPluginsBuilder::globalPluginsPath;
+%constant const char * GLOBAL_PLUGINS_PATH =
+        kdb::tools::GlobalPluginsBuilder::globalPluginsPath;
+
+%include "backendbuilder.hpp"

--- a/src/bindings/swig/ruby/kdbtools.i
+++ b/src/bindings/swig/ruby/kdbtools.i
@@ -568,35 +568,33 @@ STATUS_OSTREAM_TO_STRING(kdb::tools::ImportExportBackend)
          kdb::tools::MountpointInvalidException,
          kdb::tools::BackendCheckException,
          kdb::tools::ToolException
-) kdb::tools::Backend::setMountpoint;
+) kdb::tools::BackendInterface::setMountpoint;
 
 %catches(kdb::tools::MissingSymbol,
          kdb::tools::FileNotValidException,
          kdb::tools::BackendCheckException,
          kdb::tools::ToolException
-) kdb::tools::Backend::useConfigFile;
-
-%catches(kdb::tools::PluginAlreadyInserted,
-         kdb::tools::BackendCheckException,
-         kdb::tools::ToolException
-) kdb::tools::Backend::tryPlugin;
+) kdb::tools::MountBackendInterface::useConfigFile;
 
 %catches(kdb::tools::BackendCheckException,
          kdb::tools::PluginCheckException,
          kdb::tools::ToolException
-) kdb::tools::Backend::addPlugin;
-
-%catches(kdb::tools::NoPlugin,
-         kdb::tools::BackendCheckException,
-         kdb::tools::PluginCheckException,
-         kdb::tools::ToolException
-) kdb::tools::PluginAdder::addPlugin;
-
+) kdb::tools::BackendInterface::addPlugin;
 
 %catches(kdb::tools::NoGlobalPlugin,
          kdb::tools::BackendCheckException,
          kdb::tools::ToolException
 ) kdb::tools::GlobalPlugins::serialize;
+
+%catches(kdb::tools::TooManyPlugins,
+         kdb::tools::ToolException,
+         ...
+) kdb::tools::SerializeInterface::serialize;
+
+%catches(kdb::tools::TooManyPlugins,
+         kdb::tools::ToolException,
+         ...
+) kdb::tools::GlobalPluginsBuilder::serialize;
 
 
 %include "backend.hpp"
@@ -647,5 +645,41 @@ STATUS_OSTREAM_TO_STRING(kdb::tools::ImportExportBackend)
 %ignore kdb::tools::GlobalPluginsBuilder::globalPluginsPath;
 %constant const char * GLOBAL_PLUGINS_PATH =
         kdb::tools::GlobalPluginsBuilder::globalPluginsPath;
+
+
+%catches(kdb::tools::NoPlugin,
+         kdb::tools::CyclicOrderingViolation,
+         kdb::tools::PluginAlreadyInserted,
+         kdb::tools::PluginConfigInvalid,
+         kdb::tools::BackendCheckException,
+         kdb::tools::ToolException
+) kdb::tools::BackendBuilder::addPlugin;
+
+%catches(kdb::tools::NoPlugin,
+         kdb::tools::CyclicOrderingViolation,
+         kdb::tools::PluginAlreadyInserted,
+         kdb::tools::PluginConfigInvalid,
+         kdb::tools::BackendCheckException,
+         kdb::tools::ToolException
+) kdb::tools::BackendBuilder::addPlugins;
+
+%catches(kdb::tools::NoPlugin,
+         kdb::tools::CyclicOrderingViolation,
+         kdb::tools::PluginAlreadyInserted,
+         kdb::tools::PluginConfigInvalid,
+         kdb::tools::BackendCheckException,
+         kdb::tools::ToolException,
+         ...
+) kdb::tools::BackendBuilder::resolveNeeds;
+
+%catches(kdb::tools::ToolException,
+         ...
+) kdb::tools::BackendBuilder::fillPlugins;
+
+%catches(kdb::tools::ToolException,
+         ...
+) kdb::tools::BackendBuilder::fillPlugins;
+
+
 
 %include "backendbuilder.hpp"

--- a/src/bindings/swig/ruby/kdbtools.i
+++ b/src/bindings/swig/ruby/kdbtools.i
@@ -1,0 +1,136 @@
+/**
+ * @file
+ *
+ * @brief Swig interface file for KDB Ruby bindings
+ *
+ * @copyright BSD License (see doc/LICENSE.md or http://www.libelektra.org)
+ */
+
+%feature("autodoc", "3");
+/*
+%define CPPDOCURL "http://doc.libelektra.org/api/current/html" %enddef
+
+%define DOCSTRING
+"This module is a SWIG generated binding for KDB (http://www.libelektra.org),
+therefore the module provides wrapper classes to KDBs C++ interface and is
+mainly a 1 to 1 relation. However, to provide a more Ruby-style API to KDB,
+this module differs to the C++ API in the following way:
+ * C++ iterators for Key/KeySet are excluded. Instead KeySet implements
+   a 'each' method and includes 'Enumerable'. Therefore it is very similar to
+   a Ruby-Array. However, the KeySet cursor methods are still available.
+ * Access to native C-level KDB structures (such as ckdb::Key) is not
+   possible, as this does not make much sense within Ruby.
+ * Method names are renamed to follow Ruby naming conventions
+ * Key and KeySet methods directly modify the underlying Key/KeySet
+
+Please note, this documentation will show C++ types too (e.g. std::string).
+"
+%enddef
+*/
+/* docstring for module implemented for swig >= 3.0.18 */
+
+%module kdbtools
+
+
+
+%include "attribute.i"
+%include <std_vector.i>
+%include <std_map.i>
+%include <std_string.i>
+%include "stdint.i"
+%include "exception.i"
+%include "std_except.i"
+
+/* add mapping for std::bad_alloc exception */
+namespace std {
+  %std_exception_map(bad_alloc, SWIG_MemoryError);
+
+  %template(VectorStr) vector<string>;
+};
+
+%import "kdb.i"
+
+%{
+  #include "pluginspec.hpp"
+  #include "plugin.hpp"
+  #include "plugins.hpp"
+  #include "plugindatabase.hpp"
+
+  using namespace kdb::tools;
+%}
+
+%apply long { ssize_t }
+
+/*************************************************************************
+ *
+ * kdb::tools::PluginSpec
+ *
+ ************************************************************************/
+
+/* %predicate kdb::tools::PluginSpec::isRefNumber; */
+
+/* getter/setter */
+%rename("fullname") kdb::tools::PluginSpec::getFullName;
+%rename("fullname=") kdb::tools::PluginSpec::setFullName;
+
+%rename("name") kdb::tools::PluginSpec::getName;
+%rename("name=") kdb::tools::PluginSpec::setName;
+
+%rename("config") kdb::tools::PluginSpec::getConfig;
+%rename("config=") kdb::tools::PluginSpec::setConfig;
+
+%rename("refname") kdb::tools::PluginSpec::getRefName;
+%rename("refname=") kdb::tools::PluginSpec::setRefName;
+
+%rename("refnumber=") kdb::tools::PluginSpec::setRefNumber;
+%rename("is_refnumber?") kdb::tools::PluginSpec::isRefNumber;
+
+
+
+%include "pluginspec.hpp"
+
+/*************************************************************************
+ *
+ * kdb::tools::Plugin
+ *
+ ************************************************************************/
+
+%ignore kdb::tools::Plugin::getSymbol;
+%ignore kdb::tools::Plugin::operator=;
+
+/*
+ * parse plugin.hpp
+ */
+%include "plugin.hpp"
+
+
+/*************************************************************************
+ *
+ * kdb::tools::Plugins
+ *
+ ************************************************************************/
+
+%include "plugins.hpp"
+
+
+/*************************************************************************
+ *
+ * kdb::tools::PluginDatabase
+ *
+ ************************************************************************/
+
+%ignore kdb::tools::PluginDatabase::getSymbol;
+%ignore kdb::tools::ModulesPluginDatabase::getSymbol;
+%ignore kdb::tools::MockPluginDatabase::getSymbol;
+
+%template(IntPluginSpecMap) std::map<int, kdb::tools::PluginSpec>;
+
+%constant const int PLUGIN_STATUS_PROVIDES =
+        kdb::tools::PluginDatabase::Status::provides;
+%constant const int PLUGIN_STATUS_REAL =
+        kdb::tools::PluginDatabase::Status::real;
+%constant const int PLUGIN_STATUS_MISSING =
+        kdb::tools::PluginDatabase::Status::missing;
+
+
+%include "plugindatabase.hpp"

--- a/src/bindings/swig/ruby/kdbtools.i
+++ b/src/bindings/swig/ruby/kdbtools.i
@@ -69,6 +69,7 @@ namespace std {
   #include "backend.hpp"
   #include "backends.hpp"
   #include "backendbuilder.hpp"
+  #include "specreader.hpp"
 
   #include "toolexcept.hpp"
 
@@ -683,3 +684,32 @@ STATUS_OSTREAM_TO_STRING(kdb::tools::ImportExportBackend)
 
 
 %include "backendbuilder.hpp"
+
+
+
+
+/*************************************************************************
+ *
+ * specreader.hpp
+ *
+ ************************************************************************/
+/* std::unordered_map is currently not supported by the 
+ * SWIG standard library. So we convert it to a std::map
+ * and use the SWIG std::map type wrapping.*/
+%template(SpecBackendBuilderMap) 
+        std::map<kdb::Key, kdb::tools::SpecBackendBuilder>;
+
+/* std::unordered_map<Key, SpecBackendBuilder> is just used
+ * as return type for SpecReader::getBackends(). Thus we just
+ * need a 'out' typemap for this now */
+%typemap(out) std::unordered_map<kdb::Key, kdb::tools::SpecBackendBuilder> (std::map<kdb::Key, kdb::tools::SpecBackendBuilder> * tmp_backends) {
+        // Backends-typemap
+  tmp_backends = new std::map<kdb::Key, kdb::tools::SpecBackendBuilder>(
+        $1.begin(), $1.end());
+  %set_output(SWIG_NewPointerObj(tmp_backends,
+        SWIG_TypeQuery("std::map< kdb::Key, kdb::tools::SpecBackendBuilder > *"),
+        1));
+}
+
+
+%include "specreader.hpp"

--- a/src/bindings/swig/ruby/kdbtools.rb
+++ b/src/bindings/swig/ruby/kdbtools.rb
@@ -1,0 +1,18 @@
+# encoding: UTF-8
+##
+# @file
+#
+# @brief main module for kdbtools
+#
+# @copyright BSD License (see doc/LICENSE.md or http://www.libelektra.org)
+#
+# This module is an extension to the SWIG created wrapper to libelektra tools
+#
+
+require '_kdbtools'
+
+module Kdb
+
+
+end
+

--- a/src/bindings/swig/ruby/kdbtools.rb
+++ b/src/bindings/swig/ruby/kdbtools.rb
@@ -11,7 +11,7 @@
 
 require '_kdbtools'
 
-module Kdb
+module Kdbtools
 
 
 end

--- a/src/bindings/swig/ruby/tests/testruby_tools_backendbuilder.rb
+++ b/src/bindings/swig/ruby/tests/testruby_tools_backendbuilder.rb
@@ -1,0 +1,36 @@
+#!/usr/bin/env ruby
+##
+# @file
+#
+# @brief unit test cases for Kdbtools::BackendBuilder and friends
+#
+# @copyright BSD License (see doc/LICENSE.md or http://www.libelektra.org)
+#
+
+require 'kdbtools'
+require 'test/unit'
+require_relative 'test_helper.rb'
+
+class KdbtoolsBackendbuilderTestCases < Test::Unit::TestCase
+
+  def test_shared_ptr
+    assert_nothing_raised do
+      bb = Kdbtools::BackendBuilder.new
+
+      db = bb.get_plugin_database()
+
+      assert db.respond_to? :list_all_plugins
+      assert db.respond_to? :lookup_info
+      assert db.respond_to? :lookup_metadata
+
+      assert_instance_of Kdbtools::PluginDatabase, db
+      assert db.is_a? Kdbtools::PluginDatabase
+
+      # check if pointer is valid (should not crash)
+      plugins = db.list_all_plugins
+      assert_instance_of Array, plugins
+    end
+  end
+
+end
+

--- a/src/bindings/swig/ruby/tests/testruby_tools_backendparser.rb
+++ b/src/bindings/swig/ruby/tests/testruby_tools_backendparser.rb
@@ -1,0 +1,48 @@
+#!/usr/bin/env ruby
+##
+# @file
+#
+# @brief unit test cases for Kdbtools.parse_arguments
+#
+# @copyright BSD License (see doc/LICENSE.md or http://www.libelektra.org)
+#
+
+require 'kdbtools'
+require 'test/unit'
+require_relative 'test_helper.rb'
+
+class KdbtoolsParseArgumentsTestCases < Test::Unit::TestCase
+
+  def test_parse_arguments
+    assert_nothing_raised do
+      args = Kdbtools.parse_arguments "plugin c1=v1 c2=v2"
+
+      puts
+      puts args[0].config
+      puts
+
+      assert_instance_of Array, args
+      assert_equal 1, args.size
+      assert_instance_of Kdbtools::PluginSpec, args[0]
+
+      args = Kdbtools.parse_arguments "plugin1 c1=v1,c2=v2 plugin2 d=x"
+      assert_equal 2, args.size
+    end
+  end
+
+  def test_parse_plugin_arguments
+    assert_nothing_raised do
+      args = Kdbtools.parse_plugin_arguments "c1=v1,c2=v2"
+
+      assert_instance_of Kdb::KeySet, args
+    end
+  end
+
+  def test_parse_arguments_exceptions
+    assert_raise Kdbtools::ParseException do
+      # pass args without a plugin name
+      Kdbtools.parse_arguments "c1=b1"
+    end
+  end
+end
+

--- a/src/bindings/swig/ruby/tests/testruby_tools_modules.rb
+++ b/src/bindings/swig/ruby/tests/testruby_tools_modules.rb
@@ -1,0 +1,80 @@
+#!/usr/bin/env ruby
+##
+# @file
+#
+# @brief unit test cases for Kdbtools::Modules
+#
+# @copyright BSD License (see doc/LICENSE.md or http://www.libelektra.org)
+#
+
+require 'kdbtools'
+require 'test/unit'
+require_relative 'test_helper.rb'
+
+class KdbtoolsModulesTestCases < Test::Unit::TestCase
+
+  def test_modules_new
+    assert_nothing_raised do
+      m = Kdbtools::Modules.new
+      assert_instance_of Kdbtools::Modules, m
+      assert_not_nil m
+    end
+  end
+
+  def test_modules_load_by_name
+    assert_nothing_raised do
+      m = Kdbtools::Modules.new
+
+      p = m.load "dump"
+
+      assert_instance_of Kdbtools::Plugin, p
+
+      assert_equal "dump", p.name
+    end
+  end
+
+  def test_modules_load_by_name_and_config
+    assert_nothing_raised do
+      m = Kdbtools::Modules.new
+
+      config = Kdb::KeySet.new(
+        Kdb::Key.new("system/module", value: "without config")
+      )
+
+      p = m.load "dump", config
+
+      assert_instance_of Kdbtools::Plugin, p
+
+      assert_equal "dump", p.name
+      assert_equal config, p.get_config
+    end
+  end
+
+  def test_modules_load_by_pluginspec
+    assert_nothing_raised do
+      m = Kdbtools::Modules.new
+
+      ps = Kdbtools::PluginSpec.new "dump"
+
+      p = m.load ps
+
+      assert_instance_of Kdbtools::Plugin, p
+
+      assert_equal "dump", p.name
+      assert_equal ps.config, p.get_config
+    end
+  end
+
+  def test_load_invalid_plugin
+
+    m = Kdbtools::Modules.new
+
+    assert_raise Kdbtools::BadPluginName do
+      m.load "invalid plugin name"
+    end
+
+    assert_raise Kdbtools::NoPlugin do
+      m.load "thisplugindoesreallynotexist"
+    end
+  end
+end

--- a/src/bindings/swig/ruby/tests/testruby_tools_plugindatabase.rb
+++ b/src/bindings/swig/ruby/tests/testruby_tools_plugindatabase.rb
@@ -1,0 +1,98 @@
+#!/usr/bin/env ruby
+##
+# @file
+#
+# @brief unit test cases for Kdbtools::PluginDatabase and friends
+#
+# @copyright BSD License (see doc/LICENSE.md or http://www.libelektra.org)
+#
+
+require 'kdbtools'
+require 'test/unit'
+require_relative 'test_helper.rb'
+
+class KdbtoolsPluginDatabaseTestCases < Test::Unit::TestCase
+
+  def test_instance
+    assert_nothing_raised do
+      db = Kdbtools::ModulesPluginDatabase.new
+
+      assert db.respond_to? :list_all_plugins
+      assert db.respond_to? :lookup_info
+      assert db.respond_to? :lookup_metadata
+
+      assert_instance_of Kdbtools::ModulesPluginDatabase, db
+
+      # check if pointer is valid (should not crash)
+      db.list_all_plugins
+    end
+  end
+
+  def test_vector_of_strings
+    assert_nothing_raised do
+      db = Kdbtools::ModulesPluginDatabase.new
+
+      plugins = db.list_all_plugins
+
+      assert plugins.respond_to? :size
+      assert plugins.respond_to? :each
+      assert_instance_of Array, plugins
+
+      # require to have at least one plugin
+      assert_instance_of String, plugins[0]
+    end
+  end
+
+  def test_get_pluginspec
+    assert_nothing_raised do
+      db = Kdbtools::ModulesPluginDatabase.new
+
+      ps = db.lookup_provides "ini"
+
+      assert_instance_of Kdbtools::PluginSpec, ps
+      ps.fullname
+    end
+  end
+
+  def test_get_pluginspec_vector
+    assert_nothing_raised do
+      db = Kdbtools::ModulesPluginDatabase.new
+
+      ps = db.lookup_all_provides "ini"
+
+      assert_instance_of Array, ps
+      ps.each do |p|
+        assert_instance_of Kdbtools::PluginSpec, p
+        p.fullname
+      end
+    end
+  end
+
+  def test_get_int_pluginspec_map
+    assert_nothing_raised do
+      db = Kdbtools::ModulesPluginDatabase.new
+
+      ps = db.lookup_all_provides_with_status "ini"
+
+      assert_instance_of Kdbtools::IntPluginSpecMap, ps
+      assert ps.respond_to? :each
+      ps.each do |k,v|
+        assert_instance_of Fixnum, k
+        assert_instance_of Kdbtools::PluginSpec, v
+        v.fullname
+      end
+    end
+  end
+
+  def test_plugindatabase_status
+    assert_nothing_raised do
+      db = Kdbtools::ModulesPluginDatabase.new
+
+      ps = Kdbtools::PluginSpec.new "dump"
+      status = db.status ps
+
+      assert_equal Kdbtools::PLUGIN_STATUS_REAL, status
+    end
+  end
+end
+

--- a/src/bindings/swig/ruby/tests/testruby_tools_pluginspec.rb
+++ b/src/bindings/swig/ruby/tests/testruby_tools_pluginspec.rb
@@ -1,0 +1,80 @@
+#!/usr/bin/env ruby
+##
+# @file
+#
+# @brief unit test cases for Kdbtools::PluginSpec
+#
+# @copyright BSD License (see doc/LICENSE.md or http://www.libelektra.org)
+#
+
+require 'kdbtools'
+require 'test/unit'
+require_relative 'test_helper.rb'
+
+class KdbtoolsPluginSpecTestCases < Test::Unit::TestCase
+
+  def test_pluginspec_new
+    assert_nothing_raised do
+      o = Kdbtools::PluginSpec.new "somename"
+      assert_instance_of Kdbtools::PluginSpec, o
+      assert_not_nil o
+    end
+  end
+
+  def test_pluginspec_getters
+    assert_nothing_raised do
+      p = Kdbtools::PluginSpec.new "somename"
+
+      assert_equal "somename", p.name
+      assert_instance_of String, p.name
+      assert_instance_of String, p.fullname
+      assert_instance_of String, p.refname
+      assert_instance_of FalseClass, p.is_refnumber?
+      assert_instance_of Kdb::KeySet, p.config
+
+    end
+  end
+
+  def test_pluginspec_setters
+    assert_nothing_raised do
+      p = Kdbtools::PluginSpec.new "somename"
+
+      assert_equal "somename", p.name
+
+      p.name= "other"
+      assert_equal "other", p.name
+
+      p.refname= "myref"
+      assert_equal "myref", p.refname
+
+      p.fullname= "myfullname"
+      assert_equal "myfullname#myref", p.fullname
+
+      p.refnumber= 5
+      assert_equal "5", p.refname
+      assert_equal true, p.is_refnumber?
+
+      key = Kdb::Key.new "system/modules", value: "nothing"
+      config = Kdb::KeySet.new key
+
+      p.config= config
+      assert_equal config, p.config
+
+      key2 = Kdb::Key.new "system/modules/2", value: "nothing2"
+      config2 = Kdb::KeySet.new key2
+      p.append_config config2
+      config << config2
+      assert_equal config, p.config
+
+    end
+  end
+
+  def test_pluginspec_setter_exception
+    p = Kdbtools::PluginSpec.new "somename"
+
+    assert_raise Kdbtools::BadPluginName do
+      p.fullname= "this is an invalid name ! ;."
+    end
+  end
+
+end

--- a/src/bindings/swig/ruby/tests/testruby_tools_specreader.rb
+++ b/src/bindings/swig/ruby/tests/testruby_tools_specreader.rb
@@ -1,0 +1,43 @@
+#!/usr/bin/env ruby
+##
+# @file
+#
+# @brief unit test cases for Kdbtools::SpecReader and friends
+#
+# @copyright BSD License (see doc/LICENSE.md or http://www.libelektra.org)
+#
+
+require 'kdbtools'
+require 'test/unit'
+require_relative 'test_helper.rb'
+
+class KdbtoolsSpecReaderTestCases < Test::Unit::TestCase
+
+  def test_spec_reader
+    assert_nothing_raised do
+      bb = Kdbtools::SpecReader.new
+
+      spec = Kdb::KeySet.new
+      spec << Kdb::Key.new("spec/example/xx", 
+                           mountpoint: "/example/xx")
+
+      bb.read_specification spec
+
+      backends = bb.get_backends
+
+      assert_instance_of Kdbtools::SpecBackendBuilderMap, backends
+      assert backends.respond_to? :keys
+      assert backends.respond_to? :values
+      assert backends.respond_to? :each
+      assert backends.respond_to? :size
+
+      assert_equal 1, backends.size
+
+      assert_instance_of Kdbtools::SpecBackendBuilder, 
+                         backends[Kdb::Key.new "spec/example/xx"]
+
+    end
+  end
+
+end
+

--- a/src/libs/tools/include/backend.hpp
+++ b/src/libs/tools/include/backend.hpp
@@ -200,7 +200,10 @@ class ImportExportBackend : public PluginAdder
 	std::unordered_map<std::string, std::deque<std::shared_ptr<Plugin>>> plugins;
 
 public:
-	ImportExportBackend () { }
+	ImportExportBackend ()
+	{
+	}
+
 	void status (std::ostream & os) const;
 	void importFromFile (KeySet & ks, Key const & parentKey) const;
 	void exportToFile (KeySet const & ks, Key const & parentKey) const;

--- a/src/libs/tools/include/backend.hpp
+++ b/src/libs/tools/include/backend.hpp
@@ -200,7 +200,7 @@ class ImportExportBackend : public PluginAdder
 	std::unordered_map<std::string, std::deque<std::shared_ptr<Plugin>>> plugins;
 
 public:
-	ImportExportBackend ();
+	ImportExportBackend () { }
 	void status (std::ostream & os) const;
 	void importFromFile (KeySet & ks, Key const & parentKey) const;
 	void exportToFile (KeySet const & ks, Key const & parentKey) const;

--- a/src/libs/tools/include/backendbuilder.hpp
+++ b/src/libs/tools/include/backendbuilder.hpp
@@ -38,7 +38,7 @@ namespace tools
 class BackendBuilderInit
 {
 private:
-	//typedef std::shared_ptr<PluginDatabase> PluginDatabasePtr;
+	// typedef std::shared_ptr<PluginDatabase> PluginDatabasePtr;
 	// -> moved to plugindatabase.hpp since it is used in public API
 	PluginDatabasePtr pluginDatabase;
 
@@ -83,7 +83,7 @@ private:
 	/// Recommended plugins (not yet added)
 	std::vector<std::string> recommendedPlugins;
 
-	//typedef std::shared_ptr<PluginDatabase> PluginDatabasePtr;
+	// typedef std::shared_ptr<PluginDatabase> PluginDatabasePtr;
 	// -> moved to plugindatabase.hpp since it is used in public API
 	PluginDatabasePtr pluginDatabase;
 

--- a/src/libs/tools/include/backendbuilder.hpp
+++ b/src/libs/tools/include/backendbuilder.hpp
@@ -38,7 +38,8 @@ namespace tools
 class BackendBuilderInit
 {
 private:
-	typedef std::shared_ptr<PluginDatabase> PluginDatabasePtr;
+	//typedef std::shared_ptr<PluginDatabase> PluginDatabasePtr;
+	// -> moved to plugindatabase.hpp since it is used in public API
 	PluginDatabasePtr pluginDatabase;
 
 	BackendFactory backendFactory;
@@ -82,7 +83,8 @@ private:
 	/// Recommended plugins (not yet added)
 	std::vector<std::string> recommendedPlugins;
 
-	typedef std::shared_ptr<PluginDatabase> PluginDatabasePtr;
+	//typedef std::shared_ptr<PluginDatabase> PluginDatabasePtr;
+	// -> moved to plugindatabase.hpp since it is used in public API
 	PluginDatabasePtr pluginDatabase;
 
 	BackendFactory backendFactory;

--- a/src/libs/tools/include/plugindatabase.hpp
+++ b/src/libs/tools/include/plugindatabase.hpp
@@ -325,6 +325,9 @@ public:
 private:
 	checkConfPtr checkconf = NULL;
 };
+
+
+typedef std::shared_ptr<PluginDatabase> PluginDatabasePtr;
 }
 }
 

--- a/src/libs/tools/include/plugindatabase.hpp
+++ b/src/libs/tools/include/plugindatabase.hpp
@@ -34,7 +34,10 @@ protected:
 	typedef void (*func_t) ();
 
 public:
-	virtual ~PluginDatabase() { }
+	virtual ~PluginDatabase ()
+	{
+	}
+
 	/**
 	 * @brief list all plugins
 	 *

--- a/src/libs/tools/include/plugindatabase.hpp
+++ b/src/libs/tools/include/plugindatabase.hpp
@@ -34,6 +34,7 @@ protected:
 	typedef void (*func_t) ();
 
 public:
+	virtual ~PluginDatabase() { }
 	/**
 	 * @brief list all plugins
 	 *

--- a/src/libs/tools/include/pluginspec.hpp
+++ b/src/libs/tools/include/pluginspec.hpp
@@ -31,7 +31,10 @@ namespace tools
 class PluginSpec
 {
 public:
-	PluginSpec() { }
+	PluginSpec ()
+	{
+	}
+
 	explicit PluginSpec (std::string pluginName, KeySet pluginConfig = KeySet ());
 
 	explicit PluginSpec (std::string pluginName, std::string refName, KeySet pluginConfig = KeySet ());

--- a/src/libs/tools/include/pluginspec.hpp
+++ b/src/libs/tools/include/pluginspec.hpp
@@ -31,6 +31,7 @@ namespace tools
 class PluginSpec
 {
 public:
+	PluginSpec() { }
 	explicit PluginSpec (std::string pluginName, KeySet pluginConfig = KeySet ());
 
 	explicit PluginSpec (std::string pluginName, std::string refName, KeySet pluginConfig = KeySet ());

--- a/src/libs/tools/include/toolexcept.hpp
+++ b/src/libs/tools/include/toolexcept.hpp
@@ -15,6 +15,13 @@
 
 #include <kdbio.hpp>
 
+/* SWIG cpp preprocessor is not aware of the override statement */
+#ifndef SWIG_WITHOUT_OVERRIDE
+#define ELEKTRA_OVERRIDE override
+#else
+#define ELEKTRA_OVERRIDE
+#endif
+
 namespace kdb
 {
 
@@ -53,7 +60,7 @@ struct ParseException : public ToolException
 	{
 	}
 
-	virtual const char * what () const throw () override
+	virtual const char * what () const throw () ELEKTRA_OVERRIDE
 	{
 		return m_str.c_str ();
 	}
@@ -63,7 +70,7 @@ struct ParseException : public ToolException
 
 struct PluginCheckException : public ToolException
 {
-	virtual const char * what () const throw () override
+	virtual const char * what () const throw () ELEKTRA_OVERRIDE
 	{
 		return "When you read this, that means there was something wrong with the plugin.\n"
 		       "Seems like a check could not specify the error any further";
@@ -72,7 +79,7 @@ struct PluginCheckException : public ToolException
 
 struct BackendCheckException : public ToolException
 {
-	virtual const char * what () const throw () override
+	virtual const char * what () const throw () ELEKTRA_OVERRIDE
 	{
 		return "When you read this, that means there was something wrong with the backend.\n"
 		       "Seems like a check could not specify the error any further";
@@ -81,7 +88,7 @@ struct BackendCheckException : public ToolException
 
 struct FileNotValidException : public BackendCheckException
 {
-	virtual const char * what () const throw () override
+	virtual const char * what () const throw () ELEKTRA_OVERRIDE
 	{
 		return "The path you entered is invalid.\n"
 		       "Try to add another path instead.\n"
@@ -96,7 +103,7 @@ struct FileNotValidException : public BackendCheckException
 
 struct MountpointInvalidException : public BackendCheckException
 {
-	virtual const char * what () const throw () override
+	virtual const char * what () const throw () ELEKTRA_OVERRIDE
 	{
 		return "Given mountpoint is not a valid keyname, will abort\n"
 		       "Examples: system/hosts or user/sw/app";
@@ -113,7 +120,7 @@ struct MountpointAlreadyInUseException : public BackendCheckException
 	{
 	}
 
-	virtual const char * what () const throw () override
+	virtual const char * what () const throw () ELEKTRA_OVERRIDE
 	{
 		return m_str.c_str ();
 	}
@@ -131,7 +138,7 @@ struct NoSuchBackend : public BackendCheckException
 	{
 	}
 
-	virtual const char * what () const throw () override
+	virtual const char * what () const throw () ELEKTRA_OVERRIDE
 	{
 		return m_str.c_str ();
 	}
@@ -149,7 +156,7 @@ struct PluginAlreadyInserted : public PluginCheckException
 			"Try to add other plugins or other refnames (part after #) instead.";
 	}
 
-	virtual const char * what () const throw () override
+	virtual const char * what () const throw () ELEKTRA_OVERRIDE
 	{
 		return m_str.c_str ();
 	}
@@ -171,7 +178,7 @@ struct PluginConfigInvalid : public PluginCheckException
 	{
 	}
 
-	virtual const char * what () const throw () override
+	virtual const char * what () const throw () ELEKTRA_OVERRIDE
 	{
 		if (m_str.empty ())
 		{
@@ -202,7 +209,7 @@ struct BadPluginName : public PluginCheckException
 			"and then a-z, 0-9 and underscore (_) only";
 	}
 
-	virtual const char * what () const throw () override
+	virtual const char * what () const throw () ELEKTRA_OVERRIDE
 	{
 		return m_str.c_str ();
 	}
@@ -220,7 +227,7 @@ struct TooManyPlugins : public PluginCheckException
 	{
 	}
 
-	virtual const char * what () const throw () override
+	virtual const char * what () const throw () ELEKTRA_OVERRIDE
 	{
 		return m_str.c_str ();
 	}
@@ -230,7 +237,7 @@ struct TooManyPlugins : public PluginCheckException
 
 struct OrderingViolation : public PluginCheckException
 {
-	virtual const char * what () const throw () override
+	virtual const char * what () const throw () ELEKTRA_OVERRIDE
 	{
 		return "Ordering Violation!\n"
 		       "You tried to add a plugin which requests another plugin to be positioned first.\n"
@@ -240,7 +247,7 @@ struct OrderingViolation : public PluginCheckException
 
 struct CyclicOrderingViolation : public OrderingViolation
 {
-	virtual const char * what () const throw () override
+	virtual const char * what () const throw () ELEKTRA_OVERRIDE
 	{
 		return "Ordering Violation!\n"
 		       "Could not order plugins by their dependency because of cycle.\n"
@@ -251,7 +258,7 @@ struct CyclicOrderingViolation : public OrderingViolation
 
 struct ConflictViolation : public PluginCheckException
 {
-	virtual const char * what () const throw () override
+	virtual const char * what () const throw () ELEKTRA_OVERRIDE
 	{
 		return "Conflict Violation!\n"
 		       "You tried to add a plugin which conflicts with another.\n"
@@ -274,7 +281,7 @@ struct NoPlugin : public PluginCheckException
 	{
 	}
 
-	virtual const char * what () const throw () override
+	virtual const char * what () const throw () ELEKTRA_OVERRIDE
 	{
 		if (m_str.empty ())
 		{
@@ -305,7 +312,7 @@ private:
 
 struct ReferenceNotFound : public PluginCheckException
 {
-	virtual const char * what () const throw () override
+	virtual const char * what () const throw () ELEKTRA_OVERRIDE
 	{
 		return "Could not find a reference!\n"
 		       "Seems you forgot to create the reference before using it.\n"
@@ -323,7 +330,7 @@ struct MissingNeeded : public PluginCheckException
 	~MissingNeeded () throw ()
 	{
 	}
-	virtual const char * what () const throw () override
+	virtual const char * what () const throw () ELEKTRA_OVERRIDE
 	{
 		return msg.c_str ();
 	}
@@ -339,7 +346,7 @@ struct MissingSymbol : public PluginCheckException
 	~MissingSymbol () throw ()
 	{
 	}
-	virtual const char * what () const throw () override
+	virtual const char * what () const throw () ELEKTRA_OVERRIDE
 	{
 		return msg.c_str ();
 	}
@@ -355,7 +362,7 @@ struct WrongStatus : public PluginCheckException
 	~WrongStatus () throw ()
 	{
 	}
-	virtual const char * what () const throw () override
+	virtual const char * what () const throw () ELEKTRA_OVERRIDE
 	{
 		return msg.c_str ();
 	}
@@ -372,7 +379,7 @@ struct SymbolMismatch : public PluginCheckException
 	~SymbolMismatch () throw ()
 	{
 	}
-	virtual const char * what () const throw () override
+	virtual const char * what () const throw () ELEKTRA_OVERRIDE
 	{
 		return msg.c_str ();
 	}
@@ -388,7 +395,7 @@ struct NoGlobalPlugin : public PluginCheckException
 	~NoGlobalPlugin () throw ()
 	{
 	}
-	virtual const char * what () const throw () override
+	virtual const char * what () const throw () ELEKTRA_OVERRIDE
 	{
 		return msg.c_str ();
 	}
@@ -405,7 +412,7 @@ struct SymbolDuplicate : public PluginCheckException
 	~SymbolDuplicate () throw ()
 	{
 	}
-	virtual const char * what () const throw () override
+	virtual const char * what () const throw () ELEKTRA_OVERRIDE
 	{
 		return msg.c_str ();
 	}
@@ -413,7 +420,7 @@ struct SymbolDuplicate : public PluginCheckException
 
 struct StoragePlugin : public PluginCheckException
 {
-	virtual const char * what () const throw () override
+	virtual const char * what () const throw () ELEKTRA_OVERRIDE
 	{
 		return "There need to be exactly one storage plugin!";
 	}
@@ -422,7 +429,7 @@ struct StoragePlugin : public PluginCheckException
 
 struct ResolverPlugin : public PluginCheckException
 {
-	virtual const char * what () const throw () override
+	virtual const char * what () const throw () ELEKTRA_OVERRIDE
 	{
 		return "There need to be exactly one resolver plugin!";
 	}
@@ -430,7 +437,7 @@ struct ResolverPlugin : public PluginCheckException
 
 struct PluginNoContract : public PluginCheckException
 {
-	virtual const char * what () const throw () override
+	virtual const char * what () const throw () ELEKTRA_OVERRIDE
 	{
 		return "No contract found for that plugin!\n"
 		       "Make sure you export kdbGet correctly!";
@@ -439,7 +446,7 @@ struct PluginNoContract : public PluginCheckException
 
 struct PluginNoInfo : public PluginCheckException
 {
-	virtual const char * what () const throw () override
+	virtual const char * what () const throw () ELEKTRA_OVERRIDE
 	{
 		return "No info found for that plugin within contract!";
 	}
@@ -447,7 +454,7 @@ struct PluginNoInfo : public PluginCheckException
 
 struct VersionInfoMismatch : public PluginCheckException
 {
-	virtual const char * what () const throw () override
+	virtual const char * what () const throw () ELEKTRA_OVERRIDE
 	{
 		return "Version info does not match with library!";
 	}

--- a/src/libs/tools/src/backend.cpp
+++ b/src/libs/tools/src/backend.cpp
@@ -230,7 +230,8 @@ void Backend::setBackendConfig (KeySet const & ks)
 
 /**@pre: resolver needs to be loaded first
  * Will check the filename and use it as configFile for this backend.
- * @throw FileNotValidException if filename is not valid */
+ * @throw FileNotValidException if filename is not valid
+ * @throw MissingSymbol if plugin does not implement 'checkfile' */
 void Backend::useConfigFile (std::string file)
 {
 	typedef int (*checkFilePtr) (const char *);
@@ -273,7 +274,8 @@ void Backend::tryPlugin (PluginSpec const & spec)
 
 	for (auto & elem : plugins)
 	{
-		if (plugin->getFullName () == elem->getFullName ()) throw PluginAlreadyInserted (plugin->getFullName ());
+		if (plugin->getFullName () == elem->getFullName ())
+			throw PluginAlreadyInserted (plugin->getFullName ());
 	}
 
 

--- a/src/libs/tools/src/backend.cpp
+++ b/src/libs/tools/src/backend.cpp
@@ -274,8 +274,7 @@ void Backend::tryPlugin (PluginSpec const & spec)
 
 	for (auto & elem : plugins)
 	{
-		if (plugin->getFullName () == elem->getFullName ())
-			throw PluginAlreadyInserted (plugin->getFullName ());
+		if (plugin->getFullName () == elem->getFullName ()) throw PluginAlreadyInserted (plugin->getFullName ());
 	}
 
 


### PR DESCRIPTION
# Purpose

Ruby bindings for libtools, extends existing bindings (same src tree, same build but different Ruby module)

# Checklist

- [x] commit messages are fine (with references to issues)
- [x] I ran all tests and everything went fine
- [x] I added unit tests
- [x] affected documentation is fixed
- [x] I added code comments, logging, and assertions
- [ ] meta data is updated (e.g. README.md of plugins)

@markus2330 final version
