### PR TITLE
check_meta.sh

### DIFF
--- a/tests/shell/check_meta.sh
+++ b/tests/shell/check_meta.sh
@@ -1,0 +1,41 @@
+@INCLUDE_COMMON@
+
+echo
+echo ELEKTRA PLUGIN METATADA CONSISTENCY CHECK
+echo
+
+PLUGINS_DIR="@CMAKE_SOURCE_DIR@/src/plugins"
+META_FILE="@CMAKE_SOURCE_DIR@/doc/METADATA.ini"
+
+for PLUGIN in `ls "$PLUGINS_DIR"`;
+do
+
+    if [ ! -d "${PLUGINS_DIR}/${PLUGIN}" ];
+    then
+	continue
+    fi
+    
+    README="${PLUGINS_DIR}/${PLUGIN}/README.md"
+    PLUGIN_META=$(grep -Eo "infos/metadata(.*)" "$README" |cut -d '=' -f2)
+    for META in $PLUGIN_META;
+    do
+	grep -Eq "^\\[${META}\\]$" "$META_FILE"
+        succeed_if "Metadata $META of plugin $PLUGIN not present in METADATA.ini"
+    done
+    USED_BY=$(awk "/usedby\\/plugin= ([^\\n]*)${PLUGIN}( |\\n)/" RS= "$META_FILE")
+    USED_BY_META=$(echo "$USED_BY" | grep -Eo "^\\[.*\\]$")
+
+    OLD_IFS="$IFS"
+    IFS="$(printf '\n+')"
+
+    for META in $USED_BY_META;
+    do
+	STRIPPED_META=$(echo "$META" | sed 's/\[//g' | sed 's/\]//g')
+	grep -Eq "infos/metadata(.*)${STRIPPED_META}" "$README"
+	succeed_if "$STRIPPED_META should be used by $PLUGIN, but not present in ${PLUGIN}/README.md infos/metadata"
+    done
+
+    IFS="$OLD_IFS"
+done
+
+end_script


### PR DESCRIPTION
# Purpose

check metadata consistency (#1355)

```
 % ./check_meta.sh

ELEKTRA PLUGIN METATADA CONSISTENCY CHECK

error: order should be used by augeas, but not present in augeas/README.md infos/metadata
error: Metadata assign/condition of plugin conditionals not present in METADATA.ini
error: Metadata condition/validsuffix of plugin conditionals not present in METADATA.ini
error: Metadata check/condition/# of plugin conditionals not present in METADATA.ini
error: Metadata assign/condition/# of plugin conditionals not present in METADATA.ini
error: Metadata check/date of plugin date not present in METADATA.ini
error: Metadata check/date/format of plugin date not present in METADATA.ini
error: Metadata check/enum/# of plugin enum not present in METADATA.ini
error: Metadata check/enum/multi of plugin enum not present in METADATA.ini
error: Metadata trigger/warnings of plugin error not present in METADATA.ini
error: Metadata trigger/error of plugin error not present in METADATA.ini
error: Metadata trigger/error/nofail of plugin error not present in METADATA.ini
error: order should be used by hosts, but not present in hosts/README.md infos/metadata
error: comment should be used by hosts, but not present in hosts/README.md infos/metadata
error: comment/# should be used by hosts, but not present in hosts/README.md infos/metadata
error: comment/#/start should be used by hosts, but not present in hosts/README.md infos/metadata
error: comment/#/space should be used by hosts, but not present in hosts/README.md infos/metadata
error: internal/<plugin>/* should be used by ini, but not present in ini/README.md infos/metadata
error: order should be used by keytometa, but not present in keytometa/README.md infos/metadata
error: Metadata check/math of plugin mathcheck not present in METADATA.ini
error: Metadata check/ipaddr of plugin network not present in METADATA.ini
error: internal/<plugin>/* should be used by ni, but not present in ni/README.md infos/metadata
error: binary should be used by null, but not present in null/README.md infos/metadata
error: origname should be used by rename, but not present in rename/README.md infos/metadata
error: Metadata mandatory of plugin required not present in METADATA.ini
error: Metadata check/validation/type of plugin validation not present in METADATA.ini
error: binary should be used by xmltool, but not present in xmltool/README.md infos/metadata
error: binary should be used by yajl, but not present in yajl/README.md infos/metadata
check_meta.sh RESULTS: 59 test(s) done 28 error(s).
```