### PR TITLE
spec: also create default keys

### DIFF
--- a/src/plugins/spec/spec.c
+++ b/src/plugins/spec/spec.c
@@ -736,6 +736,14 @@ static int doGlobbing (Key * parentKey, KeySet * returned, KeySet * specKS, Conf
 				ksAppendKey (returned, keyDup (newKey));
 				keyDel (newKey);
 			}
+			else if (keyGetMeta (specKey, "default"))
+			{
+				Key * newKey = keyNew (strchr (keyName (specKey), '/'), KEY_CASCADING_NAME, KEY_VALUE,
+						       keyString (keyGetMeta (specKey, "default")), KEY_END);
+				copyMeta (newKey, specKey, parentKey);
+				ksAppendKey (returned, keyDup (newKey));
+				keyDel (newKey);
+			}
 		}
 		while ((cur = ksNext (returned)) != NULL)
 		{


### PR DESCRIPTION
# Purpose

let the spec plugin create default keys


- [x] commit messages are fine (with references to issues)
- [ ] I ran all tests and everything went fine
- [ ] I added unit tests
- [ ] affected documentation is fixed
- [ ] I added code comments, logging, and assertions
- [ ] meta data is updated (e.g. README.md of plugins)
