### PR TITLE
Check Meta: Properly Match Plugin Name

### DIFF
--- a/doc/COMPILE.md
+++ b/doc/COMPILE.md
@@ -376,7 +376,7 @@ are installed (by default off). Is needed for cross-compilation.
 
 #### INSTALL_SYSTEM_FILES
 
-Some of Elektras targets require to be installed into specific folders in the
+Some of Elektra’s targets require to be installed into specific folders in the
 file system hierarchy to work properly.
 
 This variable is enabled by default but requires the install target to have the

--- a/doc/news/2014-06-21_0.8.6.md
+++ b/doc/news/2014-06-21_0.8.6.md
@@ -108,7 +108,7 @@ the kdb tool will work.
 
 One drawback of Elektra is the small number of available storage
 plugins. While writing storage plugins isn't too hard, it still requires
-knowledge of Elektras plugin architecture. In addition it is always
+knowledge of Elektra’s plugin architecture. In addition it is always
 necessary to keep both translation directions in mind (from file to
 Elektra and back).  In order to mitigate this issue Felix Berlakovich
 is working on an Elektra storage plugin which uses Augeas [1] to read
@@ -134,9 +134,9 @@ features). With the Augeas storage plugin these features cannot be used
 with only the applications already integrated into Elektra, but with all
 applications for which lenses exist.  This storage plugin targets system
 administrators as well as developers, that wish to take advantage of
-Elektras features, but were unable to do so because of missing plugins. If
+Elektra’s features, but were unable to do so because of missing plugins. If
 no lens exists already, writing a new one requires neither programming
-skills nor knowledge of Elektras plugin architecture. Furthermore,
+skills nor knowledge of Elektra’s plugin architecture. Furthermore,
 implementing a new configuration file format is just a matter of writing a
 lens instead of writing a full-fledged parser.
 [1] http://augeas.net/
@@ -158,7 +158,7 @@ provide bindings for static languages a compiler on the metadate file
 will be used. This is comparable to using SWIG. Manuel will focus on
 implementing language bindings for Python and Lua though both techniques
 will support various other languages.  As language bindings only allow
-to call into Elektras API Manuel will also embed the interpreters of
+to call into Elektra’s API Manuel will also embed the interpreters of
 both Python and Lua into two generic plugins. Using these plugins in
 combination with the languages bindings it will be fully possible to
 write plugins for Elektra in languages other than C/C++.

--- a/doc/old/NEWS.md
+++ b/doc/old/NEWS.md
@@ -331,7 +331,7 @@ the kdb tool will work.
 
 One drawback of Elektra is the small number of available storage
 plugins. While writing storage plugins isn't too hard, it still requires
-knowledge of Elektras plugin architecture. In addition it is always
+knowledge of Elektra’s plugin architecture. In addition it is always
 necessary to keep both translation directions in mind (from file to
 Elektra and back).  In order to mitigate this issue Felix Berlakovich
 is working on an Elektra storage plugin which uses Augeas [1] to read
@@ -357,9 +357,9 @@ features). With the Augeas storage plugin these features cannot be used
 with only the applications already integrated into Elektra, but with all
 applications for which lenses exist.  This storage plugin targets system
 administrators as well as developers, that wish to take advantage of
-Elektras features, but were unable to do so because of missing plugins. If
+Elektra’s features, but were unable to do so because of missing plugins. If
 no lens exists already, writing a new one requires neither programming
-skills nor knowledge of Elektras plugin architecture. Furthermore,
+skills nor knowledge of Elektra’s plugin architecture. Furthermore,
 implementing a new configuration file format is just a matter of writing a
 lens instead of writing a full-fledged parser.
 [1] http://augeas.net/
@@ -381,7 +381,7 @@ provide bindings for static languages a compiler on the metadate file
 will be used. This is comparable to using SWIG. Manuel will focus on
 implementing language bindings for Python and Lua though both techniques
 will support various other languages.  As language bindings only allow
-to call into Elektras API Manuel will also embed the interpreters of
+to call into Elektra’s API Manuel will also embed the interpreters of
 both Python and Lua into two generic plugins. Using these plugins in
 combination with the languages bindings it will be fully possible to
 write plugins for Elektra in languages other than C/C++.

--- a/doc/tutorials/namespaces.md
+++ b/doc/tutorials/namespaces.md
@@ -69,7 +69,7 @@ When we don't provide a namespace Elektra assumes a default namespace, which sho
 So if you are a normal user the command `kdb set /b/c 'Value 2'` was synonymous to `kdb set user/b/c 'Value 2'`.
 
 At this point the key database should have this structure:
-![Elektras namespaces](/doc/images/tutorial_namespaces_namespaces.svg)
+![Elektra’s namespaces](/doc/images/tutorial_namespaces_namespaces.svg)
 
 #### Cascading Keys
 

--- a/src/bindings/README.md
+++ b/src/bindings/README.md
@@ -6,7 +6,7 @@ to use Elektra.
 
 Note that a binding does not automatically allow you to implement *plugins*
 in the respective programming languages, but you additionally need an
-[Interpreter Plugins](/src/plugins/README.md). Nevertheless, bindings
+[Interpreter Plugin](/src/plugins/README.md). Nevertheless, bindings
 can be immediately used in applications without plugins.
 
 List of currently supported bindings (included in `ALL`):

--- a/src/bindings/swig/ruby/examples/ruby_example_application.rb
+++ b/src/bindings/swig/ruby/examples/ruby_example_application.rb
@@ -2,13 +2,13 @@
 ##
 # @file
 #
