### PR TITLE
fcrypt: add sign/verify feature

### DIFF
--- a/src/error/specification
+++ b/src/error/specification
@@ -1083,3 +1083,10 @@ severity:warning
 ingroup:plugin
 macro:NOT_VALID_KEY_VALUE_PAIR
 module:mini
+
+number:176
+description:Neither a GPG recipient (specified as /gpg/key) nor a GPG signature key (specified as /fcrypt/sign) has been provided. Please provide at least one key.
+severity:error
+ingroup:plugin
+macro:FCRYPT_OPERATION_MODE
+module:fcrypt

--- a/src/plugins/fcrypt/README.md
+++ b/src/plugins/fcrypt/README.md
@@ -15,6 +15,7 @@
 ## Introduction
 
 This plugin enables file based encryption and decryption using GPG.
+Also an option for signing and verifying files using GPG is provided.
 
 This plugin encrypts backend files before the commit is executed (thus `precommit`).
 The plugin decrypts the backend files before the getstorage opens it (thus `pregetstorage`).
@@ -49,6 +50,8 @@ Please note that this is a workaround until a more sustainable solution is found
 
 ## Dependencies
 
+### Crypto Plugin
+
 This plugin uses parts of the `crypto` plugin.
 
 ### GnuPG (GPG)
@@ -76,6 +79,18 @@ But you can still access `/t/a` with `kdb get`:
 	kdb get /t/a
 
 ## Configuration
+
+### Signatures
+
+The GPG signature keys can be specified as `/fcrypt/sign` directly.
+If you want to use more than one key for signing, just enumerate like:
+
+    /fcrypt/sign/#0
+    /fcrypt/sign/#1
+
+If more than one key is defined, every private key is used to sign the file of the backend.
+
+If a signature is attached to a file, `fcrypt` automatically verifies its content whenever the file is being read.
 
 ### GPG Configuration
 

--- a/src/plugins/fcrypt/fcrypt.c
+++ b/src/plugins/fcrypt/fcrypt.c
@@ -44,6 +44,7 @@ struct _fcryptState
 typedef struct _fcryptState fcryptState;
 
 #define ELEKTRA_FCRYPT_TMP_FILE_SUFFIX "XXXXXX"
+#define ELEKTRA_FCRYPT_SIGN_KEY "/fcrypt/sign"
 
 /**
  * @brief Allocates a new string holding the name of the temporary file.
@@ -112,13 +113,14 @@ static int inTestMode (KeySet * conf)
 /**
  * @brief Read number of total GPG recipient keys from the plugin configuration.
  * @param config holds the plugin configuration
+ * @param keyName holds the name of the root key to look up
  * @returns the number of GPG recipient keys.
  */
