### PR TITLE
Ronn: Use UTF-8 as Input Encoding

### DIFF
--- a/cmake/Modules/LibAddMacros.cmake
+++ b/cmake/Modules/LibAddMacros.cmake
@@ -529,7 +529,7 @@ if (BUILD_DOCUMENTATION AND RONN_LOC) # disable function when RONN_LOC is not se
 	add_custom_command(
 		OUTPUT ${OUTFILE}
 		DEPENDS ${MDFILE}
-		COMMAND ${RONN_LOC}
+		COMMAND export RUBYOPT="-Eutf-8" && ${RONN_LOC}
 		ARGS -r --pipe ${MDFILE} > ${OUTFILE}
 		)
 	add_custom_target(man-${NAME} ALL DEPENDS ${OUTFILE})

--- a/doc/help/CMakeLists.txt
+++ b/doc/help/CMakeLists.txt
@@ -1,8 +1,6 @@
 find_program (RONN_LOC ronn)
 
 if (RONN_LOC)
-	SET (ENV{RUBYOPT} "-E utf-8")
-
 	add_custom_target (man ALL)
 
 


### PR DESCRIPTION
# Purpose

This commit should finally fix the issue mentioned in commit 214898ed:

> Before this change building the man pages would not work if the current locale only allowed ASCII characters. This commit addresses issue #1406.

. The problem with the old fix was that CMake only sets environment variables at configuration time. Now the encoding is properly set at execution time, just before `ronn` generates the man pages.

This fix will only work on Unix like systems though. We could use `cmake -E env` instead  of `export` to address this problem. However, as  far as I can tell, `cmake -E env` is [only available since CMake 3.2](http://stackoverflow.com/questions/35029277/how-to-modify-environment-variables-passed-to-custom-cmake-target#35032051).

# Checklist

- [x] I double checked the commit message
- [x] I ran all tests and everything went fine

@markus2330 👋 Please review my pull request.