### PR TITLE
kdb-global-umount: first draft #1290

### DIFF
--- a/doc/help/kdb-global-umount.md
+++ b/doc/help/kdb-global-umount.md
@@ -9,6 +9,27 @@ kdb-global-umount(1) - Unmount a global plugin from the key database
 
 Unmount a global plugin from the key database.
 
+## EXAMPLES
+
+```sh
+
+sudo kdb global-mount tracer
+
+sudo kdb global-mount
+# STDOUT-REGEX: .*tracer\nspec.*
+
+sudo kdb global-umount tracer
+
+# spec is always mounted by default
+sudo kdb global-mount
+#> spec
+
+sudo kdb global-umount spec
+
+sudo kdb global-mount
+#> 
+```
+
 ## OPTIONS
 
 - `-H`, `--help`:

--- a/doc/help/kdb-global-umount.md
+++ b/doc/help/kdb-global-umount.md
@@ -1,0 +1,27 @@
+kdb-global-umount(1) - Unmount a global plugin from the key database
+====================================================
+
+## SYNOPSIS
+
+`kdb global-umount <name>`
+
+## DESCRIPTION
+
+Unmount a global plugin from the key database.
+
+## OPTIONS
+
+- `-H`, `--help`:
+  Show the man page.
+- `-V`, `--version`:
+  Print version info.
+- `-p`, `--profile`=<profile>:
+  Use a different kdb profile.
+- `-C`, `--color`=[when]:
+  Print never/auto(default)/always colored output.
+
+## SEE ALSO
+
+- [kdb-global-mount(7)](kdb-global-mount.md).
+- [elektra-mounting(7)](elektra-mounting.md).
+- [elektra-plugins-framework(7)](elektra-plugins-framework.md).

--- a/src/plugins/conditionals/README.md
+++ b/src/plugins/conditionals/README.md
@@ -137,7 +137,6 @@ kdb export /examples/conditionals ini
 
 # cleanup
 kdb rm -r /examples/conditionals
-kdb rm -r system/elektra/globalplugins
 sudo kdb umount /examples/conditionals/sub
 sudo kdb umount /examples/conditionals
 

--- a/src/plugins/conditionals/README.md
+++ b/src/plugins/conditionals/README.md
@@ -140,4 +140,6 @@ kdb rm -r /examples/conditionals
 kdb rm -r system/elektra/globalplugins
 sudo kdb umount /examples/conditionals/sub
 sudo kdb umount /examples/conditionals
