### PR TITLE
(Markdown) Shell Recorder: Minor Improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ before_install:
       brew install yajl;
       brew install augeas;
       brew install dbus;
-      brew install qt5;
+      brew install qt;
       brew install discount;
       brew install openssl botan libgcrypt;
       brew install libgit2;

--- a/doc/help/kdb-complete.md
+++ b/doc/help/kdb-complete.md
@@ -64,13 +64,13 @@ kdb complete user --max-depth=1
 # list suggestions for the namespace user, only the next level as it ends with /
 # note the difference to the previous example, which uses no trailing /
 kdb complete user/ --max-depth=1
-#>RET: 0
-#>STDOUT: .*
+# RET:0
+# STDOUT-REGEX: .*
 
 # list all possible namespaces or mountpoints, only the current level
 kdb complete --max-depth=1
-#>RET: 0
-#>STDOUT: .*
+# RET:0
+# STDOUT-REGEX: .*
 
 # list suggestions for /sw/elektra/examples/kdb-complete, only the current level
 kdb complete /sw/elektra/examples/kdb-complete --max-depth=1

--- a/doc/help/kdb-complete.md
+++ b/doc/help/kdb-complete.md
@@ -64,12 +64,10 @@ kdb complete user --max-depth=1
 # list suggestions for the namespace user, only the next level as it ends with /
 # note the difference to the previous example, which uses no trailing /
 kdb complete user/ --max-depth=1
-# RET:0
 # STDOUT-REGEX: .*
 
 # list all possible namespaces or mountpoints, only the current level
 kdb complete --max-depth=1
-# RET:0
 # STDOUT-REGEX: .*
 
 # list suggestions for /sw/elektra/examples/kdb-complete, only the current level

--- a/doc/help/kdb-complete.md
+++ b/doc/help/kdb-complete.md
@@ -3,21 +3,21 @@ kdb-complete(1) -- Show suggestions how to complete a given path
 
 ## SYNOPSIS
 
-`kdb complete [path]`  
+`kdb complete [path]`
 
 Where `path` is the path for which the user would like to receive completion suggestion.
-If `path` is not specified, it will show every possible completion. Its synonymous 
+If `path` is not specified, it will show every possible completion. Its synonymous
 to calling `kdb complete ""`.
 
 ## DESCRIPTION
 
 Show suggestions how the current name could be completed.
-Suggestions will include existing key names, path segments of existing key names, 
+Suggestions will include existing key names, path segments of existing key names,
 namespaces and mountpoints.
-Additionally, the output will indicate whether the given path is a node or a leaf 
+Additionally, the output will indicate whether the given path is a node or a leaf
 in the hierarchy of keys, nodes end with '/' as opposed to leaves.
-It will also work for cascading keys, and will additionally display a cascading 
-key's namespace in the output to indicate from which namespace this suggestion 
+It will also work for cascading keys, and will additionally display a cascading
+key's namespace in the output to indicate from which namespace this suggestion
 originates from.
 
 ## OPTIONS
@@ -29,10 +29,10 @@ originates from.
 - `-p`, `--profile`=<profile>:
   Use a different kdb profile.
 - `-m`, `--min-depth`=<min-depth>:
-  Specify the minimum depth of completion suggestions (0 by default), exclusive 
+  Specify the minimum depth of completion suggestions (0 by default), exclusive
   and relative to the name to complete.
 - `-M`, `--max-depth`=<max-depth>:
