### PR TITLE
Plugins: Add Status Values for Plugin Functions

### DIFF
--- a/doc/CODING.md
+++ b/doc/CODING.md
@@ -76,7 +76,7 @@ Thus please use following techniques (in order of preference):
    `ELEKTRA_LOG ("formatted text to be printed according log filters", ...)`
 
    There are four log levels (ERROR is reserved for aborts within `ELEKTRA_ASSERT`):
-   - ELEKTRA_LOG_WARNING, something critical that should be shown the user (e.g. API misuse), see #ELEKTRA_LOG_LEVEL_WARNING
+   - ELEKTRA_LOG_WARNING, something critical that should be shown to the user (e.g. API misuse), see #ELEKTRA_LOG_LEVEL_WARNING
    - ELEKTRA_LOG_NOTICE, something important developers are likely interested in, see #ELEKTRA_LOG_LEVEL_NOTICE
    - ELEKTRA_LOG, standard level gives information what the code is doing without flooding the log, see #ELEKTRA_LOG_LEVEL_INFO
    - ELEKTRA_LOG_DEBUG, for less important logs, see #ELEKTRA_LOG_LEVEL_DEBUG

--- a/doc/help/elektra-algorithm.md
+++ b/doc/help/elektra-algorithm.md
@@ -117,10 +117,10 @@ The synopsis of the function is:
 
 The user passes a key set, called `returned`.
 If the user invokes `kdbGet()` the first time, he or she will usually
-pass an empty key set.	If the user wants to update the application's
+pass an empty key set. If the user wants to update the application's
 settings, `returned` will typically contain the configuration of the
 previous `kdbGet()` request.  The `parentKey` holds the information
-below which key the configuration should be retrieved.	The `handle`
+below which key the configuration should be retrieved. The `handle`
 contains the data structures needed for the algorithm, like the `Split`
 and the `Trie` objects.
 
@@ -135,7 +135,7 @@ A backend may yield keys that it is not responsible for.
 It is not possible for a backend to know that another backend has been
 mounted below and the other backend is now responsible for some of the
 keys that are still in the storage.  Additionally, plugins are not able
-to determine if they are responsible for a key or not.	Consequently, it
+to determine if they are responsible for a key or not. Consequently, it
 can happen that more than one backend delivers a key with the same name.
 
 `kdbGet()` ensures that a key is uniquely identified by its name.
@@ -197,7 +197,7 @@ and returns zero.
 
 Now we know which backends do not need an update.  For these backends, the
 previous configuration from `returned` is appointed from to the key sets
-of the `Split` object.	The algorithm will not set the *syncbits*
+of the `Split` object. The algorithm will not set the *syncbits*
 of the `Split` object for these backends because the storage of the
 backends already contains up-to-date configuration.
 
@@ -241,7 +241,7 @@ the signal is reused for reloading configuration.), notifications,
 user requests and in the worst case periodical attempts to reread
 configuration.
 
-The given goal is to keep the sequence of needed syscalls low.	If no
+The given goal is to keep the sequence of needed syscalls low. If no
 update is needed, it is sufficient to request the timestamp
 (On POSIX systems using `stat()`) of every file. No other syscall
 is needed.  Elektra’s core alone cannot check that because getting
@@ -302,7 +302,7 @@ The synopsis of the function is:
 	int kdbSet(KDB *handle, KeySet *returned, Key * parentKey);
 
 The user passes the configuration using the `KeySet` `returned`.  The key
-set will not be changed by `kdbSet()`.	The `parentKey` provides a way
+set will not be changed by `kdbSet()`. The `parentKey` provides a way
 to limit which part of the configuration is written out.  For example,
 the `parentKey` `user/sw/org/app/#0/current` will induce `kdbSet()` to
 only modify the key databases below `user/sw/org/app` even
@@ -384,7 +384,7 @@ the key database.  In order not to lose any data, `kdbSet()` fails without
 doing anything.  In conflict situations Elektra leaves the programmer
 no choice.  The programmer has to retrieve the configuration using
 `kdbGet()` again to be up to date with the key database.  Afterwards it
-is up to the application to decide which configuration to use.	In this
+is up to the application to decide which configuration to use. In this
 situation it is the best to ask the user, by showing him the description
 and reason of the error, how to continue:
 

