### PR TITLE
Travis: Also Test Experimental Plugins

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,6 @@ before_install:
       export PATH=/usr/local/bin:/usr/local/sbin:$PATH;
       brew update;
       brew tap caskroom/cask;
-      brew install cmake;
       brew install swig;
       brew install gobject-introspection;
       brew install python3;

--- a/.travis.yml
+++ b/.travis.yml
@@ -58,7 +58,7 @@ before_script:
       CMAKE_OPT+=("-DPYTHON_INCLUDE_DIR:PATH=$(python3-config --prefix)/include/python${python3_ver}m") &&
       CMAKE_OPT+=("-DPYTHON_LIBRARY:FILEPATH=$(python3-config --prefix)/lib/libpython${python3_ver}.dylib");
     fi
-  - cmake -DBUILD_STATIC=OFF -DBINDINGS=ALL -DTOOLS=ALL -DCMAKE_INSTALL_PREFIX=$TRAVIS_BUILD_DIR/../install -DKDB_DB_SYSTEM=$TRAVIS_BUILD_DIR/../kdbsystem ${CMAKE_OPT[@]} $TRAVIS_BUILD_DIR
+  - cmake -DBUILD_STATIC=OFF -DPLUGINS=ALL -DBINDINGS=ALL -DTOOLS=ALL -DCMAKE_INSTALL_PREFIX=$TRAVIS_BUILD_DIR/../install -DKDB_DB_SYSTEM=$TRAVIS_BUILD_DIR/../kdbsystem ${CMAKE_OPT[@]} $TRAVIS_BUILD_DIR
 
 script:
   - make -j3

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ before_install:
       gem install test-unit --no-document;
       export PATH=/usr/local/bin:/usr/local/sbin:$PATH;
       brew tap caskroom/cask;
+      brew install ninja;
       brew install swig;
       brew install gobject-introspection;
       brew install python3;
@@ -58,8 +59,8 @@ before_script:
       CMAKE_OPT+=("-DPYTHON_LIBRARY:FILEPATH=$(python3-config --prefix)/lib/libpython${python3_ver}.dylib");
       if [[ $(uname -r | cut -d "." -f 1) == 15 ]]; then plugins="ALL;-CRYPTO"; fi;
     fi
-  - cmake -DBUILD_STATIC=OFF -DPLUGINS="${plugins:-ALL}" -DBINDINGS=ALL -DTOOLS=ALL -DCMAKE_INSTALL_PREFIX=$TRAVIS_BUILD_DIR/../install -DKDB_DB_SYSTEM=$TRAVIS_BUILD_DIR/../kdbsystem ${CMAKE_OPT[@]} $TRAVIS_BUILD_DIR
+  - cmake -GNinja -DBUILD_STATIC=OFF -DPLUGINS="${plugins:-ALL}" -DBINDINGS=ALL -DTOOLS=ALL -DCMAKE_INSTALL_PREFIX=$TRAVIS_BUILD_DIR/../install -DKDB_DB_SYSTEM=$TRAVIS_BUILD_DIR/../kdbsystem ${CMAKE_OPT[@]} $TRAVIS_BUILD_DIR
 
 script:
-  - make -j3
-  - make run_all
+  - ninja
+  - ninja run_all

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,6 @@ before_install:
       rvm use 2.3.1;
       gem install test-unit --no-document;
       export PATH=/usr/local/bin:/usr/local/sbin:$PATH;
-      brew update;
       brew tap caskroom/cask;
       brew install swig;
       brew install gobject-introspection;

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ before_install:
       brew install dbus;
       brew install qt5;
       brew install discount;
-      brew install botan libgcrypt;
+      brew install openssl botan libgcrypt;
       brew install libgit2;
       brew install xerces-c;
       export Qt5_DIR=/usr/local/opt/qt5;
@@ -58,6 +58,7 @@ before_script:
       CMAKE_OPT+=("-DPYTHON_INCLUDE_DIR:PATH=$(python3-config --prefix)/include/python${python3_ver}m") &&
       CMAKE_OPT+=("-DPYTHON_LIBRARY:FILEPATH=$(python3-config --prefix)/lib/libpython${python3_ver}.dylib");
       if [[ $(uname -r | cut -d "." -f 1) == 15 ]]; then plugins="ALL;-CRYPTO"; fi;
+      ln -s /usr/local/opt/openssl/include/openssl/ /usr/local/include/openssl;
     fi
   - cmake -GNinja -DBUILD_STATIC=OFF -DPLUGINS="${plugins:-ALL}" -DBINDINGS=ALL -DTOOLS=ALL -DCMAKE_INSTALL_PREFIX=$TRAVIS_BUILD_DIR/../install -DKDB_DB_SYSTEM=$TRAVIS_BUILD_DIR/../kdbsystem ${CMAKE_OPT[@]} $TRAVIS_BUILD_DIR
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,7 @@ before_install:
       brew install dbus;
       brew install qt5;
       brew install discount;
+      brew install botan libgcrypt;
       brew install libgit2;
       brew install xerces-c;
       export Qt5_DIR=/usr/local/opt/qt5;

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,8 +21,6 @@ before_install:
       rvm install 2.3.1;
       rvm use 2.3.1;
       gem install test-unit --no-document;
-      export PATH=/usr/local/bin:/usr/local/sbin:$PATH;
-      brew tap caskroom/cask;
       brew install ninja;
       brew install swig;
       brew install gobject-introspection;

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,8 +56,9 @@ before_script:
       python3_ver=$(python3 -c 'import sys; print(".".join(map(str, sys.version_info[:2])))') &&
       CMAKE_OPT+=("-DPYTHON_INCLUDE_DIR:PATH=$(python3-config --prefix)/include/python${python3_ver}m") &&
       CMAKE_OPT+=("-DPYTHON_LIBRARY:FILEPATH=$(python3-config --prefix)/lib/libpython${python3_ver}.dylib");
+      if [[ $(uname -r | cut -d "." -f 1) == 15 ]]; then plugins="ALL;-CRYPTO"; fi;
     fi
-  - cmake -DBUILD_STATIC=OFF -DPLUGINS=ALL -DBINDINGS=ALL -DTOOLS=ALL -DCMAKE_INSTALL_PREFIX=$TRAVIS_BUILD_DIR/../install -DKDB_DB_SYSTEM=$TRAVIS_BUILD_DIR/../kdbsystem ${CMAKE_OPT[@]} $TRAVIS_BUILD_DIR
+  - cmake -DBUILD_STATIC=OFF -DPLUGINS="${plugins:-ALL}" -DBINDINGS=ALL -DTOOLS=ALL -DCMAKE_INSTALL_PREFIX=$TRAVIS_BUILD_DIR/../install -DKDB_DB_SYSTEM=$TRAVIS_BUILD_DIR/../kdbsystem ${CMAKE_OPT[@]} $TRAVIS_BUILD_DIR
 
 script:
   - make -j3


### PR DESCRIPTION
# Purpose

I recently noticed that Travis does not build and test experimental plugins anymore. Since (as far as I can tell) all supported experimental plugins should work on macOS, this pull request enables them again.

# Checklist

- [x] I checked all commit messages twice.