### PR TITLE
fix for running elektra-web with nginx reverse proxy and PAM auth

### DIFF
--- a/src/tools/web/client/src/actions/clusters.js
+++ b/src/tools/web/client/src/actions/clusters.js
@@ -16,7 +16,7 @@ export const CLUSTERS_FAILURE = 'CLUSTERS_FAILURE'
 
 export const fetchClusters = () => thunkCreator({
   types: [CLUSTERS_REQUEST, CLUSTERS_SUCCESS, CLUSTERS_FAILURE],
-  promise: fetch(`/clusters`)
+  promise: fetch(`/clusters`, { credentials: 'same-origin' })
     .then(response => response.json()),
 })
 
@@ -29,6 +29,7 @@ export const CLUSTER_UPDATE_FAILURE = 'CLUSTER_UPDATE_FAILURE'
 export const updateCluster = (id, data) => thunkCreator({
   types: [CLUSTER_UPDATE_REQUEST, CLUSTER_UPDATE_SUCCESS, CLUSTER_UPDATE_FAILURE],
   promise: fetch(`/clusters/${id}`, {
+    credentials: 'same-origin',
     method: 'PUT',
     headers: {
       'Content-Type': 'application/json',
@@ -45,8 +46,10 @@ export const CLUSTER_DELETE_FAILURE = 'CLUSTER_DELETE_FAILURE'
 
 export const deleteCluster = (id, data) => thunkCreator({
   types: [CLUSTER_DELETE_REQUEST, CLUSTER_DELETE_SUCCESS, CLUSTER_DELETE_FAILURE],
-  promise: fetch(`/clusters/${id}`, { method: 'DELETE' })
-    .then(response => response.json()),
+  promise: fetch(`/clusters/${id}`, {
+    credentials: 'same-origin',
+    method: 'DELETE',
+  }).then(response => response.json()),
 })
 
 // ~~~
@@ -58,6 +61,7 @@ export const CREATE_CLUSTER_FAILURE = 'CREATE_CLUSTER_FAILURE'
 export const createCluster = (data) => thunkCreator({
   types: [CREATE_CLUSTER_REQUEST, CREATE_CLUSTER_SUCCESS, CREATE_CLUSTER_FAILURE],
   promise: fetch(`/clusters`, {
+    credentials: 'same-origin',
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',

--- a/src/tools/web/client/src/actions/clusters.js
+++ b/src/tools/web/client/src/actions/clusters.js
@@ -6,7 +6,7 @@
  * @copyright BSD License (see doc/LICENSE.md or http://www.libelektra.org)
  */
 
-import { thunkCreator } from './utils'
+import { thunkCreator, parseJSONResponse } from './utils'
 
 // ~~~
 
@@ -17,7 +17,7 @@ export const CLUSTERS_FAILURE = 'CLUSTERS_FAILURE'
 export const fetchClusters = () => thunkCreator({
   types: [CLUSTERS_REQUEST, CLUSTERS_SUCCESS, CLUSTERS_FAILURE],
   promise: fetch(`/clusters`, { credentials: 'same-origin' })
-    .then(response => response.json()),
+    .then(parseJSONResponse),
 })
 
 // ~~~
@@ -35,7 +35,7 @@ export const updateCluster = (id, data) => thunkCreator({
       'Content-Type': 'application/json',
     },
     body: JSON.stringify(data),
-  }).then(response => response.json()),
+  }).then(parseJSONResponse),
 })
 
 // ~~~
@@ -49,7 +49,7 @@ export const deleteCluster = (id, data) => thunkCreator({
   promise: fetch(`/clusters/${id}`, {
     credentials: 'same-origin',
     method: 'DELETE',
-  }).then(response => response.json()),
+  }).then(parseJSONResponse),
 })
 
 // ~~~
@@ -67,5 +67,5 @@ export const createCluster = (data) => thunkCreator({
       'Content-Type': 'application/json',
     },
     body: JSON.stringify(data),
-  }).then(response => response.json()),
+  }).then(parseJSONResponse),
 })

