### PR TITLE
Quality improvements

### DIFF
--- a/scripts/cbmc
+++ b/scripts/cbmc
@@ -22,7 +22,7 @@ ARG="--depth 200 -D ELEKTRA_BMC"
 EINC="-I $EDIR/src/include -I $BDIR/src/include"
 if stringContain "Darwin" "$(uname)"; then
 	YINC="-I /usr/local/include/yajl -I $BDIR/src/plugins/yajl"
-yelse
+else
 	YINC="-I /user/include/yajl -I $BDIR/src/plugins/yajl"
 fi
 

--- a/scripts/cbmc
+++ b/scripts/cbmc
@@ -20,7 +20,11 @@ set -ex
 
 ARG="--depth 200 -D ELEKTRA_BMC"
 EINC="-I $EDIR/src/include -I $BDIR/src/include"
-YINC="-I /usr/include/yajl -I $BDIR/src/plugins/yajl"
+if stringContain "Darwin" "$(uname)"; then
+	YINC="-I /usr/local/include/yajl -I $BDIR/src/plugins/yajl"
+yelse
+	YINC="-I /user/include/yajl -I $BDIR/src/plugins/yajl"
+fi
 
 cd $EDIR/src/plugins/yajl
 cbmc --function elektraYajlSet $ARG $YINC $EINC yajl_gen.c

--- a/src/libs/ease/array.c
+++ b/src/libs/ease/array.c
@@ -60,7 +60,7 @@ int elektraArrayValidateName (const Key * key)
 			underscores++;
 		}
 
-		for (; isdigit ((unsigned char) *current); current++)
+		for (; isdigit ((unsigned char)*current); current++)
 		{
 			digits++;
 		}

--- a/src/libs/ease/array.c
+++ b/src/libs/ease/array.c
@@ -60,7 +60,7 @@ int elektraArrayValidateName (const Key * key)
 			underscores++;
 		}
 
-		for (; isdigit (*current); current++)
+		for (; isdigit ((unsigned char) *current); current++)
 		{
 			digits++;
 		}

--- a/src/libs/ease/keyname.c
+++ b/src/libs/ease/keyname.c
@@ -13,10 +13,17 @@
 /**
  * @brief get relative position of key based on parentKey
  *
+ * @pre  parentKey is either the same key as cur, or one of its parents
+ * @post a pointer to the relevant part of the parent key's name, the full
+ * name if there is no relation to the parentKey
+ *
+ * If the parentKey does not fulfill the precondition, the result won't be the
+ * correct relative key of cur.
+ *
  * @param cur the key below parentKey we want to get the relative basename of
  * @param parentKey the key that defines the root/base
  *
- * @return a pointer to the name of the key cur
+ * @return a pointer to the relative part name of the key cur
  */
 const char * elektraKeyGetRelativeName (Key const * cur, Key const * parentKey)
 {
@@ -29,6 +36,14 @@ const char * elektraKeyGetRelativeName (Key const * cur, Key const * parentKey)
 		{
 			offset += strstr (keyName (cur), keyName (parentKey)) - keyName (cur);
 		}
+	}
+	if (offset == keyGetNameSize (cur))
+	{
+		offset = keyGetNameSize (cur) - 1; // equality of the keys
+	}
+	else if (offset > keyGetNameSize (cur))
+	{
+		offset = 0; // no relation or invalid arguments, return full name
 	}
 	return keyName (cur) + offset;
 }

