### PR TITLE
crypto: fix type inconsistency in crypto_openssl

### DIFF
--- a/src/plugins/crypto/openssl_operations.c
+++ b/src/plugins/crypto/openssl_operations.c
@@ -284,7 +284,7 @@ int elektraCryptoOpenSSLEncrypt (elektraCryptoHandle * handle, Key * k, Key * er
 
 	// prepare the crypto header data
 	kdb_octet_t flags;
-	const size_t contentLen = keyGetValueSize (k);
+	const kdb_unsigned_long_t contentLen = keyGetValueSize (k);
 	const size_t headerLen = sizeof (flags) + sizeof (contentLen);
 
 	switch (keyIsString (k))


### PR DESCRIPTION
# Purpose

Mixing `size_t` and `kdb_unsigned_long_t` resulted in corrupted header interpretations between encryption and decryption when using crypto_openssl.

Fixes #1389 .

# Checklist

Please only check relevant points.
For docu fixes, spell checking and similar nothing
needs to be checked.

- [x] commit messages are fine (with references to issues)
- [x] I ran all tests and everything went fine
- [ ] I added unit tests
- [ ] affected documentation is fixed
- [ ] I added code comments, logging, and assertions
- [ ] meta data is updated (e.g. README.md of plugins)

@markus2330 please review my pull request