--- a/src/tools/web/client/src/actions/instances.js
+++ b/src/tools/web/client/src/actions/instances.js
@@ -16,7 +16,7 @@ export const INSTANCES_FAILURE = 'INSTANCES_FAILURE'
 
 export const fetchInstances = () => thunkCreator({
   types: [INSTANCES_REQUEST, INSTANCES_SUCCESS, INSTANCES_FAILURE],
-  promise: fetch(`/instances`)
+  promise: fetch(`/instances`, { credentials: 'same-origin' })
     .then(response => response.json()),
 })
 
@@ -29,6 +29,7 @@ export const INSTANCE_UPDATE_FAILURE = 'INSTANCE_UPDATE_FAILURE'
 export const updateInstance = (id, data) => thunkCreator({
   types: [INSTANCE_UPDATE_REQUEST, INSTANCE_UPDATE_SUCCESS, INSTANCE_UPDATE_FAILURE],
   promise: fetch(`/instances/${id}`, {
+    credentials: 'same-origin',
     method: 'PUT',
     headers: {
       'Content-Type': 'application/json',
@@ -45,8 +46,10 @@ export const INSTANCE_DELETE_FAILURE = 'INSTANCE_DELETE_FAILURE'
 
 export const deleteInstance = (id, data) => thunkCreator({
   types: [INSTANCE_DELETE_REQUEST, INSTANCE_DELETE_SUCCESS, INSTANCE_DELETE_FAILURE],
-  promise: fetch(`/instances/${id}`, { method: 'DELETE' })
-    .then(response => response.json()),
+  promise: fetch(`/instances/${id}`, {
+    credentials: 'same-origin',
+    method: 'DELETE',
+  }).then(response => response.json()),
 })
 
 // ~~~
@@ -58,6 +61,7 @@ export const CREATE_INSTANCE_FAILURE = 'CREATE_INSTANCE_FAILURE'
 export const createInstance = (data) => thunkCreator({
   types: [CREATE_INSTANCE_REQUEST, CREATE_INSTANCE_SUCCESS, CREATE_INSTANCE_FAILURE],
   promise: fetch(`/instances`, {
+    credentials: 'same-origin',
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',

--- a/src/tools/web/client/src/actions/instances.js
+++ b/src/tools/web/client/src/actions/instances.js
@@ -6,7 +6,7 @@
  * @copyright BSD License (see doc/LICENSE.md or http://www.libelektra.org)
  */
 
-import { thunkCreator } from './utils'
+import { thunkCreator, parseJSONResponse } from './utils'
 
 // ~~~
 
@@ -17,7 +17,7 @@ export const INSTANCES_FAILURE = 'INSTANCES_FAILURE'
 export const fetchInstances = () => thunkCreator({
   types: [INSTANCES_REQUEST, INSTANCES_SUCCESS, INSTANCES_FAILURE],
   promise: fetch(`/instances`, { credentials: 'same-origin' })
-    .then(response => response.json()),
+    .then(parseJSONResponse),
 })
 
 // ~~~
@@ -35,7 +35,7 @@ export const updateInstance = (id, data) => thunkCreator({
       'Content-Type': 'application/json',
     },
     body: JSON.stringify(data),
-  }).then(response => response.json()),
+  }).then(parseJSONResponse),
 })
 
 // ~~~
@@ -49,7 +49,7 @@ export const deleteInstance = (id, data) => thunkCreator({
   promise: fetch(`/instances/${id}`, {
     credentials: 'same-origin',
     method: 'DELETE',
-  }).then(response => response.json()),
+  }).then(parseJSONResponse),
 })
 
 // ~~~
@@ -67,5 +67,5 @@ export const createInstance = (data) => thunkCreator({
       'Content-Type': 'application/json',
     },
     body: JSON.stringify(data),
-  }).then(response => response.json()),
+  }).then(parseJSONResponse),
 })