--- a/doc/help/elektra-algorithm.md
+++ b/doc/help/elektra-algorithm.md
@@ -357,7 +357,7 @@ Up to now only file-based storages with atomic properties were
 developed.  The replacement of a file with another file that has not
 yet been written is not trivial.  The straightforward way is to lock a
 file and start writing to it.  But this approach can result in broken or
-partially finished files in events like ''out of disc space'', signals
+partially finished files in events like “out of disc space”, signals
 or other asynchronous aborts of the program.
 
 A temporary file solves most of this problem, because in problematic events

--- a/doc/tutorials/plugins.md
+++ b/doc/tutorials/plugins.md
@@ -258,12 +258,12 @@ and should serve as a rough guide on how to write a storage plugin that can read
 ### `elektraPluginGet`
 
 `elektraPluginGet` is the function responsible for turning information from a file into a usable `KeySet`.
-This function usually differs pretty greatly between each plug-in. This function should be of type `int`, it returns either `0` or on `1` on success.
+This function usually differs pretty greatly between each plug-in. This function should be of type `int`, it returns either `1` or on `0` on success.
 
-- `0`: The function was successful and the given keyset was **not changed**.
-- `1`: The function was successful and the given keyset was **updated**.
+- `1`: The function was successful (`ELEKTRA_PLUGIN_STATUS_SUCCESS`).
+- `0`: The function was successful and the given keyset/configuration was **not changed** (`ELEKTRA_PLUGIN_STATUS_NO_UPDATE`).
 
-Any other return value indicates an error. The function will take in a `Key`, usually called `parentKey` which contains a string containing the path
+Any other return value indicates an error (`ELEKTRA_PLUGIN_STATUS_ERROR`). The function will take in a `Key`, usually called `parentKey` which contains a string containing the path
 to the file that is mounted. For instance, if you run the command `kdb mount /etc/linetest system/linetest line` then `keyString(parentKey)`
 should be equal to `/etc/linetest`. At this point, you generally want to open the file so you can begin saving it into keys.
 Here is the trickier part to explain. Basically, at this point you will want to iterate through the file and create keys and store string values

--- a/src/include/kdbplugin.h
+++ b/src/include/kdbplugin.h
@@ -81,6 +81,16 @@ typedef enum {
 	// clang-format on
 } plugin_t;
 
+/* Status values for plugin functions */
+
+/** An error occurred inside the plugin function */
+#define ELEKTRA_PLUGIN_STATUS_ERROR -1
+
+/** Everything went fine */
+#define ELEKTRA_PLUGIN_STATUS_SUCCESS 1
+
+/** Everything went fine and the function **did not** update the given keyset/configuration */
+#define ELEKTRA_PLUGIN_STATUS_NO_UPDATE 0
 
 #ifdef __cplusplus
 namespace ckdb

--- a/src/include/kdbprivate.h
+++ b/src/include/kdbprivate.h
@@ -343,7 +343,7 @@ struct _Plugin
 	KeySet * config; /*!< This keyset contains configuration for the plugin.
 	 Direct below system/ there is the configuration supplied for the backend.
 	 Direct below user/ there is the configuration supplied just for the
-	 plugin, which should be of course prefered to the backend configuration.
+	 plugin, which should be of course preferred to the backend configuration.
 	 The keys inside contain information like /path which path should be used
 	 to write configuration to or /host to which host packets should be send.
 	 @see elektraPluginGetConfig() */

--- a/src/libs/elektra/kdb.c
+++ b/src/libs/elektra/kdb.c
@@ -223,7 +223,7 @@ int elektraOpenBootstrap (KDB * handle, KeySet * keys, Key * errorKey)
  * system/elektra/mountpoints will be loaded and all needed
  * libraries and mountpoints will be determined.
  * These libraries for backends will be loaded and with it the
- * @p KDB datastructure will be initialized.
+ * @p KDB data structure will be initialized.
  *
  * You must always call this method before retrieving or committing any
  * keys to the database. In the end of the program,
@@ -698,7 +698,7 @@ static void clearError (Key * key)
  * If not done earlier kdbGet() will fully retrieve all keys under the @p parentKey
  * folder recursively (See Optimization below when it will not be done).
  *
