### PR TITLE
Fix crash #234, add qt-gui.pro to build the tool with qmake

### DIFF
--- a/src/tools/qt-gui/qt-gui.pro
+++ b/src/tools/qt-gui/qt-gui.pro
@@ -1,0 +1,37 @@
+QT += quick  gui core  qml  widgets testlib dbus
+
+HEADERS +=	$$files(src/*.hpp)\
+			$$files(src/markdownconverter/*.h, true)\
+
+SOURCES +=	$$files(src/*.cpp,true)\
+
+CONFIG += qml_debug
+
+QMAKE_CXXFLAGS += -std=c++11
+
+# Additional import path used to resolve QML modules in Qt Creator's code model
+QML_IMPORT_PATH =
+
+# Default rules for deployment.
+include(deployment.pri)
+
+RESOURCES += \
+	resources.qrc
+	i18n.qrc
+
+OTHER_FILES +=	$$PWD/qml/*.qml\
+				$$PWD/qml/*.js
+
+SUBDIRS += \
+	unittest/unittest.pro \
+
+unix: LIBS += -L/usr/local/lib/ -lelektra
+unix: LIBS += -L/usr/local/lib/ -lelektratools
+unix: LIBS += -L/usr/local/lib/ -lelektra-ease
+unix: LIBS += -L/usr/local/lib/ -lmarkdown
+
+INCLUDEPATH += /usr/local/include/elektra
+INCLUDEPATH += ../../libtools/include/
+INCLUDEPATH += ../../libtools/include/merging
+INCLUDEPATH += ../../include/
+INCLUDEPATH += src/markdownconverter

--- a/src/tools/qt-gui/src/confignode.cpp
+++ b/src/tools/qt-gui/src/confignode.cpp
@@ -13,7 +13,7 @@ using namespace kdb;
 
 ConfigNode::ConfigNode (QString name, QString path, const Key & key, TreeViewModel * parentModel)
 : m_name (std::move (name)), m_path (std::move (path)), m_key (key), m_children (new TreeViewModel), m_metaData (nullptr),
-m_parentModel (parentModel), m_isExpanded (false), m_isDirty (false)
+  m_parentModel (parentModel), m_isExpanded (false), m_isDirty (false)
 {
 	setValue ();
 
@@ -25,12 +25,12 @@ m_parentModel (parentModel), m_isExpanded (false), m_isDirty (false)
 
 	connect (m_children, SIGNAL (expandNode (bool)), this, SLOT (setIsExpanded (bool)));
 	connect (this, SIGNAL (showMessage (QString, QString, QString)), parentModel,
-	SLOT (showConfigNodeMessage (QString, QString, QString)));
+		 SLOT (showConfigNodeMessage (QString, QString, QString)));
 }
 
 ConfigNode::ConfigNode (const ConfigNode & other)
 : QObject (), m_name (other.m_name), m_path (other.m_path), m_value (other.m_value), m_key (other.m_key.dup ()),
-m_children (new TreeViewModel), m_metaData (nullptr), m_parentModel (nullptr), m_isExpanded (other.m_isExpanded), m_isDirty (false)
+  m_children (new TreeViewModel), m_metaData (nullptr), m_parentModel (nullptr), m_isExpanded (other.m_isExpanded), m_isDirty (false)
 {
 	if (other.m_children)
 	{
@@ -118,14 +118,16 @@ void ConfigNode::setValue (const QVariant & value)
 	else
 		m_key = m_key.dup ();
 
-	try {
+	try
+	{
 		if (m_key.getString ().compare (value.toString ().toStdString ()) != 0)
 		{
 			m_key.setString (value.toString ().toStdString ());
 			m_value = value;
 		}
 	}
-	catch (KeyTypeMismatch ex) {
+	catch (KeyTypeMismatch ex)
+	{
 		emit showMessage (tr ("Error"), tr ("Creating/Editing binary keys is not yet supported."), ex.what ());
 		return;
 	}
@@ -261,7 +263,7 @@ void ConfigNode::populateMetaModel ()
 			node->setName (QString::fromStdString (m_key.getName ()));
 			node->setKey (m_key);
 			node->setMeta (QString::fromStdString (m_key.currentMeta ().getName ()),
-			QVariant::fromValue (QString::fromStdString (m_key.currentMeta ().getString ())));
+				       QVariant::fromValue (QString::fromStdString (m_key.currentMeta ().getString ())));
 
 			m_metaData->insertRow (m_metaData->rowCount (), node, false);
 		}
@@ -292,7 +294,7 @@ void ConfigNode::setKeyName (const QString & name)
 		catch (KeyInvalidName ex)
 		{
 			emit showMessage (tr ("Error"), tr ("Could not set name because Keyname \"%1\" is invalid.").arg (name),
-			ex.what ());
+					  ex.what ());
 			return;
 		}
 	}

--- a/src/tools/qt-gui/src/confignode.cpp
+++ b/src/tools/qt-gui/src/confignode.cpp
@@ -13,7 +13,7 @@ using namespace kdb;
 
 ConfigNode::ConfigNode (QString name, QString path, const Key & key, TreeViewModel * parentModel)
 : m_name (std::move (name)), m_path (std::move (path)), m_key (key), m_children (new TreeViewModel), m_metaData (nullptr),
-  m_parentModel (parentModel), m_isExpanded (false), m_isDirty (false)
+m_parentModel (parentModel), m_isExpanded (false), m_isDirty (false)
 {
 	setValue ();
 
@@ -25,12 +25,12 @@ ConfigNode::ConfigNode (QString name, QString path, const Key & key, TreeViewMod
 
 	connect (m_children, SIGNAL (expandNode (bool)), this, SLOT (setIsExpanded (bool)));
 	connect (this, SIGNAL (showMessage (QString, QString, QString)), parentModel,
-		 SLOT (showConfigNodeMessage (QString, QString, QString)));
+	SLOT (showConfigNodeMessage (QString, QString, QString)));
 }
 
 ConfigNode::ConfigNode (const ConfigNode & other)
 : QObject (), m_name (other.m_name), m_path (other.m_path), m_value (other.m_value), m_key (other.m_key.dup ()),
-  m_children (new TreeViewModel), m_metaData (nullptr), m_parentModel (nullptr), m_isExpanded (other.m_isExpanded), m_isDirty (false)
+m_children (new TreeViewModel), m_metaData (nullptr), m_parentModel (nullptr), m_isExpanded (other.m_isExpanded), m_isDirty (false)
 {
 	if (other.m_children)
 	{
@@ -118,10 +118,16 @@ void ConfigNode::setValue (const QVariant & value)
 	else
 		m_key = m_key.dup ();
 
-	if (m_key.getString ().compare (value.toString ().toStdString ()) != 0)
-	{
-		m_key.setString (value.toString ().toStdString ());
-		m_value = value;
+	try {
+		if (m_key.getString ().compare (value.toString ().toStdString ()) != 0)
+		{
+			m_key.setString (value.toString ().toStdString ());
+			m_value = value;
+		}
+	}
+	catch (KeyTypeMismatch ex) {
+		emit showMessage (tr ("Error"), tr ("Creating/Editing binary keys is not yet supported."), ex.what ());
+		return;
 	}
 }
 
@@ -255,7 +261,7 @@ void ConfigNode::populateMetaModel ()
 			node->setName (QString::fromStdString (m_key.getName ()));
 			node->setKey (m_key);
 			node->setMeta (QString::fromStdString (m_key.currentMeta ().getName ()),
-				       QVariant::fromValue (QString::fromStdString (m_key.currentMeta ().getString ())));
+			QVariant::fromValue (QString::fromStdString (m_key.currentMeta ().getString ())));
 
 			m_metaData->insertRow (m_metaData->rowCount (), node, false);
 		}
@@ -286,7 +292,7 @@ void ConfigNode::setKeyName (const QString & name)
 		catch (KeyInvalidName ex)
 		{
 			emit showMessage (tr ("Error"), tr ("Could not set name because Keyname \"%1\" is invalid.").arg (name),
-					  ex.what ());
+			ex.what ());
 			return;
 		}
 	}


### PR DESCRIPTION
# Purpose

Fix crash in issue #234 by handling uncaught exception. Adding qt-gui.pro file to enable people building the tool with qmake/qt-creator.

# Checklist

Please only check relevant points.
For docu fixes, spell checking and similar nothing
needs to be checked.

- [ ] commit messages are fine (with references to issues)
- [ ] I ran all tests and everything went fine
- [ ] I added unit tests
- [ ] affected documentation is fixed
- [ ] I added code comments, logging, and assertions
- [ ] meta data is updated (e.g. README.md of plugins)

@markus2330 please review my pull request