-  Specify the maximum depth of completion suggestions (unlimited by default, 1 
+  Specify the maximum depth of completion suggestions (unlimited by default, 1
   to show only the next level), inclusive and relative to the name to complete.
 - `-v`, `--verbose`:
   Give a more detailed output, showing the number of child nodes and the depth level.
@@ -95,6 +95,6 @@ kdb complete /sw/elektra/examples/kdb-complete/ --min-depth=2 --max-depth=4
 
 ## SEE ALSO
 
-- If you would only like to see existing keys under a given path, consider using 
+- If you would only like to see existing keys under a given path, consider using
   the [kdb-ls(1)](kdb-ls.md) command.
 - [elektra-key-names(7)](elektra-key-names.md) for an explanation of key names.

--- a/doc/help/kdb-complete.md
+++ b/doc/help/kdb-complete.md
@@ -55,11 +55,11 @@ kdb set /sw/elektra/examples/kdb-complete/% nothing
 
 # list suggestions for namespaces starting with us, only the current level
 kdb complete us --max-depth=1
-#>user/
+#> user/
 
 # list suggestions for namespaces starting with user, only the current level
 kdb complete user --max-depth=1
-#>user/
+#> user/
 
 # list suggestions for the namespace user, only the next level as it ends with /
 # note the difference to the previous example, which uses no trailing /
@@ -74,22 +74,22 @@ kdb complete --max-depth=1
 
 # list suggestions for /sw/elektra/examples/kdb-complete, only the current level
 kdb complete /sw/elektra/examples/kdb-complete --max-depth=1
-#>user/sw/elektra/examples/kdb-complete/
+#> user/sw/elektra/examples/kdb-complete/
 
 # list suggestions for /sw/elektra/examples/kdb-complete/, only the next level
 # again, note the difference to the previous example which has no trailing /
 kdb complete /sw/elektra/examples/kdb-complete/ --max-depth=1
-#>user/sw/elektra/examples/kdb-complete/%
-#>user/sw/elektra/examples/kdb-complete/#array_1
-#>user/sw/elektra/examples/kdb-complete/buzz
-#>user/sw/elektra/examples/kdb-complete/level1
-#>user/sw/elektra/examples/kdb-complete/lvl1/
+#> user/sw/elektra/examples/kdb-complete/%
+#> user/sw/elektra/examples/kdb-complete/#array_1
+#> user/sw/elektra/examples/kdb-complete/buzz
+#> user/sw/elektra/examples/kdb-complete/level1
+#> user/sw/elektra/examples/kdb-complete/lvl1/
 
 # list suggestions for /sw/elektra/examples/kdb-complete which are minimum 2 levels
 # away from that key, and maximum 4 levels away
 kdb complete /sw/elektra/examples/kdb-complete/ --min-depth=2 --max-depth=4
-#>user/sw/elektra/examples/kdb-complete/lvl1/lvl2/lvl3/
-#>user/sw/elektra/examples/kdb-complete/lvl1/lvl2/lvl3/lvl4/
+#> user/sw/elektra/examples/kdb-complete/lvl1/lvl2/lvl3/
+#> user/sw/elektra/examples/kdb-complete/lvl1/lvl2/lvl3/lvl4/
 
 ```
 

--- a/doc/help/kdb-complete.md
+++ b/doc/help/kdb-complete.md
@@ -89,6 +89,7 @@ kdb complete /sw/elektra/examples/kdb-complete/ --min-depth=2 --max-depth=4
 #> user/sw/elektra/examples/kdb-complete/lvl1/lvl2/lvl3/
 #> user/sw/elektra/examples/kdb-complete/lvl1/lvl2/lvl3/lvl4/
 
+kdb rm -r user/sw/elektra/examples/kdb-complete
 ```
 
 ## SEE ALSO

--- a/doc/help/kdb-complete.md
+++ b/doc/help/kdb-complete.md
@@ -64,11 +64,11 @@ kdb complete user --max-depth=1
 # list suggestions for the namespace user, only the next level as it ends with /
 # note the difference to the previous example, which uses no trailing /
 kdb complete user/ --max-depth=1
-# STDOUT-REGEX: .*
+# STDOUT-REGEX: .+
 
 # list all possible namespaces or mountpoints, only the current level
 kdb complete --max-depth=1
-# STDOUT-REGEX: .*
+# STDOUT-REGEX: .+
 
 # list suggestions for /sw/elektra/examples/kdb-complete, only the current level
 kdb complete /sw/elektra/examples/kdb-complete --max-depth=1

--- a/doc/tutorials/cascading.md
+++ b/doc/tutorials/cascading.md
@@ -25,7 +25,7 @@ With the default Elektra installation only an administrator can update configura
 
 kdb get /sw/tutorial/cascading/#0/current/test
 # RET: 1
-# STDERR:Did not find key
+# STDERR: Did not find key
 
 # Now add the key ...
 sudo kdb set system/sw/tutorial/cascading/#0/current/test "hello world"

--- a/doc/tutorials/cascading.md
+++ b/doc/tutorials/cascading.md
@@ -94,7 +94,7 @@ lookup works.
 
 During a cascading lookup for a specific key, the default Elektra behaviour can be changed by a corresponding `spec-key`, i.e. a key in the **spec** namespace **with the same name**.
 
-For example, the metadata `override/#0` of the respective `spec-key` 
+For example, the metadata `override/#0` of the respective `spec-key`
 can be specified to use a different key in favor of the key itself. This way, we can implement a redirect or symlink like behaviour and therefore even
 config from current folder (`dir` namespace) can be overwritten.
 

--- a/src/plugins/conditionals/README.md
+++ b/src/plugins/conditionals/README.md
@@ -137,6 +137,7 @@ kdb export /examples/conditionals ini
 
 # cleanup
 kdb rm -r /examples/conditionals
+kdb rm -r system/elektra/globalplugins
 sudo kdb umount /examples/conditionals/sub
 sudo kdb umount /examples/conditionals
 ```

--- a/src/plugins/hosts/README.md
+++ b/src/plugins/hosts/README.md
@@ -79,9 +79,9 @@ cat `kdb file /examples/hosts`
 
 # Check if the values are read correctly
 kdb get /examples/hosts/ipv4/localhost
-#>127.0.0.1
+#> 127.0.0.1
 kdb get /examples/hosts/ipv6/localhost
-#>::1
+#> ::1
 
 # Should both fail with error 51 and return 5
 kdb set /examples/hosts/ipv4/localhost ::1

--- a/src/plugins/mini/README.md
+++ b/src/plugins/mini/README.md
@@ -125,7 +125,7 @@ cat stderr.txt | grep 'Reason:' | sed 's/^[[:space:]]*//'
 
 # Unlike the `ini` and `ni` plugin, mINI does not support meta data.
 kdb lsmeta /examples/mini
-# RET:1
+# RET: 1
 
 # The value of `key` also contains the double quote symbol, since mINI does
 # not assign special meaning to quote characters.

--- a/src/plugins/template/template.c
+++ b/src/plugins/template/template.c
@@ -28,7 +28,7 @@ int elektraTemplateClose (Plugin * handle ELEKTRA_UNUSED, Key * errorKey ELEKTRA
 	return ELEKTRA_PLUGIN_STATUS_SUCCESS;
 }
 
-int elektraTemplateGet (Plugin * handle ELEKTRA_UNUSED, KeySet * returned ELEKTRA_UNUSED, Key * parentKey ELEKTRA_UNUSED)
+int elektraTemplateGet (Plugin * handle ELEKTRA_UNUSED, KeySet * returned, Key * parentKey)
 {
 	if (!elektraStrCmp (keyName (parentKey), "system/elektra/modules/template"))
 	{

--- a/src/plugins/xerces/README.md
+++ b/src/plugins/xerces/README.md
@@ -103,5 +103,6 @@ kdb export /examples/xercesfile xerces
 #>
 #> </xerces>
 
+sudo kdb rm -r /examples/xercesfile
 sudo kdb umount /examples/xercesfile
 ```

--- a/tests/shell/shell_recorder/common.sh
+++ b/tests/shell/shell_recorder/common.sh
@@ -1,5 +1,5 @@
 replace_newline_return () {
-	awk '{if (NR>1) {printf line"⏎";} line=$0;} END { printf line; }'
+	awk '{if (NR>1) {printf("%s⏎", line);} line=$0;} END { printf("%s", line); }'
 }
 
 regex_escape () {

--- a/tests/shell/shell_recorder/profiletest.esr
+++ b/tests/shell/shell_recorder/profiletest.esr
@@ -31,3 +31,6 @@ Mountpoint: system/
 
 STDOUT: TEST
 < kdb get /sw/org/myapp/#0/current/testkey
+
+< kdb rm -r system/elektra/globalplugins
+< kdb rm -r /sw/org/myapp/#0

--- a/tests/shell/shell_recorder/tutorial_wrapper/markdown_shell_recorder.sh
+++ b/tests/shell/shell_recorder/tutorial_wrapper/markdown_shell_recorder.sh
@@ -127,7 +127,7 @@ translate()
 		then
 			tmp=$(sed -n 's/\(\s\)*# \(.*\)/\2/p' <<<"$line")
 			cmd=$(cut -d ':' -f1 <<< "$tmp")
-			arg=$(cut -d ':' -f2- <<< "$tmp")
+			arg=$(cut -d ':' -f2- <<< "$tmp" | sed 's/[[:space:]]*//')
 
 			case "$cmd" in
 				RET)

--- a/tests/shell/shell_recorder/tutorial_wrapper/markdown_shell_recorder.sh
+++ b/tests/shell/shell_recorder/tutorial_wrapper/markdown_shell_recorder.sh
@@ -60,7 +60,7 @@ writeBlock()
 	else
 		if [ ! -z "$STDOUTRE" ]
 		then
-			echo "STDOUT-REGEX: $STDOUT" >> "$TMPFILE"
+			echo "STDOUT-REGEX: $STDOUTRE" >> "$TMPFILE"
 		else
 			if [ ! -z "$STDOUTGLOB" ];
 			then


### PR DESCRIPTION
# Purpose

This pull request fixes minor problems concerning (Markdown) Shell Recorder tests, including the issues below.

1. All Markdown Shell Recorder (MSR) tests  should now properly clean up modifications to the database.
2. The MSR now tests output following `STDOUT-REGEX:` properly.
3. Markdown Shell Recorder tests now supports whitespace after directives such as `RET:` or `STDOUT-REGEX:`.

# Checklist

- [x] I checked all commit messages twice.
- [x] I ran all tests and everything went fine.