- * @note kdbGet() might retrieve more keys then requested (that are not
+ * @note kdbGet() might retrieve more keys than requested (that are not
  *     below parentKey). These keys must be passed to calls of kdbSet(),
  *     otherwise they will be lost. This stems from the fact that the
  *     user has the only copy of the whole configuration and backends
@@ -816,7 +816,7 @@ int kdbGet (KDB * handle, KeySet * ks, Key * parentKey)
 		return 0;
 	case -1:
 		goto error;
-		// otherwise falltrough
+		// otherwise fall trough
 	}
 
 	// Appoint keys (some in the bypass)
@@ -873,7 +873,7 @@ int kdbGet (KDB * handle, KeySet * ks, Key * parentKey)
 		{
 			copyError (parentKey, oldError);
 		}
-		/* Now postprocess the updated keysets */
+		/* Now post-process the updated keysets */
 		if (splitGet (split, parentKey, handle) == -1)
 		{
 			ELEKTRA_ADD_WARNING (108, parentKey, keyName (ksCurrent (ks)));

--- a/src/plugins/doc/doc.h
+++ b/src/plugins/doc/doc.h
@@ -274,7 +274,7 @@
  * automatically add the information that the plugin was removed,
  * so you do not need the user give that information.
  *
- * @retval 0 on success
+ * @retval 1 on success
  *
  * @param handle contains internal information of the plugin
  * @param warningsKey can be used to add warnings with the macro
@@ -309,7 +309,7 @@ int elektraDocOpen (Plugin * handle, Key * warningsKey);
  * @param warningsKey can be used to to add warnings using
  *        #ELEKTRA_ADD_WARNING (Do not add errors!)
  *
- * @retval 0 on success (no other return value currently allowed)
+ * @retval 1 on success (no other return value currently allowed)
  *
  * @retval -1 on problems (only use ELEKTRA_ADD_WARNING, but never
  * set an error).
@@ -550,8 +550,8 @@ int elektraDocError (Plugin * handle, KeySet * returned, Key * parentKey);
  * @param errorKey is used to propagate error messages to the caller
  * @param conf contains the plugin configuration to be validated
  *
- * @retval 1 on success: the configuration was OK and has not been changed.
- * @retval 0 on success: the configuration has been changed and now it is OK.
+ * @retval 0 on success: the configuration was OK and has not been changed.
+ * @retval 1 on success: the configuration has been changed and now it is OK.
  * @retval -1 on failure: the configuration was not OK and could not be fixed.
  *   Set an error using #ELEKTRA_SET_ERROR to inform the user what went wrong.
  *   Additionally you can add any number of warnings with

--- a/src/plugins/doc/doc.h
+++ b/src/plugins/doc/doc.h
@@ -182,7 +182,7 @@
  * @snippet doc.c plugin include
  * @snippet doc.c plugin errors include
  *
- * @return 
+ * @return
  */
 #define ELEKTRA_SET_ERROR_GET(parentKey)
 
@@ -199,7 +199,7 @@
  * @snippet doc.c plugin include
  * @snippet doc.c plugin errors include
  *
- * @return 
+ * @return
  */
 #define ELEKTRA_SET_ERROR_SET(parentKey)
 
@@ -540,23 +540,23 @@ int elektraDocError (Plugin * handle, KeySet * returned, Key * parentKey);
 
 /**
  * @brief Validate plugin configuration at mount time.
- * 
+ *
  * During the mount phase the BackendBuilder calls this method,
  * if it is provided by the plugin.
- * 
- * In this method the plugin configuration can be checked for validity or 
+ *
+ * In this method the plugin configuration can be checked for validity or
  * integrity. Missing items can be added to complete the configuration.
- * 
+ *
  * @param errorKey is used to propagate error messages to the caller
  * @param conf contains the plugin configuration to be validated
- * 
+ *
  * @retval 1 on success: the configuration was OK and has not been changed.
  * @retval 0 on success: the configuration has been changed and now it is OK.
  * @retval -1 on failure: the configuration was not OK and could not be fixed.
  *   Set an error using #ELEKTRA_SET_ERROR to inform the user what went wrong.
  *   Additionally you can add any number of warnings with
  *   #ELEKTRA_ADD_WARNING.
- * 
+ *
  * @ingroup plugin
  */
 int elektraDocCheckConf (Key * errorKey, KeySet * conf);

--- a/src/plugins/rename/README.md
+++ b/src/plugins/rename/README.md
@@ -44,9 +44,9 @@ last transformation to be applied to all keys on kdbSet.
 * keyname
 * unchanged   // this is the default value if no configuration is given
 
-`toupper` or `tolower` tells the rename plugin to convert the whole keyname below below the parentKey to lower or uppercase.
+`toupper` or `tolower` tells the rename plugin to convert the whole keyname below the parentKey to lower or uppercase.
 
-`unchanged` returns the key to it's original name
+`unchanged` returns the key to its original name
 
 `keyname` tells the plugin to keep the name of the advanced transformation
 
@@ -56,7 +56,7 @@ last transformation to be applied to all keys on kdbSet.
 
 #### Operation
 
-The cut operation can be used to strip parts of a keys name. The cut operation is able to cut anything below the path
+The cut operation can be used to strip parts of a key’s name. The cut operation is able to cut anything below the path
 of the parent key. A renamed key may even replace the parent key. For example consider a KeySet with the
 parent key `user/config`. If the KeySet contained a key with the name `user/config/with/long/path/key1`, the cut operation
 would be able to strip the following key name parts:

--- a/src/plugins/rename/README.md
+++ b/src/plugins/rename/README.md
@@ -1,4 +1,4 @@
-- infos = Information about keytometa plugin is in keys below
+- infos = Information about rename plugin is in keys below
 - infos/author = Felix Berlakovich <elektra@berlakovich.net>
 - infos/licence = BSD
 - infos/provides = filter

--- a/src/plugins/resolver/resolver.c
+++ b/src/plugins/resolver/resolver.c
@@ -75,7 +75,7 @@ static void resolverInit (resolverHandle * p, const char * path)
 static resolverHandle * elektraGetResolverHandle (Plugin * handle, Key * parentKey)
 {
 	resolverHandles * pks = elektraPluginGetData (handle);
-	ELEKTRA_ASSERT (pks != NULL, "Unable to retrieve plugin data for handle %p with parentKey %s", handle, keyName (parentKey));
+	ELEKTRA_ASSERT (pks != NULL, "Unable to retrieve plugin data for handle %p with parentKey %s", (void *)handle, keyName (parentKey));
 
 	switch (keyGetNamespace (parentKey))
 	{

--- a/src/plugins/template/template.c
+++ b/src/plugins/template/template.c
@@ -17,7 +17,7 @@ int elektraTemplateOpen (Plugin * handle ELEKTRA_UNUSED, Key * errorKey ELEKTRA_
 	// plugin initialization logic
 	// this function is optional
 
-	return 1; // success
+	return ELEKTRA_PLUGIN_STATUS_SUCCESS;
 }
 
 int elektraTemplateClose (Plugin * handle ELEKTRA_UNUSED, Key * errorKey ELEKTRA_UNUSED)
@@ -25,7 +25,7 @@ int elektraTemplateClose (Plugin * handle ELEKTRA_UNUSED, Key * errorKey ELEKTRA
 	// free all plugin resources and shut it down
 	// this function is optional
 
-	return 1; // success
+	return ELEKTRA_PLUGIN_STATUS_SUCCESS;
 }
 
 int elektraTemplateGet (Plugin * handle ELEKTRA_UNUSED, KeySet * returned ELEKTRA_UNUSED, Key * parentKey ELEKTRA_UNUSED)
@@ -46,14 +46,11 @@ int elektraTemplateGet (Plugin * handle ELEKTRA_UNUSED, KeySet * returned ELEKTR
 		ksAppend (returned, contract);
 		ksDel (contract);
 
-		return 1; // success
+		return ELEKTRA_PLUGIN_STATUS_SUCCESS;
 	}
 	// get all keys
 
-	//  0: Everything was OK and `returned` has not been changed
-	//  1: Everything was OK and `returned` was updated
-	// -1: There was an error
-	return 1; // success
+	return ELEKTRA_PLUGIN_STATUS_NO_UPDATE;
 }
 
 int elektraTemplateSet (Plugin * handle ELEKTRA_UNUSED, KeySet * returned ELEKTRA_UNUSED, Key * parentKey ELEKTRA_UNUSED)
@@ -61,7 +58,7 @@ int elektraTemplateSet (Plugin * handle ELEKTRA_UNUSED, KeySet * returned ELEKTR
 	// set all keys
 	// this function is optional
 
-	return 1; // success
+	return ELEKTRA_PLUGIN_STATUS_NO_UPDATE;
 }
 
 int elektraTemplateError (Plugin * handle ELEKTRA_UNUSED, KeySet * returned ELEKTRA_UNUSED, Key * parentKey ELEKTRA_UNUSED)
@@ -69,7 +66,7 @@ int elektraTemplateError (Plugin * handle ELEKTRA_UNUSED, KeySet * returned ELEK
 	// handle errors (commit failed)
 	// this function is optional
 
-	return 1; // success
+	return ELEKTRA_PLUGIN_STATUS_SUCCESS;
 }
 
 int elektraTemplateCheckConfig (Key * errorKey ELEKTRA_UNUSED, KeySet * conf ELEKTRA_UNUSED)
@@ -77,11 +74,7 @@ int elektraTemplateCheckConfig (Key * errorKey ELEKTRA_UNUSED, KeySet * conf ELE
 	// validate plugin configuration
 	// this function is optional
 
-	// the return codes have the following meaning:
-	// 0: The configuration was OK and has not been changed
-	// 1: The configuration has been changed and now it is OK
-	// -1: The configuration was not OK and could not be fixed. An error has to be set to errorKey.
-	return 0;
+	return ELEKTRA_PLUGIN_STATUS_NO_UPDATE;
 }
 
 Plugin * ELEKTRA_PLUGIN_EXPORT (template)

--- a/src/plugins/template/testmod_template.c
+++ b/src/plugins/template/testmod_template.c
@@ -24,15 +24,15 @@ static void test_basics ()
 
 	KeySet * ks = ksNew (0, KS_END);
 
-	succeed_if (plugin->kdbOpen (plugin, parentKey) == 1, "call to kdbOpen was not successful");
+	succeed_if (plugin->kdbOpen (plugin, parentKey) == ELEKTRA_PLUGIN_STATUS_SUCCESS, "call to kdbOpen was not successful");
 
-	succeed_if (plugin->kdbGet (plugin, ks, parentKey) == 1, "call to kdbGet was not successful");
+	succeed_if (plugin->kdbGet (plugin, ks, parentKey) == ELEKTRA_PLUGIN_STATUS_NO_UPDATE, "call to kdbGet was not successful");
 
-	succeed_if (plugin->kdbSet (plugin, ks, parentKey) == 1, "call to kdbSet was not successful");
+	succeed_if (plugin->kdbSet (plugin, ks, parentKey) == ELEKTRA_PLUGIN_STATUS_NO_UPDATE, "call to kdbSet was not successful");
 
-	succeed_if (plugin->kdbError (plugin, ks, parentKey) == 1, "call to kdbError was not successful");
+	succeed_if (plugin->kdbError (plugin, ks, parentKey) == ELEKTRA_PLUGIN_STATUS_SUCCESS, "call to kdbError was not successful");
 
-	succeed_if (plugin->kdbClose (plugin, parentKey) == 1, "call to kdbClose was not successful");
+	succeed_if (plugin->kdbClose (plugin, parentKey) == ELEKTRA_PLUGIN_STATUS_SUCCESS, "call to kdbClose was not successful");
 
 	keyDel (parentKey);
 	ksDel (ks);


### PR DESCRIPTION
# Purpose

This pull request adds the following macros for the return values of plugin functions:

- `ELEKTRA_PLUGIN_STATUS_ERROR`: An error occurred inside the plugin function
- `ELEKTRA_PLUGIN_STATUS_SUCCESS`: Everything went fine and the function **did not** change the given keyset
- `ELEKTRA_PLUGIN_STATUS_SUCCESS_KEYSET_MODIFIED`: Everything went fine and the function did modify the given keyset

.

# Checklist

- [x] I checked all commit messages twice.
- [x] I ran all tests and everything went fine
- [x] I updated the documentation.

@markus2330 👋 Please review my pull request.
