### PR TITLE
Static code checker fixes

### DIFF
--- a/doc/TESTING.md
+++ b/doc/TESTING.md
@@ -225,10 +225,15 @@ of the issues found in the whole project.
 with LLVM/clang and is also primarily intended for C and C++ code. On macOS you have to install the 
 package `llvm` with homebrew, then you'll find the tool in the folder `/usr/local/opt/llvm/bin/`.
 
-To use it, prefix the compilation make command with `scan-build` in the build folder and specify an
-output folder for the results:
+To use it, change the c compiler and the c++ compiler to the llvm analyzer. To do this, you can
+configure the project from scratch and prefix the cmake command with `scan-build`. Alternatively, set
+the c compiler to `ccc-analyzer` and the c++ compiler to `c++-analyzer` (bundled with llvm/clang).
 
-    scan-build -o ./scanbuild_result make
+Then you can build the project with make like usual, prefixing the command with `scan-build`.
+The -o option specifies where the html results get stored. Ensure you build the project from scratch, 
+otherwise the analyzation might be incomplete.
+
+    scan-build -o ./scanbuild_result make -j 4
 
 Afterwards, the report can be viewed by using the tool `scan-view`, also found in the llvm folder.
 The report is created in the folder specified above, along with the current date of the analyzation,

--- a/doc/markdownlinkconverter/markdownlinkconverter.c
+++ b/doc/markdownlinkconverter/markdownlinkconverter.c
@@ -495,8 +495,8 @@ static void printTarget (FILE * output, char * target, char * inputFilename, int
 					return;
 				}
 			}
+			strcpy (++lastFolderDelimiter, target);
 		}