--- a/src/libs/ease/keyname.c
+++ b/src/libs/ease/keyname.c
@@ -27,7 +27,7 @@
  */
 const char * elektraKeyGetRelativeName (Key const * cur, Key const * parentKey)
 {
-	size_t offset = 0;
+	ssize_t offset = 0;
 
 	if (strcmp (keyName (parentKey), "/"))
 	{

--- a/src/libs/elektra/keyvalue.c
+++ b/src/libs/elektra/keyvalue.c
@@ -514,7 +514,7 @@ ssize_t keySetRaw (Key * key, const void * newBinary, size_t dataSize)
 		if (key->data.v)
 		{
 			elektraFree (key->data.v);
-			key->data.v = 0;
+			key->data.v = NULL;
 		}
 		key->dataSize = 0;
 		set_bit (key->flags, KEY_FLAG_SYNC);
@@ -525,20 +525,26 @@ ssize_t keySetRaw (Key * key, const void * newBinary, size_t dataSize)
 	key->dataSize = dataSize;
 	if (key->data.v)
 	{
-		char * p = 0;
-		p = realloc (key->data.v, key->dataSize);
-		if (0 == p) return -1;
-		key->data.v = p;
+		char * previous = key->data.v;
+		if (-1 == elektraRealloc ((void **)&key->data.v, key->dataSize)) return -1;
+		if (previous == key->data.v)
+		{
+			// In case the regions overlap, use memmove to stay safe
+			memmove (key->data.v, newBinary, key->dataSize);
+		}
+		else
+		{
+			memcpy (key->data.v, newBinary, key->dataSize);
+		}
 	}
 	else
 	{
 		char * p = elektraMalloc (key->dataSize);
-		if (0 == p) return -1;
+		if (NULL == p) return -1;
 		key->data.v = p;
+		memcpy (key->data.v, newBinary, key->dataSize);
 	}
 
-
-	memcpy (key->data.v, newBinary, key->dataSize);
 	set_bit (key->flags, KEY_FLAG_SYNC);
 	return keyGetValueSize (key);
 }

--- a/src/plugins/ini/ini.c
+++ b/src/plugins/ini/ini.c
@@ -398,7 +398,8 @@ static int iniKeyToElektraKey (void * vhandle, const char * section, const char 
 		else if (!lineContinuation)
 		{
 			keyDel (appendKey);
-			ELEKTRA_SET_ERRORF (141, handle->parentKey, "Key: %s\n", keyName (existingKey));
+			ELEKTRA_SET_ERRORF (141, handle->parentKey, "We found the key %s a second time in the INI file in section %s\n",
+					    keyName (existingKey), section);
 			return -1;
 		}
 	}

--- a/src/plugins/range/range.c
+++ b/src/plugins/range/range.c
@@ -12,6 +12,7 @@
 #include <errno.h>
 #include <kdberrors.h>
 #include <kdbhelper.h>
+#include <kdbassert.h>
 #include <math.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -41,8 +42,11 @@ typedef struct
 // switch min and max values if needed and apply -1 factor
 static void normalizeValues (RangeType type, RangeValue * min, RangeValue * max, RangeValue * a, RangeValue * b, int factorA, int factorB)
 {
-	unsigned long long int tmpIA = (unsigned long long)(factorA * (*a).Value.i);
-	unsigned long long int tmpIB = (unsigned long long)(factorB * (*b).Value.i);
+	ELEKTRA_ASSERT (factorA == -1 || factorA == 1, "factorA has to be -1 or 1 to guarantee range bounds, but is %d", factorA);
+	ELEKTRA_ASSERT (factorB == -1 || factorB == 1, "factorB has to be -1 or 1 to guarantee range bounds, but is %d", factorB);
+	// AddressSanitizer complains about this, but we guarantee the factor is either 1 or -1 so it's fine
+	unsigned long long int tmpIA = (unsigned long long int)(factorA * (*a).Value.i);
+	unsigned long long int tmpIB = (unsigned long long int)(factorB * (*b).Value.i);
 	long double tmpFA = factorA * (*a).Value.f;
 	long double tmpFB = factorB * (*b).Value.f;
 	switch (type)

--- a/src/plugins/range/testmod_range.c
+++ b/src/plugins/range/testmod_range.c
@@ -8,6 +8,7 @@
  */
 
 #include <kdbconfig.h>
+#include <limits.h>
 #include <locale.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -177,6 +178,21 @@ int main (int argc, char ** argv)
 
 	testChar ("g", -1, "a-f");
 	testChar ("c", 1, "a-f");
+
+	// test edge cases
+	char number[256];
+	char range[256];
+	snprintf (number, 256, "%lld", LLONG_MAX);
+	snprintf (range, 256, "%lld - %lld", LLONG_MIN, LLONG_MAX);
+	testInt (number, 1, range);
+	snprintf (number, 256, "%lld", LLONG_MIN);
+	testInt (number, 1, range);
+
+	snprintf (number, 256, "%llu", ULLONG_MAX);
+	snprintf (range, 256, "%llu - %llu", 1ULL, ULLONG_MAX);
+	testUInt (number, 1, range);
+	snprintf (number, 256, "%llu", 1ULL);
+	testUInt (number, 1, range);
 
 	setlocale (LC_ALL, old_locale);
 	elektraFree (old_locale);

--- a/src/plugins/xerces/README.md
+++ b/src/plugins/xerces/README.md
@@ -82,7 +82,7 @@ XSD transformations, schemas or DTDs are not supported yet.
 ```sh
 # Backup-and-Restore:/examples/xercesfile
 
-sudo kdb mount /xerces.xml /examples/xercesfile xerces
+sudo kdb mount xerces.xml /examples/xercesfile xerces
 
 kdb set /examples/xercesfile foo
 kdb setmeta /examples/xercesfile xerces/rootname xerces

--- a/src/plugins/xerces/README.md
+++ b/src/plugins/xerces/README.md
@@ -82,7 +82,7 @@ XSD transformations, schemas or DTDs are not supported yet.
 ```sh
 # Backup-and-Restore:/examples/xercesfile
 
-sudo kdb mount xerces.xml /examples/xercesfile xerces
+sudo kdb mount /xerces.xml /examples/xercesfile xerces
 
 kdb set /examples/xercesfile foo
 kdb setmeta /examples/xercesfile xerces/rootname xerces

--- a/src/plugins/xerces/serializer.cpp
+++ b/src/plugins/xerces/serializer.cpp
@@ -108,7 +108,7 @@ void appendKey (DOMDocument & doc, KeySet const & ks, Key const & parentKey, str
 		name++;
 	}
 
-	if (name == key.end ()) throw new XercesPluginException ("Key " + key.getFullName () + " is not under " + parentKey.getFullName ());
+	if (name == key.end ()) throw XercesPluginException ("Key " + key.getFullName () + " is not under " + parentKey.getFullName ());
 
 	// restore original root element name if present
 	const auto rootPos = name;
@@ -116,7 +116,7 @@ void appendKey (DOMDocument & doc, KeySet const & ks, Key const & parentKey, str
 	// Now create the path
 	Key currentPathKey = parentKey.dup ();
 	string actualName;
-	DOMElement * child;
+	DOMElement * child = nullptr;
 	for (; name != key.end (); name++)
 	{
 		actualName = !originalRootName.empty () && name == rootPos ? originalRootName : (*name);
@@ -135,7 +135,7 @@ void appendKey (DOMDocument & doc, KeySet const & ks, Key const & parentKey, str
 	}
 
 	// Now we are at the key's insertion point and the last key name part, the loop has already set all our elements
-	key2xml (doc, *child, actualName, key);
+	if (child) key2xml (doc, *child, actualName, key);
 }
 
 void ks2dom (DOMDocument & doc, Key const & parentKey, KeySet const & ks)

--- a/tests/abi/testabi_ks.c
+++ b/tests/abi/testabi_ks.c
@@ -1147,9 +1147,9 @@ static void test_ksLookupName ()
 	ksAppendKey (ks, keyNew ("user/named/key", KEY_VALUE, "myvalue", KEY_END));
 	ksAppendKey (ks, keyNew ("system/named/syskey", KEY_VALUE, "syskey", KEY_END));
 	ksAppendKey (ks, keyNew ("system/sysonly/key", KEY_VALUE, "sysonlykey", KEY_END));
-	ksAppendKey (ks, keyNew ("user/named/bin", KEY_BINARY, KEY_SIZE, 10, KEY_VALUE, "binary\1\2data", KEY_END));
-	ksAppendKey (ks, keyNew ("system/named/bin", KEY_BINARY, KEY_SIZE, 10, KEY_VALUE, "sys\1bin\2", KEY_END));
-	ksAppendKey (ks, keyNew ("system/named/key", KEY_BINARY, KEY_SIZE, 10, KEY_VALUE, "syskey", KEY_END));
+	ksAppendKey (ks, keyNew ("user/named/bin", KEY_BINARY, KEY_SIZE, strlen ("binary\1\2data"), KEY_VALUE, "binary\1\2data", KEY_END));
+	ksAppendKey (ks, keyNew ("system/named/bin", KEY_BINARY, KEY_SIZE, strlen ("sys\1bin\2"), KEY_VALUE, "sys\1bin\2", KEY_END));
+	ksAppendKey (ks, keyNew ("system/named/key", KEY_BINARY, KEY_SIZE, strlen ("syskey"), KEY_VALUE, "syskey", KEY_END));
 	succeed_if (ksGetSize (ks) == 8, "could not append all keys");
 
 	// a positive testcase
@@ -1213,13 +1213,13 @@ static void test_ksLookupName ()
 	succeed_if (ksCurrent (ks) == found, "current not set correctly");
 	succeed_if (found != 0, "did not find correct name");
 	succeed_if_same_string (keyName (found), "system/named/key");
-	succeed_if_same_string (keyValue (found), "syskey");
+	succeed_if (strncmp (keyValue (found), "syskey", strlen ("syskey")) == 0, "not correct value in found key");
 
 	found = ksLookupByName (ks, "user/named/bin", 0);
 	succeed_if (ksCurrent (ks) == found, "current not set correctly");
 	succeed_if (found != 0, "did not find correct name");
 	succeed_if_same_string (keyName (found), "user/named/bin");
-	succeed_if (strncmp (keyValue (found), "binary\1\2data", 10) == 0, "not correct value in found key");
+	succeed_if (strncmp (keyValue (found), "binary\1\2data", strlen ("binary\1\2data")) == 0, "not correct value in found key");
 
 	found = ksLookupByName (ks, "user/named/key", 0);
 	succeed_if (ksCurrent (ks) == found, "current not set correctly");
@@ -2048,9 +2048,9 @@ static void test_ksLookupPop ()
 	ksAppendKey (ks, keyNew ("user/named/key", KEY_VALUE, "myvalue", KEY_END));
 	ksAppendKey (ks, keyNew ("system/named/skey", KEY_VALUE, "syskey", KEY_END));
 	ksAppendKey (ks, keyNew ("system/sysonly/key", KEY_VALUE, "sysonlykey", KEY_END));
-	ksAppendKey (ks, keyNew ("user/named/bin", KEY_BINARY, KEY_SIZE, 10, KEY_VALUE, "binary\1\2data", KEY_END));
-	ksAppendKey (ks, keyNew ("system/named/bin", KEY_BINARY, KEY_SIZE, 10, KEY_VALUE, "sys\1bin\2", KEY_END));
-	ksAppendKey (ks, keyNew ("system/named/key", KEY_BINARY, KEY_SIZE, 10, KEY_VALUE, "syskey", KEY_END));
+	ksAppendKey (ks, keyNew ("user/named/bin", KEY_BINARY, KEY_SIZE, strlen ("binary\1\2data"), KEY_VALUE, "binary\1\2data", KEY_END));
+	ksAppendKey (ks, keyNew ("system/named/bin", KEY_BINARY, KEY_SIZE, strlen ("sys\1bin\2"), KEY_VALUE, "sys\1bin\2", KEY_END));
+	ksAppendKey (ks, keyNew ("system/named/key", KEY_BINARY, KEY_SIZE, strlen ("syskey"), KEY_VALUE, "syskey", KEY_END));
 	succeed_if (ksGetSize (ks) == 8, "could not append all keys");
 
 	// a positive testcase
@@ -2121,7 +2121,7 @@ static void test_ksLookupPop ()
 	succeed_if (ksCurrent (ks) == 0, "current not set correctly");
 	succeed_if (found != 0, "did not find correct name");
 	succeed_if_same_string (keyName (found), "system/named/key");
-	succeed_if_same_string (keyValue (found), "syskey");
+	succeed_if (strncmp (keyValue (found), "syskey", strlen ("syskey")) == 0, "not correct value in found key");
 	succeed_if (keyDel (found) == 0, "could not del popped key");
 
 	found = ksLookupByName (ks, "user/named/bin", KDB_O_POP);
@@ -2129,7 +2129,7 @@ static void test_ksLookupPop ()
 	succeed_if (ksCurrent (ks) == 0, "current not set correctly");
 	succeed_if (found != 0, "did not find correct name");
 	succeed_if_same_string (keyName (found), "user/named/bin");
-	succeed_if (strncmp (keyValue (found), "binary\1\2data", 10) == 0, "not correct value in found key");
+	succeed_if (strncmp (keyValue (found), "binary\1\2data", strlen ("binary\1\2data")) == 0, "not correct value in found key");
 	succeed_if (keyDel (found) == 0, "could not del popped key");
 
 	found = ksLookupByName (ks, "user/named/key", KDB_O_POP);

--- a/tests/ctest/test_keyname.c
+++ b/tests/ctest/test_keyname.c
@@ -79,9 +79,37 @@ static void test_relative_generic ()
 	parent = keyNew ("user", KEY_END);
 	child = keyNew ("user/K", KEY_END);
 	test_relative ("K", child, parent);
+	test_relative ("user", parent, child);
 	keyDel (child);
 	child = keyNew ("user/KK\\/Kitchens/What/Were/You/Thinking?", KEY_END);
 	test_relative ("KK\\/Kitchens/What/Were/You/Thinking?", child, parent);
+	keyDel (child);
+	keyDel (parent);
+}
+
+static void test_relative_equal ()
+{
+	printf ("Get relative name of key which is the same as the parent key\n");
+
+	Key * parent = keyNew ("system/parentChild", KEY_END);
+	Key * child = keyNew ("system/parentChild", KEY_END);
+	test_relative ("", child, parent);
+
+	keyDel (parent);
+	parent = keyNew ("/parentChild", KEY_END);
+	test_relative ("", child, parent);
+
+	keyDel (child);
+	keyDel (parent);
+	child = keyNew ("system/parentChild/#");
+	parent = keyNew ("system/parentChild/#");
+	test_relative ("", child, parent);
+
+	keyDel (child);
+	child = keyNew ("system/parentChild/#123");
+	// expected according to it's spec
+	test_relative ("23", child, parent);
+
 	keyDel (child);
 	keyDel (parent);
 }
@@ -100,6 +128,7 @@ int main (int argc, char ** argv)
 	test_relative_root ();
 	test_relative_cascading ();
 	test_relative_generic ();
+	test_relative_equal ();
 
 	printf ("\n%s RESULTS: %d test(s) done. %d error(s).\n", program_name, nbTest, nbError);
 

--- a/tests/ctest/test_keyname.c
+++ b/tests/ctest/test_keyname.c
@@ -101,12 +101,12 @@ static void test_relative_equal ()
 
 	keyDel (child);
 	keyDel (parent);
-	child = keyNew ("system/parentChild/#");
-	parent = keyNew ("system/parentChild/#");
+	child = keyNew ("system/parentChild/#", KEY_END);
+	parent = keyNew ("system/parentChild/#", KEY_END);
 	test_relative ("", child, parent);
 
 	keyDel (child);
-	child = keyNew ("system/parentChild/#123");
+	child = keyNew ("system/parentChild/#123", KEY_END);
 	// expected according to it's spec
 	test_relative ("23", child, parent);
 


### PR DESCRIPTION
# Purpose

A bunch of small quality improvements.

# Checklist

Please only check relevant points.
For docu fixes, spell checking and similar nothing
needs to be checked.

- [X] commit messages are fine (with references to issues)
- [X] I ran all tests and everything went fine
- [X] I added unit tests
- [X] affected documentation is fixed
- [X] I added code comments, logging, and assertions
- [X] meta data is updated (e.g. README.md of plugins)

@markus2330 some considerations:

ASAN: I've had two places it complained about during the tests. one was in the range.c file (see changed files), but as it only gets multiplied by 1 or -1 it should not matter. i've added an assertion to guarantee that. it still complains though, doesn't seem to get the assertion

The other place it complains about is in keyvalue.c  on line 541 (`memcpy (key->data.v, newBinary, key->dataSize);`). The exact error is

```
95: ==63583==ERROR: AddressSanitizer: global-buffer-overflow on address 0x00010a8aa749 at pc 0x00010a9da1e8 bp 0x7fff553cc500 sp 0x7fff553cbcb0
95: READ of size 10 at 0x00010a8aa749 thread T0
95:     #0 0x10a9da1e7 in __asan_memcpy (libclang_rt.asan_osx_dynamic.dylib:x86_64+0x4a1e7)
95:     #1 0x10a9550ed in keySetRaw keyvalue.c:541
```

I don't get this issue though, after checking the affected code, it seems fine to me. It either uses realloc or elektraMalloc to allocate key->dataSize bytes, then it copies that many bytes with memcpy, so in both cases enough should be allocated and no overflow. The only thing i can possibly think of is that it could maybe copy "too much" if the argument dataSize is larger than the size of newBinary maybe? Or could it be that this is some bug in this __asan_memcpy call itself, of which we don't have much influence over?

CBMC: after fixing the paths on mac, i get a totally different result than in the initial issue #1370 . My output looks like
```
size of program expression: 14356 steps
simple slicing removed 105 assignments
Generated 8 VCC(s), 6 remaining after simplification
Passing problem to propositional reduction
converting SSA
Running propositional reduction
Post-processing
Solving with MiniSAT 2.2.1 with simplifier
245089 variables, 557781 clauses
SAT checker: instance is SATISFIABLE
Solving with MiniSAT 2.2.1 with simplifier
245089 variables, 45210 clauses
SAT checker inconsistent: instance is UNSATISFIABLE
Runtime decision procedure: 3.66s

** Results:
[] free called for new[] object: SUCCESS
[free.assertion.1] free argument is dynamic object: FAILURE
[free.assertion.2] free argument has offset zero: FAILURE
[free.assertion.3] double free: SUCCESS
[free.assertion.4] free called for new[] object: SUCCESS

** 2 of 5 failed (2 iterations)
VERIFICATION FAILED
```
without a specific hint where to search for the issues.

rest should be ok i think.
