### PR TITLE
fix-getopt

### DIFF
--- a/src/tools/kdb/check.hpp
+++ b/src/tools/kdb/check.hpp
@@ -22,7 +22,7 @@ public:
 
 	virtual std::string getShortOptions () override
 	{
-		return "vcfC";
+		return "vcfC::";
 	}
 
 	virtual std::string getSynopsis () override

--- a/src/tools/kdb/cmdline.cpp
+++ b/src/tools/kdb/cmdline.cpp
@@ -58,8 +58,9 @@ Cmdline::Cmdline (int argc, char ** argv, Command * command)
 	helpText += "\n";
 
 	string allOptions = command->getShortOptions ();
-	allOptions += "HVp";
+	allOptions += "HVp:";
 
+	// Make sure to use the unsorted allOptions for getopt to preserve argument chars : and ::
 	std::set<string::value_type> unique_sorted_chars (allOptions.begin (), allOptions.end ());
 	string acceptedOptions (unique_sorted_chars.begin (), unique_sorted_chars.end ());
 
@@ -109,7 +110,7 @@ Cmdline::Cmdline (int argc, char ** argv, Command * command)
 	}
 	if (acceptedOptions.find ('m') != string::npos)
 	{
-		option o = { "min-depth", optional_argument, nullptr, 'm' };
+		option o = { "min-depth", required_argument, nullptr, 'm' };
 		long_options.push_back (o);
 		helpText +=
 			"-m --min-depth           Specify the minimum depth of completion suggestions (0 by default), inclusive "
@@ -117,7 +118,7 @@ Cmdline::Cmdline (int argc, char ** argv, Command * command)
 	}
 	if (acceptedOptions.find ('M') != string::npos)
 	{
-		option o = { "max-depth", optional_argument, nullptr, 'M' };
+		option o = { "max-depth", required_argument, nullptr, 'M' };
 		long_options.push_back (o);
 		helpText +=
 			"-M --max-depth           Specify the maximum depth of completion suggestions (unlimited by default, 1 to show "
@@ -260,7 +261,7 @@ Cmdline::Cmdline (int argc, char ** argv, Command * command)
 
 	opterr = 0;
 
-	while ((opt = getopt_long (argc, argv, acceptedOptions.c_str (), &long_options[0], &index)) != EOF)
+	while ((opt = getopt_long (argc, argv, allOptions.c_str (), &long_options[0], &index)) != EOF)
 	{
 		switch (opt)
 		{
@@ -351,7 +352,7 @@ Cmdline::Cmdline (int argc, char ** argv, Command * command)
 		opterr = 1;
 	}
 
-	while ((opt = getopt_long (argc, argv, acceptedOptions.c_str (), &long_options[0], &index)) != EOF)
+	while ((opt = getopt_long (argc, argv, allOptions.c_str (), &long_options[0], &index)) != EOF)
 	{
 		switch (opt)
 		{

--- a/src/tools/kdb/complete.hpp
+++ b/src/tools/kdb/complete.hpp
@@ -25,7 +25,7 @@ public:
 
 	virtual std::string getShortOptions () override
 	{
-		return "dmMv0";
+		return "dm:M:v0";
 	}
 
 	virtual std::string getSynopsis () override

--- a/src/tools/kdb/convert.hpp
+++ b/src/tools/kdb/convert.hpp
@@ -23,7 +23,7 @@ public:
 
 	virtual std::string getShortOptions () override
 	{
-		return "vC";
+		return "vC::";
 	}
 
 	virtual std::string getSynopsis () override

--- a/src/tools/kdb/cp.hpp
+++ b/src/tools/kdb/cp.hpp
@@ -23,7 +23,7 @@ public:
 
 	virtual std::string getShortOptions () override
 	{
-		return "rvC";
+		return "rvC::";
 	}
 
 	virtual std::string getSynopsis () override

--- a/src/tools/kdb/editor.hpp
+++ b/src/tools/kdb/editor.hpp
@@ -21,7 +21,7 @@ public:
 
 	virtual std::string getShortOptions ()
 	{
-		return "esvCN";
+		return "e:s:vC::N";
 	}
 
 	virtual std::string getSynopsis ()

--- a/src/tools/kdb/export.hpp
+++ b/src/tools/kdb/export.hpp
@@ -24,7 +24,7 @@ public:
 
 	virtual std::string getShortOptions () override
 	{
-		return "EcC";
+		return "EcC::";
 	}
 
 	virtual std::string getSynopsis () override

--- a/src/tools/kdb/file.hpp
+++ b/src/tools/kdb/file.hpp
@@ -23,7 +23,7 @@ public:
 
 	virtual std::string getShortOptions () override
 	{
-		return "nNC";
+		return "nNC::";
 	}
 
 	virtual std::string getSynopsis () override

--- a/src/tools/kdb/fstab.hpp
+++ b/src/tools/kdb/fstab.hpp
@@ -23,7 +23,7 @@ public:
 
 	virtual std::string getShortOptions () override
 	{
-		return "vC";
+		return "vC::";
 	}
 
 	virtual std::string getSynopsis () override

--- a/src/tools/kdb/get.hpp
+++ b/src/tools/kdb/get.hpp
@@ -21,7 +21,7 @@ public:
 
 	virtual std::string getShortOptions () override
 	{
-		return "anvC";
+		return "anvC::";
 	}
 
 	virtual std::string getSynopsis () override

--- a/src/tools/kdb/globalmount.hpp
+++ b/src/tools/kdb/globalmount.hpp
@@ -34,7 +34,7 @@ public:
 
 	virtual std::string getShortOptions () override
 	{
-		return "WC"; // TODO: c not implemented
+		return "WC::"; // TODO: c not implemented
 	}
 
 	virtual std::string getSynopsis () override

--- a/src/tools/kdb/import.hpp
+++ b/src/tools/kdb/import.hpp
@@ -23,7 +23,7 @@ public:
 
 	virtual std::string getShortOptions () override
 	{
-		return "svcCN";
+		return "s:vcC::N";
 	}
 
 	virtual std::string getSynopsis () override

--- a/src/tools/kdb/info.hpp
+++ b/src/tools/kdb/info.hpp
@@ -24,7 +24,7 @@ public:
 
 	virtual std::string getShortOptions () override
 	{
-		return "lcC";
+		return "lcC::";
 	}
 
 	virtual std::string getSynopsis () override

--- a/src/tools/kdb/list.hpp
+++ b/src/tools/kdb/list.hpp
@@ -20,7 +20,7 @@ public:
 
 	virtual std::string getShortOptions () override
 	{
-		return "0vC";
+		return "0vC::";
 	}
 
 	virtual std::string getSynopsis () override

--- a/src/tools/kdb/listcommands.hpp
+++ b/src/tools/kdb/listcommands.hpp
@@ -20,7 +20,7 @@ public:
 
 	virtual std::string getShortOptions () override
 	{
-		return "0vC";
+		return "0vC::";
 	}
 
 	virtual std::string getSynopsis () override

--- a/src/tools/kdb/merge.hpp
+++ b/src/tools/kdb/merge.hpp
@@ -26,7 +26,7 @@ public:
 
 	virtual std::string getShortOptions () override
 	{
-		return "iHsvfC";
+		return "iHs:vfC::";
 	}
 
 	virtual std::string getSynopsis () override

--- a/src/tools/kdb/metaget.hpp
+++ b/src/tools/kdb/metaget.hpp
@@ -23,7 +23,7 @@ public:
 
 	virtual std::string getShortOptions () override
 	{
-		return "nC";
+		return "nC::";
 	}
 
 	virtual std::string getSynopsis () override

--- a/src/tools/kdb/metals.hpp
+++ b/src/tools/kdb/metals.hpp
@@ -23,7 +23,7 @@ public:
 
 	virtual std::string getShortOptions () override
 	{
-		return "0vC";
+		return "0vC::";
 	}
 
 	virtual std::string getSynopsis () override

--- a/src/tools/kdb/metaremove.hpp
+++ b/src/tools/kdb/metaremove.hpp
@@ -23,7 +23,7 @@ public:
 
 	virtual std::string getShortOptions () override
 	{
-		return "C";
+		return "C::";
 	}
 
 	virtual std::string getSynopsis () override

--- a/src/tools/kdb/metaset.hpp
+++ b/src/tools/kdb/metaset.hpp
@@ -24,7 +24,7 @@ public:
 
 	virtual std::string getShortOptions () override
 	{
-		return "qvC";
+		return "qvC::";
 	}
 
 	virtual std::string getSynopsis () override

--- a/src/tools/kdb/mount.hpp
+++ b/src/tools/kdb/mount.hpp
@@ -35,7 +35,7 @@ public:
 
 	virtual std::string getShortOptions () override
 	{
-		return "idR0123cqWC";
+		return "idR:0123cqWC::";
 	}
 
 	virtual std::string getSynopsis () override

--- a/src/tools/kdb/mv.hpp
+++ b/src/tools/kdb/mv.hpp
@@ -23,7 +23,7 @@ public:
 
 	virtual std::string getShortOptions () override
 	{
-		return "rvC";
+		return "rvC::";
 	}
 
 	virtual std::string getSynopsis () override

--- a/src/tools/kdb/remount.hpp
+++ b/src/tools/kdb/remount.hpp
@@ -24,7 +24,7 @@ public:
 
 	virtual std::string getShortOptions () override
 	{
-		return "idC";
+		return "idC::";
 	}
 
 	virtual std::string getSynopsis () override

--- a/src/tools/kdb/rm.hpp
+++ b/src/tools/kdb/rm.hpp
@@ -23,7 +23,7 @@ public:
 
 	virtual std::string getShortOptions () override
 	{
-		return "rC";
+		return "rC::";
 	}
 
 	virtual std::string getSynopsis () override

--- a/src/tools/kdb/set.hpp
+++ b/src/tools/kdb/set.hpp
@@ -23,7 +23,7 @@ public:
 
 	virtual std::string getShortOptions () override
 	{
-		return "vqNC";
+		return "vqNC::";
 	}
 
 	virtual std::string getSynopsis () override

--- a/src/tools/kdb/sget.hpp
+++ b/src/tools/kdb/sget.hpp
@@ -22,7 +22,7 @@ public:
 
 	virtual std::string getShortOptions () override
 	{
-		return "C";
+		return "C::";
 	}
 
 	virtual std::string getSynopsis () override

--- a/src/tools/kdb/shell.hpp
+++ b/src/tools/kdb/shell.hpp
@@ -24,7 +24,7 @@ public:
 
 	virtual std::string getShortOptions () override
 	{
-		return "C";
+		return "C::";
 	}
 
 	virtual std::string getSynopsis () override

--- a/src/tools/kdb/specmount.hpp
+++ b/src/tools/kdb/specmount.hpp
@@ -33,7 +33,7 @@ public:
 
 	virtual std::string getShortOptions () override
 	{
-		return "idRcWvqC";
+		return "idR:cWvqC::";
 	}
 
 	virtual std::string getSynopsis () override

--- a/src/tools/kdb/test.hpp
+++ b/src/tools/kdb/test.hpp
@@ -38,7 +38,7 @@ public:
 
 	virtual std::string getShortOptions () override
 	{
-		return "C";
+		return "C::";
 	}
 
 	virtual std::string getSynopsis () override

--- a/src/tools/kdb/umount.hpp
+++ b/src/tools/kdb/umount.hpp
@@ -23,7 +23,7 @@ public:
 
 	virtual std::string getShortOptions () override
 	{
-		return "vC";
+		return "vC::";
 	}
 
 	virtual std::string getSynopsis () override

--- a/src/tools/kdb/validation.hpp
+++ b/src/tools/kdb/validation.hpp
@@ -23,7 +23,7 @@ public:
 
 	virtual std::string getShortOptions () override
 	{
-		return "C";
+		return "C::";
 	}
 
 	virtual std::string getSynopsis () override


### PR DESCRIPTION
# Purpose

Apparently for the kdb tools options that have arguments don't work in the short format. 
This is due to an error in our getopt string. As seen on e.g. https://linux.die.net/man/3/getopt_long

> optstring is a string containing the legitimate option characters.
> If such a character is followed by a colon, the option requires an argument, so getopt() places a pointer to the following text in the same argv-element, or the text of the following argv-element, in optarg.
> Two colons mean an option takes an optional arg;

# Checklist

Please only check relevant points.
For docu fixes, spell checking and similar nothing
needs to be checked.

- [X] commit messages are fine (with references to issues)
- [X] I ran all tests and everything went fine
- [ ] I added unit tests
- [ ] affected documentation is fixed
- [X] I added code comments, logging, and assertions
- [ ] meta data is updated (e.g. README.md of plugins)

@markus2330 yet another small quality improvement but i thought it deserves its own branch since its rather a bugfix and so we can quickly merge it as #1345 now depends on it.
