### PR TITLE
crypto: code cleanup and documentation fixes

### DIFF
--- a/src/plugins/crypto/contract.h
+++ b/src/plugins/crypto/contract.h
@@ -12,7 +12,6 @@ keyNew ("system/elektra/modules/" ELEKTRA_PLUGIN_NAME, KEY_VALUE, "crypto plugin
 	keyNew ("system/elektra/modules/" ELEKTRA_PLUGIN_NAME "/exports/close", KEY_FUNC, CRYPTO_PLUGIN_FUNCTION (close), KEY_END),
 	keyNew ("system/elektra/modules/" ELEKTRA_PLUGIN_NAME "/exports/get", KEY_FUNC, CRYPTO_PLUGIN_FUNCTION (get), KEY_END),
 	keyNew ("system/elektra/modules/" ELEKTRA_PLUGIN_NAME "/exports/set", KEY_FUNC, CRYPTO_PLUGIN_FUNCTION (set), KEY_END),
-	keyNew ("system/elektra/modules/" ELEKTRA_PLUGIN_NAME "/exports/error", KEY_FUNC, CRYPTO_PLUGIN_FUNCTION (error), KEY_END),
 	keyNew ("system/elektra/modules/" ELEKTRA_PLUGIN_NAME "/exports/checkconf", KEY_FUNC, CRYPTO_PLUGIN_FUNCTION (checkconf), KEY_END),
 #include ELEKTRA_README (crypto)
 	keyNew ("system/elektra/modules/" ELEKTRA_PLUGIN_NAME "/infos/version", KEY_VALUE, PLUGINVERSION, KEY_END),

--- a/src/plugins/crypto/crypto.c
+++ b/src/plugins/crypto/crypto.c
@@ -336,8 +336,10 @@ error:
 /**
  * @brief initialize the crypto provider for the first instance of the plugin.
  *
+ * @param handle holds the plugin handle
+ * @param errorKey holds an error description in case of failure
  * @retval 1 on success
- * @retval -1 on failure
+ * @retval -1 on failure. Check errorKey
  */
 int CRYPTO_PLUGIN_FUNCTION (open) (Plugin * handle ELEKTRA_UNUSED, Key * errorKey)
 {
@@ -358,6 +360,8 @@ int CRYPTO_PLUGIN_FUNCTION (open) (Plugin * handle ELEKTRA_UNUSED, Key * errorKe
 /**
  * @brief finalizes the crypto provider for the last instance of the plugin.
  *
+ * @param handle holds the plugin handle
+ * @param errorKey holds an error description in case of failure. Not used at the moment.
  * @retval 1 on success
  * @retval -1 on failure
  */
@@ -398,8 +402,11 @@ int CRYPTO_PLUGIN_FUNCTION (close) (Plugin * handle, Key * errorKey ELEKTRA_UNUS
  * The crypto configuration is expected to be contained within the KeySet ks.
  * All keys having a metakey "crypto/encrypted" with a strlen() > 0 are being decrypted.
  *
+ * @param handle holds the plugin handle
+ * @param ks holds the data to be operated on
+ * @param parentKey holds an error description in case of failure
  * @retval 1 on success
- * @retval -1 on failure
+ * @retval -1 on failure. Check parentKey.
  */
 int CRYPTO_PLUGIN_FUNCTION (get) (Plugin * handle, KeySet * ks, Key * parentKey)
 {
@@ -414,11 +421,6 @@ int CRYPTO_PLUGIN_FUNCTION (get) (Plugin * handle, KeySet * ks, Key * parentKey)
 		return 1;
 	}
 
-	// the actual decryption
-
-	// for now we expect the crypto configuration to be stored in the KeySet ks
-	// we may add more options in the future
-
 	return elektraCryptoDecrypt (handle, ks, parentKey);
 }
 
@@ -428,14 +430,14 @@ int CRYPTO_PLUGIN_FUNCTION (get) (Plugin * handle, KeySet * ks, Key * parentKey)
  * If a key has the metakey "crypto/encrypt" with a strlen() > 0, then the value
  * will be encrypted using the configuration stored in the KeySet ks.
  *
+ * @param handle holds the plugin handle
+ * @param ks holds the data to be operated on
+ * @param parentKey holds an error description in case of failure
  * @retval 1 on success
- * @retval -1 on failure
+ * @retval -1 on failure. Check parentKey.
  */
 int CRYPTO_PLUGIN_FUNCTION (set) (Plugin * handle, KeySet * ks, Key * parentKey)
 {
-	// for now we expect the crypto configuration to be stored in the KeySet ks
-	// we may add more options in the future
-
 	return elektraCryptoEncrypt (handle, ks, parentKey);
 }
 
@@ -451,6 +453,8 @@ int CRYPTO_PLUGIN_FUNCTION (set) (Plugin * handle, KeySet * ks, Key * parentKey)
  * An error might occur during the password generation, encryption and decryption.
  * The error will be appended to errorKey.
  *
+ * @param errorKey holds an error description in case of failure
+ * @param conf holds the plugin configuration
  * @retval 0 no changes were made to the configuration
  * @retval 1 the master password has been appended to the configuration
  * @retval -1 an error occurred. Check errorKey
@@ -494,16 +498,6 @@ int CRYPTO_PLUGIN_FUNCTION (checkconf) (Key * errorKey, KeySet * conf)
 	}
 }
 
-/**
- * @brief TBD
- * @retval 1 on success
- * @retval -1 on failure
- */
-int CRYPTO_PLUGIN_FUNCTION (error) (Plugin * handle ELEKTRA_UNUSED, KeySet * ks ELEKTRA_UNUSED, Key * parentKey ELEKTRA_UNUSED)
-{
-	return 1;
-}
-
 Plugin * ELEKTRA_PLUGIN_EXPORT (crypto)
 {
 	// clang-format off
@@ -512,6 +506,5 @@ Plugin * ELEKTRA_PLUGIN_EXPORT (crypto)
 			ELEKTRA_PLUGIN_CLOSE, &CRYPTO_PLUGIN_FUNCTION(close),
 			ELEKTRA_PLUGIN_GET,   &CRYPTO_PLUGIN_FUNCTION(get),
 			ELEKTRA_PLUGIN_SET,   &CRYPTO_PLUGIN_FUNCTION(set),
-			ELEKTRA_PLUGIN_ERROR, &CRYPTO_PLUGIN_FUNCTION(error),
 			ELEKTRA_PLUGIN_END);
 }

