### PR TITLE
Fix xerces plugin locale

### DIFF
--- a/src/plugins/xerces/serializer.cpp
+++ b/src/plugins/xerces/serializer.cpp
@@ -36,7 +36,8 @@ DOMElement * findChildWithName (DOMNode const & elem, string const & name)
 	return nullptr;
 }
 
-void key2xml (DOMDocument & doc, DOMElement & elem, string name, Key const & key)
+// the name parameter is only used in debug mode for logging, not in production, so we suppress the warning
+void key2xml (DOMDocument & doc, DOMElement & elem, string name ELEKTRA_UNUSED, Key const & key)
 {
 	ELEKTRA_LOG_DEBUG ("updating element %s", name.c_str ());
 

--- a/src/plugins/xerces/util.hpp
+++ b/src/plugins/xerces/util.hpp
@@ -14,6 +14,7 @@
 
 #include <memory>
 #include <xercesc/util/XMLString.hpp>
+#include <xercesc/util/TransService.hpp>
 
 namespace xerces
 {
@@ -50,12 +51,14 @@ using XercesPtr = std::unique_ptr<T, XercesDeleter<T>>;
 
 inline XercesPtr<XMLCh> toXMLCh (std::string const & str)
 {
-	return XercesPtr<XMLCh> (XERCES_CPP_NAMESPACE::XMLString::transcode (str.c_str ()));
+	// XMLByte required by TranscodeFromStr is an unsigned char * but basically they can be used equivalently
+	return XercesPtr<XMLCh> (XERCES_CPP_NAMESPACE::TranscodeFromStr (reinterpret_cast<const XMLByte*> (str.c_str ()), str.size(), "UTF-8").adopt());
 }
 
 inline XercesPtr<char> toCStr (XMLCh const * xmlCh)
 {
-	return XercesPtr<char> (XERCES_CPP_NAMESPACE::XMLString::transcode (xmlCh));
+	// XMLByte returned by TranscodeToStr is an unsigned char * but basically they can be used equivalently
+	return XercesPtr<char> (reinterpret_cast<char*>(XERCES_CPP_NAMESPACE::TranscodeToStr (xmlCh,"UTF-8").adopt()));
 }
 
 inline std::string toStr (XMLCh const * xmlCh)

--- a/src/plugins/xerces/util.hpp
+++ b/src/plugins/xerces/util.hpp
@@ -13,8 +13,8 @@
 #define ELEKTRA_PLUGIN_XERCES_UTIL_H
 
 #include <memory>
-#include <xercesc/util/XMLString.hpp>
 #include <xercesc/util/TransService.hpp>
+#include <xercesc/util/XMLString.hpp>
 
 namespace xerces
 {
@@ -52,13 +52,14 @@ using XercesPtr = std::unique_ptr<T, XercesDeleter<T>>;
 inline XercesPtr<XMLCh> toXMLCh (std::string const & str)
 {
 	// XMLByte required by TranscodeFromStr is an unsigned char * but basically they can be used equivalently
-	return XercesPtr<XMLCh> (XERCES_CPP_NAMESPACE::TranscodeFromStr (reinterpret_cast<const XMLByte*> (str.c_str ()), str.size(), "UTF-8").adopt());
+	return XercesPtr<XMLCh> (
+		XERCES_CPP_NAMESPACE::TranscodeFromStr (reinterpret_cast<const XMLByte *> (str.c_str ()), str.size (), "UTF-8").adopt ());
 }
 
 inline XercesPtr<char> toCStr (XMLCh const * xmlCh)
 {
 	// XMLByte returned by TranscodeToStr is an unsigned char * but basically they can be used equivalently
-	return XercesPtr<char> (reinterpret_cast<char*>(XERCES_CPP_NAMESPACE::TranscodeToStr (xmlCh,"UTF-8").adopt()));
+	return XercesPtr<char> (reinterpret_cast<char *> (XERCES_CPP_NAMESPACE::TranscodeToStr (xmlCh, "UTF-8").adopt ()));
 }
 
 inline std::string toStr (XMLCh const * xmlCh)


### PR DESCRIPTION
# Purpose
Use UTF-8 instead of the system locale for the xerces plugin to avoid problems if the locale is set to POSIX or something similar when trying to parse xml files with special characters.

# Checklist

- [X] commit messages are fine (with references to issues)
- [X] I ran all tests and everything went fine
- [ ] I added unit tests
- [ ] affected documentation is fixed
- [X] I added code comments, logging, and assertions
- [ ] meta data is updated (e.g. README.md of plugins)

WIP to see if it works