### PR TITLE
tools kdb: add new command rmmeta

### DIFF
--- a/doc/help/kdb-rmmeta.md
+++ b/doc/help/kdb-rmmeta.md
@@ -1,0 +1,32 @@
+kdb-rmmeta(1) -- Remove metakey of a key from the key database
+==============================================================
+
+## SYNOPSIS
+
+`kdb rmmeta <key name> <metaname>`
+
+Where `key name` is the name of the key and `metaname` is the name of the metakey you want to remove.
+
+## DESCRIPTION
+
+This command removes a metakey of a key from the Key database.
+
+## OPTIONS
+
+- `-H`, `--help`:
+  Show the man page.
+- `-V`, `--version`:
+  Print version info.
+- `-p`, `--profile`=<profile>:
+  Use a different kdb profile.
+- `-C`, `--color`=[when]:
+  Print never/auto(default)/always colored output.
+
+## EXAMPLES
+
+To remove metakey `metakey` of a key:
+`kdb rmmeta user/example metakey`
+
+## SEE ALSO
+
+- [elektra-key-names(7)](elektra-key-names.md) for an explanation of key names.

--- a/src/tools/kdb/factory.hpp
+++ b/src/tools/kdb/factory.hpp
@@ -41,6 +41,7 @@
 #include <metaget.hpp>
 #include <metals.hpp>
 #include <metaset.hpp>
+#include <metaremove.hpp>
 #include <mount.hpp>
 #include <mv.hpp>
 #include <remount.hpp>
@@ -90,6 +91,7 @@ public:
 		m_factory.insert (std::make_pair ("remount", new Cnstancer<RemountCommand> ()));
 		m_factory.insert (std::make_pair ("shell", new Cnstancer<ShellCommand> ()));
 		m_factory.insert (std::make_pair ("getmeta", new Cnstancer<MetaGetCommand> ()));
+		m_factory.insert (std::make_pair ("rmmeta", new Cnstancer<MetaRemoveCommand> ()));
 		m_factory.insert (std::make_pair ("setmeta", new Cnstancer<MetaSetCommand> ()));
 		m_factory.insert (std::make_pair ("lsmeta", new Cnstancer<MetaLsCommand> ()));
 		m_factory.insert (std::make_pair ("info", new Cnstancer<InfoCommand> ()));

--- a/src/tools/kdb/metaremove.cpp
+++ b/src/tools/kdb/metaremove.cpp
@@ -1,0 +1,54 @@
+/**
+ * @file
+ *
+ * @brief
+ *
+ * @copyright BSD License (see doc/LICENSE.md or http://www.libelektra.org)
+ */
+
+#include <metaremove.hpp>
+
+#include <cmdline.hpp>
+#include <kdb.hpp>
+
+#include <iostream>
+#include <string>
+
+using namespace std;
+using namespace kdb;
+
+MetaRemoveCommand::MetaRemoveCommand ()
+{
+}
+
+MetaRemoveCommand::~MetaRemoveCommand ()
+{
+}
+
+int MetaRemoveCommand::execute (Cmdline const & cl)
+{
+	if (cl.arguments.size () != 2)
+	{
+		throw invalid_argument ("Need 2 arguments");
+	}
+	Key parentKey = cl.createKey (0);
+	string metaname = cl.arguments[1];
+
+	KeySet conf;
+	kdb.get (conf, parentKey);
+	printWarnings (cerr, parentKey);
+
+	Key k = conf.lookup (parentKey);
+
+	if (!k)
+	{
+		cerr << "Key not found" << endl;
+		return 1;
+	}
+
+	k.delMeta (metaname);
+
+	kdb.set (conf, parentKey);
+
+	return 0;
+}

--- a/src/tools/kdb/metaremove.hpp
+++ b/src/tools/kdb/metaremove.hpp
@@ -1,0 +1,48 @@
+/**
+ * @file
+ *
+ * @brief
+ *
+ * @copyright BSD License (see doc/LICENSE.md or http://www.libelektra.org)
+ */
+
+#ifndef METAREMOVE_HPP
+#define METAREMOVE_HPP
+
+#include "coloredkdbio.hpp"
+#include <command.hpp>
+#include <kdb.hpp>
+
+class MetaRemoveCommand : public Command
+{
+	kdb::KDB kdb;
+
+public:
+	MetaRemoveCommand ();
+	~MetaRemoveCommand ();
+
+	virtual std::string getShortOptions () override
+	{
+		return "C";
+	}
+
+	virtual std::string getSynopsis() override
+	{
+		return "<key-name> <metaname>";
+	}
+
+	virtual std::string getShortHelpText() override
+	{
+		return "Remove a metakey.";
+	}
+
+	virtual std::string getLongHelpText() override
+	{
+		return "";
+	}
+
+	virtual int execute (Cmdline const & cmdline) override;
+};
+
+#endif
+


### PR DESCRIPTION
Add the missing command rmmeta to remove a metakey of a key.

# Purpose

I'm using this in the my puppet module for the `kdb` provider (fallback implementation if ruby bindings aren't available/usable)

# Checklist

- [x] commit messages are fine (with references to issues)
- [x] I ran all tests and everything went fine
- [ ] I added unit tests
- [x] affected documentation is fixed
- [ ] I added code comments, logging, and assertions
- [ ] meta data is updated (e.g. README.md of plugins)

@markus2330 please review my pull request