--- a/src/tools/web/client/src/actions/kdb.js
+++ b/src/tools/web/client/src/actions/kdb.js
@@ -16,7 +16,10 @@ export const GET_KEY_FAILURE = 'GET_KEY_FAILURE'
 
 export const getKey = (id, path, cluster = false) => thunkCreator({
   types: [GET_KEY_REQUEST, GET_KEY_SUCCESS, GET_KEY_FAILURE],
-  promise: fetch(`/${cluster ? 'clusters' : 'instances'}/${id}/kdb/${encodePath(path)}`)
+  promise: fetch(
+    `/${cluster ? 'clusters' : 'instances'}/${id}/kdb/${encodePath(path)}`,
+    { credentials: 'same-origin' }
+  )
     .then(response => response.json())
     .then(result => {
       return { ...result, id, path }
@@ -34,13 +37,17 @@ export const SET_KEY_FAILURE = 'SET_KEY_FAILURE'
 export const setKey = (id, path, value, cluster = false) => thunkCreator({
   request: { id, path, value }, // TODO: use this syntax everywhere
   types: [SET_KEY_REQUEST, SET_KEY_SUCCESS, SET_KEY_FAILURE],
-  promise: fetch(`/${cluster ? 'clusters' : 'instances'}/${id}/kdb/${encodePath(path)}`, {
-    method: 'PUT',
-    headers: {
-      'Content-Type': 'text/plain',
-    },
-    body: value,
-  }).then(response => response.json()),
+  promise: fetch(
+    `/${cluster ? 'clusters' : 'instances'}/${id}/kdb/${encodePath(path)}`,
+    {
+      credentials: 'same-origin',
+      method: 'PUT',
+      headers: {
+        'Content-Type': 'text/plain',
+      },
+      body: value,
+    }
+  ).then(response => response.json()),
 })
 
 export const setClusterKey = (id, path, value) => setKey(id, path, value, true)
@@ -54,9 +61,13 @@ export const DELETE_KEY_FAILURE = 'DELETE_KEY_FAILURE'
 export const deleteKey = (id, path, cluster = false) => thunkCreator({
   request: { id, path },
   types: [DELETE_KEY_REQUEST, DELETE_KEY_SUCCESS, DELETE_KEY_FAILURE],
-  promise: fetch(`/${cluster ? 'clusters' : 'instances'}/${id}/kdb/${encodePath(path)}`, {
-    method: 'DELETE',
-  }).then(response => response.json()),
+  promise: fetch(
+    `/${cluster ? 'clusters' : 'instances'}/${id}/kdb/${encodePath(path)}`,
+    {
+      credentials: 'same-origin',
+      method: 'DELETE',
+    }
+  ).then(response => response.json()),
 })
 
 export const deleteClusterKey = (id, path) => deleteKey(id, path, true)

--- a/src/tools/web/client/src/actions/kdb.js
+++ b/src/tools/web/client/src/actions/kdb.js
@@ -6,7 +6,7 @@
  * @copyright BSD License (see doc/LICENSE.md or http://www.libelektra.org)
  */
 
-import { thunkCreator, encodePath } from './utils'
+import { thunkCreator, encodePath, parseJSONResponse } from './utils'
 
 // ~~~
 
@@ -20,7 +20,7 @@ export const getKey = (id, path, cluster = false) => thunkCreator({
     `/${cluster ? 'clusters' : 'instances'}/${id}/kdb/${encodePath(path)}`,
     { credentials: 'same-origin' }
   )
-    .then(response => response.json())
+    .then(parseJSONResponse)
     .then(result => {
       return { ...result, id, path }
     }),
@@ -47,7 +47,7 @@ export const setKey = (id, path, value, cluster = false) => thunkCreator({
       },
       body: value,
     }
-  ).then(response => response.json()),
+  ).then(parseJSONResponse),
 })
 
 export const setClusterKey = (id, path, value) => setKey(id, path, value, true)
@@ -67,7 +67,7 @@ export const deleteKey = (id, path, cluster = false) => thunkCreator({
       credentials: 'same-origin',
       method: 'DELETE',
     }
-  ).then(response => response.json()),
+  ).then(parseJSONResponse),
 })
 
 export const deleteClusterKey = (id, path) => deleteKey(id, path, true)

