### PR TITLE
ruby kdbtools: MountBackendBuilder.to_add getter + missing exception

### DIFF
--- a/src/bindings/swig/ruby/kdbtools.i
+++ b/src/bindings/swig/ruby/kdbtools.i
@@ -584,15 +584,18 @@ STATUS_OSTREAM_TO_STRING(kdb::tools::ImportExportBackend)
 
 %catches(kdb::tools::NoGlobalPlugin,
          kdb::tools::BackendCheckException,
+         kdb::tools::OrderingViolation,
          kdb::tools::ToolException
 ) kdb::tools::GlobalPlugins::serialize;
 
 %catches(kdb::tools::TooManyPlugins,
+         kdb::tools::OrderingViolation,
          kdb::tools::ToolException,
          ...
 ) kdb::tools::SerializeInterface::serialize;
 
 %catches(kdb::tools::TooManyPlugins,
+         kdb::tools::OrderingViolation,
          kdb::tools::ToolException,
          ...
 ) kdb::tools::GlobalPluginsBuilder::serialize;
@@ -639,6 +642,11 @@ STATUS_OSTREAM_TO_STRING(kdb::tools::ImportExportBackend)
 %ignore kdb::tools::BackendBuilder::end;
 %ignore kdb::tools::BackendBuilder::cbegin;
 %ignore kdb::tools::BackendBuilder::cend;
+%extend kdb::tools::BackendBuilder {
+    PluginSpecVector to_add() {
+       return PluginSpecVector($self->begin(), $self->end());
+    }
+}
 
 %rename("backend_config") kdb::tools::BackendBuilder::getBackendConfig;
 %rename("backend_config=") kdb::tools::BackendBuilder::setBackendConfig;


### PR DESCRIPTION
# Purpose

To allow better plugin handling with puppet-libelektra (kdbmount), we have to check which plugins a Backend actually resolves. This PR addes a `to_add` getter method to `Kdbtools::MountBackendBuilder` to allow to query the actually used plugins by the Backend. The C++ API has iterator methods for this, but these are excluded by the Ruby bindings.

# Checklist

- [x] commit messages are fine (with references to issues)
- [x] I ran all tests and everything went fine
- [ ] I added unit tests
- [x] affected documentation is fixed
- [x] I added code comments, logging, and assertions
- [ ] meta data is updated (e.g. README.md of plugins)

@markus2330 please review my pull request
