### PR TITLE
Fix kdb set base name

### DIFF
--- a/src/libs/elektra/keyname.c
+++ b/src/libs/elektra/keyname.c
@@ -1081,7 +1081,7 @@ ssize_t keySetBaseName (Key * key, const char * baseName)
 	if (!baseName)
 	{
 		// Avoid deleting the last / of a cascading key by increasing the size by one again
-		key->keySize += 1 == key->keySize && KEY_NS_CASCADING == keyGetNamespace (key);
+		key->keySize += (1 == key->keySize) && (KEY_NS_CASCADING == keyGetNamespace (key));
 
 		// just remove base name, so we are finished
 		elektraFinalizeName (key);

--- a/src/libs/elektra/keyname.c
+++ b/src/libs/elektra/keyname.c
@@ -1080,6 +1080,9 @@ ssize_t keySetBaseName (Key * key, const char * baseName)
 
 	if (!baseName)
 	{
+		// Avoid deleting the last / of a cascading key by increasing the size by one again
+		key->keySize += 1 == key->keySize && KEY_NS_CASCADING == keyGetNamespace (key);
+		
 		// just remove base name, so we are finished
 		elektraFinalizeName (key);
 		return key->keySize;

--- a/src/libs/elektra/keyname.c
+++ b/src/libs/elektra/keyname.c
@@ -1082,7 +1082,7 @@ ssize_t keySetBaseName (Key * key, const char * baseName)
 	{
 		// Avoid deleting the last / of a cascading key by increasing the size by one again
 		key->keySize += 1 == key->keySize && KEY_NS_CASCADING == keyGetNamespace (key);
-		
+
 		// just remove base name, so we are finished
 		elektraFinalizeName (key);
 		return key->keySize;

--- a/tests/abi/testabi_key.c
+++ b/tests/abi/testabi_key.c
@@ -2078,7 +2078,12 @@ static void test_keySetBaseName ()
 	succeed_if_same_string (keyBaseName (k), "");
 
 	keySetName (k, "/");
-	succeed_if (keySetBaseName (k, 0) -1, "could remove root name");
+	succeed_if (keySetBaseName (k, 0) == -1, "could remove root name");
+	succeed_if_same_string (keyName (k), "/");
+	succeed_if_same_string (keyBaseName (k), "");
+
+	keySetName (k, "/x");
+	succeed_if (keySetBaseName (k, 0) == 2, "removing single character basename of cascading key with depth 1 failed");
 	succeed_if_same_string (keyName (k), "/");
 	succeed_if_same_string (keyBaseName (k), "");
 
@@ -2096,6 +2101,25 @@ static void test_keySetBaseName ()
 	succeed_if (keySetBaseName (k, 0) >= 0, "removing basename of non cascading key with depth 2 failed");
 	succeed_if_same_string (keyName (k), "system/foo");
 	succeed_if_same_string (keyBaseName (k), "foo");
+	succeed_if (keySetBaseName (k, 0) >= 0, "second removing basename of non cascading key with depth 2 failed");
+	succeed_if_same_string (keyName (k), "system");
+	succeed_if_same_string (keyBaseName (k), "");
+
+	keySetName (k, "/foo/bar");
+	succeed_if (keySetBaseName (k, 0) >= 0, "removing basename of cascading key with depth 2 failed");
+	succeed_if_same_string (keyName (k), "/foo");
+	succeed_if_same_string (keyBaseName (k), "foo");
+	succeed_if (keySetBaseName (k, 0) == 2, "second removing basename of cascading key with depth 2 failed");
+	succeed_if_same_string (keyName (k), "/");
+	succeed_if_same_string (keyBaseName (k), "");
+	succeed_if (keySetBaseName (k, 0) == -1, "third removing basename of cascading key with depth 2 was possible");
+	succeed_if_same_string (keyName (k), "/");
+	succeed_if_same_string (keyBaseName (k), "");
+
+	keySetName (k, "/\\/");
+	succeed_if (keySetBaseName (k, 0) == 2, "removing basename of single character escaped cascading key with depth 1 failed");
+	succeed_if_same_string (keyName (k), "/");
+	succeed_if_same_string (keyBaseName (k), "");
 
 	keySetName (k, "system");
 	succeed_if (keySetBaseName (k, "valid") == -1, "add root name, but set was used");

--- a/tests/abi/testabi_key.c
+++ b/tests/abi/testabi_key.c
@@ -2121,6 +2121,26 @@ static void test_keySetBaseName ()
 	succeed_if_same_string (keyName (k), "/");
 	succeed_if_same_string (keyBaseName (k), "");
 
+	keySetName (k, "/\\.");
+	succeed_if (keySetBaseName (k, 0) == 2, "removing basename of single character escaped dot cascading key with depth 1 failed");
+	succeed_if_same_string (keyName (k), "/");
+	succeed_if_same_string (keyBaseName (k), "");
+
+	keySetName (k, "/\\..");
+	succeed_if (keySetBaseName (k, 0) == 2, "removing basename of escaped dot dot cascading key with depth 1 failed");
+	succeed_if_same_string (keyName (k), "/");
+	succeed_if_same_string (keyBaseName (k), "");
+
+	keySetName (k, "/\\%");
+	succeed_if (keySetBaseName (k, 0) == 2, "removing basename of single character escaped % cascading key with depth 1 failed");
+	succeed_if_same_string (keyName (k), "/");
+	succeed_if_same_string (keyBaseName (k), "");
+
+	keySetName (k, "/#_1");
+	succeed_if (keySetBaseName (k, 0) == 2, "removing basename of array cascading key with depth 1 failed");
+	succeed_if_same_string (keyName (k), "/");
+	succeed_if_same_string (keyBaseName (k), "");
+
 	keySetName (k, "system");
 	succeed_if (keySetBaseName (k, "valid") == -1, "add root name, but set was used");
 	succeed_if_same_string (keyName (k), "system");

--- a/tests/abi/testabi_key.c
+++ b/tests/abi/testabi_key.c
@@ -2077,6 +2077,26 @@ static void test_keySetBaseName ()
 	succeed_if_same_string (keyName (k), "system");
 	succeed_if_same_string (keyBaseName (k), "");
 
+	keySetName (k, "/");
+	succeed_if (keySetBaseName (k, 0) -1, "could remove root name");
+	succeed_if_same_string (keyName (k), "/");
+	succeed_if_same_string (keyBaseName (k), "");
+
+	keySetName (k, "/cascading");
+	succeed_if (keySetBaseName (k, 0) == 2, "removing basename of cascading key with depth 1 failed");
+	succeed_if_same_string (keyName (k), "/");
+	succeed_if_same_string (keyBaseName (k), "");
+
+	keySetName (k, "system/notCascading");
+	succeed_if (keySetBaseName (k, 0) >= 0, "removing basename of non cascading key with depth 1 failed");
+	succeed_if_same_string (keyName (k), "system");
+	succeed_if_same_string (keyBaseName (k), "");
+
+	keySetName (k, "system/foo/bar");
+	succeed_if (keySetBaseName (k, 0) >= 0, "removing basename of non cascading key with depth 2 failed");
+	succeed_if_same_string (keyName (k), "system/foo");
+	succeed_if_same_string (keyBaseName (k), "foo");
+
 	keySetName (k, "system");
 	succeed_if (keySetBaseName (k, "valid") == -1, "add root name, but set was used");
 	succeed_if_same_string (keyName (k), "system");
@@ -2204,7 +2224,6 @@ static void test_keySetBaseName ()
 	succeed_if_same_string (keyName (k), "system/\\%");
 	succeed_if_same_string (keyBaseName (k), "%");
 	//! [base3]
-
 
 	keyDel (k);
 }


### PR DESCRIPTION
# Purpose

Fix the bug that setting the basename of a cascading key like /cascading to NULL will also delete the namespace, so the / that marks the key as cascading.

# Checklist

- [X] commit messages are fine (with references to issues)
- [X] I ran all tests and everything went fine
- [X] I added unit tests
- [X] I added code comments, logging, and assertions

@markus2330 IMO this is a special case that only happens when deleting a cascading key with depth 1 (so something like /cascading) as the setBaseName method simply strips everything up to including the last / character.
For everything with a namespace this is fine (e.g. user/key gets stripped to user), but for a cascading namespace, the last / has to be preserved. This only seems to be relevant upon basename deletion, therefore i've put the appropriate adjustment in the if branch. Also added unit tests for such cases.