--- a/src/tools/web/client/src/actions/router.js
+++ b/src/tools/web/client/src/actions/router.js
@@ -17,7 +17,7 @@ export const CONFIGURE_INSTANCE_FAILURE = 'CONFIGURE_INSTANCE_FAILURE'
 export const configureInstance = (id) => thunkCreator({
   id,
   types: [CONFIGURE_INSTANCE_REQUEST, CONFIGURE_INSTANCE_SUCCESS, CONFIGURE_INSTANCE_FAILURE],
-  promise: fetch(`/instances/${id}/kdb`)
+  promise: fetch(`/instances/${id}/kdb`, { credentials: 'same-origin' })
     .then(response => response.json())
     .then(result => {
       return { ...result, id }
@@ -33,7 +33,7 @@ export const CONFIGURE_CLUSTER_FAILURE = 'CONFIGURE_CLUSTER_FAILURE'
 export const configureCluster = (id) => thunkCreator({
   id,
   types: [CONFIGURE_CLUSTER_REQUEST, CONFIGURE_CLUSTER_SUCCESS, CONFIGURE_CLUSTER_FAILURE],
-  promise: fetch(`/clusters/${id}/kdb`)
+  promise: fetch(`/clusters/${id}/kdb`, { credentials: 'same-origin' })
     .then(response => response.json())
     .then(result => {
       return { ...result, id }

--- a/src/tools/web/client/src/actions/router.js
+++ b/src/tools/web/client/src/actions/router.js
@@ -6,7 +6,7 @@
  * @copyright BSD License (see doc/LICENSE.md or http://www.libelektra.org)
  */
 
-import { thunkCreator } from './utils'
+import { thunkCreator, parseJSONResponse } from './utils'
 
 // ~~~
 
@@ -18,7 +18,7 @@ export const configureInstance = (id) => thunkCreator({
   id,
   types: [CONFIGURE_INSTANCE_REQUEST, CONFIGURE_INSTANCE_SUCCESS, CONFIGURE_INSTANCE_FAILURE],
   promise: fetch(`/instances/${id}/kdb`, { credentials: 'same-origin' })
-    .then(response => response.json())
+    .then(parseJSONResponse)
     .then(result => {
       return { ...result, id }
     }),
@@ -34,7 +34,7 @@ export const configureCluster = (id) => thunkCreator({
   id,
   types: [CONFIGURE_CLUSTER_REQUEST, CONFIGURE_CLUSTER_SUCCESS, CONFIGURE_CLUSTER_FAILURE],
   promise: fetch(`/clusters/${id}/kdb`, { credentials: 'same-origin' })
-    .then(response => response.json())
+    .then(parseJSONResponse)
     .then(result => {
       return { ...result, id }
     }),

--- a/src/tools/web/client/src/actions/utils.js
+++ b/src/tools/web/client/src/actions/utils.js
@@ -32,3 +32,13 @@ export const thunkCreator = (action) => {
 // encode kdb path with encodeURIComponent
 export const encodePath = (path) =>
   path.split('/').map(encodeURIComponent).join('/')
+
+export const parseJSONResponse = (response) => {
+  return response.text().then(text => {
+    try {
+      return JSON.parse(text)
+    } catch (err) {
+      throw new Error('invalid response from server')
+    }
+  })
+}


### PR DESCRIPTION
Fixes #1424

The problem was that the `fetch()` requests in the app did not send the `Authorization` header, thus nginx rejected the requests. This was fixed by adding `{ credentials: 'same-origin' }` to the fetch options, as suggested in: https://bugs.chromium.org/p/chromium/issues/detail?id=504344

This PR also shows invalid server responses as "Error: invalid response from server" instead of showing the JSON error.