-# @brief example Ruby application to illustrate usage of Elektras Ruby bindings
+# @brief example Ruby application to illustrate usage of Elektra’s Ruby bindings
 #
 # @copyright BSD License (see doc/LICENSE.md or http://www.libelektra.org)
 #
 #
 # This example is a simple command line application, which illustrates the most
-# basic usage scenarios of the Elektras Ruby bindings. The application performs
+# basic usage scenarios of Elektra’s Ruby bindings. The application performs
 # the following steps:
 #  * open kdb database
 #  * fetch all Elektra keys considered with this application
@@ -17,7 +17,7 @@
 #  * modify an existing key
 #  * query and modify a keys metadata
 #
-# To run this example you have to install Elektras Ruby bindings or add the
+# To run this example you have to install Elektra’s Ruby bindings or add the
 # path, under which the compiled Elektra Ruby library can be found to your
 # 'RUBYLIB' environment variable.
 #

--- a/src/bindings/swig/ruby/tests/testruby_kdb.rb
+++ b/src/bindings/swig/ruby/tests/testruby_kdb.rb
@@ -148,7 +148,7 @@ class KdbTestCases < Test::Unit::TestCase
       # if called with block, nil is returned
       assert_nil block_ret
 
-      # test implicite close, we must not be able to get a keyset again
+      # test implicit close, we must not be able to get a keyset again
       assert_not_nil db_access
       assert_raise Kdb::KDBException do
         db_access.get Kdb::KeySet.new, "/"

--- a/src/plugins/mozprefs/README.md
+++ b/src/plugins/mozprefs/README.md
@@ -12,7 +12,7 @@
 ## Basics
 
 This plugin works on [Mozilla preference files](https://developer.mozilla.org/en-US/docs/Mozilla/Preferences/A_brief_guide_to_Mozilla_preferences)
-and is used in Elektras [Firefox autoconfig script](autoconfig/README.md).
+and is used in Elektra’s [Firefox autoconfig script](autoconfig/README.md).
 
 ### Preference Types
 

--- a/src/plugins/mozprefs/autoconfig/README.md
+++ b/src/plugins/mozprefs/autoconfig/README.md
@@ -1,6 +1,6 @@
 ## Introduction
 
-This file explains how Firefox preferences can be manipulated at runtime using Elektras intercept open and a custom autoconfig script. 
+This file explains how Firefox preferences can be manipulated at runtime using Elektra’s intercept open and a custom autoconfig script.
 
 ## Basics
 

--- a/src/plugins/ni/README.md
+++ b/src/plugins/ni/README.md
@@ -5,7 +5,7 @@
 - infos/needs =
 - infos/placements = getstorage setstorage
 - infos/status = maintained unittest libc nodep
-- infos/metadata = order
+- infos/metadata =
 - infos/description = Reads and writes the nickel ini format
 
 ## Introduction

--- a/src/tools/rest-backend/README.md
+++ b/src/tools/rest-backend/README.md
@@ -31,7 +31,7 @@ installed tools and something like `External tools are located in /usr/local/lib
 With this path we can run the service like `cd /usr/local/lib/elektra/tool_exec/ && sh run-@tool@`.
 An alternative is to make use of the `kdb` tool and run `kdb run-@tool@`.
 
-The REST service can also be configured. All configuration is read from Elektras
+The REST service can also be configured. All configuration is read from Elektra’s
 key database at start-time of the service. Further details and configuration options
 are listed below.
 

--- a/src/tools/rest-frontend/README.md
+++ b/src/tools/rest-frontend/README.md
@@ -2,7 +2,7 @@
 
 ## Introduction
 
-This document aims to provide information about Elektras `@tool@`,
+This document aims to provide information about Elektra’s `@tool@`,
 which is the frontend of the `rest-backend` allowing for search and sharing of configuration snippets.
 Besides that functionality, the frontend also contains the Elektra website.
 

--- a/tests/shell/check_meta.sh
+++ b/tests/shell/check_meta.sh
@@ -14,7 +14,7 @@ do
 	then
 	continue
 	fi
-	
+
 	README="${PLUGINS_DIR}/${PLUGIN}/README.md"
 	PLUGIN_META=$(grep -Eo "infos/metadata(.*)" "$README" |cut -d '=' -f2)
 	for META in $PLUGIN_META;

--- a/tests/shell/check_meta.sh
+++ b/tests/shell/check_meta.sh
@@ -23,7 +23,7 @@ do
 		succeed_if "Metadata $META is in infos/metadata of ${PLUGINS_DIR}/$PLUGIN/README.md, but not present in $META_FILE for $PLUGIN"
 	done
 
-	USED_BY=$(awk "/usedby\\/plugin= ([^\\n]*)${PLUGIN}( |\\n)/" RS= "$META_FILE")
+	USED_BY=$(awk "/usedby\\/plugin=([^\\n]*) ${PLUGIN}( |\\n)/" RS= "$META_FILE")
 	USED_BY_META=$(echo "$USED_BY" | grep -Eo "^\\[.*\\]$")
 
 	OLD_IFS="$IFS"


### PR DESCRIPTION
# Purpose

This pull request should fix the false positive reported by `check_meta.sh` (see issue #1381).

# Checklist

- [x] All references to issues in the commit messages should be correct.
- [x] I ran all tests and everything went fine.
- [x] I updated the metadata specification of the NI plugin.

@markus2330 👋 Please review my pull request.