### PR TITLE
simpleini: make 'format' param more robust

### DIFF
--- a/src/error/specification
+++ b/src/error/specification
@@ -1063,3 +1063,10 @@ severity:error
 ingroup:plugin
 module:multifile
 macro:MULTI_GLOB_FAILED
+
+number:173
+description:invalid line format pattern
+severity:error
+ingroup:plugin
+macro:INVALID_FORMAT
+module:simpleini

--- a/src/plugins/simpleini/CMakeLists.txt
+++ b/src/plugins/simpleini/CMakeLists.txt
@@ -11,5 +11,6 @@ if (HAVE_GLIBC)
 			simpleini.c
 		LINK_ELEKTRA
 			elektra-ease
+			elektra-utility
 		)
 endif()

--- a/src/plugins/simpleini/CMakeLists.txt
+++ b/src/plugins/simpleini/CMakeLists.txt
@@ -12,5 +12,6 @@ if (HAVE_GLIBC)
 		LINK_ELEKTRA
 			elektra-ease
 			elektra-utility
+		ADD_TEST
 		)
 endif()

--- a/src/plugins/simpleini/README.md
+++ b/src/plugins/simpleini/README.md
@@ -43,7 +43,7 @@ For example, if you want every key to be marked `%:key value` you would use:
 
 - Lines in a different format (e.g. comments) are discarded.
 - The order per line must be key and then value: the plugin cannot be used if the value is first
-- Spaces are trimmed
+- Whitespace before and after keynames are trimmed (but not for value)
 - Delimiting symbols cannot be part of the key.
 - The last occurrence of the same key wins (others are discarded).
 - The parent Key cannot be used.

--- a/src/plugins/simpleini/testmod_simpleini.c
+++ b/src/plugins/simpleini/testmod_simpleini.c
@@ -1,0 +1,141 @@
+/**
+ * @file
+ *
+ * @brief Tests for simpleini plugin
+ *
+ * @copyright BSD License (see doc/LICENSE.md or http://www.libelektra.org)
+ *
+ */
+
+#include <stdlib.h>
+#include <string.h>
+
+#include <kdbconfig.h>
+
+#include <tests_plugin.h>
+
+
+static void test_readFormat (const char * format, const char * fileContent, int numKeys, const char ** keys, const char ** values)
+{
+	const char * tmpFile = elektraFilename ();
+	FILE * fh = fopen (tmpFile, "w");
+	if (fh)
+	{
+		fputs (fileContent, fh);
+		fclose (fh);
+	}
+
+	Key * parentKey = keyNew ("user/tests/simpleini", KEY_VALUE, tmpFile, KEY_END);
+	KeySet * conf = 0;
+	if (format)
+	{
+		conf = ksNew (1, keyNew ("system/format", KEY_VALUE, format, KEY_END), KS_END);
+	}
+	else
+	{
+		conf = ksNew (0, KS_END);
+	}
+
+	PLUGIN_OPEN ("simpleini");
+
+	KeySet * ks = ksNew (numKeys, KS_END);
+	Key * key = 0;
+
+	succeed_if (plugin->kdbGet (plugin, ks, parentKey) == 1, "kdbGet was not successful");
+
+	Key * lookup = 0;
+	for (int i = 0; i < numKeys; i++)
+	{
+		lookup = keyNew ("user/tests/simpleini", KEY_END);
+		keyAddBaseName (lookup, keys[i]);
+		printf ("testing key '%s'\n", keyBaseName (lookup));
+		succeed_if ((key = ksLookup (ks, lookup, 0)) != NULL, "key not found");
+		succeed_if (strcmp (values[i], keyString (key)) == 0, "value of key did not match");
+		keyDel (lookup);
+	}
+
+	keyDel (key);
+	ksDel (ks);
+	keyDel (parentKey);
+	PLUGIN_CLOSE ();
+}
+
+static void test_formatNotAccepted (const char * format)
+{
+	Key * parentKey = keyNew ("user/tests/simpleini", KEY_VALUE, elektraFilename (), KEY_END);
+	KeySet * conf = ksNew (1, keyNew ("system/format", KEY_VALUE, format, KEY_END), KS_END);
+	PLUGIN_OPEN ("simpleini");
+
+	KeySet * ks = ksNew (0, KS_END);
+
+	succeed_if (plugin->kdbGet (plugin, ks, parentKey) != 1, "kdbGet was successful for an invalid format");
+
+	ksDel (ks);
+	keyDel (parentKey);
+	PLUGIN_CLOSE ();
+}
+
+
+static void test_readDefaultFormat ()
+{
+	const char * expected_keys[] = { "key1", "key2", "key3", "key4" };
+	const char * expected_values[] = { "value1", "value2", "value3", "value4 " };
+
+	test_readFormat (NULL, // format
+			 "key1 = value1\n"
+			 " key2 = value2\n"
+			 "key3  = value3\n"
+			 "key4 = value4 \n",
+			 4, expected_keys, expected_values);
+}
+
+static void test_readFormat_wo_space ()
+{
+
+	const char * expected_keys[] = { "key1", "key2", "key3", "key4" };
+	const char * expected_values[] = { "value1", "value2", "value3", " value4 " };
+
+	test_readFormat ("%=%", // format
+			 "key1=value1\n"
+			 " key2=value2\n"
+			 "key3 =value3\n"
+			 "key4= value4 \n",
+			 4, expected_keys, expected_values);
+}
+
+static void test_readFormat_special1 ()
+{
+
+	const char * expected_keys[] = { "key1", "key2", "key3", "key4" };
+	const char * expected_values[] = { "value1", "value2", "value3", " value4 " };
+
+	test_readFormat ("% :=_%", // format
+			 "key1 :=_value1\n"
+			 " key2 :=_value2\n"
+			 "key3  :=_value3\n"
+			 "key4 :=_ value4 \n",
+			 4, expected_keys, expected_values);
+}
+
+
+int main (int argc, char ** argv)
+{
+	printf ("SIMPLEINI    TESTS\n");
+	printf ("==================\n\n");
+
+	init (argc, argv);
+
+	test_readDefaultFormat ();
+	test_readFormat_wo_space ();
+	test_readFormat_special1 ();
+	test_formatNotAccepted ("%");
+	test_formatNotAccepted ("");
+	test_formatNotAccepted ("%%%");
+	test_formatNotAccepted ("%% %");
+	test_formatNotAccepted ("%% %%");
+
+
+	printf ("\ntestmod_simpleini RESULTS: %d test(s) done. %d error(s).\n", nbTest, nbError);
+
+	return nbError;
+}


### PR DESCRIPTION
Build a more robust scanf format specifier out of the given 'format'
config setting. This allows formats like "%=%".

Additionally, this fixes a mem corruption vulnerability, due to unsafe
scanf format pattern.

# Checklist

Please only check relevant points.
For docu fixes, spell checking and similar nothing
needs to be checked.

- [x] commit messages are fine (with references to issues)
- [x] I ran all tests and everything went fine
- [ ] I added unit tests
- [x] affected documentation is fixed
- [x] I added code comments, logging, and assertions
- [x] meta data is updated (e.g. README.md of plugins)

@markus2330 please review my pull request
