### PR TITLE
ruby bindings: check for min siwg 3.0.8 version

### DIFF
--- a/src/bindings/swig/ruby/CMakeLists.txt
+++ b/src/bindings/swig/ruby/CMakeLists.txt
@@ -11,8 +11,8 @@ find_package(Ruby)
 
 if (NOT RUBY_FOUND)
 	remove_binding(swig_ruby "ruby interpreter or ruby header files not found (package ruby-dev/ruby-devel installed?)")
-elseif (SWIG_VERSION MATCHES "^[12]\\.")
-	remove_binding(swig_ruby "found SWIG version (${SWIG_VERSION}) is not suitable. SWIG version >= 3.x required")
+elseif (SWIG_VERSION MATCHES "^([12]\\.)|(3\\.0\\.[01234567])")
+	remove_binding(swig_ruby "found SWIG version (${SWIG_VERSION}) is not suitable. SWIG version >= 3.0.8 required")
 else()
 
 	message(STATUS "Include Binding swig_ruby")

--- a/src/bindings/swig/ruby/README.md
+++ b/src/bindings/swig/ruby/README.md
@@ -174,7 +174,10 @@ This is very similar to the `KeySet` iteration and can be accessed with `meta`:
 
 ## Building
 
-Note that cmake does *not* automatically rebuild SWIG bindings
-when header files are changed. Remove the build directory
-in that case.
+Building the Ruby bindings from Elektra src tree requires to have SWIG >= 3.0.8
+installed. Additionally ruby header files (Debian/Ubuntu ruby-dev) are required
+too. 
+
+The bindings where tested with Ruby >= 2.1.0, lower version might work but are
+not tested.
 


### PR DESCRIPTION
We require at least 3.0.8 because of shared pointer feature for Ruby
bindings generator.

# Checklist

- [x] commit messages are fine (with references to issues)
- [ ] I ran all tests and everything went fine
- [ ] I added unit tests
- [x] affected documentation is fixed
- [ ] I added code comments, logging, and assertions
- [x] meta data is updated (e.g. README.md of plugins)
- [x] run cmake for Debian Jessie, which now does not accept swig version 3.0.2

@markus2330 please review my pull request