-static size_t getRecipientCount (KeySet * config)
+static size_t getRecipientCount (KeySet * config, const char * keyName)
 {
 	Key * k;
 	size_t recipientCount = 0;
-	Key * root = ksLookupByName (config, ELEKTRA_CRYPTO_PARAM_GPG_KEY, 0);
+	Key * root = ksLookupByName (config, keyName, 0);
 
 	if (!root) return 0;
 
@@ -245,25 +247,27 @@ static int fcryptGpgCallAndCleanup (Key * parentKey, KeySet * pluginConfig, char
 }
 
 /**
- * @brief encrypt the file specified at parentKey
+ * @brief encrypt or sign the file specified at parentKey
  * @param pluginConfig holds the plugin configuration
- * @pararm parentKey holds the path to the file to be encrypted. Will hold an error description in case of failure.
+ * @param parentKey holds the path to the file to be encrypted. Will hold an error description in case of failure.
  * @retval 1 on success
  * @retval -1 on error, errorKey holds an error description
  */
 static int fcryptEncrypt (KeySet * pluginConfig, Key * parentKey)
 {
-	const size_t recipientCount = getRecipientCount (pluginConfig);
-	if (recipientCount == 0)
+	const size_t recipientCount = getRecipientCount (pluginConfig, ELEKTRA_CRYPTO_PARAM_GPG_KEY);
+	const size_t signatureCount = getRecipientCount (pluginConfig, ELEKTRA_FCRYPT_SIGN_KEY);
+
+	if (recipientCount == 0 && signatureCount == 0)
 	{
-		ELEKTRA_SET_ERRORF (ELEKTRA_ERROR_CRYPTO_CONFIG_FAULT, parentKey,
-				    "Missing GPG key (specified as %s) in plugin configuration.", ELEKTRA_CRYPTO_PARAM_GPG_KEY);
+		ELEKTRA_SET_ERRORF (
+			ELEKTRA_ERROR_FCRYPT_OPERATION_MODE, parentKey,
+			"Missing GPG recipient key (specified as %s) or GPG signature key (specified as %s) in plugin configuration.",
+			ELEKTRA_CRYPTO_PARAM_GPG_KEY, ELEKTRA_FCRYPT_SIGN_KEY);
 		return -1;
 	}
 
-	const size_t testMode = inTestMode (pluginConfig);
 	int tmpFileFd = -1;
-
 	char * tmpFile = getTemporaryFileName (keyString (parentKey), &tmpFileFd);
 	if (!tmpFile)
 	{
@@ -271,8 +275,19 @@ static int fcryptEncrypt (KeySet * pluginConfig, Key * parentKey)
 		return -1;
 	}
 
+	const size_t testMode = inTestMode (pluginConfig);
+
 	// prepare argument vector for gpg call
-	int argc = 8 + (2 * recipientCount) + (2 * testMode);
+	// 7 static arguments (magic number below) are:
+	//   1. path to the binary
+	//   2. --batch
+	//   3. -o
+	//   4. path to tmp file
+	//   5. yes
+	//   6. file to be encrypted
+	//   7. NULL terminator
+	int argc = 7 + (2 * recipientCount) + (2 * signatureCount) + (2 * testMode) + (recipientCount > 0 ? 1 : 0) +
+		   (signatureCount > 0 ? 1 : 0);
 	kdb_unsigned_short_t i = 0;
 	char * argv[argc];
 	argv[i++] = NULL;
@@ -305,6 +320,29 @@ static int fcryptEncrypt (KeySet * pluginConfig, Key * parentKey)
 		}
 	}
 
+	// add signature keys
+	root = ksLookupByName (pluginConfig, ELEKTRA_FCRYPT_SIGN_KEY, 0);
+
+	// append root signature key
+	if (root && strlen (keyString (root)) > 0)
+	{
+		argv[i++] = "-u";
+		// NOTE argv[] values will not be modified, so const can be discarded safely
+		argv[i++] = (char *)keyString (root);
+	}
+
+	// append keys beneath root (fcrypt/sign/#_) as gpg signature keys
+	ksRewind (pluginConfig);
+	while ((k = ksNext (pluginConfig)) != 0)
+	{
+		if (keyIsBelow (k, root))
+		{
+			argv[i++] = "-u";
+			// NOTE argv[] values will not be modified, so const can be discarded safely
+			argv[i++] = (char *)keyString (k);
+		}
+	}
+
 	// if we are in test mode we add the trust model
 	if (testMode > 0)
 	{
@@ -313,7 +351,16 @@ static int fcryptEncrypt (KeySet * pluginConfig, Key * parentKey)
 	}
 
 	// prepare rest of the argument vector
-	argv[i++] = "-e";
+	if (recipientCount > 0)
+	{
+		// encrypt the file
+		argv[i++] = "-e";
+	}
+	if (signatureCount > 0)
+	{
+		// sign the file
+		argv[i++] = "-s";
+	}
 	argv[i++] = (char *)keyString (parentKey);
 	argv[i++] = NULL;
 
@@ -327,7 +374,7 @@ static int fcryptEncrypt (KeySet * pluginConfig, Key * parentKey)
 /**
  * @brief decrypt the file specified at parentKey
  * @param pluginConfig holds the plugin configuration
- * @pararm parentKey holds the path to the file to be encrypted. Will hold an error description in case of failure.
+ * @param parentKey holds the path to the file to be encrypted. Will hold an error description in case of failure.
  * @retval 1 on success
  * @retval -1 on error, errorKey holds an error description
  */
