### PR TITLE
crypto: fix OpenSSL compile errors for Debian Stretch

### DIFF
--- a/src/plugins/crypto/compile_openssl.c
+++ b/src/plugins/crypto/compile_openssl.c
@@ -11,7 +11,6 @@
 
 int main ()
 {
-	EVP_CIPHER_CTX opensslSpecificType;
-
+	EVP_CIPHER_CTX * opensslSpecificType;
 	return 0;
 }

--- a/src/plugins/crypto/crypto.h
+++ b/src/plugins/crypto/crypto.h
@@ -55,8 +55,8 @@ typedef gcry_cipher_hd_t elektraCryptoHandle;
 #include <openssl/evp.h>
 typedef struct
 {
-	EVP_CIPHER_CTX encrypt;
-	EVP_CIPHER_CTX decrypt;
+	EVP_CIPHER_CTX * encrypt;
+	EVP_CIPHER_CTX * decrypt;
 } elektraCryptoHandle;
 
 #elif defined(ELEKTRA_CRYPTO_API_BOTAN)


### PR DESCRIPTION
# Purpose

crypto: fix OpenSSL compile errors for Debian Stretch

See #1437 for full discussion.

# Checklist

Please only check relevant points.
For docu fixes, spell checking and similar nothing
needs to be checked.

- [x] commit messages are fine (with references to issues)
- [x] I ran all tests and everything went fine
- [ ] I added unit tests
- [ ] affected documentation is fixed
- [ ] I added code comments, logging, and assertions
- [ ] meta data is updated (e.g. README.md of plugins)

@markus2330 please review my pull request