+
+sudo kdb global-umount conditionals
 ```

--- a/src/tools/kdb/factory.hpp
+++ b/src/tools/kdb/factory.hpp
@@ -32,6 +32,7 @@
 #include <fstab.hpp>
 #include <get.hpp>
 #include <globalmount.hpp>
+#include <globalumount.hpp>
 #include <import.hpp>
 #include <info.hpp>
 #include <list.hpp>
@@ -111,7 +112,9 @@ public:
 		m_factory.insert (std::make_pair ("spec-mount", new Cnstancer<SpecMountCommand> ()));
 		m_factory.insert (std::make_pair ("smount", new Cnstancer<SpecMountCommand> ()));
 		m_factory.insert (std::make_pair ("global-mount", new Cnstancer<GlobalMountCommand> ()));
+		m_factory.insert (std::make_pair ("global-umount", new Cnstancer<GlobalUmountCommand> ()));
 		m_factory.insert (std::make_pair ("gmount", new Cnstancer<GlobalMountCommand> ()));
+		m_factory.insert (std::make_pair ("gumount", new Cnstancer<GlobalUmountCommand> ()));
 		m_factory.insert (std::make_pair ("list-commands", new Cnstancer<ListCommandsCommand> ()));
 	}
 

--- a/src/tools/kdb/globalumount.cpp
+++ b/src/tools/kdb/globalumount.cpp
@@ -1,0 +1,54 @@
+/**
+ * @file
+ *
+ * @brief
+ *
+ * @copyright BSD License (see LICENSE.md or https://www.libelektra.org)
+ */
+
+#include <globalumount.hpp>
+
+#include <cmdline.hpp>
+#include <kdb.hpp>
+
+#include <algorithm>
+#include <iostream>
+
+using namespace std;
+using namespace kdb;
+
+GlobalUmountCommand::GlobalUmountCommand ()
+{
+}
+
+int GlobalUmountCommand::execute (Cmdline const & cl)
+{
+	if (cl.arguments.size () != 1) throw invalid_argument ("1 argument required");
+
+	KeySet conf;
+	// they are all mounted in that array
+	Key parentKey ("system/elektra/globalplugins/postcommit/user/plugins/", KEY_END);
+	kdb.get (conf, parentKey);
+	printWarnings (cerr, parentKey);
+
+	conf = conf.cut (parentKey);
+
+	const string name = cl.arguments[0];
+	auto it =
+		find_if (conf.begin (), conf.end (), [&](Key key) { return key.isDirectBelow (parentKey) && key.get<string> () == name; });
+
+	if (it == conf.end ())
+	{
+		cerr << "Global Plugin " << name << " does not exist" << endl;
+		return 1;
+	}
+
+	conf.cut (*it);
+	kdb.set (conf, parentKey);
+
+	return 0;
+}
+
+GlobalUmountCommand::~GlobalUmountCommand ()
+{
+}

--- a/src/tools/kdb/globalumount.hpp
+++ b/src/tools/kdb/globalumount.hpp
@@ -1,0 +1,47 @@
+/**
+ * @file
+ *
+ * @brief
+ *
+ * @copyright BSD License (see LICENSE.md or https://www.libelektra.org)
+ */
+
+#ifndef GLOBALUMOUNT_HPP
+#define GLOBALUMOUNT_HPP
+
+#include "coloredkdbio.hpp"
+#include <command.hpp>
+#include <kdb.hpp>
+
+class GlobalUmountCommand : public Command
+{
+	kdb::KDB kdb;
+
+public:
+	GlobalUmountCommand ();
+	~GlobalUmountCommand ();
+
+	virtual std::string getShortOptions () override
+	{
+		return "C";
+	}
+
+	virtual std::string getSynopsis () override
+	{
+		return "<name>";
+	}
+
+	virtual std::string getShortHelpText () override
+	{
+		return "Unmounts a global plugin from key database.";
+	}
+
+	virtual std::string getLongHelpText () override
+	{
+		return "";
+	}
+
+	virtual int execute (Cmdline const & cmdline) override;
+};
+
+#endif

--- a/tests/shell/shell_recorder/tutorial_wrapper/CMakeLists.txt
+++ b/tests/shell/shell_recorder/tutorial_wrapper/CMakeLists.txt
@@ -17,6 +17,7 @@ endfunction ()
 
 add_s_test (tutorial_cascading "${CMAKE_SOURCE_DIR}/doc/tutorials/cascading.md")
 add_s_test (kdb-complete "${CMAKE_SOURCE_DIR}/doc/help/kdb-complete.md")
+add_s_test (kdb-global-umount "${CMAKE_SOURCE_DIR}/doc/help/kdb-global-umount.md")
 
 add_plugin_shell_test (blockresolver)
 add_plugin_shell_test (conditionals)


### PR DESCRIPTION
# Purpose

Adds global-umount tool

# Checklist

- [X] commit messages are fine (with references to issues)
- [ ] I ran all tests and everything went fine
- [ ] I added unit tests
- [X] affected documentation is fixed
- [X] I added code comments, logging, and assertions
- [X] meta data is updated (e.g. README.md of plugins)

@markus2330 Honestly this bugged me quite a lot because to me it seems to be too easy the way it currently is. So i was trying to find out what i'm missing. But judging from the kdb tools library (which is not really easy to understand imo) it seems that global plugins are always mounted to this particular path and just removing the keys from there seems to be sufficient. There is no need to reorder the array of global plugins or anything as the next time you mount a new global plugin, the mounting code reorders it anyway.

But shouldn't global plugins also have an entry in system/elektra/modules so i could call their corresponding close function before or is that not necessary?