@@ -342,6 +389,17 @@ static int fcryptDecrypt (KeySet * pluginConfig, Key * parentKey)
 	}
 
 	const size_t testMode = inTestMode (pluginConfig);
+
+	// prepare argument vector for gpg call
+	// 8 static arguments (magic number below) are:
+	//   1. path to the binary
+	//   2. --batch
+	//   3. -o
+	//   4. path to tmp file
+	//   5. yes
+	//   6. -d
+	//   7. file to be encrypted
+	//   8. NULL terminator
 	int argc = 8 + (2 * testMode);
 	char * argv[argc];
 	int i = 0;
@@ -351,7 +409,7 @@ static int fcryptDecrypt (KeySet * pluginConfig, Key * parentKey)
 	argv[i++] = "--yes";
 
 	// if we are in test mode we add the trust model
-	if (inTestMode (pluginConfig))
+	if (testMode)
 	{
 		argv[i++] = "--trust-model";
 		argv[i++] = "always";
@@ -363,7 +421,6 @@ static int fcryptDecrypt (KeySet * pluginConfig, Key * parentKey)
 	// safely discarding const from keyString() return value
 	argv[i++] = (char *)keyString (parentKey);
 	argv[i++] = NULL;
-
 
 	// NOTE the decryption process works like this:
 	// gpg2 --batch --yes -o tmpfile -d configFile
@@ -494,16 +551,7 @@ int ELEKTRA_PLUGIN_FUNCTION (ELEKTRA_PLUGIN_NAME, set) (Plugin * handle, KeySet 
 }
 
 /**
- * @brief Checks for the existence of the master password, that is used for encryption and decryption.
- *
- * If the master password can not be found it will be generated randomly.
- * Then it will be encrypted and stored in conf.
- *
- * If the master password can be found, it will be decrypted temporarily in order to verify its correctness.
- * conf will not be modified in this case.
- *
- * An error might occur during the password generation, encryption and decryption.
- * The error will be appended to errorKey.
+ * @brief Checks if at least one GPG recipient or at least one GPG signature key hast been provided within the plugin configuration.
  *
  * @retval 0 no changes were made to the configuration
  * @retval 1 the master password has been appended to the configuration
@@ -511,10 +559,13 @@ int ELEKTRA_PLUGIN_FUNCTION (ELEKTRA_PLUGIN_NAME, set) (Plugin * handle, KeySet 
  */
 int ELEKTRA_PLUGIN_FUNCTION (ELEKTRA_PLUGIN_NAME, checkconf) (Key * errorKey, KeySet * conf)
 {
-	if (getRecipientCount (conf) == 0)
+	const size_t recipientCount = getRecipientCount (conf, ELEKTRA_CRYPTO_PARAM_GPG_KEY);
+	const size_t signatureCount = getRecipientCount (conf, ELEKTRA_FCRYPT_SIGN_KEY);
+
+	if (recipientCount == 0 && signatureCount == 0)
 	{
 		char * errorDescription = CRYPTO_PLUGIN_FUNCTION (getMissingGpgKeyErrorText) (conf);
-		ELEKTRA_SET_ERROR (ELEKTRA_ERROR_CRYPTO_CONFIG_FAULT, errorKey, errorDescription);
+		ELEKTRA_SET_ERROR (ELEKTRA_ERROR_FCRYPT_OPERATION_MODE, errorKey, errorDescription);
 		elektraFree (errorDescription);
 		return -1;
 	}


### PR DESCRIPTION
# Purpose

Enable sign/verify operation for `fcrypt`.

See `README.md` to find out how it is supposed to work.

See #1009 for full discussion. Closes #1009 .

# TODO

- [x] add unit tests
- [ ] check the behaviour of failed verifications

# Checklist

Please only check relevant points.
For docu fixes, spell checking and similar nothing
needs to be checked.

- [X] commit messages are fine (with references to issues)
- [x] I ran all tests and everything went fine
- [x] I added unit tests
- [x] affected documentation is fixed
- [x] I added code comments, logging, and assertions