--- a/src/plugins/crypto/crypto.h
+++ b/src/plugins/crypto/crypto.h
@@ -76,7 +76,6 @@ int CRYPTO_PLUGIN_FUNCTION (close) (Plugin * handle, Key * errorKey);
 int CRYPTO_PLUGIN_FUNCTION (get) (Plugin * handle, KeySet * ks, Key * parentKey);
 int CRYPTO_PLUGIN_FUNCTION (set) (Plugin * handle, KeySet * ks, Key * parentKey);
 int CRYPTO_PLUGIN_FUNCTION (checkconf) (Key * errorKey, KeySet * conf);
-int CRYPTO_PLUGIN_FUNCTION (error) (Plugin * handle, KeySet * ks, Key * parentKey);
 
 Plugin * ELEKTRA_PLUGIN_EXPORT (crypto);
 

--- a/src/plugins/crypto/test_internals.h
+++ b/src/plugins/crypto/test_internals.h
@@ -125,7 +125,6 @@ static void test_init (const char * pluginName)
 		succeed_if (plugin->kdbClose != 0, "no close pointer");
 		succeed_if (plugin->kdbGet != 0, "no get pointer");
 		succeed_if (plugin->kdbSet != 0, "no set pointer");
-		succeed_if (plugin->kdbError != 0, "no error pointer");
 
 		// try re-opening the plugin
 		succeed_if (plugin->kdbClose (plugin, parentKey) == 1, "kdb close failed");


### PR DESCRIPTION
# Purpose

- remove unsued `error()` function from plugin exports
- fix several doxygen comments

# Checklist

Please only check relevant points.
For docu fixes, spell checking and similar nothing
needs to be checked.

- [ ] commit messages are fine (with references to issues)
- [x] I ran all tests and everything went fine
- [ ] I added unit tests
- [ ] affected documentation is fixed
- [ ] I added code comments, logging, and assertions
- [ ] meta data is updated (e.g. README.md of plugins)

@markus2330 please review my pull request
