### PR TITLE
bashisms-test

### DIFF
--- a/scripts/ffconfig/setupConfig
+++ b/scripts/ffconfig/setupConfig
@@ -1,3 +1,4 @@
+#!/bin/bash
 # main script for guided preference setup used by configure-firefox
 
 prefType=

--- a/scripts/ffconfig/setupHomepage
+++ b/scripts/ffconfig/setupHomepage
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 # guided setup for homepage preferences used by configure-firefox
 
 welcomeSetup()

--- a/scripts/ffconfig/setupProxy
+++ b/scripts/ffconfig/setupProxy
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 # guided setup for proxy preferences used by configure-firefox
 
 setProxyType()

--- a/scripts/ffconfig/writeConfigFiles
+++ b/scripts/ffconfig/writeConfigFiles
@@ -1,3 +1,5 @@
+#!/bin/sh
+
 # creates autoconfig.js and elektra.cfs for configure-firefox
 
 FFLibDir=$1

--- a/tests/shell/check_bashisms.sh
+++ b/tests/shell/check_bashisms.sh
@@ -1,0 +1,20 @@
+@INCLUDE_COMMON@
+
+echo
+echo ELEKTRA SCRIPTS BASHISMS TEST
+echo
+
+command -v checkbashisms >/dev/null 2>&1 || { echo "checkbashisms command needed for this test, aborting" >&2; exit 0; }
+
+cd "@CMAKE_SOURCE_DIR@"
+
+# this way we also check subdirectories
+scripts=$(find scripts/ -type f | xargs)
+checkbashisms $scripts
+ret=$?
+# 2 means skipped file, e.g. README.md, that is fine
+# only 1, 3 and 4 are actually bad
+test $ret -eq 0 || test $ret -eq 2
+exit_if_fail "Possible bashisms detected, please check."
+
+end_script


### PR DESCRIPTION
# Purpose

Add bashisms regression check test as requested in #160 

# Checklist

- [X] commit messages are fine (with references to issues)
- [X] I ran all tests and everything went fine
- [X] I added unit tests
- [X] affected documentation is fixed
- [X] I added code comments, logging, and assertions
- [X] meta data is updated (e.g. README.md of plugins)

@markus2330 please review my pull request. checkbashisms will return 0 on success and 2 on a skipped file (e.g. it skips files which have a shebang pointing to awk). Therefore i handle 2 also as successful, as there is no real way to determine if skipping the file is ok (as it usually is) or not (e.g. cannot read file for whatsoever reason).
We might have to install the tool on the build server, otherwise it will skip the check.