-		strcpy (++lastFolderDelimiter, target);
 	}
 	else
 	{

--- a/src/include/kdbassert.h
+++ b/src/include/kdbassert.h
@@ -19,10 +19,8 @@ void elektraAbort (const char * expression, const char * function, const char * 
 #endif
 
 // For scan-build / clang analyzer to detect our assertions abort
-#ifndef CLANG_ANALYZER_NORETURN
-#if __has_feature(attribute_analyzer_noreturn)
-__attribute__((analyzer_noreturn))
-#endif
+#ifdef __clang_analyzer__
+	__attribute__((analyzer_noreturn))
 #endif
 	;
 

--- a/src/include/kdbassert.h
+++ b/src/include/kdbassert.h
@@ -17,6 +17,13 @@ void elektraAbort (const char * expression, const char * function, const char * 
 #ifdef __GNUC__
 	__attribute__ ((format (printf, 5, 6)))
 #endif
+
+// For scan-build / clang analyzer to detect our assertions abort
+#ifndef CLANG_ANALYZER_NORETURN
+#if __has_feature(attribute_analyzer_noreturn)
+__attribute__((analyzer_noreturn))
+#endif
+#endif
 	;
 
 #ifdef __cplusplus

--- a/src/include/kdbassert.h
+++ b/src/include/kdbassert.h
@@ -20,7 +20,7 @@ void elektraAbort (const char * expression, const char * function, const char * 
 
 // For scan-build / clang analyzer to detect our assertions abort
 #ifdef __clang_analyzer__
-	__attribute__((analyzer_noreturn))
+	__attribute__ ((analyzer_noreturn))
 #endif
 	;
 

--- a/src/libs/elektra/internal.c
+++ b/src/libs/elektra/internal.c
@@ -680,7 +680,7 @@ size_t elektraUnescapeKeyName (const char * source, char * dest)
 
 	ELEKTRA_ASSERT (sp != NULL && dp != NULL, "Got null pointer sp: %p dp: %p", (void *)sp, (void *)dp);
 
-	if (*source == '/')
+	if (*sp == '/')
 	{
 		// handling for cascading names
 		*dp = 0;

--- a/src/libs/elektra/keyset.c
+++ b/src/libs/elektra/keyset.c
@@ -272,7 +272,8 @@ KeySet * ksDeepDup (const KeySet * source)
 		{
 			keyClearSync (d);
 		}
-		if (ksAppendKey (keyset, d) == -1) {
+		if (ksAppendKey (keyset, d) == -1)
+		{
 			ksDel (keyset);
 			return 0;
 		}
@@ -821,8 +822,10 @@ ssize_t ksAppendKey (KeySet * ks, Key * toAppend)
 		/* We want to append a new key
 		  in position insertpos */
 		++ks->size;
-		if (ks->size >= ks->alloc) {
-			if (ksResize (ks, ks->alloc * 2 - 1) == -1) {
+		if (ks->size >= ks->alloc)
+		{
+			if (ksResize (ks, ks->alloc * 2 - 1) == -1)
+			{
 				--ks->size;
 				return -1;
 			}

--- a/src/libs/elektra/keyset.c
+++ b/src/libs/elektra/keyset.c
@@ -250,7 +250,7 @@ KeySet * ksDup (const KeySet * source)
  *
  * @param source has to be an initialized source KeySet
  * @return a deep copy of source on success
- * @retval 0 on NULL pointer
+ * @retval 0 on NULL pointer or a memory error happened
  * @see ksNew(), ksDel()
  * @see keyDup() for key duplication
  * @see ksDup() for flat copy
@@ -272,7 +272,10 @@ KeySet * ksDeepDup (const KeySet * source)
 		{
 			keyClearSync (d);
 		}
-		ksAppendKey (keyset, d);
+		if (ksAppendKey (keyset, d) == -1) {
+			ksDel (keyset);
+			return 0;
+		}
 	}
 
 	return keyset;
@@ -818,7 +821,12 @@ ssize_t ksAppendKey (KeySet * ks, Key * toAppend)
 		/* We want to append a new key
 		  in position insertpos */
 		++ks->size;
-		if (ks->size >= ks->alloc) ksResize (ks, ks->alloc * 2 - 1);
+		if (ks->size >= ks->alloc) {
+			if (ksResize (ks, ks->alloc * 2 - 1) == -1) {
+				--ks->size;
+				return -1;
+			}
+		}
 		keyIncRef (toAppend);
 
 		if (insertpos == (ssize_t)ks->size - 1)

--- a/src/libs/elektra/keytest.c
+++ b/src/libs/elektra/keytest.c
@@ -256,7 +256,7 @@ int keyIsBelow (const Key * key, const Key * check)
 		{
 			size_t size = 0;
 			char * ptr = (char *)keyname;
-			ptr = keyNameGetOneLevel (ptr, &size);
+			keyNameGetOneLevel (ptr, &size);
 			if (size == (size_t)keysize)
 			{
 				return 1;
@@ -278,13 +278,12 @@ int keyIsBelow (const Key * key, const Key * check)
 	{
 		size_t size = 0;
 		char * ptr = (char *)checkname;
-		ptr = keyNameGetOneLevel (ptr, &size);
+		keyNameGetOneLevel (ptr, &size);
 		if (size == (size_t)checksize)
 		{
 			return 0;
 		}
 		checkname += size;
-		checksize = elektraStrLen (checkname);
 		ptr = strrchr (ucheckname, '\0');
 		uchecksize -= (ptr - ucheckname);
 		ucheckname = ptr;

--- a/src/libs/meta/meta.c
+++ b/src/libs/meta/meta.c
@@ -1211,7 +1211,6 @@ int elektraSortTopology (KeySet * ks, Key ** array)
 		adjMatrix[j].isResolved = 0;
 		adjMatrix[j].deps = elektraCalloc (sizeof (unsigned long) * size);
 	}
-	i = 0;
 	kdb_octet_t hasOrder = 0;
 	if (keyGetMeta (localArray[0], "order")) hasOrder = 1;
 	unsigned int unresolved = 0;

--- a/src/plugins/conditionals/conditionals.c
+++ b/src/plugins/conditionals/conditionals.c
@@ -328,7 +328,7 @@ static CondResult evalCondition (const Key * curKey, const char * leftSide, Comp
 		if (ret == 0 && !strcmp (leftSide, "'1'")) result = TRUE;
 		break;
 	case OR:
-		if (!strcmp (leftSide, "'1'") || !strcmp (rightSide, "'1'")) result = TRUE;
+		if (!strcmp (leftSide, "'1'") || (rightSide && !strcmp (rightSide, "'1'"))) result = TRUE;
 		break;
 	default:
 		result = ERROR;

--- a/src/plugins/ini/ini.c
+++ b/src/plugins/ini/ini.c
@@ -1227,7 +1227,9 @@ static int iniWriteKeySet (FILE * fh, Key * parentKey, KeySet * returned, IniPlu
 				keyDel (sectionKey);
 				sectionKey = parentKey;
 				removeSectionKey = 0;
-			} else {
+			}
+			else
+			{
 				sectionKey = cur;
 			}
 		}

--- a/src/plugins/ini/ini.c
+++ b/src/plugins/ini/ini.c
@@ -1227,8 +1227,9 @@ static int iniWriteKeySet (FILE * fh, Key * parentKey, KeySet * returned, IniPlu
 				keyDel (sectionKey);
 				sectionKey = parentKey;
 				removeSectionKey = 0;
+			} else {
+				sectionKey = cur;
 			}
-			sectionKey = cur;
 		}
 		writeComments (cur, fh, config->commentChar);
 		iniWriteMeta (fh, cur);

--- a/src/plugins/ini/inih-r29/inih.c
+++ b/src/plugins/ini/inih-r29/inih.c
@@ -200,7 +200,6 @@ int ini_parse_file (FILE * file, const struct IniConfig * config, void * user)
 						}
 						else
 						{
-							end = line + (strlen (line) - 1);
 							strncpy0 (section + strlen (section), line, sizeof (section) - strlen (section));
 						}
 					}
@@ -371,7 +370,6 @@ int ini_parse_file (FILE * file, const struct IniConfig * config, void * user)
 				}
 				else
 				{
-					end = find_char_or_comment (start, '\0');
 					name = rstrip (start);
 					strncpy0 (prev_name, name, sizeof (prev_name));
 					if (!config->keyHandler (user, section, name, NULL, 0) && !error) error = lineno;
@@ -399,12 +397,10 @@ int ini_parse_file (FILE * file, const struct IniConfig * config, void * user)
 						if (*(ptr + 1) == '"')
 						{
 							*(ptr + 1) = '\0';
-							end = (ptr + 2);
 						}
 						else if (*(ptr + 2) == '"')
 						{
 							*(ptr + 2) = '\0';
-							end = (ptr + 3);
 						}
 						if (*(ptr - 1) == '"')
 							*(ptr - 1) = '\0';
@@ -415,7 +411,7 @@ int ini_parse_file (FILE * file, const struct IniConfig * config, void * user)
 					else if (*ptr == delim)
 					{
 						*ptr = '\0';
-						end = rstrip (start);
+						rstrip (start);
 						if (*start == '"') ++start;
 						if (*(ptr - 1) == '"')
 							*(ptr - 1) = '\0';
@@ -428,7 +424,7 @@ int ini_parse_file (FILE * file, const struct IniConfig * config, void * user)
 						if (!end) end = strrstr (start + 1, tmpDel);
 						*end = '\0';
 						ptr = end + 2;
-						end = rstrip (start);
+						rstrip (start);
 						name = start;
 					}
 					value = ptr + 1;

--- a/src/plugins/line/testgetline.c
+++ b/src/plugins/line/testgetline.c
@@ -11,9 +11,9 @@
 int main (void)
 {
 
-	char * line;
+	char * line = 0;
 	size_t len = 0;
-	FILE * fp;
+	FILE * fp = 0;
 	getline (&line, &len, fp);
 	return 0;
 }

--- a/src/plugins/lineendings/lineendings.c
+++ b/src/plugins/lineendings/lineendings.c
@@ -89,7 +89,6 @@ static int checkLineEndings (const char * fileName, Lineending validLineEnding, 
 				return -2;
 			}
 			++line;
-			found = NA;
 		}
 		else if (lineEnding != found && found != NA)
 		{

--- a/src/plugins/list/list.c
+++ b/src/plugins/list/list.c
@@ -414,8 +414,8 @@ int elektraListAddPlugin (Plugin * handle, KeySet * pluginConfig)
 		return 0;
 	}
 	ksRewind (pluginConfig);
+	ksNext (pluginConfig);
 	Key * lookup = ksNext (pluginConfig);
-	lookup = ksNext (pluginConfig);
 	if (keyBaseName (lookup)[0] != '#')
 	{
 		return -1;
@@ -442,8 +442,8 @@ int elektraListEditPlugin (Plugin * handle, KeySet * pluginConfig)
 		return 0;
 	}
 	ksRewind (pluginConfig);
-	Key * lookup = ksNext (pluginConfig);
-	lookup = ksNext (pluginConfig);
+	ksNext (pluginConfig);
+	Key * lookup = lookup = ksNext (pluginConfig);
 	if (keyBaseName (lookup)[0] != '#')
 	{
 		return -1;

--- a/src/plugins/mathcheck/mathcheck.c
+++ b/src/plugins/mathcheck/mathcheck.c
@@ -179,6 +179,7 @@ static PNElem doPrefixCalculation (PNElem * stack, PNElem * stackPtr)
 		}
 		else
 		{
+			result.op = NA;
 			return result;
 		}
 	}

--- a/src/plugins/resolver/testmod_resolver.c
+++ b/src/plugins/resolver/testmod_resolver.c
@@ -178,7 +178,8 @@ void test_tempname ()
 
 	Key * parentKey = keyNew ("system", KEY_END);
 	plugin->kdbGet (plugin, 0, parentKey);
-	succeed_if (h && !strncmp (h->system.tempfile, KDB_DB_SYSTEM "/elektra.ecf", sizeof (KDB_DB_SYSTEM)), "resulting filename not correct");
+	succeed_if (h && !strncmp (h->system.tempfile, KDB_DB_SYSTEM "/elektra.ecf", sizeof (KDB_DB_SYSTEM)),
+		    "resulting filename not correct");
 
 	keyDel (parentKey);
 	elektraPluginClose (plugin, 0);

--- a/src/plugins/resolver/testmod_resolver.c
+++ b/src/plugins/resolver/testmod_resolver.c
@@ -141,7 +141,7 @@ void test_lockname ()
 
 	Key * parentKey = keyNew ("system", KEY_END);
 	plugin->kdbGet (plugin, 0, parentKey);
-	succeed_if (!strcmp (h->system.dirname, KDB_DB_SYSTEM), "resulting filename not correct");
+	succeed_if (h && !strcmp (h->system.dirname, KDB_DB_SYSTEM), "resulting filename not correct");
 
 	keyDel (parentKey);
 	elektraPluginClose (plugin, 0);
@@ -178,7 +178,7 @@ void test_tempname ()
 
 	Key * parentKey = keyNew ("system", KEY_END);
 	plugin->kdbGet (plugin, 0, parentKey);
-	succeed_if (!strncmp (h->system.tempfile, KDB_DB_SYSTEM "/elektra.ecf", sizeof (KDB_DB_SYSTEM)), "resulting filename not correct");
+	succeed_if (h && !strncmp (h->system.tempfile, KDB_DB_SYSTEM "/elektra.ecf", sizeof (KDB_DB_SYSTEM)), "resulting filename not correct");
 
 	keyDel (parentKey);
 	elektraPluginClose (plugin, 0);

--- a/src/plugins/uname/testuname.c
+++ b/src/plugins/uname/testuname.c
@@ -12,7 +12,7 @@ int main ()
 {
 	struct utsname buf;
 
-	int ret = uname (&buf);
+	uname (&buf);
 	(void)buf.sysname;
 	(void)buf.nodename;
 	(void)buf.release;

--- a/src/plugins/validation/lookupre.c
+++ b/src/plugins/validation/lookupre.c
@@ -85,8 +85,6 @@ Key * ksLookupRE (KeySet * ks, const regex_t * regexp)
 	regmatch_t offsets;
 	Key *walker = 0, *end = 0;
 
-	walker = ksCurrent (ks);
-
 	while ((walker = ksNext (ks)) != end)
 	{
 		if (!regexec (regexp, keyString (walker), 1, &offsets, 0)) return walker;

--- a/src/plugins/xmltool/kdbtools.c
+++ b/src/plugins/xmltool/kdbtools.c
@@ -255,7 +255,7 @@ static int consumeKeyNode (KeySet * ks, const char * context, xmlTextReaderPtr r
 
 				if (xmlTextReaderNodeType (reader) == 15) /* found a </key> */
 					end = 1;
-				else
+				else if (newKey)
 				{
 					/* found a sub <key> */
 					/* prepare the context (parent) */
@@ -272,7 +272,6 @@ static int consumeKeyNode (KeySet * ks, const char * context, xmlTextReaderPtr r
 		if (newKey && !appended)
 		{
 			keyDel (newKey);
-			appended = 1;
 		}
 	}
 

--- a/tests/abi/testabi_ks.c
+++ b/tests/abi/testabi_ks.c
@@ -545,7 +545,7 @@ static void test_ksCursor ()
 	ksRewind (ks);
 	for (i = 0; i < 5; i++)
 	{
-		key = ksNext (ks);
+		ksNext (ks);
 		if (i == 1)
 		{
 			cursor = ksGetCursor (ks);
@@ -553,7 +553,7 @@ static void test_ksCursor ()
 		}
 	}
 	ksSetCursor (ks, cursor);
-	key = ksCurrent (ks);
+	ksCurrent (ks);
 
 	ksDel (ks);
 
@@ -563,7 +563,7 @@ static void test_ksCursor ()
 	ksRewind (ks);
 	for (i = 0; i < 4; i++)
 	{
-		key = ksNext (ks);
+		ksNext (ks);
 		if (i == 1)
 		{
 			cursor = ksGetCursor (ks);
@@ -583,7 +583,7 @@ static void test_ksCursor ()
 	ksRewind (ks);
 	for (i = 0; i < 4; i++)
 	{
-		key = ksNext (ks);
+		ksNext (ks);
 		cursor = ksGetCursor (ks);
 		name[5] = '0' + i;
 		succeed_if_same_string (keyName (ksAtCursor (ks, cursor)), name);
@@ -756,7 +756,7 @@ static void test_ksSort ()
 	succeed_if (keyGetRef (k2) == 1, "reference counter not incremented after insertion");
 
 	ksRewind (ks);
-	key = ksNext (ks);
+	ksNext (ks);
 	ksDel (ks);
 
 	ks = ksNew (0, KS_END);
@@ -766,7 +766,7 @@ static void test_ksSort ()
 	ksAppendKey (ks, k1);
 
 	ksRewind (ks);
-	key = ksNext (ks);
+	ksNext (ks);
 	ksDel (ks);
 
 	ks = ksNew (0, KS_END);

--- a/tests/cframework/tests.c
+++ b/tests/cframework/tests.c
@@ -153,14 +153,18 @@ int compare_line_files (const char * filename, const char * genfilename)
 	char * org = 0;
 	char * gen = 0;
 	int line = 0;
+	int remainingBufferLength = BUFFER_LENGTH;
 
 	forg = fopen (filename, "r");
 	fgen = fopen (genfilename, "r");
 
 	strncpy (bufferorg, "could not open file, orig: ", BUFFER_LENGTH);
-	strncat (bufferorg, filename, BUFFER_LENGTH);
-	strncat (bufferorg, " gen: ", BUFFER_LENGTH);
-	strncat (bufferorg, genfilename, BUFFER_LENGTH);
+	remainingBufferLength -= strlen("could not open file, orig: ");
+	strncat (bufferorg, filename, remainingBufferLength);
+	remainingBufferLength -= strlen(filename);
+	strncat (bufferorg, " gen: ", remainingBufferLength);
+	remainingBufferLength -= strlen(" gen: ");
+	strncat (bufferorg, genfilename, remainingBufferLength);
 
 	exit_if_fail (forg && fgen, bufferorg);
 

--- a/tests/cframework/tests.c
+++ b/tests/cframework/tests.c
@@ -159,11 +159,11 @@ int compare_line_files (const char * filename, const char * genfilename)
 	fgen = fopen (genfilename, "r");
 
 	strncpy (bufferorg, "could not open file, orig: ", BUFFER_LENGTH);
-	remainingBufferLength -= strlen("could not open file, orig: ");
+	remainingBufferLength -= strlen ("could not open file, orig: ");
 	strncat (bufferorg, filename, remainingBufferLength);
-	remainingBufferLength -= strlen(filename);
+	remainingBufferLength -= strlen (filename);
 	strncat (bufferorg, " gen: ", remainingBufferLength);
-	remainingBufferLength -= strlen(" gen: ");
+	remainingBufferLength -= strlen (" gen: ");
 	strncat (bufferorg, genfilename, remainingBufferLength);
 
 	exit_if_fail (forg && fgen, bufferorg);

--- a/tests/ctest/test_internal.c
+++ b/tests/ctest/test_internal.c
@@ -118,7 +118,7 @@ static void test_elektraUnescapeKeyName ()
 	printf ("test unescape key name \n");
 
 	char dest[2000];
-	char * p = dest;
+	char * p = NULL;
 
 	succeed_if (elektraUnescapeKeyName ("abc", dest) == 4, "size of unescaping wrong");
 	succeed_if_same_string ("abc", dest);

--- a/tests/ctest/test_mount.c
+++ b/tests/ctest/test_mount.c
@@ -232,11 +232,12 @@ static void test_simpletrie ()
 
 	Key * mp = backend->mountpoint;
 	succeed_if (mp, "no mountpoint found");
-	if (mp) {
+	if (mp)
+	{
 		succeed_if_same_string (keyName (mp), "user/tests/backend/simple");
 		succeed_if_same_string (keyString (mp), "simple");
 	}
-	
+
 	Plugin * plugin = backend->getplugins[1];
 
 	KeySet * test_config = set_pluginconf ();
@@ -408,7 +409,8 @@ static void test_us ()
 
 	Key * mp = backend->mountpoint;
 	succeed_if (mp, "no mountpoint found");
-	if (mp) {
+	if (mp)
+	{
 		succeed_if_same_string (keyName (mp), "user");
 		succeed_if_same_string (keyString (mp), "user");
 	}

--- a/tests/ctest/test_mount.c
+++ b/tests/ctest/test_mount.c
@@ -135,21 +135,21 @@ static void test_simple ()
 	keySetName (searchKey, "user/tests/simple");
 	backend = trieLookup (kdb->trie, searchKey);
 	succeed_if (backend, "there should be a backend");
-	compare_key (backend->mountpoint, mp);
+	if (backend) compare_key (backend->mountpoint, mp);
 
 
 	keySetName (searchKey, "user/tests/simple/below");
 	Backend * b2 = trieLookup (kdb->trie, searchKey);
 	succeed_if (b2, "there should be a backend");
 	succeed_if (backend == b2, "should be same backend");
-	compare_key (b2->mountpoint, mp);
+	if (b2) compare_key (b2->mountpoint, mp);
 
 
 	keySetName (searchKey, "user/tests/simple/deep/below");
 	b2 = trieLookup (kdb->trie, searchKey);
 	succeed_if (b2, "there should be a backend");
 	succeed_if (backend == b2, "should be same backend");
-	compare_key (b2->mountpoint, mp);
+	if (b2) compare_key (b2->mountpoint, mp);
 
 	keyDel (errorKey);
 	ksDel (modules);
@@ -230,11 +230,13 @@ static void test_simpletrie ()
 	exit_if_fail (backend->setplugins[1] != 0, "there should be a plugin");
 	succeed_if (backend->setplugins[2] == 0, "there should be no plugin");
 
-	Key * mp;
-	succeed_if ((mp = backend->mountpoint) != 0, "no mountpoint found");
-	succeed_if_same_string (keyName (mp), "user/tests/backend/simple");
-	succeed_if_same_string (keyString (mp), "simple");
-
+	Key * mp = backend->mountpoint;
+	succeed_if (mp, "no mountpoint found");
+	if (mp) {
+		succeed_if_same_string (keyName (mp), "user/tests/backend/simple");
+		succeed_if_same_string (keyString (mp), "simple");
+	}
+	
 	Plugin * plugin = backend->getplugins[1];
 
 	KeySet * test_config = set_pluginconf ();
@@ -404,11 +406,12 @@ static void test_us ()
 	exit_if_fail (backend->setplugins[1] == 0, "there should be no plugin");
 	succeed_if (backend->setplugins[2] == 0, "there should be no plugin");
 
-	Key * mp;
-	succeed_if ((mp = backend->mountpoint) != 0, "no mountpoint found");
-	succeed_if_same_string (keyName (mp), "user");
-	succeed_if_same_string (keyString (mp), "user");
-
+	Key * mp = backend->mountpoint;
+	succeed_if (mp, "no mountpoint found");
+	if (mp) {
+		succeed_if_same_string (keyName (mp), "user");
+		succeed_if_same_string (keyString (mp), "user");
+	}
 
 	keySetName (key, "system/anywhere/tests/backend/two");
 	Backend * two = trieLookup (kdb->trie, key);
@@ -459,7 +462,7 @@ static void test_endings ()
 	keySetName (searchKey, "user/endings");
 	backend = trieLookup (kdb->trie, searchKey);
 	succeed_if (backend, "there should be a backend");
-	compare_key (backend->mountpoint, mp);
+	if (backend) compare_key (backend->mountpoint, mp);
 
 
 	keySetName (searchKey, "user/endings#");
@@ -468,7 +471,7 @@ static void test_endings ()
 	Backend * b2 = trieLookup (kdb->trie, searchKey);
 	succeed_if (b2, "there should be a backend");
 	succeed_if (backend != b2, "should be other backend");
-	compare_key (b2->mountpoint, mp);
+	if (b2) compare_key (b2->mountpoint, mp);
 
 
 	keySetName (searchKey, "user/endings/_");
@@ -477,7 +480,7 @@ static void test_endings ()
 	b2 = trieLookup (kdb->trie, searchKey);
 	succeed_if (b2, "there should be a backend");
 	succeed_if (backend == b2, "should be the same backend");
-	compare_key (b2->mountpoint, mp);
+	if (b2) compare_key (b2->mountpoint, mp);
 
 
 	keySetName (searchKey, "user/endings/X");
@@ -486,7 +489,7 @@ static void test_endings ()
 	b2 = trieLookup (kdb->trie, searchKey);
 	succeed_if (b2, "there should be a backend");
 	succeed_if (backend == b2, "should be the same backend");
-	compare_key (b2->mountpoint, mp);
+	if (b2) compare_key (b2->mountpoint, mp);
 
 
 	keySetName (searchKey, "user/endings_");
@@ -510,7 +513,7 @@ static void test_endings ()
 	b2 = trieLookup (kdb->trie, searchKey);
 	succeed_if (b2, "there should be a backend");
 	succeed_if (backend != b2, "should be other backend");
-	compare_key (b2->mountpoint, mp);
+	if (b2) compare_key (b2->mountpoint, mp);
 
 	keySetName (searchKey, "user/endings\200");
 	keySetName (mp, "user/endings\200");
@@ -518,7 +521,7 @@ static void test_endings ()
 	b2 = trieLookup (kdb->trie, searchKey);
 	succeed_if (b2, "there should be a backend");
 	succeed_if (backend != b2, "should be other backend");
-	compare_key (b2->mountpoint, mp);
+	if (b2) compare_key (b2->mountpoint, mp);
 
 	// output_trie(trie);
 
@@ -561,21 +564,21 @@ static void test_oldroot ()
 	keySetName (searchKey, "user/tests/simple");
 	backend = trieLookup (kdb->trie, searchKey);
 	succeed_if (backend, "there should be a backend");
-	compare_key (backend->mountpoint, mp);
+	if (backend) compare_key (backend->mountpoint, mp);
 
 
 	keySetName (searchKey, "user/tests/simple/below");
 	Backend * b2 = trieLookup (kdb->trie, searchKey);
 	succeed_if (b2, "there should be a backend");
 	succeed_if (backend == b2, "should be same backend");
-	compare_key (b2->mountpoint, mp);
+	if (b2) compare_key (b2->mountpoint, mp);
 
 
 	keySetName (searchKey, "user/tests/simple/deep/below");
 	b2 = trieLookup (kdb->trie, searchKey);
 	succeed_if (b2, "there should be a backend");
 	succeed_if (backend == b2, "should be same backend");
-	compare_key (b2->mountpoint, mp);
+	if (b2) compare_key (b2->mountpoint, mp);
 
 	keyDel (mp);
 	keyDel (rmp);
@@ -623,40 +626,40 @@ static void test_cascading ()
 	keySetName (searchKey, "user/tests/simple");
 	backend = trieLookup (kdb->trie, searchKey);
 	succeed_if (backend, "there should be a backend");
-	compare_key (backend->mountpoint, mp);
+	if (backend) compare_key (backend->mountpoint, mp);
 
 
 	keySetName (searchKey, "user/tests/simple/below");
 	Backend * b2 = trieLookup (kdb->trie, searchKey);
 	succeed_if (b2, "there should be a backend");
 	succeed_if (backend == b2, "should be same backend");
-	compare_key (b2->mountpoint, mp);
+	if (b2) compare_key (b2->mountpoint, mp);
 
 
 	keySetName (searchKey, "user/tests/simple/deep/below");
 	b2 = trieLookup (kdb->trie, searchKey);
 	succeed_if (b2, "there should be a backend");
 	succeed_if (backend == b2, "should be same backend");
-	compare_key (b2->mountpoint, mp);
+	if (b2) compare_key (b2->mountpoint, mp);
 
 
 	keySetName (searchKey, "system/tests/simple");
 	backend = trieLookup (kdb->trie, searchKey);
 	succeed_if (backend, "there should be a backend");
-	compare_key (backend->mountpoint, mp);
+	if (backend) compare_key (backend->mountpoint, mp);
 
 	keySetName (searchKey, "system/tests/simple/below");
 	b2 = trieLookup (kdb->trie, searchKey);
 	succeed_if (b2, "there should be a backend");
 	succeed_if (backend == b2, "should be same backend");
-	compare_key (b2->mountpoint, mp);
+	if (b2) compare_key (b2->mountpoint, mp);
 
 
 	keySetName (searchKey, "system/tests/simple/deep/below");
 	b2 = trieLookup (kdb->trie, searchKey);
 	succeed_if (b2, "there should be a backend");
 	succeed_if (backend == b2, "should be same backend");
-	compare_key (b2->mountpoint, mp);
+	if (b2) compare_key (b2->mountpoint, mp);
 
 
 	keyDel (errorKey);
@@ -696,7 +699,7 @@ static void test_root ()
 	keySetName (searchKey, "user");
 	b2 = trieLookup (kdb->trie, searchKey);
 	succeed_if (b2, "there should be a backend");
-	compare_key (b2->mountpoint, rmp);
+	if (b2) compare_key (b2->mountpoint, rmp);
 
 
 	Backend * backend = 0;
@@ -704,21 +707,21 @@ static void test_root ()
 	keySetName (searchKey, "user/tests/simple");
 	backend = trieLookup (kdb->trie, searchKey);
 	succeed_if (backend, "there should be a backend");
-	compare_key (backend->mountpoint, mp);
+	if (backend) compare_key (backend->mountpoint, mp);
 
 
 	keySetName (searchKey, "user/tests/simple/below");
 	b2 = trieLookup (kdb->trie, searchKey);
 	succeed_if (b2, "there should be a backend");
 	succeed_if (backend == b2, "should be same backend");
-	compare_key (b2->mountpoint, mp);
+	if (b2) compare_key (b2->mountpoint, mp);
 
 
 	keySetName (searchKey, "user/tests/simple/deep/below");
 	b2 = trieLookup (kdb->trie, searchKey);
 	succeed_if (b2, "there should be a backend");
 	succeed_if (backend == b2, "should be same backend");
-	compare_key (b2->mountpoint, mp);
+	if (b2) compare_key (b2->mountpoint, mp);
 
 	keyDel (mp);
 	keyDel (rmp);
@@ -754,7 +757,7 @@ static void test_default ()
 	keySetName (searchKey, "user");
 	b2 = trieLookup (kdb->trie, searchKey);
 	succeed_if (b2, "there should be a backend");
-	compare_key (b2->mountpoint, rmp);
+	if (b2) compare_key (b2->mountpoint, rmp);
 
 
 	Backend * backend = 0;
@@ -762,34 +765,34 @@ static void test_default ()
 	keySetName (searchKey, "user/tests/simple");
 	backend = trieLookup (kdb->trie, searchKey);
 	succeed_if (backend, "there should be a backend");
-	compare_key (backend->mountpoint, mp);
+	if (backend) compare_key (backend->mountpoint, mp);
 
 
 	keySetName (searchKey, "user/tests/simple/below");
 	b2 = trieLookup (kdb->trie, searchKey);
 	succeed_if (b2, "there should be a backend");
 	succeed_if (backend == b2, "should be same backend");
-	compare_key (b2->mountpoint, mp);
+	if (b2) compare_key (b2->mountpoint, mp);
 
 
 	keySetName (searchKey, "user/tests/simple/deep/below");
 	b2 = trieLookup (kdb->trie, searchKey);
 	succeed_if (b2, "there should be a backend");
 	succeed_if (backend == b2, "should be same backend");
-	compare_key (b2->mountpoint, mp);
+	if (b2) compare_key (b2->mountpoint, mp);
 
 	Key * dmp = keyNew ("", KEY_VALUE, "default", KEY_END);
 	keySetName (searchKey, "system/elektra");
 	b2 = trieLookup (kdb->trie, searchKey);
 	succeed_if (b2, "there should be a backend");
 	succeed_if (b2 == kdb->defaultBackend, "should be the default backend");
-	compare_key (b2->mountpoint, dmp);
+	if (b2) compare_key (b2->mountpoint, dmp);
 
 	keySetName (searchKey, "system/elektra/below");
 	b2 = trieLookup (kdb->trie, searchKey);
 	succeed_if (b2, "there should be a backend");
 	succeed_if (b2 == kdb->defaultBackend, "should be the default backend");
-	compare_key (b2->mountpoint, dmp);
+	if (b2) compare_key (b2->mountpoint, dmp);
 
 	keyDel (dmp);
 	keyDel (mp);
@@ -845,13 +848,13 @@ static void test_init ()
 	b2 = trieLookup (kdb->trie, searchKey);
 	succeed_if (b2, "there should be a backend");
 	succeed_if (b2 == kdb->initBackend, "should be the init backend");
-	compare_key (b2->mountpoint, dmp);
+	if (b2) compare_key (b2->mountpoint, dmp);
 
 	keySetName (searchKey, "system/elektra/below");
 	b2 = trieLookup (kdb->trie, searchKey);
 	succeed_if (b2, "there should be a backend");
 	succeed_if (b2 == kdb->initBackend, "should be the init backend");
-	compare_key (b2->mountpoint, dmp);
+	if (b2) compare_key (b2->mountpoint, dmp);
 
 	keySetName (searchKey, "system");
 	b2 = trieLookup (kdb->trie, searchKey);
@@ -894,7 +897,7 @@ static void test_rootInit ()
 	keySetName (searchKey, "user");
 	b2 = trieLookup (kdb->trie, searchKey);
 	succeed_if (b2, "there should be a backend");
-	compare_key (b2->mountpoint, rmp);
+	if (b2) compare_key (b2->mountpoint, rmp);
 
 
 	Backend * backend = 0;
@@ -902,46 +905,46 @@ static void test_rootInit ()
 	keySetName (searchKey, "user/tests/simple");
 	backend = trieLookup (kdb->trie, searchKey);
 	succeed_if (backend, "there should be a backend");
-	compare_key (backend->mountpoint, mp);
+	if (backend) compare_key (backend->mountpoint, mp);
 
 
 	keySetName (searchKey, "user/tests/simple/below");
 	b2 = trieLookup (kdb->trie, searchKey);
 	succeed_if (b2, "there should be a backend");
 	succeed_if (backend == b2, "should be same backend");
-	compare_key (b2->mountpoint, mp);
+	if (b2) compare_key (b2->mountpoint, mp);
 
 
 	keySetName (searchKey, "user/tests/simple/deep/below");
 	b2 = trieLookup (kdb->trie, searchKey);
 	succeed_if (b2, "there should be a backend");
 	succeed_if (backend == b2, "should be same backend");
-	compare_key (b2->mountpoint, mp);
+	if (b2) compare_key (b2->mountpoint, mp);
 
 	Key * dmp = keyNew ("", KEY_VALUE, "default", KEY_END);
 	keySetName (searchKey, "system/elektra");
 	b2 = trieLookup (kdb->trie, searchKey);
 	succeed_if (b2, "there should be a backend");
 	succeed_if (b2 == kdb->initBackend, "should be the init backend");
-	compare_key (b2->mountpoint, dmp);
+	if (b2) compare_key (b2->mountpoint, dmp);
 
 	keySetName (searchKey, "system/elektra/below");
 	b2 = trieLookup (kdb->trie, searchKey);
 	succeed_if (b2, "there should be a backend");
 	succeed_if (b2 == kdb->initBackend, "should be the init backend");
-	compare_key (b2->mountpoint, dmp);
+	if (b2) compare_key (b2->mountpoint, dmp);
 
 	keySetName (searchKey, "system");
 	b2 = trieLookup (kdb->trie, searchKey);
 	succeed_if (b2, "there should be a backend");
 	succeed_if (b2 != kdb->initBackend, "should not be the init backend");
-	compare_key (b2->mountpoint, rmp);
+	if (b2) compare_key (b2->mountpoint, rmp);
 
 	keySetName (searchKey, "system/something");
 	b2 = trieLookup (kdb->trie, searchKey);
 	succeed_if (b2, "there should be a backend");
 	succeed_if (b2 != kdb->initBackend, "should not be the init backend");
-	compare_key (b2->mountpoint, rmp);
+	if (b2) compare_key (b2->mountpoint, rmp);
 
 	keyDel (dmp);
 	keyDel (mp);
@@ -979,7 +982,7 @@ static void test_modules ()
 	keySetName (searchKey, "user");
 	b2 = trieLookup (kdb->trie, searchKey);
 	succeed_if (b2, "there should be a backend");
-	compare_key (b2->mountpoint, rmp);
+	if (b2) compare_key (b2->mountpoint, rmp);
 
 
 	Backend * backend = 0;
@@ -987,34 +990,34 @@ static void test_modules ()
 	keySetName (searchKey, "user/tests/simple");
 	backend = trieLookup (kdb->trie, searchKey);
 	succeed_if (backend, "there should be a backend");
-	compare_key (backend->mountpoint, mp);
+	if (backend) compare_key (backend->mountpoint, mp);
 
 
 	keySetName (searchKey, "user/tests/simple/below");
 	b2 = trieLookup (kdb->trie, searchKey);
 	succeed_if (b2, "there should be a backend");
 	succeed_if (backend == b2, "should be same backend");
-	compare_key (b2->mountpoint, mp);
+	if (b2) compare_key (b2->mountpoint, mp);
 
 
 	keySetName (searchKey, "user/tests/simple/deep/below");
 	b2 = trieLookup (kdb->trie, searchKey);
 	succeed_if (b2, "there should be a backend");
 	succeed_if (backend == b2, "should be same backend");
-	compare_key (b2->mountpoint, mp);
+	if (b2) compare_key (b2->mountpoint, mp);
 
 	Key * dmp = keyNew ("", KEY_VALUE, "default", KEY_END);
 	keySetName (searchKey, "system/elektra");
 	b2 = trieLookup (kdb->trie, searchKey);
 	succeed_if (b2, "there should be a backend");
 	succeed_if (b2 == kdb->defaultBackend, "should be the default backend");
-	compare_key (b2->mountpoint, dmp);
+	if (b2) compare_key (b2->mountpoint, dmp);
 
 	keySetName (searchKey, "system/elektra/below");
 	b2 = trieLookup (kdb->trie, searchKey);
 	succeed_if (b2, "there should be a backend");
 	succeed_if (b2 == kdb->defaultBackend, "should be the default backend");
-	compare_key (b2->mountpoint, dmp);
+	if (b2) compare_key (b2->mountpoint, dmp);
 
 	Key * mmp = keyNew ("system/elektra/modules", KEY_VALUE, "modules", KEY_END);
 	keyAddBaseName (mmp, "default");

--- a/tests/ctest/test_mountsplit.c
+++ b/tests/ctest/test_mountsplit.c
@@ -139,21 +139,21 @@ static void test_simple ()
 	keySetName (searchKey, "user/tests/simple");
 	backend = trieLookup (kdb->trie, searchKey);
 	succeed_if (backend, "there should be a backend");
-	compare_key (backend->mountpoint, mp);
+	if (backend) compare_key (backend->mountpoint, mp);
 
 
 	keySetName (searchKey, "user/tests/simple/below");
 	Backend * b2 = trieLookup (kdb->trie, searchKey);
 	succeed_if (b2, "there should be a backend");
 	succeed_if (backend == b2, "should be same backend");
-	compare_key (b2->mountpoint, mp);
+	if (b2) compare_key (b2->mountpoint, mp);
 
 
 	keySetName (searchKey, "user/tests/simple/deep/below");
 	b2 = trieLookup (kdb->trie, searchKey);
 	succeed_if (b2, "there should be a backend");
 	succeed_if (backend == b2, "should be same backend");
-	compare_key (b2->mountpoint, mp);
+	if (b2) compare_key (b2->mountpoint, mp);
 
 	keyDel (errorKey);
 	ksDel (modules);
@@ -203,11 +203,12 @@ static void test_us ()
 	keyAddBaseName (key, "below");
 	Backend * backend2 = trieLookup (kdb->trie, key);
 	succeed_if (backend == backend2, "should be same backend");
-
-	succeed_if ((mp = backend->mountpoint) != 0, "no mountpoint found");
-	succeed_if_same_string (keyName (mp), "user");
-	succeed_if_same_string (keyString (mp), "user");
-
+	mp = backend->mountpoint;
+	succeed_if (mp, "no mountpoint found");
+	if (mp) {
+		succeed_if_same_string (keyName (mp), "user");
+		succeed_if_same_string (keyString (mp), "user");
+	}
 
 	keySetName (key, "system/anywhere/tests/backend/two");
 	Backend * two = trieLookup (kdb->trie, key);
@@ -274,40 +275,40 @@ static void test_cascading ()
 	keySetName (searchKey, "user/tests/simple");
 	backend = trieLookup (kdb->trie, searchKey);
 	succeed_if (backend, "there should be a backend");
-	compare_key (backend->mountpoint, mp);
+	if (backend) compare_key (backend->mountpoint, mp);
 
 
 	keySetName (searchKey, "user/tests/simple/below");
 	Backend * b2 = trieLookup (kdb->trie, searchKey);
 	succeed_if (b2, "there should be a backend");
 	succeed_if (backend == b2, "should be same backend");
-	compare_key (b2->mountpoint, mp);
+	if (b2) compare_key (b2->mountpoint, mp);
 
 
 	keySetName (searchKey, "user/tests/simple/deep/below");
 	b2 = trieLookup (kdb->trie, searchKey);
 	succeed_if (b2, "there should be a backend");
 	succeed_if (backend == b2, "should be same backend");
-	compare_key (b2->mountpoint, mp);
+	if (b2) compare_key (b2->mountpoint, mp);
 
 
 	keySetName (searchKey, "system/tests/simple");
 	backend = trieLookup (kdb->trie, searchKey);
 	succeed_if (backend, "there should be a backend");
-	compare_key (backend->mountpoint, mp);
+	if (backend) compare_key (backend->mountpoint, mp);
 
 	keySetName (searchKey, "system/tests/simple/below");
 	b2 = trieLookup (kdb->trie, searchKey);
 	succeed_if (b2, "there should be a backend");
 	succeed_if (backend == b2, "should be same backend");
-	compare_key (b2->mountpoint, mp);
+	if (b2) compare_key (b2->mountpoint, mp);
 
 
 	keySetName (searchKey, "system/tests/simple/deep/below");
 	b2 = trieLookup (kdb->trie, searchKey);
 	succeed_if (b2, "there should be a backend");
 	succeed_if (backend == b2, "should be same backend");
-	compare_key (b2->mountpoint, mp);
+	if (b2) compare_key (b2->mountpoint, mp);
 
 
 	keyDel (errorKey);
@@ -364,28 +365,28 @@ static void test_root ()
 	keySetName (searchKey, "user");
 	b2 = trieLookup (kdb->trie, searchKey);
 	succeed_if (b2, "there should be a backend");
-	compare_key (b2->mountpoint, rmp);
+	if (b2) compare_key (b2->mountpoint, rmp);
 
 
 	Backend * backend = 0;
 	keySetName (searchKey, "user/tests/simple");
 	backend = trieLookup (kdb->trie, searchKey);
 	succeed_if (backend, "there should be a backend");
-	compare_key (backend->mountpoint, mp);
+	if (backend) compare_key (backend->mountpoint, mp);
 
 
 	keySetName (searchKey, "user/tests/simple/below");
 	b2 = trieLookup (kdb->trie, searchKey);
 	succeed_if (b2, "there should be a backend");
 	succeed_if (backend == b2, "should be same backend");
-	compare_key (b2->mountpoint, mp);
+	if (b2) compare_key (b2->mountpoint, mp);
 
 
 	keySetName (searchKey, "user/tests/simple/deep/below");
 	b2 = trieLookup (kdb->trie, searchKey);
 	succeed_if (b2, "there should be a backend");
 	succeed_if (backend == b2, "should be same backend");
-	compare_key (b2->mountpoint, mp);
+	if (b2) compare_key (b2->mountpoint, mp);
 
 	keyDel (mp);
 	keyDel (rmp);
@@ -443,41 +444,41 @@ static void test_default ()
 	keySetName (searchKey, "user");
 	b2 = trieLookup (kdb->trie, searchKey);
 	succeed_if (b2, "there should be a backend");
-	compare_key (b2->mountpoint, rmp);
+	if (b2) compare_key (b2->mountpoint, rmp);
 
 
 	Backend * backend = 0;
 	keySetName (searchKey, "user/tests/simple");
 	backend = trieLookup (kdb->trie, searchKey);
 	succeed_if (backend, "there should be a backend");
-	compare_key (backend->mountpoint, mp);
+	if (backend) compare_key (backend->mountpoint, mp);
 
 
 	keySetName (searchKey, "user/tests/simple/below");
 	b2 = trieLookup (kdb->trie, searchKey);
 	succeed_if (b2, "there should be a backend");
 	succeed_if (backend == b2, "should be same backend");
-	compare_key (b2->mountpoint, mp);
+	if (b2) compare_key (b2->mountpoint, mp);
 
 
 	keySetName (searchKey, "user/tests/simple/deep/below");
 	b2 = trieLookup (kdb->trie, searchKey);
 	succeed_if (b2, "there should be a backend");
 	succeed_if (backend == b2, "should be same backend");
-	compare_key (b2->mountpoint, mp);
+	if (b2) compare_key (b2->mountpoint, mp);
 
 	Key * dmp = keyNew ("", KEY_VALUE, "default", KEY_END);
 	keySetName (searchKey, "system/elektra");
 	b2 = trieLookup (kdb->trie, searchKey);
 	succeed_if (b2, "there should be a backend");
 	succeed_if (b2 == kdb->defaultBackend, "should be the default backend");
-	compare_key (b2->mountpoint, dmp);
+	if (b2) compare_key (b2->mountpoint, dmp);
 
 	keySetName (searchKey, "system/elektra/below");
 	b2 = trieLookup (kdb->trie, searchKey);
 	succeed_if (b2, "there should be a backend");
 	succeed_if (b2 == kdb->defaultBackend, "should be the default backend");
-	compare_key (b2->mountpoint, dmp);
+	if (b2) compare_key (b2->mountpoint, dmp);
 
 	keyDel (dmp);
 	keyDel (mp);
@@ -543,41 +544,41 @@ static void test_modules ()
 	keySetName (searchKey, "user");
 	b2 = trieLookup (kdb->trie, searchKey);
 	succeed_if (b2, "there should be a backend");
-	compare_key (b2->mountpoint, rmp);
+	if (b2) compare_key (b2->mountpoint, rmp);
 
 
 	Backend * backend = 0;
 	keySetName (searchKey, "user/tests/simple");
 	backend = trieLookup (kdb->trie, searchKey);
 	succeed_if (backend, "there should be a backend");
-	compare_key (backend->mountpoint, mp);
+	if (backend) compare_key (backend->mountpoint, mp);
 
 
 	keySetName (searchKey, "user/tests/simple/below");
 	b2 = trieLookup (kdb->trie, searchKey);
 	succeed_if (b2, "there should be a backend");
 	succeed_if (backend == b2, "should be same backend");
-	compare_key (b2->mountpoint, mp);
+	if (b2) compare_key (b2->mountpoint, mp);
 
 
 	keySetName (searchKey, "user/tests/simple/deep/below");
 	b2 = trieLookup (kdb->trie, searchKey);
 	succeed_if (b2, "there should be a backend");
 	succeed_if (backend == b2, "should be same backend");
-	compare_key (b2->mountpoint, mp);
+	if (b2) compare_key (b2->mountpoint, mp);
 
 	Key * dmp = keyNew ("", KEY_VALUE, "default", KEY_END);
 	keySetName (searchKey, "system/elektra");
 	b2 = trieLookup (kdb->trie, searchKey);
 	succeed_if (b2, "there should be a backend");
 	succeed_if (b2 == kdb->defaultBackend, "should be the default backend");
-	compare_key (b2->mountpoint, dmp);
+	if (b2) compare_key (b2->mountpoint, dmp);
 
 	keySetName (searchKey, "system/elektra/below");
 	b2 = trieLookup (kdb->trie, searchKey);
 	succeed_if (b2, "there should be a backend");
 	succeed_if (b2 == kdb->defaultBackend, "should be the default backend");
-	compare_key (b2->mountpoint, dmp);
+	if (b2) compare_key (b2->mountpoint, dmp);
 
 	Key * mmp = keyNew ("system/elektra/modules", KEY_VALUE, "modules", KEY_END);
 	keyAddBaseName (mmp, "default");

--- a/tests/ctest/test_mountsplit.c
+++ b/tests/ctest/test_mountsplit.c
@@ -205,7 +205,8 @@ static void test_us ()
 	succeed_if (backend == backend2, "should be same backend");
 	mp = backend->mountpoint;
 	succeed_if (mp, "no mountpoint found");
-	if (mp) {
+	if (mp)
+	{
 		succeed_if_same_string (keyName (mp), "user");
 		succeed_if_same_string (keyString (mp), "user");
 	}

--- a/tests/ctest/test_opmphm_init.c
+++ b/tests/ctest/test_opmphm_init.c
@@ -169,7 +169,8 @@ static void test_mapping_success ()
 				{
 					for (size_t i = 0; i < n - 1; ++i)
 					{
-						succeed_if (getNumber (sortOrder[i], w) < getNumber (sortOrder[i + 1], w), "sort incorrect");
+						succeed_if (getNumber (sortOrder[i], w) < getNumber (sortOrder[i + 1], w),
+							    "sort incorrect");
 					}
 				}
 				// cleanup
@@ -275,7 +276,8 @@ static void test_mapping_success ()
 				{
 					for (size_t i = 0; i < n - 1; ++i)
 					{
-						succeed_if (getNumber (sortOrder[i], w) < getNumber (sortOrder[i + 1], w), "sort incorrect");
+						succeed_if (getNumber (sortOrder[i], w) < getNumber (sortOrder[i + 1], w),
+							    "sort incorrect");
 					}
 				}
 				// cleanup
@@ -322,7 +324,6 @@ static void test_mapping_fail ()
 				for (size_t i = 0; i < n; ++i)
 				{
 					getOrderedPair (&order[i], w, i);
-				
 				}
 			}
 			// set error

--- a/tests/ctest/test_opmphm_init.c
+++ b/tests/ctest/test_opmphm_init.c
@@ -51,6 +51,7 @@ const size_t maxNcomplex = 1000;
 
 static void test_basic_functions ()
 {
+	printf ("test_basic_functions\n");
 	Opmphm * opmphm = opmphmNew ();
 	exit_if_fail (opmphm, "malloc");
 	succeed_if (opmphmIsEmpty (opmphm), "opmphm should be empty");
@@ -59,6 +60,7 @@ static void test_basic_functions ()
 
 static void test_test_functions ()
 {
+	printf ("test_test_functions\n");
 	for (size_t w = 2; w < opmphmGetWidth (maxNsimple); ++w)
 	{
 		for (size_t n = 0; n < getPower (w, OPMPHMTUPLE); ++n)
@@ -72,6 +74,7 @@ static void test_test_functions ()
 
 static void test_mapping_success ()
 {
+	printf ("test_mapping_success\n");
 	/* test w, always full. w^OPMPHMTUPLE elements in each run.
 	 * order.h[] in ascending order
 	 */
@@ -95,9 +98,12 @@ static void test_mapping_success ()
 			init.minOrder = 0;
 			init.maxOrder = n - 1;
 			// fill
-			for (size_t i = 0; i < n; ++i)
+			if (order)
 			{
-				getOrderedPair (&order[i], w, i);
+				for (size_t i = 0; i < n; ++i)
+				{
+					getOrderedPair (&order[i], w, i);
+				}
 			}
 			// build
 			OpmphmOrder ** sortOrder = opmphmInit (opmphm, &init, order, n);
@@ -106,9 +112,12 @@ static void test_mapping_success ()
 			exit_if_fail (ret >= 0, "malloc");
 			// check
 			succeed_if (!ret, "not duplicate data marked as duplicate");
-			for (size_t i = 0; i < n - 1; ++i)
+			if (sortOrder)
 			{
-				succeed_if (getNumber (sortOrder[i], w) < getNumber (sortOrder[i + 1], w), "sort incorrect");
+				for (size_t i = 0; i < n - 1; ++i)
+				{
+					succeed_if (getNumber (sortOrder[i], w) < getNumber (sortOrder[i + 1], w), "sort incorrect");
+				}
 			}
 			// cleanup
 			opmphmDel (opmphm);
@@ -142,9 +151,12 @@ static void test_mapping_success ()
 				init.minOrder = 0;
 				init.maxOrder = n - 1;
 				// fill
-				for (size_t i = 0; i < n; ++i)
+				if (order)
 				{
-					getOrderedPair (&order[i], w, i);
+					for (size_t i = 0; i < n; ++i)
+					{
+						getOrderedPair (&order[i], w, i);
+					}
 				}
 				// build
 				OpmphmOrder ** sortOrder = opmphmInit (opmphm, &init, order, n);
@@ -153,9 +165,12 @@ static void test_mapping_success ()
 				exit_if_fail (ret >= 0, "malloc");
 				// check
 				succeed_if (!ret, "not duplicate data marked as duplicate");
-				for (size_t i = 0; i < n - 1; ++i)
+				if (sortOrder)
 				{
-					succeed_if (getNumber (sortOrder[i], w) < getNumber (sortOrder[i + 1], w), "sort incorrect");
+					for (size_t i = 0; i < n - 1; ++i)
+					{
+						succeed_if (getNumber (sortOrder[i], w) < getNumber (sortOrder[i + 1], w), "sort incorrect");
+					}
 				}
 				// cleanup
 				opmphmDel (opmphm);
@@ -189,9 +204,12 @@ static void test_mapping_success ()
 			init.minOrder = 0;
 			init.maxOrder = n - 1;
 			// fill
-			for (size_t i = 0; i < n; ++i)
+			if (order)
 			{
-				getOrderedPair (&order[i], w, n - 1 - i);
+				for (size_t i = 0; i < n; ++i)
+				{
+					getOrderedPair (&order[i], w, n - 1 - i);
+				}
 			}
 			// build
 			OpmphmOrder ** sortOrder = opmphmInit (opmphm, &init, order, n);
@@ -200,9 +218,12 @@ static void test_mapping_success ()
 			exit_if_fail (ret >= 0, "malloc");
 			// check
 			succeed_if (!ret, "not duplicate data marked as duplicate");
-			for (size_t i = 0; i < n - 1; ++i)
+			if (sortOrder)
 			{
-				succeed_if (getNumber (sortOrder[i], w) < getNumber (sortOrder[i + 1], w), "sort incorrect");
+				for (size_t i = 0; i < n - 1; ++i)
+				{
+					succeed_if (getNumber (sortOrder[i], w) < getNumber (sortOrder[i + 1], w), "sort incorrect");
+				}
 			}
 			// cleanup
 			opmphmDel (opmphm);
@@ -236,9 +257,12 @@ static void test_mapping_success ()
 				init.minOrder = 0;
 				init.maxOrder = n - 1;
 				// fill
-				for (size_t i = 0; i < n; ++i)
+				if (order)
 				{
-					getOrderedPair (&order[i], w, n - 1 - i);
+					for (size_t i = 0; i < n; ++i)
+					{
+						getOrderedPair (&order[i], w, n - 1 - i);
+					}
 				}
 				// build
 				OpmphmOrder ** sortOrder = opmphmInit (opmphm, &init, order, n);
@@ -247,9 +271,12 @@ static void test_mapping_success ()
 				exit_if_fail (ret >= 0, "malloc");
 				// check
 				succeed_if (!ret, "not duplicate data marked as duplicate");
-				for (size_t i = 0; i < n - 1; ++i)
+				if (sortOrder)
 				{
-					succeed_if (getNumber (sortOrder[i], w) < getNumber (sortOrder[i + 1], w), "sort incorrect");
+					for (size_t i = 0; i < n - 1; ++i)
+					{
+						succeed_if (getNumber (sortOrder[i], w) < getNumber (sortOrder[i + 1], w), "sort incorrect");
+					}
 				}
 				// cleanup
 				opmphmDel (opmphm);
@@ -265,6 +292,7 @@ static void test_mapping_success ()
 
 static void test_mapping_fail ()
 {
+	printf ("test_mapping_fail\n");
 	/* test w, always full. w^OPMPHMTUPLE elements in each run.
 	 * order.h[] in ascending order
 	 * only 1 duplicate, should be detected during partition
@@ -289,9 +317,13 @@ static void test_mapping_fail ()
 			init.minOrder = 0;
 			init.maxOrder = n - 1;
 			// fill
-			for (size_t i = 0; i < n; ++i)
+			if (order)
 			{
-				getOrderedPair (&order[i], w, i);
+				for (size_t i = 0; i < n; ++i)
+				{
+					getOrderedPair (&order[i], w, i);
+				
+				}
 			}
 			// set error
 			order[n * (3 / 4)].h[OPMPHMTUPLE / 2] = (order[n * (3 / 4)].h[OPMPHMTUPLE / 2] + 1) % w;
@@ -335,13 +367,16 @@ static void test_mapping_fail ()
 				init.minOrder = 0;
 				init.maxOrder = n - 1;
 				// fill
-				for (size_t i = 0; i < n; ++i)
+				if (order)
 				{
-					getOrderedPair (&order[i], w, i);
-				}
-				for (unsigned int t = 0; t < OPMPHMTUPLE; ++t)
-				{
-					order[n - 1].h[t] = order[0].h[t];
+					for (size_t i = 0; i < n; ++i)
+					{
+						getOrderedPair (&order[i], w, i);
+					}
+					for (unsigned int t = 0; t < OPMPHMTUPLE; ++t)
+					{
+						order[n - 1].h[t] = order[0].h[t];
+					}
 				}
 				// build
 				OpmphmOrder ** sortOrder = opmphmInit (opmphm, &init, order, n);

--- a/tests/ctest/test_splitget.c
+++ b/tests/ctest/test_splitget.c
@@ -100,10 +100,12 @@ static void test_simple ()
 	succeed_if (split->size == 2, "not correct size after appointing");
 
 	succeed_if (split->handles[0] != -0, "no backend");
-	succeed_if (split->handles[0]->specsize == -1, "spec size wrong");
-	succeed_if (split->handles[0]->usersize == -1, "user size wrong");
-	succeed_if (split->handles[0]->systemsize == -1, "system size wrong");
-	succeed_if (split->handles[0]->dirsize == -1, "dir size wrong");
+	if (split->handles[0] != -0) {
+		succeed_if (split->handles[0]->specsize == -1, "spec size wrong");
+		succeed_if (split->handles[0]->usersize == -1, "user size wrong");
+		succeed_if (split->handles[0]->systemsize == -1, "system size wrong");
+		succeed_if (split->handles[0]->dirsize == -1, "dir size wrong");
+	}
 
 	succeed_if (split->handles[1] == -0, "backend at bypass?");
 
@@ -169,17 +171,19 @@ static void test_cascading ()
 	succeed_if (split->handles[0] == backend, "should be user backend");
 
 	keySetName (parentKey, "user/cascading/simple/below");
-	backend = trieLookup (handle->trie, parentKey);
+	/*backend = */trieLookup (handle->trie, parentKey);
 	// succeed_if (split->handles[1] == backend, "should be cascading backend");
 
 	succeed_if (splitAppoint (split, handle, ks) == 1, "could not appoint keys");
 	succeed_if (split->size == 2, "not correct size after appointing");
 
 	succeed_if (split->handles[0] != -0, "no backend");
-	succeed_if (split->handles[0]->specsize == -1, "spec size wrong");
-	succeed_if (split->handles[0]->usersize == -1, "user size wrong");
-	succeed_if (split->handles[0]->systemsize == -1, "system size wrong");
-	succeed_if (split->handles[0]->dirsize == -1, "dir size wrong");
+	if (split->handles[0] != -0) {
+		succeed_if (split->handles[0]->specsize == -1, "spec size wrong");
+		succeed_if (split->handles[0]->usersize == -1, "user size wrong");
+		succeed_if (split->handles[0]->systemsize == -1, "system size wrong");
+		succeed_if (split->handles[0]->dirsize == -1, "dir size wrong");
+	}
 
 	succeed_if (split->handles[1] == -0, "backend at bypass?");
 
@@ -230,10 +234,12 @@ static void test_get ()
 
 	succeed_if (split->size == 2, "not correct size after appointing");
 	succeed_if (split->handles[0] != -0, "no backend");
-	succeed_if (split->handles[0]->specsize == -1, "spec size wrong");
-	succeed_if (split->handles[0]->usersize == -1, "user size wrong");
-	succeed_if (split->handles[0]->systemsize == -1, "system size wrong");
-	succeed_if (split->handles[0]->dirsize == -1, "dir size wrong");
+	if (split->handles[0] != -0) {
+		succeed_if (split->handles[0]->specsize == -1, "spec size wrong");
+		succeed_if (split->handles[0]->usersize == -1, "user size wrong");
+		succeed_if (split->handles[0]->systemsize == -1, "system size wrong");
+		succeed_if (split->handles[0]->dirsize == -1, "dir size wrong");
+	}
 	succeed_if (split->handles[1] == -0, "backend at bypass?");
 
 	split->syncbits[0] = 3; /* Simulate a kdbGet() */
@@ -242,10 +248,12 @@ static void test_get ()
 	succeed_if (output_warnings (parentKey), "warning(s) found");
 	succeed_if (split->size == 2, "not correct size after get");
 	succeed_if (split->handles[0] != -0, "no backend");
-	succeed_if (split->handles[0]->specsize == -1, "spec size wrong");
-	succeed_if (split->handles[0]->usersize == 3, "user size wrong");
-	succeed_if (split->handles[0]->systemsize == -1, "system size wrong");
-	succeed_if (split->handles[0]->dirsize == -1, "dir size wrong");
+	if (split->handles[0] != -0) {
+		succeed_if (split->handles[0]->specsize == -1, "spec size wrong");
+		succeed_if (split->handles[0]->usersize == 3, "user size wrong");
+		succeed_if (split->handles[0]->systemsize == -1, "system size wrong");
+		succeed_if (split->handles[0]->dirsize == -1, "dir size wrong");
+	}
 
 	succeed_if (split->size == 2, "there is an empty keset");
 	succeed_if (ksGetSize (split->keysets[0]) == 3, "wrong size");

--- a/tests/ctest/test_splitget.c
+++ b/tests/ctest/test_splitget.c
@@ -100,7 +100,8 @@ static void test_simple ()
 	succeed_if (split->size == 2, "not correct size after appointing");
 
 	succeed_if (split->handles[0] != -0, "no backend");
-	if (split->handles[0] != -0) {
+	if (split->handles[0] != -0)
+	{
 		succeed_if (split->handles[0]->specsize == -1, "spec size wrong");
 		succeed_if (split->handles[0]->usersize == -1, "user size wrong");
 		succeed_if (split->handles[0]->systemsize == -1, "system size wrong");
@@ -171,14 +172,15 @@ static void test_cascading ()
 	succeed_if (split->handles[0] == backend, "should be user backend");
 
 	keySetName (parentKey, "user/cascading/simple/below");
-	/*backend = */trieLookup (handle->trie, parentKey);
+	/*backend = */ trieLookup (handle->trie, parentKey);
 	// succeed_if (split->handles[1] == backend, "should be cascading backend");
 
 	succeed_if (splitAppoint (split, handle, ks) == 1, "could not appoint keys");
 	succeed_if (split->size == 2, "not correct size after appointing");
 
 	succeed_if (split->handles[0] != -0, "no backend");
-	if (split->handles[0] != -0) {
+	if (split->handles[0] != -0)
+	{
 		succeed_if (split->handles[0]->specsize == -1, "spec size wrong");
 		succeed_if (split->handles[0]->usersize == -1, "user size wrong");
 		succeed_if (split->handles[0]->systemsize == -1, "system size wrong");
@@ -234,7 +236,8 @@ static void test_get ()
 
 	succeed_if (split->size == 2, "not correct size after appointing");
 	succeed_if (split->handles[0] != -0, "no backend");
-	if (split->handles[0] != -0) {
+	if (split->handles[0] != -0)
+	{
 		succeed_if (split->handles[0]->specsize == -1, "spec size wrong");
 		succeed_if (split->handles[0]->usersize == -1, "user size wrong");
 		succeed_if (split->handles[0]->systemsize == -1, "system size wrong");
@@ -248,7 +251,8 @@ static void test_get ()
 	succeed_if (output_warnings (parentKey), "warning(s) found");
 	succeed_if (split->size == 2, "not correct size after get");
 	succeed_if (split->handles[0] != -0, "no backend");
-	if (split->handles[0] != -0) {
+	if (split->handles[0] != -0)
+	{
 		succeed_if (split->handles[0]->specsize == -1, "spec size wrong");
 		succeed_if (split->handles[0]->usersize == 3, "user size wrong");
 		succeed_if (split->handles[0]->systemsize == -1, "system size wrong");

--- a/tests/ctest/test_splitset.c
+++ b/tests/ctest/test_splitset.c
@@ -172,12 +172,14 @@ static void test_mount ()
 	succeed_if (split->syncbits[2] == 2, "spec part need to by synced");
 	succeed_if (split->syncbits[3] == 2, "dir part need to by synced");
 	succeed_if (split->syncbits[4] == 2, "system/elektra part need to by synced");
-	succeed_if (ksGetSize (split->keysets[0]) == 2, "size of keyset not correct");
-	succeed_if (ksGetSize (split->keysets[1]) == 2, "size of keyset not correct");
-	succeed_if (ksGetSize (split->keysets[2]) == 0, "size of keyset not correct");
-	succeed_if (ksGetSize (split->keysets[3]) == 0, "size of keyset not correct");
-	compare_keyset (split->keysets[1], split1);
-	compare_keyset (split->keysets[0], split2);
+	if (split->keysets) {
+		succeed_if (ksGetSize (split->keysets[0]) == 2, "size of keyset not correct");
+		succeed_if (ksGetSize (split->keysets[1]) == 2, "size of keyset not correct");
+		succeed_if (ksGetSize (split->keysets[2]) == 0, "size of keyset not correct");
+		succeed_if (ksGetSize (split->keysets[3]) == 0, "size of keyset not correct");
+		compare_keyset (split->keysets[1], split1);
+		compare_keyset (split->keysets[0], split2);
+	}
 	splitDel (split);
 
 
@@ -193,8 +195,10 @@ static void test_mount ()
 	succeed_if (split->syncbits[2] == 2, "spec part does not need to by synced");
 	succeed_if (split->syncbits[3] == 2, "dir part does not need to by synced");
 	succeed_if (split->syncbits[4] == 2, "user part does not need to by synced");
-	succeed_if (ksGetSize (split->keysets[0]) == 2, "size of keyset not correct");
-	succeed_if (ksGetSize (split->keysets[1]) == 2, "size of keyset not correct");
+	if (split->keysets) {
+		succeed_if (ksGetSize (split->keysets[0]) == 2, "size of keyset not correct");
+		succeed_if (ksGetSize (split->keysets[1]) == 2, "size of keyset not correct");
+	}
 	succeed_if (split->size == 5, "not split according user, system");
 	splitDel (split);
 
@@ -209,8 +213,10 @@ static void test_mount ()
 	succeed_if (split->syncbits[2] == 2, "spec part does not need to by synced");
 	succeed_if (split->syncbits[3] == 2, "dir part does not need to by synced");
 	succeed_if (split->syncbits[4] == 2, "user part does not need to by synced");
-	succeed_if (ksGetSize (split->keysets[0]) == 2, "size of keyset not correct");
-	succeed_if (ksGetSize (split->keysets[1]) == 2, "size of keyset not correct");
+	if (split->keysets) {
+		succeed_if (ksGetSize (split->keysets[0]) == 2, "size of keyset not correct");
+		succeed_if (ksGetSize (split->keysets[1]) == 2, "size of keyset not correct");
+	}
 	succeed_if (split->size == 5, "not split according user, system");
 	splitDel (split);
 
@@ -225,8 +231,10 @@ static void test_mount ()
 	succeed_if (split->syncbits[2] == 2, "spec part does not need to by synced");
 	succeed_if (split->syncbits[3] == 2, "dir part does not need to by synced");
 	succeed_if (split->syncbits[4] == 2, "user part does not need to by synced");
-	succeed_if (ksGetSize (split->keysets[0]) == 2, "size of keyset not correct");
-	succeed_if (ksGetSize (split->keysets[1]) == 2, "size of keyset not correct");
+	if (split->keysets) {
+		succeed_if (ksGetSize (split->keysets[0]) == 2, "size of keyset not correct");
+		succeed_if (ksGetSize (split->keysets[1]) == 2, "size of keyset not correct");
+	}
 	succeed_if (split->size == 5, "not split according user, system");
 	splitDel (split);
 
@@ -264,7 +272,9 @@ static void test_easyparent ()
 	succeed_if (split->size == 1, "not split by parent");
 	succeed_if (split->syncbits[0] == 3, "user part need not to by synced");
 	succeed_if_same_string (keyName (split->parents[0]), "user");
-	compare_keyset (split->keysets[0], split2);
+	if (split->keysets) {
+		compare_keyset (split->keysets[0], split2);
+	}
 
 	splitDel (split);
 	keyDel (parentKey);
@@ -279,7 +289,9 @@ static void test_easyparent ()
 	succeed_if (split->size == 1, "not split by parent");
 	succeed_if (split->syncbits[0] == 3, "system part need to by synced");
 	succeed_if_same_string (keyName (split->parents[0]), "system");
-	compare_keyset (split->keysets[0], split1);
+	if (split->keysets) {
+		compare_keyset (split->keysets[0], split1);
+	}
 
 	splitDel (split);
 	keyDel (parentKey);
@@ -326,10 +338,11 @@ static void test_optimize ()
 	succeed_if (split->syncbits[4] == 2, "system/elektra part need to by synced");
 	compare_keyset (split->keysets[0], split1);
 	compare_keyset (split->keysets[1], split2);
-	succeed_if (ksGetSize (split->keysets[2]) == 0, "size of keyset not correct");
-	succeed_if (ksGetSize (split->keysets[3]) == 0, "size of keyset not correct");
-	succeed_if (ksGetSize (split->keysets[4]) == 0, "size of keyset not correct");
-
+	if (split->keysets) {
+		succeed_if (ksGetSize (split->keysets[2]) == 0, "size of keyset not correct");
+		succeed_if (ksGetSize (split->keysets[3]) == 0, "size of keyset not correct");
+		succeed_if (ksGetSize (split->keysets[4]) == 0, "size of keyset not correct");
+	}
 	splitDel (split);
 
 
@@ -347,12 +360,13 @@ static void test_optimize ()
 	succeed_if (split->syncbits[2] == 2, "spec part need to by synced");
 	succeed_if (split->syncbits[3] == 2, "dir part need to by synced");
 	succeed_if (split->syncbits[4] == 2, "system/elektra part need to by synced");
-	compare_keyset (split->keysets[0], split1);
-	compare_keyset (split->keysets[1], split2);
-	succeed_if (ksGetSize (split->keysets[2]) == 0, "size of keyset not correct");
-	succeed_if (ksGetSize (split->keysets[3]) == 0, "size of keyset not correct");
-	succeed_if (ksGetSize (split->keysets[4]) == 0, "size of keyset not correct");
-
+	if (split->keysets) {
+		compare_keyset (split->keysets[0], split1);
+		compare_keyset (split->keysets[1], split2);
+		succeed_if (ksGetSize (split->keysets[2]) == 0, "size of keyset not correct");
+		succeed_if (ksGetSize (split->keysets[3]) == 0, "size of keyset not correct");
+		succeed_if (ksGetSize (split->keysets[4]) == 0, "size of keyset not correct");
+	}
 	splitDel (split);
 
 
@@ -375,12 +389,13 @@ static void test_optimize ()
 	succeed_if (split->syncbits[2] == 2, "spec part need to by synced");
 	succeed_if (split->syncbits[3] == 2, "dir part need to by synced");
 	succeed_if (split->syncbits[4] == 2, "system/elektra part need to by synced");
-	compare_keyset (split->keysets[0], split1);
-	compare_keyset (split->keysets[1], split2);
-	succeed_if (ksGetSize (split->keysets[2]) == 0, "size of keyset not correct");
-	succeed_if (ksGetSize (split->keysets[3]) == 0, "size of keyset not correct");
-	succeed_if (ksGetSize (split->keysets[4]) == 0, "size of keyset not correct");
-
+	if (split->keysets) {
+		compare_keyset (split->keysets[0], split1);
+		compare_keyset (split->keysets[1], split2);
+		succeed_if (ksGetSize (split->keysets[2]) == 0, "size of keyset not correct");
+		succeed_if (ksGetSize (split->keysets[3]) == 0, "size of keyset not correct");
+		succeed_if (ksGetSize (split->keysets[4]) == 0, "size of keyset not correct");
+	}
 	splitDel (split);
 
 
@@ -426,17 +441,19 @@ static void test_three ()
 	succeed_if (split->syncbits[4] == 2, "dirpart need to by synced");
 	succeed_if (split->syncbits[5] == 3, "user default part need to by synced");
 	succeed_if (split->syncbits[6] == 2, "system/elektra default part need to by synced");
-	succeed_if (ksGetSize (split->keysets[0]) == 4, "size of keyset not correct");
-	succeed_if (ksGetSize (split->keysets[1]) == 3, "size of keyset not correct");
-	succeed_if (ksGetSize (split->keysets[2]) == 2, "size of keyset not correct");
-	succeed_if (ksGetSize (split->keysets[3]) == 0, "size of keyset not correct");
-	succeed_if (ksGetSize (split->keysets[4]) == 0, "size of keyset not correct");
-	succeed_if (ksGetSize (split->keysets[5]) == 1, "size of keyset not correct");
-	succeed_if (ksGetSize (split->keysets[6]) == 0, "size of keyset not correct");
-	compare_keyset (split->keysets[0], split0);
-	compare_keyset (split->keysets[1], split1);
-	compare_keyset (split->keysets[2], split2);
-	compare_keyset (split->keysets[5], split5);
+	if (split->keysets) {
+		succeed_if (ksGetSize (split->keysets[0]) == 4, "size of keyset not correct");
+		succeed_if (ksGetSize (split->keysets[1]) == 3, "size of keyset not correct");
+		succeed_if (ksGetSize (split->keysets[2]) == 2, "size of keyset not correct");
+		succeed_if (ksGetSize (split->keysets[3]) == 0, "size of keyset not correct");
+		succeed_if (ksGetSize (split->keysets[4]) == 0, "size of keyset not correct");
+		succeed_if (ksGetSize (split->keysets[5]) == 1, "size of keyset not correct");
+		succeed_if (ksGetSize (split->keysets[6]) == 0, "size of keyset not correct");
+		compare_keyset (split->keysets[0], split0);
+		compare_keyset (split->keysets[1], split1);
+		compare_keyset (split->keysets[2], split2);
+		compare_keyset (split->keysets[5], split5);
+	}
 
 	splitPrepare (split);
 
@@ -493,12 +510,13 @@ static void test_userremove ()
 	succeed_if (split->keysets, "did not alloc keysets array");
 	succeed_if (split->handles, "did not alloc handles array");
 	succeed_if (split->size == 4, "split size wrong");
-	succeed_if (ksGetSize (split->keysets[0]) == 0, "wrong size");
-	succeed_if (ksGetSize (split->keysets[1]) == 0, "wrong size");
-	succeed_if (ksGetSize (split->keysets[2]) == 1, "wrong size");
-	compare_keyset (split->keysets[2], ks);
-	succeed_if (ksGetSize (split->keysets[3]) == 0, "wrong size");
-
+	if (split->keysets) {
+		succeed_if (ksGetSize (split->keysets[0]) == 0, "wrong size");
+		succeed_if (ksGetSize (split->keysets[1]) == 0, "wrong size");
+		succeed_if (ksGetSize (split->keysets[2]) == 1, "wrong size");
+		compare_keyset (split->keysets[2], ks);
+		succeed_if (ksGetSize (split->keysets[3]) == 0, "wrong size");
+	}
 	splitDel (split);
 
 
@@ -513,8 +531,10 @@ static void test_userremove ()
 	succeed_if (split->handles, "did not alloc handles array");
 	succeed_if (split->size == 1, "everything is in two keyset");
 	// output_split(split);
-	succeed_if (ksGetSize (split->keysets[0]) == 1, "wrong size");
-	compare_keyset (split->keysets[0], ks);
+	if (split->keysets) {
+		succeed_if (ksGetSize (split->keysets[0]) == 1, "wrong size");
+		compare_keyset (split->keysets[0], ks);
+	}
 	keyDel (parent);
 
 	splitDel (split);
@@ -531,7 +551,9 @@ static void test_userremove ()
 	succeed_if (split->handles, "did not alloc handles array");
 	succeed_if (split->size == 1, "everything is in two keyset");
 	// output_split(split);
-	succeed_if (ksGetSize (split->keysets[0]) == 0, "should be dropped");
+	if (split->keysets) {
+		succeed_if (ksGetSize (split->keysets[0]) == 0, "should be dropped");
+	}
 	keyDel (parent);
 
 	splitDel (split);
@@ -548,11 +570,13 @@ static void test_userremove ()
 	succeed_if (split->keysets, "did not alloc keysets array");
 	succeed_if (split->handles, "did not alloc handles array");
 	succeed_if (split->size == 4, "wrong size of split");
-	succeed_if (ksGetSize (split->keysets[0]) == 0, "wrong size");
-	succeed_if (ksGetSize (split->keysets[1]) == 0, "wrong size");
-	succeed_if (ksGetSize (split->keysets[2]) == 1, "wrong size");
-	compare_keyset (split->keysets[2], ks);
-	succeed_if (ksGetSize (split->keysets[3]) == 0, "wrong size");
+	if (split->keysets) {
+		succeed_if (ksGetSize (split->keysets[0]) == 0, "wrong size");
+		succeed_if (ksGetSize (split->keysets[1]) == 0, "wrong size");
+		succeed_if (ksGetSize (split->keysets[2]) == 1, "wrong size");
+		compare_keyset (split->keysets[2], ks);
+		succeed_if (ksGetSize (split->keysets[3]) == 0, "wrong size");
+	}
 
 	splitDel (split);
 
@@ -568,8 +592,10 @@ static void test_userremove ()
 	succeed_if (split->handles, "did not alloc handles array");
 	succeed_if (split->size == 1, "everything is in two keyset");
 	// output_split(split);
-	succeed_if (ksGetSize (split->keysets[0]) == 1, "wrong size");
-	compare_keyset (split->keysets[0], ks);
+	if (split->keysets) {
+		succeed_if (ksGetSize (split->keysets[0]) == 1, "wrong size");
+		compare_keyset (split->keysets[0], ks);
+	}
 	keyDel (parent);
 
 	splitDel (split);
@@ -586,7 +612,9 @@ static void test_userremove ()
 	succeed_if (split->handles, "did not alloc handles array");
 	succeed_if (split->size == 1, "everything is in two keyset");
 	// output_split(split);
-	succeed_if (ksGetSize (split->keysets[0]) == 0, "should be dropped");
+	if (split->keysets) {
+		succeed_if (ksGetSize (split->keysets[0]) == 0, "should be dropped");
+	}
 	keyDel (parent);
 
 	splitPrepare (split);
@@ -623,11 +651,13 @@ static void test_systemremove ()
 	succeed_if (split->keysets, "did not alloc keysets array");
 	succeed_if (split->handles, "did not alloc handles array");
 	succeed_if (split->size == 4, "everything is in two keyset");
-	succeed_if (ksGetSize (split->keysets[0]) == 0, "wrong size");
-	succeed_if (ksGetSize (split->keysets[1]) == 0, "wrong size");
-	succeed_if (ksGetSize (split->keysets[2]) == 0, "wrong size");
-	succeed_if (ksGetSize (split->keysets[3]) == 1, "wrong size");
-	compare_keyset (split->keysets[3], ks);
+	if (split->keysets) {
+		succeed_if (ksGetSize (split->keysets[0]) == 0, "wrong size");
+		succeed_if (ksGetSize (split->keysets[1]) == 0, "wrong size");
+		succeed_if (ksGetSize (split->keysets[2]) == 0, "wrong size");
+		succeed_if (ksGetSize (split->keysets[3]) == 1, "wrong size");
+		compare_keyset (split->keysets[3], ks);
+	}
 
 	splitDel (split);
 
@@ -643,8 +673,10 @@ static void test_systemremove ()
 	succeed_if (split->handles, "did not alloc handles array");
 	succeed_if (split->size == 1, "everything is in one keyset");
 	// output_split(split);
-	succeed_if (ksGetSize (split->keysets[0]) == 1, "wrong size");
-	compare_keyset (split->keysets[0], ks);
+	if (split->keysets) {
+		succeed_if (ksGetSize (split->keysets[0]) == 1, "wrong size");
+		compare_keyset (split->keysets[0], ks);
+	}
 	keyDel (parent);
 
 	splitDel (split);
@@ -662,7 +694,9 @@ static void test_systemremove ()
 	succeed_if (split->handles, "did not alloc handles array");
 	succeed_if (split->size == 1, "everything is in one keyset");
 	// output_split(split);
-	succeed_if (ksGetSize (split->keysets[0]) == 0, "should be dropped");
+	if (split->keysets) {
+		succeed_if (ksGetSize (split->keysets[0]) == 0, "should be dropped");
+	}
 	keyDel (parent);
 
 	splitDel (split);
@@ -679,11 +713,13 @@ static void test_systemremove ()
 	succeed_if (split->keysets, "did not alloc keysets array");
 	succeed_if (split->handles, "did not alloc handles array");
 	succeed_if (split->size == 4, "everything is in two keyset");
-	succeed_if (ksGetSize (split->keysets[0]) == 0, "wrong size");
-	succeed_if (ksGetSize (split->keysets[1]) == 0, "wrong size");
-	succeed_if (ksGetSize (split->keysets[2]) == 0, "wrong size");
-	succeed_if (ksGetSize (split->keysets[3]) == 1, "wrong size");
-	compare_keyset (split->keysets[3], ks);
+	if (split->keysets) {
+		succeed_if (ksGetSize (split->keysets[0]) == 0, "wrong size");
+		succeed_if (ksGetSize (split->keysets[1]) == 0, "wrong size");
+		succeed_if (ksGetSize (split->keysets[2]) == 0, "wrong size");
+		succeed_if (ksGetSize (split->keysets[3]) == 1, "wrong size");
+		compare_keyset (split->keysets[3], ks);
+	}
 
 	splitDel (split);
 
@@ -699,8 +735,10 @@ static void test_systemremove ()
 	succeed_if (split->handles, "did not alloc handles array");
 	succeed_if (split->size == 1, "everything is in two keyset");
 	// output_split(split);
-	succeed_if (ksGetSize (split->keysets[0]) == 1, "wrong size");
-	compare_keyset (split->keysets[0], ks);
+	if (split->keysets) {
+		succeed_if (ksGetSize (split->keysets[0]) == 1, "wrong size");
+		compare_keyset (split->keysets[0], ks);
+	}
 	keyDel (parent);
 
 	splitDel (split);
@@ -717,7 +755,9 @@ static void test_systemremove ()
 	succeed_if (split->handles, "did not alloc handles array");
 	succeed_if (split->size == 1, "everything is in two keyset");
 	// output_split(split);
-	succeed_if (ksGetSize (split->keysets[0]) == 0, "should be dropped");
+	if (split->keysets) {
+		succeed_if (ksGetSize (split->keysets[0]) == 0, "should be dropped");
+	}
 	keyDel (parent);
 
 	splitPrepare (split);
@@ -753,10 +793,12 @@ static void test_emptyremove ()
 	succeed_if (split->keysets, "did not alloc keysets array");
 	succeed_if (split->handles, "did not alloc handles array");
 	succeed_if (split->size == 4, "there is an empty keset");
-	succeed_if (ksGetSize (split->keysets[0]) == 0, "wrong size");
-	succeed_if (ksGetSize (split->keysets[1]) == 0, "wrong size");
-	succeed_if (ksGetSize (split->keysets[2]) == 0, "wrong size");
-	succeed_if (ksGetSize (split->keysets[3]) == 0, "wrong size");
+	if (split->keysets) {
+		succeed_if (ksGetSize (split->keysets[0]) == 0, "wrong size");
+		succeed_if (ksGetSize (split->keysets[1]) == 0, "wrong size");
+		succeed_if (ksGetSize (split->keysets[2]) == 0, "wrong size");
+		succeed_if (ksGetSize (split->keysets[3]) == 0, "wrong size");
+	}
 
 	splitDel (split);
 
@@ -772,10 +814,12 @@ static void test_emptyremove ()
 	succeed_if (split->keysets, "did not alloc keysets array");
 	succeed_if (split->handles, "did not alloc handles array");
 	succeed_if (split->size == 4, "there is an empty keset");
-	succeed_if (ksGetSize (split->keysets[0]) == 0, "wrong size");
-	succeed_if (ksGetSize (split->keysets[1]) == 0, "wrong size");
-	succeed_if (ksGetSize (split->keysets[2]) == 0, "wrong size");
-	succeed_if (ksGetSize (split->keysets[3]) == 0, "wrong size");
+	if (split->keysets) {
+		succeed_if (ksGetSize (split->keysets[0]) == 0, "wrong size");
+		succeed_if (ksGetSize (split->keysets[1]) == 0, "wrong size");
+		succeed_if (ksGetSize (split->keysets[2]) == 0, "wrong size");
+		succeed_if (ksGetSize (split->keysets[3]) == 0, "wrong size");
+	}
 
 	splitDel (split);
 
@@ -791,11 +835,12 @@ static void test_emptyremove ()
 	succeed_if (split->keysets, "did not alloc keysets array");
 	succeed_if (split->handles, "did not alloc handles array");
 	succeed_if (split->size == 4, "there is an empty keset");
-	succeed_if (ksGetSize (split->keysets[0]) == 0, "wrong size");
-	succeed_if (ksGetSize (split->keysets[1]) == 0, "wrong size");
-	succeed_if (ksGetSize (split->keysets[2]) == 0, "wrong size");
-	succeed_if (ksGetSize (split->keysets[3]) == 0, "wrong size");
-
+	if (split->keysets) {
+		succeed_if (ksGetSize (split->keysets[0]) == 0, "wrong size");
+		succeed_if (ksGetSize (split->keysets[1]) == 0, "wrong size");
+		succeed_if (ksGetSize (split->keysets[2]) == 0, "wrong size");
+		succeed_if (ksGetSize (split->keysets[3]) == 0, "wrong size");
+	}
 	splitPrepare (split);
 	succeed_if (split->size == 1, "there is an empty keset");
 	succeed_if_same_string (keyName (split->parents[0]), "user");

--- a/tests/ctest/test_splitset.c
+++ b/tests/ctest/test_splitset.c
@@ -172,7 +172,8 @@ static void test_mount ()
 	succeed_if (split->syncbits[2] == 2, "spec part need to by synced");
 	succeed_if (split->syncbits[3] == 2, "dir part need to by synced");
 	succeed_if (split->syncbits[4] == 2, "system/elektra part need to by synced");
-	if (split->keysets) {
+	if (split->keysets)
+	{
 		succeed_if (ksGetSize (split->keysets[0]) == 2, "size of keyset not correct");
 		succeed_if (ksGetSize (split->keysets[1]) == 2, "size of keyset not correct");
 		succeed_if (ksGetSize (split->keysets[2]) == 0, "size of keyset not correct");
@@ -195,7 +196,8 @@ static void test_mount ()
 	succeed_if (split->syncbits[2] == 2, "spec part does not need to by synced");
 	succeed_if (split->syncbits[3] == 2, "dir part does not need to by synced");
 	succeed_if (split->syncbits[4] == 2, "user part does not need to by synced");
-	if (split->keysets) {
+	if (split->keysets)
+	{
 		succeed_if (ksGetSize (split->keysets[0]) == 2, "size of keyset not correct");
 		succeed_if (ksGetSize (split->keysets[1]) == 2, "size of keyset not correct");
 	}
@@ -213,7 +215,8 @@ static void test_mount ()
 	succeed_if (split->syncbits[2] == 2, "spec part does not need to by synced");
 	succeed_if (split->syncbits[3] == 2, "dir part does not need to by synced");
 	succeed_if (split->syncbits[4] == 2, "user part does not need to by synced");
-	if (split->keysets) {
+	if (split->keysets)
+	{
 		succeed_if (ksGetSize (split->keysets[0]) == 2, "size of keyset not correct");
 		succeed_if (ksGetSize (split->keysets[1]) == 2, "size of keyset not correct");
 	}
@@ -231,7 +234,8 @@ static void test_mount ()
 	succeed_if (split->syncbits[2] == 2, "spec part does not need to by synced");
 	succeed_if (split->syncbits[3] == 2, "dir part does not need to by synced");
 	succeed_if (split->syncbits[4] == 2, "user part does not need to by synced");
-	if (split->keysets) {
+	if (split->keysets)
+	{
 		succeed_if (ksGetSize (split->keysets[0]) == 2, "size of keyset not correct");
 		succeed_if (ksGetSize (split->keysets[1]) == 2, "size of keyset not correct");
 	}
@@ -272,7 +276,8 @@ static void test_easyparent ()
 	succeed_if (split->size == 1, "not split by parent");
 	succeed_if (split->syncbits[0] == 3, "user part need not to by synced");
 	succeed_if_same_string (keyName (split->parents[0]), "user");
-	if (split->keysets) {
+	if (split->keysets)
+	{
 		compare_keyset (split->keysets[0], split2);
 	}
 
@@ -289,7 +294,8 @@ static void test_easyparent ()
 	succeed_if (split->size == 1, "not split by parent");
 	succeed_if (split->syncbits[0] == 3, "system part need to by synced");
 	succeed_if_same_string (keyName (split->parents[0]), "system");
-	if (split->keysets) {
+	if (split->keysets)
+	{
 		compare_keyset (split->keysets[0], split1);
 	}
 
@@ -338,7 +344,8 @@ static void test_optimize ()
 	succeed_if (split->syncbits[4] == 2, "system/elektra part need to by synced");
 	compare_keyset (split->keysets[0], split1);
 	compare_keyset (split->keysets[1], split2);
-	if (split->keysets) {
+	if (split->keysets)
+	{
 		succeed_if (ksGetSize (split->keysets[2]) == 0, "size of keyset not correct");
 		succeed_if (ksGetSize (split->keysets[3]) == 0, "size of keyset not correct");
 		succeed_if (ksGetSize (split->keysets[4]) == 0, "size of keyset not correct");
@@ -360,7 +367,8 @@ static void test_optimize ()
 	succeed_if (split->syncbits[2] == 2, "spec part need to by synced");
 	succeed_if (split->syncbits[3] == 2, "dir part need to by synced");
 	succeed_if (split->syncbits[4] == 2, "system/elektra part need to by synced");
-	if (split->keysets) {
+	if (split->keysets)
+	{
 		compare_keyset (split->keysets[0], split1);
 		compare_keyset (split->keysets[1], split2);
 		succeed_if (ksGetSize (split->keysets[2]) == 0, "size of keyset not correct");
@@ -389,7 +397,8 @@ static void test_optimize ()
 	succeed_if (split->syncbits[2] == 2, "spec part need to by synced");
 	succeed_if (split->syncbits[3] == 2, "dir part need to by synced");
 	succeed_if (split->syncbits[4] == 2, "system/elektra part need to by synced");
-	if (split->keysets) {
+	if (split->keysets)
+	{
 		compare_keyset (split->keysets[0], split1);
 		compare_keyset (split->keysets[1], split2);
 		succeed_if (ksGetSize (split->keysets[2]) == 0, "size of keyset not correct");
@@ -441,7 +450,8 @@ static void test_three ()
 	succeed_if (split->syncbits[4] == 2, "dirpart need to by synced");
 	succeed_if (split->syncbits[5] == 3, "user default part need to by synced");
 	succeed_if (split->syncbits[6] == 2, "system/elektra default part need to by synced");
-	if (split->keysets) {
+	if (split->keysets)
+	{
 		succeed_if (ksGetSize (split->keysets[0]) == 4, "size of keyset not correct");
 		succeed_if (ksGetSize (split->keysets[1]) == 3, "size of keyset not correct");
 		succeed_if (ksGetSize (split->keysets[2]) == 2, "size of keyset not correct");
@@ -510,7 +520,8 @@ static void test_userremove ()
 	succeed_if (split->keysets, "did not alloc keysets array");
 	succeed_if (split->handles, "did not alloc handles array");
 	succeed_if (split->size == 4, "split size wrong");
-	if (split->keysets) {
+	if (split->keysets)
+	{
 		succeed_if (ksGetSize (split->keysets[0]) == 0, "wrong size");
 		succeed_if (ksGetSize (split->keysets[1]) == 0, "wrong size");
 		succeed_if (ksGetSize (split->keysets[2]) == 1, "wrong size");
@@ -531,7 +542,8 @@ static void test_userremove ()
 	succeed_if (split->handles, "did not alloc handles array");
 	succeed_if (split->size == 1, "everything is in two keyset");
 	// output_split(split);
-	if (split->keysets) {
+	if (split->keysets)
+	{
 		succeed_if (ksGetSize (split->keysets[0]) == 1, "wrong size");
 		compare_keyset (split->keysets[0], ks);
 	}
@@ -551,7 +563,8 @@ static void test_userremove ()
 	succeed_if (split->handles, "did not alloc handles array");
 	succeed_if (split->size == 1, "everything is in two keyset");
 	// output_split(split);
-	if (split->keysets) {
+	if (split->keysets)
+	{
 		succeed_if (ksGetSize (split->keysets[0]) == 0, "should be dropped");
 	}
 	keyDel (parent);
@@ -570,7 +583,8 @@ static void test_userremove ()
 	succeed_if (split->keysets, "did not alloc keysets array");
 	succeed_if (split->handles, "did not alloc handles array");
 	succeed_if (split->size == 4, "wrong size of split");
-	if (split->keysets) {
+	if (split->keysets)
+	{
 		succeed_if (ksGetSize (split->keysets[0]) == 0, "wrong size");
 		succeed_if (ksGetSize (split->keysets[1]) == 0, "wrong size");
 		succeed_if (ksGetSize (split->keysets[2]) == 1, "wrong size");
@@ -592,7 +606,8 @@ static void test_userremove ()
 	succeed_if (split->handles, "did not alloc handles array");
 	succeed_if (split->size == 1, "everything is in two keyset");
 	// output_split(split);
-	if (split->keysets) {
+	if (split->keysets)
+	{
 		succeed_if (ksGetSize (split->keysets[0]) == 1, "wrong size");
 		compare_keyset (split->keysets[0], ks);
 	}
@@ -612,7 +627,8 @@ static void test_userremove ()
 	succeed_if (split->handles, "did not alloc handles array");
 	succeed_if (split->size == 1, "everything is in two keyset");
 	// output_split(split);
-	if (split->keysets) {
+	if (split->keysets)
+	{
 		succeed_if (ksGetSize (split->keysets[0]) == 0, "should be dropped");
 	}
 	keyDel (parent);
@@ -651,7 +667,8 @@ static void test_systemremove ()
 	succeed_if (split->keysets, "did not alloc keysets array");
 	succeed_if (split->handles, "did not alloc handles array");
 	succeed_if (split->size == 4, "everything is in two keyset");
-	if (split->keysets) {
+	if (split->keysets)
+	{
 		succeed_if (ksGetSize (split->keysets[0]) == 0, "wrong size");
 		succeed_if (ksGetSize (split->keysets[1]) == 0, "wrong size");
 		succeed_if (ksGetSize (split->keysets[2]) == 0, "wrong size");
@@ -673,7 +690,8 @@ static void test_systemremove ()
 	succeed_if (split->handles, "did not alloc handles array");
 	succeed_if (split->size == 1, "everything is in one keyset");
 	// output_split(split);
-	if (split->keysets) {
+	if (split->keysets)
+	{
 		succeed_if (ksGetSize (split->keysets[0]) == 1, "wrong size");
 		compare_keyset (split->keysets[0], ks);
 	}
@@ -694,7 +712,8 @@ static void test_systemremove ()
 	succeed_if (split->handles, "did not alloc handles array");
 	succeed_if (split->size == 1, "everything is in one keyset");
 	// output_split(split);
-	if (split->keysets) {
+	if (split->keysets)
+	{
 		succeed_if (ksGetSize (split->keysets[0]) == 0, "should be dropped");
 	}
 	keyDel (parent);
@@ -713,7 +732,8 @@ static void test_systemremove ()
 	succeed_if (split->keysets, "did not alloc keysets array");
 	succeed_if (split->handles, "did not alloc handles array");
 	succeed_if (split->size == 4, "everything is in two keyset");
-	if (split->keysets) {
+	if (split->keysets)
+	{
 		succeed_if (ksGetSize (split->keysets[0]) == 0, "wrong size");
 		succeed_if (ksGetSize (split->keysets[1]) == 0, "wrong size");
 		succeed_if (ksGetSize (split->keysets[2]) == 0, "wrong size");
@@ -735,7 +755,8 @@ static void test_systemremove ()
 	succeed_if (split->handles, "did not alloc handles array");
 	succeed_if (split->size == 1, "everything is in two keyset");
 	// output_split(split);
-	if (split->keysets) {
+	if (split->keysets)
+	{
 		succeed_if (ksGetSize (split->keysets[0]) == 1, "wrong size");
 		compare_keyset (split->keysets[0], ks);
 	}
@@ -755,7 +776,8 @@ static void test_systemremove ()
 	succeed_if (split->handles, "did not alloc handles array");
 	succeed_if (split->size == 1, "everything is in two keyset");
 	// output_split(split);
-	if (split->keysets) {
+	if (split->keysets)
+	{
 		succeed_if (ksGetSize (split->keysets[0]) == 0, "should be dropped");
 	}
 	keyDel (parent);
@@ -793,7 +815,8 @@ static void test_emptyremove ()
 	succeed_if (split->keysets, "did not alloc keysets array");
 	succeed_if (split->handles, "did not alloc handles array");
 	succeed_if (split->size == 4, "there is an empty keset");
-	if (split->keysets) {
+	if (split->keysets)
+	{
 		succeed_if (ksGetSize (split->keysets[0]) == 0, "wrong size");
 		succeed_if (ksGetSize (split->keysets[1]) == 0, "wrong size");
 		succeed_if (ksGetSize (split->keysets[2]) == 0, "wrong size");
@@ -814,7 +837,8 @@ static void test_emptyremove ()
 	succeed_if (split->keysets, "did not alloc keysets array");
 	succeed_if (split->handles, "did not alloc handles array");
 	succeed_if (split->size == 4, "there is an empty keset");
-	if (split->keysets) {
+	if (split->keysets)
+	{
 		succeed_if (ksGetSize (split->keysets[0]) == 0, "wrong size");
 		succeed_if (ksGetSize (split->keysets[1]) == 0, "wrong size");
 		succeed_if (ksGetSize (split->keysets[2]) == 0, "wrong size");
@@ -835,7 +859,8 @@ static void test_emptyremove ()
 	succeed_if (split->keysets, "did not alloc keysets array");
 	succeed_if (split->handles, "did not alloc handles array");
 	succeed_if (split->size == 4, "there is an empty keset");
-	if (split->keysets) {
+	if (split->keysets)
+	{
 		succeed_if (ksGetSize (split->keysets[0]) == 0, "wrong size");
 		succeed_if (ksGetSize (split->keysets[1]) == 0, "wrong size");
 		succeed_if (ksGetSize (split->keysets[2]) == 0, "wrong size");

--- a/tests/ctest/test_trie.c
+++ b/tests/ctest/test_trie.c
@@ -72,21 +72,20 @@ static void test_simple ()
 	keySetName (searchKey, "user/tests/simple");
 	backend = trieLookup (trie, searchKey);
 	succeed_if (backend, "there should be a backend");
-	compare_key (backend->mountpoint, mp);
-
+	if (backend) compare_key (backend->mountpoint, mp);
 
 	keySetName (searchKey, "user/tests/simple/below");
 	Backend * b2 = trieLookup (trie, searchKey);
 	succeed_if (b2, "there should be a backend");
 	succeed_if (backend == b2, "should be same backend");
-	compare_key (b2->mountpoint, mp);
+	if (b2) compare_key (b2->mountpoint, mp);
 
 
 	keySetName (searchKey, "user/tests/simple/deep/below");
 	b2 = trieLookup (trie, searchKey);
 	succeed_if (b2, "there should be a backend");
 	succeed_if (backend == b2, "should be same backend");
-	compare_key (b2->mountpoint, mp);
+	if (b2) compare_key (b2->mountpoint, mp);
 
 	trieClose (trie, 0);
 	keyDel (mp);
@@ -125,7 +124,7 @@ static void test_iterate ()
 	keySetName (searchKey, "user/tests/hosts");
 	backend = trieLookup (trie, searchKey);
 	succeed_if (backend, "there should be a backend");
-	compare_key (backend->mountpoint, mp);
+	if (backend) compare_key (backend->mountpoint, mp);
 	// printf ("backend: %p\n", (void*)backend);
 
 
@@ -133,7 +132,7 @@ static void test_iterate ()
 	Backend * b2 = trieLookup (trie, searchKey);
 	succeed_if (b2, "there should be a backend");
 	succeed_if (backend == b2, "should be same backend");
-	compare_key (b2->mountpoint, mp);
+	if (b2) compare_key (b2->mountpoint, mp);
 	// printf ("b2: %p\n", (void*)b2);
 
 
@@ -141,7 +140,7 @@ static void test_iterate ()
 	b2 = trieLookup (trie, searchKey);
 	succeed_if (b2, "there should be a backend");
 	succeed_if (backend == b2, "should be same backend");
-	compare_key (b2->mountpoint, mp);
+	if (b2) compare_key (b2->mountpoint, mp);
 
 
 	Key * mp2 = keyNew ("user/tests/hosts/below", KEY_VALUE, "below", KEY_END);
@@ -149,16 +148,16 @@ static void test_iterate ()
 	Backend * b3 = trieLookup (trie, searchKey);
 	succeed_if (b3, "there should be a backend");
 	succeed_if (backend != b3, "should be different backend");
-	compare_key (b3->mountpoint, mp2);
+	if (b3) compare_key (b3->mountpoint, mp2);
 	backend = b3;
 	// printf ("b3: %p\n", (void*)b3);
 
 
 	keySetName (searchKey, "user/tests/hosts/below/other/deep/below");
-	b2 = trieLookup (trie, searchKey);
+	b3 = trieLookup (trie, searchKey);
 	succeed_if (b3, "there should be a backend");
 	succeed_if (backend == b3, "should be same backend");
-	compare_key (b3->mountpoint, mp2);
+	if (b3) compare_key (b3->mountpoint, mp2);
 
 	KeySet * mps = ksNew (0, KS_END);
 	collect_mountpoints (trie, mps);
@@ -194,7 +193,7 @@ static void test_reviterate ()
 	keySetName (searchKey, "user/tests/hosts");
 	backend = trieLookup (trie, searchKey);
 	succeed_if (backend, "there should be a backend");
-	compare_key (backend->mountpoint, mp);
+	if (backend) compare_key (backend->mountpoint, mp);
 	// printf ("backend: %p\n", (void*)backend);
 
 
@@ -202,7 +201,7 @@ static void test_reviterate ()
 	Backend * b2 = trieLookup (trie, searchKey);
 	succeed_if (b2, "there should be a backend");
 	succeed_if (backend == b2, "should be same backend");
-	compare_key (b2->mountpoint, mp);
+	if (b2) compare_key (b2->mountpoint, mp);
 	// printf ("b2: %p\n", (void*)b2);
 
 
@@ -210,7 +209,7 @@ static void test_reviterate ()
 	b2 = trieLookup (trie, searchKey);
 	succeed_if (b2, "there should be a backend");
 	succeed_if (backend == b2, "should be same backend");
-	compare_key (b2->mountpoint, mp);
+	if (b2) compare_key (b2->mountpoint, mp);
 
 
 	Key * mp2 = keyNew ("user/tests/hosts/below", KEY_VALUE, "below", KEY_END);
@@ -218,16 +217,16 @@ static void test_reviterate ()
 	Backend * b3 = trieLookup (trie, searchKey);
 	succeed_if (b3, "there should be a backend");
 	succeed_if (backend != b3, "should be different backend");
-	compare_key (b3->mountpoint, mp2);
+	if (b3) compare_key (b3->mountpoint, mp2);
 	backend = b3;
 	// printf ("b3: %p\n", (void*)b3);
 
 
 	keySetName (searchKey, "user/tests/hosts/below/other/deep/below");
 	b2 = trieLookup (trie, searchKey);
-	succeed_if (b3, "there should be a backend");
-	succeed_if (backend == b3, "should be same backend");
-	compare_key (b3->mountpoint, mp2);
+	succeed_if (b2, "there should be a backend");
+	succeed_if (backend == b2, "should be same backend");
+	if (b2) compare_key (b2->mountpoint, mp2);
 
 	KeySet * mps = ksNew (0, KS_END);
 	collect_mountpoints (trie, mps);
@@ -315,48 +314,46 @@ static void test_moreiterate ()
 	keySetName (searchKey, "user/tests/hosts/below");
 	Backend * b3 = trieLookup (trie, searchKey);
 	succeed_if (b3, "there should be a backend");
-	compare_key (b3->mountpoint, ksLookupByName (mps, "user/tests/hosts/below", 0));
-	backend = b3;
+	if (b3) compare_key (b3->mountpoint, ksLookupByName (mps, "user/tests/hosts/below", 0));
 	// printf ("b3: %p\n", (void*)b3);
 
 
 	keySetName (searchKey, "user/tests/hosts/below/other/deep/below");
-	b2 = trieLookup (trie, searchKey);
-	succeed_if (b3, "there should be a backend");
-	compare_key (b3->mountpoint, ksLookupByName (mps, "user/tests/hosts/below", 0));
+	backend = trieLookup (trie, searchKey);
+	succeed_if (backend, "there should be a backend");
+	if (backend) compare_key (backend->mountpoint, ksLookupByName (mps, "user/tests/hosts/below", 0));
 
 	keySetName (searchKey, "system");
 	backend = trieLookup (trie, searchKey);
 	succeed_if (backend, "there should be a backend");
-	compare_key (backend->mountpoint, ksLookupByName (mps, "system", 0));
+	if (backend) compare_key (backend->mountpoint, ksLookupByName (mps, "system", 0));
 	// printf ("backend: %p\n", (void*)backend);
 
 
 	keySetName (searchKey, "system/tests/hosts/other/below");
 	b2 = trieLookup (trie, searchKey);
 	succeed_if (b2, "there should be a backend");
-	compare_key (b2->mountpoint, ksLookupByName (mps, "system/tests/hosts", 0));
+	if (b2) compare_key (b2->mountpoint, ksLookupByName (mps, "system/tests/hosts", 0));
 	// printf ("b2: %p\n", (void*)b2);
 
 
 	keySetName (searchKey, "system/tests/hosts/other/deep/below");
 	b2 = trieLookup (trie, searchKey);
 	succeed_if (b2, "there should be a backend");
-	compare_key (b2->mountpoint, ksLookupByName (mps, "system/tests/hosts", 0));
+	if (b2) compare_key (b2->mountpoint, ksLookupByName (mps, "system/tests/hosts", 0));
 
 
 	keySetName (searchKey, "system/tests/hosts/below");
 	b3 = trieLookup (trie, searchKey);
 	succeed_if (b3, "there should be a backend");
-	compare_key (b3->mountpoint, ksLookupByName (mps, "system/tests/hosts/below", 0));
-	backend = b3;
+	if (b3) compare_key (b3->mountpoint, ksLookupByName (mps, "system/tests/hosts/below", 0));
 	// printf ("b3: %p\n", (void*)b3);
 
 
 	keySetName (searchKey, "system/tests/hosts/below/other/deep/below");
 	b2 = trieLookup (trie, searchKey);
-	succeed_if (b3, "there should be a backend");
-	compare_key (b3->mountpoint, ksLookupByName (mps, "system/tests/hosts/below", 0));
+	succeed_if (b2, "there should be a backend");
+	if (b2) compare_key (b2->mountpoint, ksLookupByName (mps, "system/tests/hosts/below", 0));
 
 	KeySet * mps_cmp = ksNew (0, KS_END);
 	collect_mountpoints (trie, mps_cmp);
@@ -441,68 +438,66 @@ static void test_revmoreiterate ()
 		keySetName (searchKey, "user");
 		Backend * backend = trieLookup (trie, searchKey);
 		succeed_if (backend, "there should be a backend");
-		compare_key (backend->mountpoint, ksLookupByName (mps, "user", 0));
+		if (backend) compare_key (backend->mountpoint, ksLookupByName (mps, "user", 0));
 		// printf ("backend: %p\n", (void*)backend);
 
 
 		keySetName (searchKey, "user/tests/hosts/other/below");
 		Backend * b2 = trieLookup (trie, searchKey);
 		succeed_if (b2, "there should be a backend");
-		compare_key (b2->mountpoint, ksLookupByName (mps, "user/tests/hosts", 0));
+		if (b2) compare_key (b2->mountpoint, ksLookupByName (mps, "user/tests/hosts", 0));
 		// printf ("b2: %p\n", (void*)b2);
 
 
 		keySetName (searchKey, "user/tests/hosts/other/deep/below");
 		b2 = trieLookup (trie, searchKey);
 		succeed_if (b2, "there should be a backend");
-		compare_key (b2->mountpoint, ksLookupByName (mps, "user/tests/hosts", 0));
+		if (b2) compare_key (b2->mountpoint, ksLookupByName (mps, "user/tests/hosts", 0));
 
 
 		keySetName (searchKey, "user/tests/hosts/below");
 		Backend * b3 = trieLookup (trie, searchKey);
 		succeed_if (b3, "there should be a backend");
-		compare_key (b3->mountpoint, ksLookupByName (mps, "user/tests/hosts/below", 0));
-		backend = b3;
+		if (b3) compare_key (b3->mountpoint, ksLookupByName (mps, "user/tests/hosts/below", 0));
 		// printf ("b3: %p\n", (void*)b3);
 
 
 		keySetName (searchKey, "user/tests/hosts/below/other/deep/below");
-		b2 = trieLookup (trie, searchKey);
-		succeed_if (b3, "there should be a backend");
-		compare_key (b3->mountpoint, ksLookupByName (mps, "user/tests/hosts/below", 0));
+		backend = trieLookup (trie, searchKey);
+		succeed_if (backend, "there should be a backend");
+		if (backend) compare_key (backend->mountpoint, ksLookupByName (mps, "user/tests/hosts/below", 0));
 
 		keySetName (searchKey, "system");
 		backend = trieLookup (trie, searchKey);
 		succeed_if (backend, "there should be a backend");
-		compare_key (backend->mountpoint, ksLookupByName (mps, "system", 0));
+		if (backend) compare_key (backend->mountpoint, ksLookupByName (mps, "system", 0));
 		// printf ("backend: %p\n", (void*)backend);
 
 
 		keySetName (searchKey, "system/tests/hosts/other/below");
 		b2 = trieLookup (trie, searchKey);
 		succeed_if (b2, "there should be a backend");
-		compare_key (b2->mountpoint, ksLookupByName (mps, "system/tests/hosts", 0));
+		if (b2) compare_key (b2->mountpoint, ksLookupByName (mps, "system/tests/hosts", 0));
 		// printf ("b2: %p\n", (void*)b2);
 
 
 		keySetName (searchKey, "system/tests/hosts/other/deep/below");
 		b2 = trieLookup (trie, searchKey);
 		succeed_if (b2, "there should be a backend");
-		compare_key (b2->mountpoint, ksLookupByName (mps, "system/tests/hosts", 0));
+		if (b2) compare_key (b2->mountpoint, ksLookupByName (mps, "system/tests/hosts", 0));
 
 
 		keySetName (searchKey, "system/tests/hosts/below");
 		b3 = trieLookup (trie, searchKey);
 		succeed_if (b3, "there should be a backend");
-		compare_key (b3->mountpoint, ksLookupByName (mps, "system/tests/hosts/below", 0));
-		backend = b3;
+		if (b3) compare_key (b3->mountpoint, ksLookupByName (mps, "system/tests/hosts/below", 0));
 		// printf ("b3: %p\n", (void*)b3);
 
 
 		keySetName (searchKey, "system/tests/hosts/below/other/deep/below");
 		b2 = trieLookup (trie, searchKey);
-		succeed_if (b3, "there should be a backend");
-		compare_key (b3->mountpoint, ksLookupByName (mps, "system/tests/hosts/below", 0));
+		succeed_if (b2, "there should be a backend");
+		if (b2) compare_key (b2->mountpoint, ksLookupByName (mps, "system/tests/hosts/below", 0));
 
 		/*
 		printf ("---------\n");
@@ -544,7 +539,7 @@ static void test_umlauts ()
 	keySetName (searchKey, "user/umlauts/test");
 	backend = trieLookup (trie, searchKey);
 	succeed_if (backend, "there should be a backend");
-	compare_key (backend->mountpoint, mp);
+	if (backend) compare_key (backend->mountpoint, mp);
 
 
 	keySetName (searchKey, "user/umlauts#test");
@@ -553,7 +548,7 @@ static void test_umlauts ()
 	Backend * b2 = trieLookup (trie, searchKey);
 	succeed_if (b2, "there should be a backend");
 	succeed_if (backend != b2, "should be other backend");
-	compare_key (b2->mountpoint, mp);
+	if (b2) compare_key (b2->mountpoint, mp);
 
 
 	keySetName (searchKey, "user/umlauts test");
@@ -562,7 +557,7 @@ static void test_umlauts ()
 	b2 = trieLookup (trie, searchKey);
 	succeed_if (b2, "there should be a backend");
 	succeed_if (backend != b2, "should be other backend");
-	compare_key (b2->mountpoint, mp);
+	if (b2) compare_key (b2->mountpoint, mp);
 
 	keySetName (searchKey, "user/umlauts\200test");
 	keySetName (mp, "user/umlauts\200test");
@@ -570,7 +565,7 @@ static void test_umlauts ()
 	b2 = trieLookup (trie, searchKey);
 	succeed_if (b2, "there should be a backend");
 	succeed_if (backend != b2, "should be other backend");
-	compare_key (b2->mountpoint, mp);
+	if (b2) compare_key (b2->mountpoint, mp);
 
 	// output_trie(trie);
 
@@ -626,7 +621,7 @@ static void test_endings ()
 		keySetName (searchKey, "user/endings");
 		backend = trieLookup (trie, searchKey);
 		succeed_if (backend, "there should be a backend");
-		compare_key (backend->mountpoint, mp);
+		if (backend) compare_key (backend->mountpoint, mp);
 
 
 		keySetName (searchKey, "user/endings#");
@@ -635,7 +630,7 @@ static void test_endings ()
 		Backend * b2 = trieLookup (trie, searchKey);
 		succeed_if (b2, "there should be a backend");
 		succeed_if (backend != b2, "should be other backend");
-		compare_key (b2->mountpoint, mp);
+		if (b2) compare_key (b2->mountpoint, mp);
 
 
 		keySetName (searchKey, "user/endings/_");
@@ -644,7 +639,7 @@ static void test_endings ()
 		b2 = trieLookup (trie, searchKey);
 		succeed_if (b2, "there should be a backend");
 		succeed_if (backend == b2, "should be the same backend");
-		compare_key (b2->mountpoint, mp);
+		if (b2) compare_key (b2->mountpoint, mp);
 
 
 		keySetName (searchKey, "user/endings/X");
@@ -653,7 +648,7 @@ static void test_endings ()
 		b2 = trieLookup (trie, searchKey);
 		succeed_if (b2, "there should be a backend");
 		succeed_if (backend == b2, "should be the same backend");
-		compare_key (b2->mountpoint, mp);
+		if (b2) compare_key (b2->mountpoint, mp);
 
 
 		keySetName (searchKey, "user/endings_");
@@ -677,7 +672,7 @@ static void test_endings ()
 		b2 = trieLookup (trie, searchKey);
 		succeed_if (b2, "there should be a backend");
 		succeed_if (backend != b2, "should be other backend");
-		compare_key (b2->mountpoint, mp);
+		if (b2) compare_key (b2->mountpoint, mp);
 
 		keySetName (searchKey, "user/endings\200");
 		keySetName (mp, "user/endings\200");
@@ -685,7 +680,7 @@ static void test_endings ()
 		b2 = trieLookup (trie, searchKey);
 		succeed_if (b2, "there should be a backend");
 		succeed_if (backend != b2, "should be other backend");
-		compare_key (b2->mountpoint, mp);
+		if (b2) compare_key (b2->mountpoint, mp);
 
 		// output_trie(trie);
 
@@ -709,28 +704,28 @@ static void test_root ()
 	Key * rmp = keyNew ("", KEY_VALUE, "root", KEY_END);
 	Backend * backend = trieLookup (trie, searchKey);
 	succeed_if (backend, "there should be the root backend");
-	compare_key (backend->mountpoint, rmp);
+	if (backend) compare_key (backend->mountpoint, rmp);
 
 
 	Key * mp = keyNew ("user/tests/simple", KEY_VALUE, "simple", KEY_END);
 	keySetName (searchKey, "user/tests/simple");
 	backend = trieLookup (trie, searchKey);
 	succeed_if (backend, "there should be a backend");
-	compare_key (backend->mountpoint, mp);
+	if (backend) compare_key (backend->mountpoint, mp);
 
 
 	keySetName (searchKey, "user/tests/simple/below");
 	Backend * b2 = trieLookup (trie, searchKey);
 	succeed_if (b2, "there should be a backend");
 	succeed_if (backend == b2, "should be same backend");
-	compare_key (b2->mountpoint, mp);
+	if (b2) compare_key (b2->mountpoint, mp);
 
 
 	keySetName (searchKey, "user/tests/simple/deep/below");
 	b2 = trieLookup (trie, searchKey);
 	succeed_if (b2, "there should be a backend");
 	succeed_if (backend == b2, "should be same backend");
-	compare_key (b2->mountpoint, mp);
+	if (b2) compare_key (b2->mountpoint, mp);
 
 	// output_trie(trie);
 


### PR DESCRIPTION
# Purpose

Fix issues reported by static code checkers

# Checklist

- [X] commit messages are fine (with references to issues)
- [X] I ran all tests and everything went fine
- [ ] I added unit tests
- [X] affected documentation is fixed
- [X] I added code comments, logging, and assertions
- [X] meta data is updated (e.g. README.md of plugins)

@markus2330 most of the issues have been minor things like unnecessary dead stores which i've removed, but there were also some possible null dereferences and obvious mistakes in some tests. If you find a change too drastic i can also just make it ignore some of the dead stores instead of removing them.
Furthermore i've made scan-build aware of our ELEKTRA_ASSERT to avoid some false positives and improved the documentation.
The only 4 reports left are in python.cpp of the python bindings, where it is not aware that SWIG_NewPointerObj takes care about freeing the allocated memory. I can supress the warnings though that requires some defines around the affected code. Is it even necessary?

