### PR TITLE
Canonical: Preview

### DIFF
--- a/doc/METADATA.ini
+++ b/doc/METADATA.ini
@@ -589,6 +589,34 @@ status= proposal
 description= Add the error but do not fail (to test broken plugins)
 
 #
+# Transformations of the key's value
+#
+
+[transform/canonical]
+usedby/plugin= canonical
+type= string
+status= implemented
+description= Pattern to match against the keys value or an array parent
+
+[transform/canonical/set]
+usedby/plugin= canonical
+type= string
+status= implemented
+description= New value to set on match
+
+[transform/canonical/#]
+usedby/plugin= canonical
+type= string
+status= implemented
+description= Array of transform/canonical metadata
+
+[transform/canonical/#/set]
+usedby/plugin= canonical
+type= string
+status= implemented
+description= same as trasnform/canonical/set but with arrays
+
+#
 # Other information about keys
 #
 

--- a/src/plugins/README.md
+++ b/src/plugins/README.md
@@ -155,6 +155,7 @@ Transformations:
 - [keytometa](keytometa/) transforms keys to metadata
 - [rename](rename/) renames keys according to different rules
 - [boolean](boolean/) canonicalizes boolean keys
+- [canonical](canonical/) canonicalizes key values
 
 Doing other stuff:
 

--- a/src/plugins/canonical/CMakeLists.txt
+++ b/src/plugins/canonical/CMakeLists.txt
@@ -7,5 +7,6 @@ add_plugin (canonical
 	LINK_ELEKTRA
 		elektra-meta
 		elektra-utility
+		elektra-ease
 	ADD_TEST
 	)

--- a/src/plugins/canonical/CMakeLists.txt
+++ b/src/plugins/canonical/CMakeLists.txt
@@ -1,0 +1,11 @@
+include (LibAddMacros)
+
+add_plugin (canonical
+	SOURCES
+		canonical.h
+		canonical.c
+	LINK_ELEKTRA
+		elektra-meta
+		elektra-utility
+	ADD_TEST
+	)

--- a/src/plugins/canonical/README.md
+++ b/src/plugins/canonical/README.md
@@ -16,87 +16,96 @@ Canonicalizes keyvalues matching a lists of valid values, posix extended regex o
 ## Examples
 
  - Lists:
-
-```
-	user/key = TRue
-		transform/canonical/list/insensitive = "'TRUE', 'ON', 'ENABLE'"
-		transform/canonical/list/insensitive/canonical = 1
-
-	kdb get user/key 
-	1		
-```
-```
-	user/key = TRue
-		transform/canonical/list/sensitive = "'TRUE', 'ON', 'ENABLE'"
-		transform/canonical/list/sensitive/canonical = 1
-
-	kdb get user/key 
-	TRue		
-```
-```
-	user/keyon = ON
-		transform/canonical/list/sensitive = #1
-		transform/canonical/list/sensitive/#0 = "'TRUE', 'true'"
-		transform/canonical/list/sensitive/#0/canonical = "1true"
-		transform/canonical/list/sensitive/#1 = "'on', 'ON'"
-		transform/canonical/list/sensitive/#1/canonical = "1on"
-
-	user/keytrue = TRUE
-		transform/canonical/list/sensitive = #1
-		transform/canonical/list/sensitive/#0 = "'TRUE', 'true'"
-		transform/canonical/list/sensitive/#0/canonical = "1true"
-		transform/canonical/list/sensitive/#1 = "'on', 'ON'"
-		transform/canonical/list/sensitive/#1/canonical = "1on"
-
-	kdb get user/keyon 
-	1on
-
-	kdb get user/keytrue
-	1true
-```
+	- Single
+		```
+			user/key = TRue
+				transform/canonical/list/insensitive = "'TRUE', 'ON', 'ENABLE'"
+				transform/canonical/list/insensitive/canonical = 1
+		
+			kdb get user/key 
+			1		
+		```
+		```
+			user/key = TRue
+				transform/canonical/list/sensitive = "'TRUE', 'ON', 'ENABLE'"
+				transform/canonical/list/sensitive/canonical = 1
+		
+			kdb get user/key 
+			TRue		
+		```
+	- Array
+		```
+			user/keyon = ON
+				transform/canonical/list/sensitive = #1
+				transform/canonical/list/sensitive/#0 = "'TRUE', 'true'"
+				transform/canonical/list/sensitive/#0/canonical = "1true"
+				transform/canonical/list/sensitive/#1 = "'on', 'ON'"
+				transform/canonical/list/sensitive/#1/canonical = "1on"
+		
+			user/keytrue = TRUE
+				transform/canonical/list/sensitive = #1
+				transform/canonical/list/sensitive/#0 = "'TRUE', 'true'"
+				transform/canonical/list/sensitive/#0/canonical = "1true"
+				transform/canonical/list/sensitive/#1 = "'on', 'ON'"
+				transform/canonical/list/sensitive/#1/canonical = "1on"
+		
+			kdb get user/keyon 
+			1on
+		
+			kdb get user/keytrue
+			1true
+		```
+	- Enum-like
+		```
+			user/key = ON
+				transform/canonical/list/insensitive = #2
+				transform/canonical/list/insensitive/#0 = "'FALSE', 'OFF', 'DISABLE', 'CLOSED'"
+				transform/canonical/list/insensitive/#1 = "'TRUE', 'ON', 'ENABLE', 'OPEN'"
+				transform/canonical/list/insensitive/#2 = "'OTHER', 'NONE', ''"
+		
+			kdb get user/key
+			1
+		```
  - Regex:
-
-```
-	user/key = TRue
-		transform/canonical/regex = "TR[Uu][Ee]"
-		transform/canonical/regex/canonical = 1
-
-	kdb get user/key 
-	1		
-```
-```
-	user/keyenable = enABLE
-		transform/canonical/regex = #1
-		transform/canonical/regex/#0 = "TR.?E"
-		transform/canonical/regex/#0/canonical = "1true"
-		transform/canonical/regex/#1 = ".*ABLE"
-		transform/canonical/regex/#1/canonical = "1enable"
-
-	kdb get user/keyenable
-	1enable
-```
-
+	```
+		user/key = TRue
+			transform/canonical/regex = "TR[Uu][Ee]"
+			transform/canonical/regex/canonical = 1
+	
+		kdb get user/key 
+		1		
+	```
+	```
+		user/keyenable = enABLE
+			transform/canonical/regex = #1
+			transform/canonical/regex/#0 = "TR.?E"
+			transform/canonical/regex/#0/canonical = "1true"
+			transform/canonical/regex/#1 = ".*ABLE"
+			transform/canonical/regex/#1/canonical = "1enable"
+	
+		kdb get user/keyenable
+		1enable
+	```
  - FNMatch:
-
-```
-	user/key = TRue
-		transform/canonical/fnmatch = "??ue"
-		transform/canonical/fnmatch/canonical = 1
-
-	kdb get user/key 
-	1		
-```
-```
-	user/keyenable = enABLE
-		transform/canonical/fnmatch = #1
-		transform/canonical/fnmatch/#0 = "TR*"
-		transform/canonical/fnmatch/#0/canonical = "1true"
-		transform/canonical/fnmatch/#1 = "en*"
-		transform/canonical/fnmatch/#1/canonical = "1enable"
-
-	kdb get user/keyenable
-	1enable
-```
+	```
+		user/key = TRue
+			transform/canonical/fnmatch = "??ue"
+			transform/canonical/fnmatch/canonical = 1
+	
+		kdb get user/key 
+		1		
+	```
+	```
+		user/keyenable = enABLE
+			transform/canonical/fnmatch = #1
+			transform/canonical/fnmatch/#0 = "TR*"
+			transform/canonical/fnmatch/#0/canonical = "1true"
+			transform/canonical/fnmatch/#1 = "en*"
+			transform/canonical/fnmatch/#1/canonical = "1enable"
+	
+		kdb get user/keyenable
+		1enable
+	```
 
 ## Dependencies
 

--- a/src/plugins/canonical/README.md
+++ b/src/plugins/canonical/README.md
@@ -1,37 +1,102 @@
 - infos = Information about the canonical plugin is in keys below
-- infos/author = Author Name <elektra@libelektra.org>
+- infos/author = Thomas Waser <thomas.waser@libelektra.org>
 - infos/licence = BSD
 - infos/needs =
 - infos/provides =
 - infos/recommends =
-- infos/placements =
-- infos/status = recommended productive maintained reviewed conformant compatible coverage specific unittest shelltest tested nodep libc configurable final preview memleak experimental difficult unfinished old nodoc concept orphan obsolete discouraged -1000000
-- infos/metadata =
+- infos/placements = postgetstorage presetstorage
+- infos/status = maintained conformant compatible specific unittest tested preview experimental nodoc 
+- infos/metadata = transform/canonical/fnmatch transform/canonical/fnmatch/canonical transform/canonical/regex transform/canonical/regex/canonical transform/canonical/fnmatch/# transform/canonical/fnmatch/#/canonical transform/canonical/regex/# transform/canonical/regex/#/canonical transform/canonical/list/sensitive transform/canonical/list/sensitive/canonical transform/canonical/list/insensitive transform/canonical/list/insensitive/canonical transform/canonical/list/sensitive/# transform/canonical/list/sensitive/#/canonical transform/canonical/list/insensitive/# transform/canonical/list/insensitive/#/canonical
 - infos/description = one-line description of canonical
 
 ## Introduction
 
-Copy this canonical if you want to start a new
-plugin written in C.
+Canonicalizes keyvalues matching a lists of valid values, posix extended regex or fnmatch(3) pattern. 
 
-## Usage
+## Examples
 
-You can use `scripts/copy-canonical`
-to automatically rename everything to your
-plugin name:
+ - Lists:
 
-	cd src/plugins
-	../../scripts/copy-canonical yourplugin
+```
+	user/key = TRue
+		transform/canonical/list/insensitive = "'TRUE', 'ON', 'ENABLE'"
+		transform/canonical/list/insensitive/canonical = 1
 
-Then update the README.md of your newly created plugin:
+	kdb get user/key 
+	1		
+```
+```
+	user/key = TRue
+		transform/canonical/list/sensitive = "'TRUE', 'ON', 'ENABLE'"
+		transform/canonical/list/sensitive/canonical = 1
 
-- enter your full name+email in `infos/author`
-- make sure `status` and other clauses conform to
-  descriptions in `doc/CONTRACT.ini`
-- update the one-line description above
-- add your plugin in `src/plugins/README.md`
-- and rewrite the rest of this `README.md` to give a great
-  explanation of what your plugin does
+	kdb get user/key 
+	TRue		
+```
+```
+	user/keyon = ON
+		transform/canonical/list/sensitive = #1
+		transform/canonical/list/sensitive/#0 = "'TRUE', 'true'"
+		transform/canonical/list/sensitive/#0/canonical = "1true"
+		transform/canonical/list/sensitive/#1 = "'on', 'ON'"
+		transform/canonical/list/sensitive/#1/canonical = "1on"
+
+	user/keytrue = TRUE
+		transform/canonical/list/sensitive = #1
+		transform/canonical/list/sensitive/#0 = "'TRUE', 'true'"
+		transform/canonical/list/sensitive/#0/canonical = "1true"
+		transform/canonical/list/sensitive/#1 = "'on', 'ON'"
+		transform/canonical/list/sensitive/#1/canonical = "1on"
+
+	kdb get user/keyon 
+	1on
+
+	kdb get user/keytrue
+	1true
+```
+ - Regex:
+
+```
+	user/key = TRue
+		transform/canonical/regex = "TR[Uu][Ee]"
+		transform/canonical/regex/canonical = 1
+
+	kdb get user/key 
+	1		
+```
+```
+	user/keyenable = enABLE
+		transform/canonical/regex = #1
+		transform/canonical/regex/#0 = "TR.?E"
+		transform/canonical/regex/#0/canonical = "1true"
+		transform/canonical/regex/#1 = ".*ABLE"
+		transform/canonical/regex/#1/canonical = "1enable"
+
+	kdb get user/keyenable
+	1enable
+```
+
+ - FNMatch:
+
+```
+	user/key = TRue
+		transform/canonical/fnmatch = "??ue"
+		transform/canonical/fnmatch/canonical = 1
+
+	kdb get user/key 
+	1		
+```
+```
+	user/keyenable = enABLE
+		transform/canonical/fnmatch = #1
+		transform/canonical/fnmatch/#0 = "TR*"
+		transform/canonical/fnmatch/#0/canonical = "1true"
+		transform/canonical/fnmatch/#1 = "en*"
+		transform/canonical/fnmatch/#1/canonical = "1enable"
+
+	kdb get user/keyenable
+	1enable
+```
 
 ## Dependencies
 

--- a/src/plugins/canonical/README.md
+++ b/src/plugins/canonical/README.md
@@ -6,7 +6,7 @@
 - infos/recommends =
 - infos/placements = postgetstorage presetstorage
 - infos/status = maintained conformant compatible specific unittest tested preview experimental nodoc 
-- infos/metadata = transform/canonical/fnmatch transform/canonical/fnmatch/canonical transform/canonical/regex transform/canonical/regex/canonical transform/canonical/fnmatch/# transform/canonical/fnmatch/#/canonical transform/canonical/regex/# transform/canonical/regex/#/canonical transform/canonical/list/sensitive transform/canonical/list/sensitive/canonical transform/canonical/list/insensitive transform/canonical/list/insensitive/canonical transform/canonical/list/sensitive/# transform/canonical/list/sensitive/#/canonical transform/canonical/list/insensitive/# transform/canonical/list/insensitive/#/canonical
+- infos/metadata = transform/canonical transform/canonical/set transform/canonical/# transform/canonical/#/set
 - infos/description = one-line description of canonical
 
 ## Introduction
@@ -19,16 +19,16 @@ Canonicalizes keyvalues matching a lists of valid values, posix extended regex o
 	- Single
 		```
 			user/key = TRue
-				transform/canonical/list/insensitive = "'TRUE', 'ON', 'ENABLE'"
-				transform/canonical/list/insensitive/canonical = 1
+				transform/canonical = "caselist:'TRUE', 'ON', 'ENABLE'"
+				transform/canonical/set = 1
 		
 			kdb get user/key 
 			1		
 		```
 		```
 			user/key = TRue
-				transform/canonical/list/sensitive = "'TRUE', 'ON', 'ENABLE'"
-				transform/canonical/list/sensitive/canonical = 1
+				transform/canonical = "list:'TRUE', 'ON', 'ENABLE'"
+				transform/canonical/set = 1
 		
 			kdb get user/key 
 			TRue		
@@ -36,18 +36,18 @@ Canonicalizes keyvalues matching a lists of valid values, posix extended regex o
 	- Array
 		```
 			user/keyon = ON
-				transform/canonical/list/sensitive = #1
-				transform/canonical/list/sensitive/#0 = "'TRUE', 'true'"
-				transform/canonical/list/sensitive/#0/canonical = "1true"
-				transform/canonical/list/sensitive/#1 = "'on', 'ON'"
-				transform/canonical/list/sensitive/#1/canonical = "1on"
+				transform/canonical = #1
+				transform/canonical/#0 = "list:'TRUE', 'true'"
+				transform/canonical/#0/set = "1true"
+				transform/canonical/#1 = "list:'on', 'ON'"
+				transform/canonical/#1/set = "1on"
 		
 			user/keytrue = TRUE
-				transform/canonical/list/sensitive = #1
-				transform/canonical/list/sensitive/#0 = "'TRUE', 'true'"
-				transform/canonical/list/sensitive/#0/canonical = "1true"
-				transform/canonical/list/sensitive/#1 = "'on', 'ON'"
-				transform/canonical/list/sensitive/#1/canonical = "1on"
+				transform/canonical = #1
+				transform/canonical/#0 = "list:'TRUE', 'true'"
+				transform/canonical/#0/set = "1true"
+				transform/canonical/#1 = "list:'on', 'ON'"
+				transform/canonical/#1/set = "1on"
 		
 			kdb get user/keyon 
 			1on
@@ -58,10 +58,10 @@ Canonicalizes keyvalues matching a lists of valid values, posix extended regex o
 	- Enum-like
 		```
 			user/key = ON
-				transform/canonical/list/insensitive = #2
-				transform/canonical/list/insensitive/#0 = "'FALSE', 'OFF', 'DISABLE', 'CLOSED'"
-				transform/canonical/list/insensitive/#1 = "'TRUE', 'ON', 'ENABLE', 'OPEN'"
-				transform/canonical/list/insensitive/#2 = "'OTHER', 'NONE', ''"
+				transform/canonical = #2
+				transform/canonical/#0 = "list:'FALSE', 'OFF', 'DISABLE', 'CLOSED'"
+				transform/canonical/#1 = "list:'TRUE', 'ON', 'ENABLE', 'OPEN'"
+				transform/canonical/#2 = "list:'OTHER', 'NONE', ''"
 		
 			kdb get user/key
 			1
@@ -69,19 +69,19 @@ Canonicalizes keyvalues matching a lists of valid values, posix extended regex o
  - Regex:
 	```
 		user/key = TRue
-			transform/canonical/regex = "TR[Uu][Ee]"
-			transform/canonical/regex/canonical = 1
+			transform/canonical = "regex:TR[Uu][Ee]"
+			transform/canonical/set = 1
 	
 		kdb get user/key 
 		1		
 	```
 	```
 		user/keyenable = enABLE
-			transform/canonical/regex = #1
-			transform/canonical/regex/#0 = "TR.?E"
-			transform/canonical/regex/#0/canonical = "1true"
-			transform/canonical/regex/#1 = ".*ABLE"
-			transform/canonical/regex/#1/canonical = "1enable"
+			transform/canonical = #1
+			transform/canonical/#0 = "regex:TR.?E"
+			transform/canonical/#0/set = "1true"
+			transform/canonical/#1 = "regex:.*ABLE"
+			transform/canonical/#1/set = "1enable"
 	
 		kdb get user/keyenable
 		1enable
@@ -89,22 +89,33 @@ Canonicalizes keyvalues matching a lists of valid values, posix extended regex o
  - FNMatch:
 	```
 		user/key = TRue
-			transform/canonical/fnmatch = "??ue"
-			transform/canonical/fnmatch/canonical = 1
+			transform/canonical = "fnm:??ue"
+			transform/canonical/set = 1
 	
 		kdb get user/key 
 		1		
 	```
 	```
 		user/keyenable = enABLE
-			transform/canonical/fnmatch = #1
-			transform/canonical/fnmatch/#0 = "TR*"
-			transform/canonical/fnmatch/#0/canonical = "1true"
-			transform/canonical/fnmatch/#1 = "en*"
-			transform/canonical/fnmatch/#1/canonical = "1enable"
+			transform/canonical = #1
+			transform/canonical/#0 = "fnm:TR*"
+			transform/canonical/#0/set = "1true"
+			transform/canonical/#1 = "fnm:en*"
+			transform/canonical/#1/set = "1enable"
 	
 		kdb get user/keyenable
 		1enable
+	```
+ - Mixed:
+	```
+		user/key = ABC
+			transform/canonical = #2
+			transform/canonical/#0 = "regex:[a-zA-Z]"
+			transform/canonical/#1 = "fnm:??3"
+			transform/canonical/#2 = "list:'+++','---','==='"
+		
+		kdb get user/key
+		0
 	```
 
 ## Dependencies

--- a/src/plugins/canonical/README.md
+++ b/src/plugins/canonical/README.md
@@ -1,0 +1,46 @@
+- infos = Information about the canonical plugin is in keys below
+- infos/author = Author Name <elektra@libelektra.org>
+- infos/licence = BSD
+- infos/needs =
+- infos/provides =
+- infos/recommends =
+- infos/placements =
+- infos/status = recommended productive maintained reviewed conformant compatible coverage specific unittest shelltest tested nodep libc configurable final preview memleak experimental difficult unfinished old nodoc concept orphan obsolete discouraged -1000000
+- infos/metadata =
+- infos/description = one-line description of canonical
+
+## Introduction
+
+Copy this canonical if you want to start a new
+plugin written in C.
+
+## Usage
+
+You can use `scripts/copy-canonical`
+to automatically rename everything to your
+plugin name:
+
+	cd src/plugins
+	../../scripts/copy-canonical yourplugin
+
+Then update the README.md of your newly created plugin:
+
+- enter your full name+email in `infos/author`
+- make sure `status` and other clauses conform to
+  descriptions in `doc/CONTRACT.ini`
+- update the one-line description above
+- add your plugin in `src/plugins/README.md`
+- and rewrite the rest of this `README.md` to give a great
+  explanation of what your plugin does
+
+## Dependencies
+
+None.
+
+## Examples
+
+None.
+
+## Limitations
+
+None.

--- a/src/plugins/canonical/canonical.c
+++ b/src/plugins/canonical/canonical.c
@@ -1,0 +1,365 @@
+/**
+ * @file
+ *
+ * @brief Source for canonical plugin
+ *
+ * @copyright BSD License (see LICENSE.md or https://www.libelektra.org)
+ *
+ */
+
+#include "canonical.h"
+
+#include <fnmatch.h>
+#include <kdbhelper.h>
+#include <kdbmeta.h>
+#include <kdbutility.h>
+#include <regex.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <strings.h>
+
+
+int elektraCanonicalOpen (Plugin * handle ELEKTRA_UNUSED, Key * errorKey ELEKTRA_UNUSED)
+{
+	// plugin initialization logic
+	// this function is optional
+
+	return ELEKTRA_PLUGIN_STATUS_SUCCESS;
+}
+
+int elektraCanonicalClose (Plugin * handle ELEKTRA_UNUSED, Key * errorKey ELEKTRA_UNUSED)
+{
+	// free all plugin resources and shut it down
+	// this function is optional
+
+	return ELEKTRA_PLUGIN_STATUS_SUCCESS;
+}
+
+static char ** stringToArray (const char * string, const char * delim)
+{
+	if (!string || !delim) return NULL;
+
+	char ** array = NULL;
+	int elems = 1;
+	const char * ptr = string;
+
+	while (*ptr)
+	{
+		if (*ptr == *delim)
+		{
+			++elems;
+		}
+		++ptr;
+	}
+	++elems; // terminating element
+	array = elektraCalloc (elems * sizeof (char *));
+	char * localString = NULL;
+	if (string[0] == '[' || string[0] == '(' || string[0] == '{')
+		localString = elektraStrDup (string + 1);
+	else
+		localString = elektraStrDup (string);
+	char lastChar = localString[strlen (localString) - 1];
+	if (lastChar == ']' || lastChar == ')' || lastChar == '}') localString[strlen (localString) - 1] = '\0';
+
+	int current = 0;
+	ptr = strtok (localString, delim);
+	while (ptr)
+	{
+		if (*ptr == '\0')
+		{
+			ptr = strtok (NULL, delim);
+			continue;
+		}
+		char * tmp = elektraStrDup (ptr);
+		char * start = elektraLskip (tmp);
+		(void)elektraRstrip (start, NULL);
+		if (start[0] == '\'') ++start;
+		if (start[strlen (start) - 1] == '\'') start[strlen (start) - 1] = '\0';
+		array[current++] = elektraStrDup (start);
+		elektraFree (tmp);
+		ptr = strtok (NULL, delim);
+	}
+	if (current + 1 < elems)
+	{
+		elektraRealloc ((void **)array, (current + 1) * (sizeof (char *)));
+		array[current] = NULL;
+	}
+	elektraFree (localString);
+	return array;
+}
+
+static void freeArray (char ** array)
+{
+	for (size_t i = 0; array[i] != NULL; ++i)
+	{
+		elektraFree (array[i]);
+	}
+	elektraFree (array);
+}
+
+static int canonicalRegexSingle (Key * key, const Key * meta)
+{
+	const char * value = keyString (key);
+	const char * regexString = keyString (meta);
+	fprintf (stderr, " === RegexSingle ===\n === %s - %s:(%s)\n", regexString, keyName (key), value);
+
+	regex_t regex;
+	int ret = regcomp (&regex, regexString, REG_EXTENDED);
+
+	if (ret != 0)
+	{
+		char buffer[1000];
+		regerror (ret, &regex, buffer, 999);
+		fprintf (stderr, "regex error: %s\n", buffer);
+		regfree (&regex);
+		return -1;
+	}
+	int nomatch = 0;
+	nomatch = regexec (&regex, value, 0, NULL, 0);
+	regfree (&regex);
+	if (!nomatch)
+	{
+		fprintf (stderr, "   %s matched %s\n", regexString, value);
+		keySetMeta (key, "transform/canonical/origvalue", value);
+		Key * searchKey = keyNew (keyName (meta), KEY_META_NAME, KEY_END);
+		keyAddBaseName (searchKey, "canonical");
+		fprintf (stderr, "searchKey: %s\n", keyName (searchKey));
+		const char * canonicalValue = keyString (keyGetMeta (key, keyName (searchKey)));
+		keyDel (searchKey);
+		fprintf (stderr, "canonicalValueKey: %s\n", canonicalValue);
+		keySetString (key, canonicalValue);
+		return 1;
+	}
+	return 0;
+}
+
+static int canonicalRegexArray (Key * key, const Key * meta)
+{
+	KeySet * lists = elektraMetaArrayToKS (key, keyName (meta));
+	Key * elem = NULL;
+	const char * value = keyString (key);
+	fprintf (stderr, " === RegexArray ===\n === %s:(%s)\n", keyName (key), value);
+	int rc = 0;
+	while ((elem = ksNext (lists)) != NULL)
+	{
+		fprintf (stderr, "elem: %s:(%s)\n", keyName (elem), keyString (elem));
+		rc = canonicalRegexSingle (key, elem);
+		if (rc != 0) break;
+	}
+	ksDel (lists);
+	return rc;
+}
+
+
+static int canonicalRegex (Key * key, const Key * meta)
+{
+	int rc = 0;
+	if (keyString (meta)[0] == '#')
+		rc = canonicalRegexArray (key, meta);
+	else
+		rc = canonicalRegexSingle (key, meta);
+
+	return rc;
+}
+
+static int canonicalFNMatchSingle (Key * key, const Key * meta)
+{
+	const char * value = keyString (key);
+	const char * pattern = keyString (meta);
+	fprintf (stderr, " === FNMatchSingle ===\n === %s - %s:(%s)\n", pattern, keyName (key), value);
+	if (!fnmatch (pattern, value, 0))
+	{
+		keySetMeta (key, "transform/canonical/origvalue", value);
+		Key * searchKey = keyNew (keyName (meta), KEY_META_NAME, KEY_END);
+		keyAddBaseName (searchKey, "canonical");
+		fprintf (stderr, "searchKey: %s\n", keyName (searchKey));
+		const char * canonicalValue = keyString (keyGetMeta (key, keyName (searchKey)));
+		keyDel (searchKey);
+		fprintf (stderr, "canonicalValueKey: %s\n", canonicalValue);
+		keySetString (key, canonicalValue);
+		return 1;
+	}
+	return 0;
+}
+
+static int canonicalFNMatchArray (Key * key, const Key * meta)
+{
+	KeySet * lists = elektraMetaArrayToKS (key, keyName (meta));
+	Key * elem = NULL;
+	const char * value = keyString (key);
+	fprintf (stderr, " === FNMatchArray ===\n === %s:(%s)\n", keyName (key), value);
+	int rc = 0;
+	while ((elem = ksNext (lists)) != NULL)
+	{
+		fprintf (stderr, "elem: %s:(%s)\n", keyName (elem), keyString (elem));
+		rc = canonicalFNMatchSingle (key, elem);
+		if (rc != 0) break;
+	}
+	ksDel (lists);
+	return rc;
+}
+
+static int canonicalFNMatch (Key * key, const Key * meta)
+{
+	int rc = 0;
+	if (keyString (meta)[0] == '#')
+		rc = canonicalFNMatchArray (key, meta);
+	else
+		rc = canonicalFNMatchSingle (key, meta);
+
+	return rc;
+}
+
+static int canonicalListSingle (Key * key, const Key * meta, int (*cmpFun) (const char *, const char *))
+{
+	const char * value = keyString (key);
+	fprintf (stderr, " === ListSingle ===\n === %s:(%s)\n", keyName (key), value);
+	char ** list = stringToArray (keyString (meta), ",");
+	if (!list) return -1;
+	int rc = 0;
+	for (size_t i = 0; list[i] != NULL; ++i)
+	{
+		fprintf (stderr, "list[%zd] \'%s\'\n", i, list[i]);
+		if (!cmpFun (value, list[i]))
+		{
+			keySetMeta (key, "transform/canonical/origvalue", value);
+			Key * searchKey = keyNew (keyName (meta), KEY_META_NAME, KEY_END);
+			keyAddBaseName (searchKey, "canonical");
+			fprintf (stderr, "searchKey: %s\n", keyName (searchKey));
+			const char * canonicalValue = keyString (keyGetMeta (key, keyName (searchKey)));
+			keyDel (searchKey);
+			fprintf (stderr, "canonicalValueKey: %s\n", canonicalValue);
+			keySetString (key, canonicalValue);
+			rc = 1;
+			break;
+		}
+	}
+	freeArray (list);
+	return rc;
+}
+
+
+static int canonicalListArray (Key * key, const Key * meta, int (*cmpFun) (const char *, const char *))
+{
+	KeySet * lists = elektraMetaArrayToKS (key, keyName (meta));
+	Key * elem = NULL;
+	const char * value = keyString (key);
+	fprintf (stderr, " === ListArray ===\n === %s:(%s)\n", keyName (key), value);
+	int rc = 0;
+	while ((elem = ksNext (lists)) != NULL)
+	{
+		fprintf (stderr, "elem: %s:(%s)\n", keyName (elem), keyString (elem));
+		rc = canonicalListSingle (key, elem, cmpFun);
+		if (rc != 0) break;
+	}
+	ksDel (lists);
+	return rc;
+}
+
+static int canonicalCaseSensitiveList (Key * key, const Key * meta)
+{
+	int rc = 0;
+	if (keyString (meta)[0] == '#')
+		rc = canonicalListArray (key, meta, &strcmp);
+	else
+		rc = canonicalListSingle (key, meta, &strcmp);
+	return rc;
+}
+
+static int canonicalCaseInsensitiveList (Key * key, const Key * meta)
+{
+	int rc = 0;
+	if (keyString (meta)[0] == '#')
+		rc = canonicalListArray (key, meta, &strcasecmp);
+	else
+		rc = canonicalListSingle (key, meta, &strcasecmp);
+	return rc;
+}
+
+int elektraCanonicalGet (Plugin * handle ELEKTRA_UNUSED, KeySet * returned, Key * parentKey)
+{
+	if (!elektraStrCmp (keyName (parentKey), "system/elektra/modules/canonical"))
+	{
+		KeySet * contract = ksNew (
+			30, keyNew ("system/elektra/modules/canonical", KEY_VALUE, "canonical plugin waits for your orders", KEY_END),
+			keyNew ("system/elektra/modules/canonical/exports", KEY_END),
+			keyNew ("system/elektra/modules/canonical/exports/open", KEY_FUNC, elektraCanonicalOpen, KEY_END),
+			keyNew ("system/elektra/modules/canonical/exports/close", KEY_FUNC, elektraCanonicalClose, KEY_END),
+			keyNew ("system/elektra/modules/canonical/exports/get", KEY_FUNC, elektraCanonicalGet, KEY_END),
+			keyNew ("system/elektra/modules/canonical/exports/set", KEY_FUNC, elektraCanonicalSet, KEY_END),
+			keyNew ("system/elektra/modules/canonical/exports/error", KEY_FUNC, elektraCanonicalError, KEY_END),
+			keyNew ("system/elektra/modules/canonical/exports/checkconf", KEY_FUNC, elektraCanonicalCheckConfig, KEY_END),
+#include ELEKTRA_README (canonical)
+			keyNew ("system/elektra/modules/canonical/infos/version", KEY_VALUE, PLUGINVERSION, KEY_END), KS_END);
+		ksAppend (returned, contract);
+		ksDel (contract);
+
+		return ELEKTRA_PLUGIN_STATUS_SUCCESS;
+	}
+	Key * cur = NULL;
+	while ((cur = ksNext (returned)) != NULL)
+	{
+		const Key * pattern = NULL;
+		if (((pattern = keyGetMeta (cur, "transform/canonical/regex")) != NULL) &&
+		    (keyGetMeta (cur, "transform/canonical/origvalue") == NULL))
+		{
+			canonicalRegex (cur, pattern);
+		}
+		if (((pattern = keyGetMeta (cur, "transform/canonical/fnmatch")) != NULL) &&
+		    (keyGetMeta (cur, "transform/canonical/origvalue") == NULL))
+		{
+			canonicalFNMatch (cur, pattern);
+		}
+		if (((pattern = keyGetMeta (cur, "transform/canonical/list/insensitive")) != NULL) &&
+		    (keyGetMeta (cur, "transform/canonical/origvalue") == NULL))
+		{
+			canonicalCaseInsensitiveList (cur, pattern);
+		}
+		if (((pattern = keyGetMeta (cur, "transform/canonical/list/sensitive")) != NULL) &&
+		    (keyGetMeta (cur, "transform/canonical/origvalue") == NULL))
+		{
+			canonicalCaseSensitiveList (cur, pattern);
+		}
+	}
+
+	// get all keys
+
+	return ELEKTRA_PLUGIN_STATUS_NO_UPDATE;
+}
+
+int elektraCanonicalSet (Plugin * handle ELEKTRA_UNUSED, KeySet * returned ELEKTRA_UNUSED, Key * parentKey ELEKTRA_UNUSED)
+{
+	// set all keys
+	// this function is optional
+
+	return ELEKTRA_PLUGIN_STATUS_NO_UPDATE;
+}
+
+int elektraCanonicalError (Plugin * handle ELEKTRA_UNUSED, KeySet * returned ELEKTRA_UNUSED, Key * parentKey ELEKTRA_UNUSED)
+{
+	// handle errors (commit failed)
+	// this function is optional
+
+	return ELEKTRA_PLUGIN_STATUS_SUCCESS;
+}
+
+int elektraCanonicalCheckConfig (Key * errorKey ELEKTRA_UNUSED, KeySet * conf ELEKTRA_UNUSED)
+{
+	// validate plugin configuration
+	// this function is optional
+
+	return ELEKTRA_PLUGIN_STATUS_NO_UPDATE;
+}
+
+Plugin * ELEKTRA_PLUGIN_EXPORT (canonical)
+{
+	// clang-format off
+    return elektraPluginExport ("canonical",
+            ELEKTRA_PLUGIN_OPEN,	&elektraCanonicalOpen,
+            ELEKTRA_PLUGIN_CLOSE,	&elektraCanonicalClose,
+            ELEKTRA_PLUGIN_GET,	&elektraCanonicalGet,
+            ELEKTRA_PLUGIN_SET,	&elektraCanonicalSet,
+            ELEKTRA_PLUGIN_ERROR,	&elektraCanonicalError,
+            ELEKTRA_PLUGIN_END);
+}

--- a/src/plugins/canonical/canonical.c
+++ b/src/plugins/canonical/canonical.c
@@ -102,7 +102,6 @@ static int canonicalRegexSingle (Key * key, const Key * meta)
 {
 	const char * value = keyString (key);
 	const char * regexString = keyString (meta);
-	fprintf (stderr, " === RegexSingle ===\n === %s - %s:(%s)\n", regexString, keyName (key), value);
 
 	regex_t regex;
 	int ret = regcomp (&regex, regexString, REG_EXTENDED);
@@ -111,7 +110,6 @@ static int canonicalRegexSingle (Key * key, const Key * meta)
 	{
 		char buffer[1000];
 		regerror (ret, &regex, buffer, 999);
-		fprintf (stderr, "regex error: %s\n", buffer);
 		regfree (&regex);
 		return -1;
 	}
@@ -120,14 +118,11 @@ static int canonicalRegexSingle (Key * key, const Key * meta)
 	regfree (&regex);
 	if (!nomatch)
 	{
-		fprintf (stderr, "   %s matched %s\n", regexString, value);
 		keySetMeta (key, "transform/canonical/origvalue", value);
 		Key * searchKey = keyNew (keyName (meta), KEY_META_NAME, KEY_END);
 		keyAddBaseName (searchKey, "canonical");
-		fprintf (stderr, "searchKey: %s\n", keyName (searchKey));
 		const char * canonicalValue = keyString (keyGetMeta (key, keyName (searchKey)));
 		keyDel (searchKey);
-		fprintf (stderr, "canonicalValueKey: %s\n", canonicalValue);
 		keySetString (key, canonicalValue);
 		return 1;
 	}
@@ -138,12 +133,9 @@ static int canonicalRegexArray (Key * key, const Key * meta)
 {
 	KeySet * lists = elektraMetaArrayToKS (key, keyName (meta));
 	Key * elem = NULL;
-	const char * value = keyString (key);
-	fprintf (stderr, " === RegexArray ===\n === %s:(%s)\n", keyName (key), value);
 	int rc = 0;
 	while ((elem = ksNext (lists)) != NULL)
 	{
-		fprintf (stderr, "elem: %s:(%s)\n", keyName (elem), keyString (elem));
 		rc = canonicalRegexSingle (key, elem);
 		if (rc != 0) break;
 	}
@@ -167,16 +159,13 @@ static int canonicalFNMatchSingle (Key * key, const Key * meta)
 {
 	const char * value = keyString (key);
 	const char * pattern = keyString (meta);
-	fprintf (stderr, " === FNMatchSingle ===\n === %s - %s:(%s)\n", pattern, keyName (key), value);
 	if (!fnmatch (pattern, value, 0))
 	{
 		keySetMeta (key, "transform/canonical/origvalue", value);
 		Key * searchKey = keyNew (keyName (meta), KEY_META_NAME, KEY_END);
 		keyAddBaseName (searchKey, "canonical");
-		fprintf (stderr, "searchKey: %s\n", keyName (searchKey));
 		const char * canonicalValue = keyString (keyGetMeta (key, keyName (searchKey)));
 		keyDel (searchKey);
-		fprintf (stderr, "canonicalValueKey: %s\n", canonicalValue);
 		keySetString (key, canonicalValue);
 		return 1;
 	}
@@ -187,12 +176,9 @@ static int canonicalFNMatchArray (Key * key, const Key * meta)
 {
 	KeySet * lists = elektraMetaArrayToKS (key, keyName (meta));
 	Key * elem = NULL;
-	const char * value = keyString (key);
-	fprintf (stderr, " === FNMatchArray ===\n === %s:(%s)\n", keyName (key), value);
 	int rc = 0;
 	while ((elem = ksNext (lists)) != NULL)
 	{
-		fprintf (stderr, "elem: %s:(%s)\n", keyName (elem), keyString (elem));
 		rc = canonicalFNMatchSingle (key, elem);
 		if (rc != 0) break;
 	}
@@ -214,22 +200,18 @@ static int canonicalFNMatch (Key * key, const Key * meta)
 static int canonicalListSingle (Key * key, const Key * meta, int (*cmpFun) (const char *, const char *))
 {
 	const char * value = keyString (key);
-	fprintf (stderr, " === ListSingle ===\n === %s:(%s)\n", keyName (key), value);
 	char ** list = stringToArray (keyString (meta), ",");
 	if (!list) return -1;
 	int rc = 0;
 	for (size_t i = 0; list[i] != NULL; ++i)
 	{
-		fprintf (stderr, "list[%zd] \'%s\'\n", i, list[i]);
 		if (!cmpFun (value, list[i]))
 		{
 			keySetMeta (key, "transform/canonical/origvalue", value);
 			Key * searchKey = keyNew (keyName (meta), KEY_META_NAME, KEY_END);
 			keyAddBaseName (searchKey, "canonical");
-			fprintf (stderr, "searchKey: %s\n", keyName (searchKey));
 			const char * canonicalValue = keyString (keyGetMeta (key, keyName (searchKey)));
 			keyDel (searchKey);
-			fprintf (stderr, "canonicalValueKey: %s\n", canonicalValue);
 			keySetString (key, canonicalValue);
 			rc = 1;
 			break;
@@ -244,12 +226,9 @@ static int canonicalListArray (Key * key, const Key * meta, int (*cmpFun) (const
 {
 	KeySet * lists = elektraMetaArrayToKS (key, keyName (meta));
 	Key * elem = NULL;
-	const char * value = keyString (key);
-	fprintf (stderr, " === ListArray ===\n === %s:(%s)\n", keyName (key), value);
 	int rc = 0;
 	while ((elem = ksNext (lists)) != NULL)
 	{
-		fprintf (stderr, "elem: %s:(%s)\n", keyName (elem), keyString (elem));
 		rc = canonicalListSingle (key, elem, cmpFun);
 		if (rc != 0) break;
 	}

--- a/src/plugins/canonical/canonical.c
+++ b/src/plugins/canonical/canonical.c
@@ -332,7 +332,16 @@ int elektraCanonicalSet (Plugin * handle ELEKTRA_UNUSED, KeySet * returned ELEKT
 {
 	// set all keys
 	// this function is optional
-
+	Key * cur = NULL;
+	while ((cur = ksNext (returned)) != NULL)
+	{
+		const Key * origKey = keyGetMeta (cur, "transform/canonical/origvalue");
+		if (origKey)
+		{
+			keySetString (cur, keyString (origKey));
+			keySetMeta (cur, keyName (origKey), 0);
+		}
+	}
 	return ELEKTRA_PLUGIN_STATUS_NO_UPDATE;
 }
 

--- a/src/plugins/canonical/canonical.h
+++ b/src/plugins/canonical/canonical.h
@@ -1,0 +1,25 @@
+/**
+ * @file
+ *
+ * @brief Header for canonical plugin
+ *
+ * @copyright BSD License (see LICENSE.md or https://www.libelektra.org)
+ *
+ */
+
+#ifndef ELEKTRA_PLUGIN_CANONICAL_H
+#define ELEKTRA_PLUGIN_CANONICAL_H
+
+#include <kdbplugin.h>
+
+
+int elektraCanonicalOpen (Plugin * handle, Key * errorKey);
+int elektraCanonicalClose (Plugin * handle, Key * errorKey);
+int elektraCanonicalGet (Plugin * handle, KeySet * ks, Key * parentKey);
+int elektraCanonicalSet (Plugin * handle, KeySet * ks, Key * parentKey);
+int elektraCanonicalError (Plugin * handle, KeySet * ks, Key * parentKey);
+int elektraCanonicalCheckConfig (Key * errorKey, KeySet * conf);
+
+Plugin * ELEKTRA_PLUGIN_EXPORT (canonical);
+
+#endif

--- a/src/plugins/canonical/canonical.h
+++ b/src/plugins/canonical/canonical.h
@@ -13,11 +13,8 @@
 #include <kdbplugin.h>
 
 
-int elektraCanonicalOpen (Plugin * handle, Key * errorKey);
-int elektraCanonicalClose (Plugin * handle, Key * errorKey);
 int elektraCanonicalGet (Plugin * handle, KeySet * ks, Key * parentKey);
 int elektraCanonicalSet (Plugin * handle, KeySet * ks, Key * parentKey);
-int elektraCanonicalError (Plugin * handle, KeySet * ks, Key * parentKey);
 int elektraCanonicalCheckConfig (Key * errorKey, KeySet * conf);
 
 Plugin * ELEKTRA_PLUGIN_EXPORT (canonical);

--- a/src/plugins/canonical/testmod_canonical.c
+++ b/src/plugins/canonical/testmod_canonical.c
@@ -416,6 +416,48 @@ static void testFNMatchArray ()
 }
 
 
+static void testTristateList ()
+{
+	Key * parentKey = keyNew ("user/tests/canonical", KEY_VALUE, "", KEY_END);
+	KeySet * ks = ksNew (
+		20, keyNew ("user/tests/canonical/TTrue", KEY_VALUE, "On", KEY_META, "transform/canonical/list/insensitive", "#2", KEY_META,
+			    "transform/canonical/list/insensitive/#0", "'TRUE','ON','OPEN','ENABLE'", KEY_META,
+			    "transform/canonical/list/insensitive/#0/canonical", "1", KEY_META, "transform/canonical/list/insensitive/#1",
+			    "'FALSE','OFF','CLOSED','DISABLE'", KEY_META, "transform/canonical/list/insensitive/#1/canonical", "0",
+			    KEY_META, "transform/canonical/list/insensitive/#2", "'OTHER','NONE',''", KEY_META,
+			    "transform/canonical/list/insensitive/#2/canonical", "2", KEY_END),
+		keyNew ("user/tests/canonical/TFalse", KEY_VALUE, "Disable", KEY_META, "transform/canonical/list/insensitive", "#2",
+			KEY_META, "transform/canonical/list/insensitive/#0", "'TRUE','ON','OPEN','ENABLE'", KEY_META,
+			"transform/canonical/list/insensitive/#0/canonical", "1", KEY_META, "transform/canonical/list/insensitive/#1",
+			"'FALSE','OFF','CLOSED','DISABLE'", KEY_META, "transform/canonical/list/insensitive/#1/canonical", "0", KEY_META,
+			"transform/canonical/list/insensitive/#2", "'OTHER','NONE',''", KEY_META,
+			"transform/canonical/list/insensitive/#2/canonical", "2", KEY_END),
+		keyNew ("user/tests/canonical/TOther", KEY_VALUE, "", KEY_META, "transform/canonical/list/insensitive", "#2", KEY_META,
+			"transform/canonical/list/insensitive/#0", "'TRUE','ON','OPEN','ENABLE'", KEY_META,
+			"transform/canonical/list/insensitive/#0/canonical", "1", KEY_META, "transform/canonical/list/insensitive/#1",
+			"'FALSE','OFF','CLOSED','DISABLE'", KEY_META, "transform/canonical/list/insensitive/#1/canonical", "0", KEY_META,
+			"transform/canonical/list/insensitive/#2", "'OTHER','NONE',''", KEY_META,
+			"transform/canonical/list/insensitive/#2/canonical", "2", KEY_END),
+
+		KS_END);
+
+	KeySet * conf = ksNew (0, KS_END);
+	PLUGIN_OPEN ("canonical");
+
+	ksRewind (ks);
+
+	succeed_if (plugin->kdbGet (plugin, ks, parentKey) != (-1), "kdbGet failed");
+
+	succeed_if (!strcmp (keyString (ksLookupByName (ks, "user/tests/canonical/TTrue", KDB_O_NONE)), "1"), "kdbGet failed on TTrue");
+	succeed_if (!strcmp (keyString (ksLookupByName (ks, "user/tests/canonical/TFalse", KDB_O_NONE)), "0"), "kdbGet failed on TFalse");
+	succeed_if (!strcmp (keyString (ksLookupByName (ks, "user/tests/canonical/TOther", KDB_O_NONE)), "2"), "kdbGet failed on match3");
+	ksDel (ks);
+
+	keyDel (parentKey);
+	PLUGIN_CLOSE ();
+}
+
+
 int main (int argc, char ** argv)
 {
 	printf ("CANONICAL     TESTS\n");
@@ -431,6 +473,7 @@ int main (int argc, char ** argv)
 	testRegexArray ();
 	testFNMatchSingle ();
 	testFNMatchArray ();
+	testTristateList ();
 	printf ("\ntestmod_canonical RESULTS: %d test(s) done. %d error(s).\n", nbTest, nbError);
 
 	return nbError;

--- a/src/plugins/canonical/testmod_canonical.c
+++ b/src/plugins/canonical/testmod_canonical.c
@@ -3,7 +3,7 @@
  *
  * @brief Tests for canonical plugin
  *
- * @copyright BSD License (see LICENSE.md or https://www.libelektra.org)
+ * @copyright BSD License (see LICENSE.md or https:/www.libelektra.org)
  *
  */
 
@@ -18,16 +18,14 @@ static void testSensitiveListSingle ()
 {
 	Key * parentKey = keyNew ("user/tests/canonical", KEY_VALUE, "", KEY_END);
 	KeySet * ks = ksNew (
-		20, keyNew ("user/tests/canonical/match1", KEY_VALUE, "TRUE", KEY_META, "transform/canonical/list/sensitive",
-			    "  'TRUE' , 'true'  ,    'ON' ,'ENABLE'  , 'enable' ", KEY_META, "transform/canonical/list/sensitive/canonical",
-			    "1", KEY_END),
-		keyNew ("user/tests/canonical/match2", KEY_VALUE, "ENABLE", KEY_META, "transform/canonical/list/sensitive",
-			"'TRUE' ,  'true','ON','ENABLE','enable'", KEY_META, "transform/canonical/list/sensitive/canonical", "1", KEY_END),
-		keyNew ("user/tests/canonical/nomatch1", KEY_VALUE, "TRue", KEY_META, "transform/canonical/list/sensitive",
-			"'TRUE'  , 'true',  'ON' ,  'ENABLE' , 'enable' ", KEY_META, "transform/canonical/list/sensitive/canonical", "1",
-			KEY_END),
-		keyNew ("user/tests/canonical/nomatch2", KEY_VALUE, "ENAble", KEY_META, "transform/canonical/list/sensitive",
-			"'TRUE','true','ON','ENABLE','enable'", KEY_META, "transform/canonical/list/sensitive/canonical", "1", KEY_END),
+		20, keyNew ("user/tests/canonical/match1", KEY_VALUE, "TRUE", KEY_META, "transform/canonical",
+			    "list:  'TRUE' , 'true'  ,    'ON' ,'ENABLE'  , 'enable' ", KEY_META, "transform/canonical/set", "1", KEY_END),
+		keyNew ("user/tests/canonical/match2", KEY_VALUE, "ENABLE", KEY_META, "transform/canonical",
+			"list:'TRUE' ,  'true','ON','ENABLE','enable'", KEY_META, "transform/canonical/set", "1", KEY_END),
+		keyNew ("user/tests/canonical/nomatch1", KEY_VALUE, "TRue", KEY_META, "transform/canonical",
+			"list:'TRUE'  , 'true',  'ON' ,  'ENABLE' , 'enable' ", KEY_META, "transform/canonical/set", "1", KEY_END),
+		keyNew ("user/tests/canonical/nomatch2", KEY_VALUE, "ENAble", KEY_META, "transform/canonical",
+			"list:'TRUE','true','ON','ENABLE','enable'", KEY_META, "transform/canonical/set", "1", KEY_END),
 
 		KS_END);
 
@@ -54,18 +52,17 @@ static void testSensitiveListSingle ()
 static void testInsensitiveListSingle ()
 {
 	Key * parentKey = keyNew ("user/tests/canonical", KEY_VALUE, "", KEY_END);
-	KeySet * ks = ksNew (
-		20,
-		keyNew ("user/tests/canonical/match1", KEY_VALUE, "TRUE", KEY_META, "transform/canonical/list/insensitive",
-			"'TRUE','true','ON','ENABLE','enable'", KEY_META, "transform/canonical/list/insensitive/canonical", "1", KEY_END),
-		keyNew ("user/tests/canonical/match2", KEY_VALUE, "ENABLE", KEY_META, "transform/canonical/list/insensitive",
-			"'TRUE','true','ON','ENABLE','enable'", KEY_META, "transform/canonical/list/insensitive/canonical", "1", KEY_END),
-		keyNew ("user/tests/canonical/match3", KEY_VALUE, "TRue", KEY_META, "transform/canonical/list/insensitive",
-			"'TRUE','true','ON','ENABLE','enable'", KEY_META, "transform/canonical/list/insensitive/canonical", "1", KEY_END),
-		keyNew ("user/tests/canonical/match4", KEY_VALUE, "ENAble", KEY_META, "transform/canonical/list/insensitive",
-			"'TRUE','true','ON','ENABLE','enable'", KEY_META, "transform/canonical/list/insensitive/canonical", "1", KEY_END),
+	KeySet * ks =
+		ksNew (20, keyNew ("user/tests/canonical/match1", KEY_VALUE, "TRUE", KEY_META, "transform/canonical",
+				   "caselist:'TRUE','true','ON','ENABLE','enable'", KEY_META, "transform/canonical/set", "1", KEY_END),
+		       keyNew ("user/tests/canonical/match2", KEY_VALUE, "ENABLE", KEY_META, "transform/canonical",
+			       "caselist:'TRUE','true','ON','ENABLE','enable'", KEY_META, "transform/canonical/set", "1", KEY_END),
+		       keyNew ("user/tests/canonical/match3", KEY_VALUE, "TRue", KEY_META, "transform/canonical",
+			       "caselist:'TRUE','true','ON','ENABLE','enable'", KEY_META, "transform/canonical/set", "1", KEY_END),
+		       keyNew ("user/tests/canonical/match4", KEY_VALUE, "ENAble", KEY_META, "transform/canonical",
+			       "caselist:'TRUE','true','ON','ENABLE','enable'", KEY_META, "transform/canonical/set", "1", KEY_END),
 
-		KS_END);
+		       KS_END);
 
 	KeySet * conf = ksNew (0, KS_END);
 	PLUGIN_OPEN ("canonical");
@@ -90,45 +87,33 @@ static void testSensitiveListArray ()
 {
 	Key * parentKey = keyNew ("user/tests/canonical", KEY_VALUE, "", KEY_END);
 	KeySet * ks = ksNew (
-		20, keyNew ("user/tests/canonical/match1", KEY_VALUE, "TRUE", KEY_META, "transform/canonical/list/sensitive", "#2",
-			    KEY_META, "transform/canonical/list/sensitive/#0", "'TRUE','true'", KEY_META,
-			    "transform/canonical/list/sensitive/#0/canonical", "1true", KEY_META, "transform/canonical/list/sensitive/#1",
-			    "'ON'", KEY_META, "transform/canonical/list/sensitive/#1/canonical", "1on", KEY_META,
-			    "transform/canonical/list/sensitive/#2", "'enable','ENABLE'", KEY_META,
-			    "transform/canonical/list/sensitive/#2/canonical", "1enable", KEY_END),
+		20, keyNew ("user/tests/canonical/match1", KEY_VALUE, "TRUE", KEY_META, "transform/canonical", "#2", KEY_META,
+			    "transform/canonical/#0", "list:'TRUE','true'", KEY_META, "transform/canonical/#0/set", "1true", KEY_META,
+			    "transform/canonical/#1", "list:'ON'", KEY_META, "transform/canonical/#1/set", "1on", KEY_META,
+			    "transform/canonical/#2", "list:'enable','ENABLE'", KEY_META, "transform/canonical/#2/set", "1enable", KEY_END),
 
-		keyNew ("user/tests/canonical/match2", KEY_VALUE, "ON", KEY_META, "transform/canonical/list/sensitive", "#2", KEY_META,
-			"transform/canonical/list/sensitive/#0", "'TRUE','true'", KEY_META,
-			"transform/canonical/list/sensitive/#0/canonical", "1true", KEY_META, "transform/canonical/list/sensitive/#1",
-			"'ON'", KEY_META, "transform/canonical/list/sensitive/#1/canonical", "1on", KEY_META,
-			"transform/canonical/list/sensitive/#2", "'enable','ENABLE'", KEY_META,
-			"transform/canonical/list/sensitive/#2/canonical", "1enable", KEY_END),
-		keyNew ("user/tests/canonical/match3", KEY_VALUE, "ENABLE", KEY_META, "transform/canonical/list/sensitive", "#2", KEY_META,
-			"transform/canonical/list/sensitive/#0", "'TRUE','true'", KEY_META,
-			"transform/canonical/list/sensitive/#0/canonical", "1true", KEY_META, "transform/canonical/list/sensitive/#1",
-			"'ON'", KEY_META, "transform/canonical/list/sensitive/#1/canonical", "1on", KEY_META,
-			"transform/canonical/list/sensitive/#2", "'enable','ENABLE'", KEY_META,
-			"transform/canonical/list/sensitive/#2/canonical", "1enable", KEY_END),
+		keyNew ("user/tests/canonical/match2", KEY_VALUE, "ON", KEY_META, "transform/canonical", "#2", KEY_META,
+			"transform/canonical/#0", "list:'TRUE','true'", KEY_META, "transform/canonical/#0/set", "1true", KEY_META,
+			"transform/canonical/#1", "list:'ON'", KEY_META, "transform/canonical/#1/set", "1on", KEY_META,
+			"transform/canonical/#2", "list:'enable','ENABLE'", KEY_META, "transform/canonical/#2/set", "1enable", KEY_END),
+		keyNew ("user/tests/canonical/match3", KEY_VALUE, "ENABLE", KEY_META, "transform/canonical", "#2", KEY_META,
+			"transform/canonical/#0", "list:'TRUE','true'", KEY_META, "transform/canonical/#0/set", "1true", KEY_META,
+			"transform/canonical/#1", "list:'ON'", KEY_META, "transform/canonical/#1/set", "1on", KEY_META,
+			"transform/canonical/#2", "list:'enable','ENABLE'", KEY_META, "transform/canonical/#2/set", "1enable", KEY_END),
 
-		keyNew ("user/tests/canonical/nomatch1", KEY_VALUE, "TRue", KEY_META, "transform/canonical/list/sensitive", "#2", KEY_META,
-			"transform/canonical/list/sensitive/#0", "'TRUE','true'", KEY_META,
-			"transform/canonical/list/sensitive/#0/canonical", "1true", KEY_META, "transform/canonical/list/sensitive/#1",
-			"'ON'", KEY_META, "transform/canonical/list/sensitive/#1/canonical", "1on", KEY_META,
-			"transform/canonical/list/sensitive/#2", "'enable','ENABLE'", KEY_META,
-			"transform/canonical/list/sensitive/#2/canonical", "1enable", KEY_END),
+		keyNew ("user/tests/canonical/nomatch1", KEY_VALUE, "TRue", KEY_META, "transform/canonical", "#2", KEY_META,
+			"transform/canonical/#0", "list:'TRUE','true'", KEY_META, "transform/canonical/#0/set", "1true", KEY_META,
+			"transform/canonical/#1", "list:'ON'", KEY_META, "transform/canonical/#1/set", "1on", KEY_META,
+			"transform/canonical/#2", "list:'enable','ENABLE'", KEY_META, "transform/canonical/#2/set", "1enable", KEY_END),
 
-		keyNew ("user/tests/canonical/nomatch2", KEY_VALUE, "On", KEY_META, "transform/canonical/list/sensitive", "#2", KEY_META,
-			"transform/canonical/list/sensitive/#0", "'TRUE','true'", KEY_META,
-			"transform/canonical/list/sensitive/#0/canonical", "1true", KEY_META, "transform/canonical/list/sensitive/#1",
-			"'ON'", KEY_META, "transform/canonical/list/sensitive/#1/canonical", "1on", KEY_META,
-			"transform/canonical/list/sensitive/#2", "'enable','ENABLE'", KEY_META,
-			"transform/canonical/list/sensitive/#2/canonical", "1enable", KEY_END),
-		keyNew ("user/tests/canonical/nomatch3", KEY_VALUE, "ENAble", KEY_META, "transform/canonical/list/sensitive", "#2",
-			KEY_META, "transform/canonical/list/sensitive/#0", "'TRUE','true'", KEY_META,
-			"transform/canonical/list/sensitive/#0/canonical", "1true", KEY_META, "transform/canonical/list/sensitive/#1",
-			"'ON'", KEY_META, "transform/canonical/list/sensitive/#1/canonical", "1on", KEY_META,
-			"transform/canonical/list/sensitive/#2", "'enable','ENABLE'", KEY_META,
-			"transform/canonical/list/sensitive/#2/canonical", "1enable", KEY_END),
+		keyNew ("user/tests/canonical/nomatch2", KEY_VALUE, "On", KEY_META, "transform/canonical", "#2", KEY_META,
+			"transform/canonical/#0", "list:'TRUE','true'", KEY_META, "transform/canonical/#0/set", "1true", KEY_META,
+			"transform/canonical/#1", "list:'ON'", KEY_META, "transform/canonical/#1/set", "1on", KEY_META,
+			"transform/canonical/#2", "list:'enable','ENABLE'", KEY_META, "transform/canonical/#2/set", "1enable", KEY_END),
+		keyNew ("user/tests/canonical/nomatch3", KEY_VALUE, "ENAble", KEY_META, "transform/canonical", "#2", KEY_META,
+			"transform/canonical/#0", "list:'TRUE','true'", KEY_META, "transform/canonical/#0/set", "1true", KEY_META,
+			"transform/canonical/#1", "list:'ON'", KEY_META, "transform/canonical/#1/set", "1on", KEY_META,
+			"transform/canonical/#2", "list:'enable','ENABLE'", KEY_META, "transform/canonical/#2/set", "1enable", KEY_END),
 
 		KS_END);
 
@@ -161,45 +146,34 @@ static void testInsensitiveListArray ()
 {
 	Key * parentKey = keyNew ("user/tests/canonical", KEY_VALUE, "", KEY_END);
 	KeySet * ks = ksNew (
-		20, keyNew ("user/tests/canonical/match1", KEY_VALUE, "TRUE", KEY_META, "transform/canonical/list/insensitive", "#2",
-			    KEY_META, "transform/canonical/list/insensitive/#0", "'TRUE','true'", KEY_META,
-			    "transform/canonical/list/insensitive/#0/canonical", "1true", KEY_META,
-			    "transform/canonical/list/insensitive/#1", "'ON'", KEY_META,
-			    "transform/canonical/list/insensitive/#1/canonical", "1on", KEY_META, "transform/canonical/list/insensitive/#2",
-			    "'enable','ENABLE'", KEY_META, "transform/canonical/list/insensitive/#2/canonical", "1enable", KEY_END),
+		20,
+		keyNew ("user/tests/canonical/match1", KEY_VALUE, "TRUE", KEY_META, "transform/canonical", "#2", KEY_META,
+			"transform/canonical/#0", "caselist:'TRUE','true'", KEY_META, "transform/canonical/#0/set", "1true", KEY_META,
+			"transform/canonical/#1", "caselist:'ON'", KEY_META, "transform/canonical/#1/set", "1on", KEY_META,
+			"transform/canonical/#2", "caselist:'enable','ENABLE'", KEY_META, "transform/canonical/#2/set", "1enable", KEY_END),
 
-		keyNew ("user/tests/canonical/match2", KEY_VALUE, "ON", KEY_META, "transform/canonical/list/insensitive", "#2", KEY_META,
-			"transform/canonical/list/insensitive/#0", "'TRUE','true'", KEY_META,
-			"transform/canonical/list/insensitive/#0/canonical", "1true", KEY_META, "transform/canonical/list/insensitive/#1",
-			"'ON'", KEY_META, "transform/canonical/list/insensitive/#1/canonical", "1on", KEY_META,
-			"transform/canonical/list/insensitive/#2", "'enable','ENABLE'", KEY_META,
-			"transform/canonical/list/insensitive/#2/canonical", "1enable", KEY_END),
-		keyNew ("user/tests/canonical/match3", KEY_VALUE, "ENABLE", KEY_META, "transform/canonical/list/insensitive", "#2",
-			KEY_META, "transform/canonical/list/insensitive/#0", "'TRUE','true'", KEY_META,
-			"transform/canonical/list/insensitive/#0/canonical", "1true", KEY_META, "transform/canonical/list/insensitive/#1",
-			"'ON'", KEY_META, "transform/canonical/list/insensitive/#1/canonical", "1on", KEY_META,
-			"transform/canonical/list/insensitive/#2", "'enable','ENABLE'", KEY_META,
-			"transform/canonical/list/insensitive/#2/canonical", "1enable", KEY_END),
+		keyNew ("user/tests/canonical/match2", KEY_VALUE, "ON", KEY_META, "transform/canonical", "#2", KEY_META,
+			"transform/canonical/#0", "caselist:'TRUE','true'", KEY_META, "transform/canonical/#0/set", "1true", KEY_META,
+			"transform/canonical/#1", "caselist:'ON'", KEY_META, "transform/canonical/#1/set", "1on", KEY_META,
+			"transform/canonical/#2", "caselist:'enable','ENABLE'", KEY_META, "transform/canonical/#2/set", "1enable", KEY_END),
+		keyNew ("user/tests/canonical/match3", KEY_VALUE, "ENABLE", KEY_META, "transform/canonical", "#2", KEY_META,
+			"transform/canonical/#0", "caselist:'TRUE','true'", KEY_META, "transform/canonical/#0/set", "1true", KEY_META,
+			"transform/canonical/#1", "caselist:'ON'", KEY_META, "transform/canonical/#1/set", "1on", KEY_META,
+			"transform/canonical/#2", "caselist:'enable','ENABLE'", KEY_META, "transform/canonical/#2/set", "1enable", KEY_END),
 
-		keyNew ("user/tests/canonical/match4", KEY_VALUE, "TRue", KEY_META, "transform/canonical/list/insensitive", "#2", KEY_META,
-			"transform/canonical/list/insensitive/#0", "'TRUE','true'", KEY_META,
-			"transform/canonical/list/insensitive/#0/canonical", "1true", KEY_META, "transform/canonical/list/insensitive/#1",
-			"'ON'", KEY_META, "transform/canonical/list/insensitive/#1/canonical", "1on", KEY_META,
-			"transform/canonical/list/insensitive/#2", "'enable','ENABLE'", KEY_META,
-			"transform/canonical/list/insensitive/#2/canonical", "1enable", KEY_END),
+		keyNew ("user/tests/canonical/match4", KEY_VALUE, "TRue", KEY_META, "transform/canonical", "#2", KEY_META,
+			"transform/canonical/#0", "caselist:'TRUE','true'", KEY_META, "transform/canonical/#0/set", "1true", KEY_META,
+			"transform/canonical/#1", "caselist:'ON'", KEY_META, "transform/canonical/#1/set", "1on", KEY_META,
+			"transform/canonical/#2", "caselist:'enable','ENABLE'", KEY_META, "transform/canonical/#2/set", "1enable", KEY_END),
 
-		keyNew ("user/tests/canonical/match5", KEY_VALUE, "On", KEY_META, "transform/canonical/list/insensitive", "#2", KEY_META,
-			"transform/canonical/list/insensitive/#0", "'TRUE','true'", KEY_META,
-			"transform/canonical/list/insensitive/#0/canonical", "1true", KEY_META, "transform/canonical/list/insensitive/#1",
-			"'ON'", KEY_META, "transform/canonical/list/insensitive/#1/canonical", "1on", KEY_META,
-			"transform/canonical/list/insensitive/#2", "'enable','ENABLE'", KEY_META,
-			"transform/canonical/list/insensitive/#2/canonical", "1enable", KEY_END),
-		keyNew ("user/tests/canonical/match6", KEY_VALUE, "ENAble", KEY_META, "transform/canonical/list/insensitive", "#2",
-			KEY_META, "transform/canonical/list/insensitive/#0", "'TRUE','true'", KEY_META,
-			"transform/canonical/list/insensitive/#0/canonical", "1true", KEY_META, "transform/canonical/list/insensitive/#1",
-			"'ON'", KEY_META, "transform/canonical/list/insensitive/#1/canonical", "1on", KEY_META,
-			"transform/canonical/list/insensitive/#2", "'enable','ENABLE'", KEY_META,
-			"transform/canonical/list/insensitive/#2/canonical", "1enable", KEY_END),
+		keyNew ("user/tests/canonical/match5", KEY_VALUE, "On", KEY_META, "transform/canonical", "#2", KEY_META,
+			"transform/canonical/#0", "caselist:'TRUE','true'", KEY_META, "transform/canonical/#0/set", "1true", KEY_META,
+			"transform/canonical/#1", "caselist:'ON'", KEY_META, "transform/canonical/#1/set", "1on", KEY_META,
+			"transform/canonical/#2", "caselist:'enable','ENABLE'", KEY_META, "transform/canonical/#2/set", "1enable", KEY_END),
+		keyNew ("user/tests/canonical/match6", KEY_VALUE, "ENAble", KEY_META, "transform/canonical", "#2", KEY_META,
+			"transform/canonical/#0", "caselist:'TRUE','true'", KEY_META, "transform/canonical/#0/set", "1true", KEY_META,
+			"transform/canonical/#1", "caselist:'ON'", KEY_META, "transform/canonical/#1/set", "1on", KEY_META,
+			"transform/canonical/#2", "caselist:'enable','ENABLE'", KEY_META, "transform/canonical/#2/set", "1enable", KEY_END),
 
 		KS_END);
 
@@ -230,14 +204,14 @@ static void testInsensitiveListArray ()
 static void testRegexSingle ()
 {
 	Key * parentKey = keyNew ("user/tests/canonical", KEY_VALUE, "", KEY_END);
-	KeySet * ks = ksNew (20, keyNew ("user/tests/canonical/match1", KEY_VALUE, "TRUE", KEY_META, "transform/canonical/regex",
-					 "TR[uU][eE]", KEY_META, "transform/canonical/regex/canonical", "1", KEY_END),
-			     keyNew ("user/tests/canonical/nomatch1", KEY_VALUE, "ENABLE", KEY_META, "transform/canonical/regex",
-				     "TR[uU][eE]", KEY_META, "transform/canonical/regex/canonical", "1", KEY_END),
-			     keyNew ("user/tests/canonical/match2", KEY_VALUE, "TRue", KEY_META, "transform/canonical/regex", "TR[uU][eE]",
-				     KEY_META, "transform/canonical/regex/canonical", "1", KEY_END),
-			     keyNew ("user/tests/canonical/nomatch2", KEY_VALUE, "ENAble", KEY_META, "transform/canonical/regex",
-				     "TR[uU][eE]", KEY_META, "transform/canonical/regex/canonical", "1", KEY_END),
+	KeySet * ks = ksNew (20, keyNew ("user/tests/canonical/match1", KEY_VALUE, "TRUE", KEY_META, "transform/canonical",
+					 "regex:TR[uU][eE]", KEY_META, "transform/canonical/set", "1", KEY_END),
+			     keyNew ("user/tests/canonical/nomatch1", KEY_VALUE, "ENABLE", KEY_META, "transform/canonical",
+				     "regex:TR[uU][eE]", KEY_META, "transform/canonical/set", "1", KEY_END),
+			     keyNew ("user/tests/canonical/match2", KEY_VALUE, "TRue", KEY_META, "transform/canonical", "regex:TR[uU][eE]",
+				     KEY_META, "transform/canonical/set", "1", KEY_END),
+			     keyNew ("user/tests/canonical/nomatch2", KEY_VALUE, "ENAble", KEY_META, "transform/canonical",
+				     "regex:TR[uU][eE]", KEY_META, "transform/canonical/set", "1", KEY_END),
 
 			     KS_END);
 
@@ -264,34 +238,33 @@ static void testRegexSingle ()
 static void testRegexArray ()
 {
 	Key * parentKey = keyNew ("user/tests/canonical", KEY_VALUE, "", KEY_END);
-	KeySet * ks = ksNew (
-		20,
-		keyNew ("user/tests/canonical/match1", KEY_VALUE, "TRUE", KEY_META, "transform/canonical/regex", "#2", KEY_META,
-			"transform/canonical/regex/#0", "(TRUE|true)", KEY_META, "transform/canonical/regex/#0/canonical", "1true",
-			KEY_META, "transform/canonical/regex/#1", "ON", KEY_META, "transform/canonical/regex/#1/canonical", "1on", KEY_META,
-			"transform/canonical/regex/#2", ".*ABLE", KEY_META, "transform/canonical/regex/#2/canonical", "1enable", KEY_END),
-		keyNew ("user/tests/canonical/match2", KEY_VALUE, "ON", KEY_META, "transform/canonical/regex", "#2", KEY_META,
-			"transform/canonical/regex/#0", "(TRUE|true)", KEY_META, "transform/canonical/regex/#0/canonical", "1true",
-			KEY_META, "transform/canonical/regex/#1", "ON", KEY_META, "transform/canonical/regex/#1/canonical", "1on", KEY_META,
-			"transform/canonical/regex/#2", ".*ABLE", KEY_META, "transform/canonical/regex/#2/canonical", "1enable", KEY_END),
-		keyNew ("user/tests/canonical/match3", KEY_VALUE, "ENABLE", KEY_META, "transform/canonical/regex", "#2", KEY_META,
-			"transform/canonical/regex/#0", "(TRUE|true)", KEY_META, "transform/canonical/regex/#0/canonical", "1true",
-			KEY_META, "transform/canonical/regex/#1", "ON", KEY_META, "transform/canonical/regex/#1/canonical", "1on", KEY_META,
-			"transform/canonical/regex/#2", ".*ABLE", KEY_META, "transform/canonical/regex/#2/canonical", "1enable", KEY_END),
+	KeySet * ks =
+		ksNew (20, keyNew ("user/tests/canonical/match1", KEY_VALUE, "TRUE", KEY_META, "transform/canonical", "#2", KEY_META,
+				   "transform/canonical/#0", "regex:(TRUE|true)", KEY_META, "transform/canonical/#0/set", "1true", KEY_META,
+				   "transform/canonical/#1", "ON", KEY_META, "transform/canonical/#1/set", "1on", KEY_META,
+				   "transform/canonical/#2", "regex:.*ABLE", KEY_META, "transform/canonical/#2/set", "1enable", KEY_END),
+		       keyNew ("user/tests/canonical/match2", KEY_VALUE, "ON", KEY_META, "transform/canonical", "#2", KEY_META,
+			       "transform/canonical/#0", "regex:(TRUE|true)", KEY_META, "transform/canonical/#0/set", "1true", KEY_META,
+			       "transform/canonical/#1", "ON", KEY_META, "transform/canonical/#1/set", "1on", KEY_META,
+			       "transform/canonical/#2", "regex:.*ABLE", KEY_META, "transform/canonical/#2/set", "1enable", KEY_END),
+		       keyNew ("user/tests/canonical/match3", KEY_VALUE, "ENABLE", KEY_META, "transform/canonical", "#2", KEY_META,
+			       "transform/canonical/#0", "regex:(TRUE|true)", KEY_META, "transform/canonical/#0/set", "1true", KEY_META,
+			       "transform/canonical/#1", "ON", KEY_META, "transform/canonical/#1/set", "1on", KEY_META,
+			       "transform/canonical/#2", "regex:.*ABLE", KEY_META, "transform/canonical/#2/set", "1enable", KEY_END),
 
-		keyNew ("user/tests/canonical/nomatch1", KEY_VALUE, "TRue", KEY_META, "transform/canonical/regex", "#2", KEY_META,
-			"transform/canonical/regex/#0", "(TRUE|true)", KEY_META, "transform/canonical/regex/#0/canonical", "1true",
-			KEY_META, "transform/canonical/regex/#1", "ON", KEY_META, "transform/canonical/regex/#1/canonical", "1on", KEY_META,
-			"transform/canonical/regex/#2", ".*ABLE", KEY_META, "transform/canonical/regex/#2/canonical", "1enable", KEY_END),
-		keyNew ("user/tests/canonical/nomatch2", KEY_VALUE, "on", KEY_META, "transform/canonical/regex", "#2", KEY_META,
-			"transform/canonical/regex/#0", "(TRUE|true)", KEY_META, "transform/canonical/regex/#0/canonical", "1true",
-			KEY_META, "transform/canonical/regex/#1", "ON", KEY_META, "transform/canonical/regex/#1/canonical", "1on", KEY_META,
-			"transform/canonical/regex/#2", ".*ABLE", KEY_META, "transform/canonical/regex/#2/canonical", "1enable", KEY_END),
-		keyNew ("user/tests/canonical/nomatch3", KEY_VALUE, "ENAble", KEY_META, "transform/canonical/regex", "#2", KEY_META,
-			"transform/canonical/regex/#0", "(TRUE|true)", KEY_META, "transform/canonical/regex/#0/canonical", "1true",
-			KEY_META, "transform/canonical/regex/#1", "ON", KEY_META, "transform/canonical/regex/#1/canonical", "1on", KEY_META,
-			"transform/canonical/regex/#2", ".*ABLE", KEY_META, "transform/canonical/regex/#2/canonical", "1enable", KEY_END),
-		KS_END);
+		       keyNew ("user/tests/canonical/nomatch1", KEY_VALUE, "TRue", KEY_META, "transform/canonical", "#2", KEY_META,
+			       "transform/canonical/#0", "regex:(TRUE|true)", KEY_META, "transform/canonical/#0/set", "1true", KEY_META,
+			       "transform/canonical/#1", "ON", KEY_META, "transform/canonical/#1/set", "1on", KEY_META,
+			       "transform/canonical/#2", "regex:.*ABLE", KEY_META, "transform/canonical/#2/set", "1enable", KEY_END),
+		       keyNew ("user/tests/canonical/nomatch2", KEY_VALUE, "on", KEY_META, "transform/canonical", "#2", KEY_META,
+			       "transform/canonical/#0", "regex:(TRUE|true)", KEY_META, "transform/canonical/#0/set", "1true", KEY_META,
+			       "transform/canonical/#1", "ON", KEY_META, "transform/canonical/#1/set", "1on", KEY_META,
+			       "transform/canonical/#2", "regex:.*ABLE", KEY_META, "transform/canonical/#2/set", "1enable", KEY_END),
+		       keyNew ("user/tests/canonical/nomatch3", KEY_VALUE, "ENAble", KEY_META, "transform/canonical", "#2", KEY_META,
+			       "transform/canonical/#0", "regex:(TRUE|true)", KEY_META, "transform/canonical/#0/set", "1true", KEY_META,
+			       "transform/canonical/#1", "ON", KEY_META, "transform/canonical/#1/set", "1on", KEY_META,
+			       "transform/canonical/#2", "regex:.*ABLE", KEY_META, "transform/canonical/#2/set", "1enable", KEY_END),
+		       KS_END);
 
 	KeySet * conf = ksNew (0, KS_END);
 	PLUGIN_OPEN ("canonical");
@@ -322,14 +295,14 @@ static void testRegexArray ()
 static void testFNMatchSingle ()
 {
 	Key * parentKey = keyNew ("user/tests/canonical", KEY_VALUE, "", KEY_END);
-	KeySet * ks = ksNew (20, keyNew ("user/tests/canonical/match1", KEY_VALUE, "TRUE", KEY_META, "transform/canonical/fnmatch", "TR??",
-					 KEY_META, "transform/canonical/fnmatch/canonical", "1", KEY_END),
-			     keyNew ("user/tests/canonical/nomatch1", KEY_VALUE, "ENABLE", KEY_META, "transform/canonical/fnmatch", "TR??",
-				     KEY_META, "transform/canonical/fnmatch/canonical", "1", KEY_END),
-			     keyNew ("user/tests/canonical/match2", KEY_VALUE, "TRue", KEY_META, "transform/canonical/fnmatch", "TR??",
-				     KEY_META, "transform/canonical/fnmatch/canonical", "1", KEY_END),
-			     keyNew ("user/tests/canonical/nomatch2", KEY_VALUE, "ENAble", KEY_META, "transform/canonical/fnmatch", "TR??",
-				     KEY_META, "transform/canonical/fnmatch/canonical", "1", KEY_END),
+	KeySet * ks = ksNew (20, keyNew ("user/tests/canonical/match1", KEY_VALUE, "TRUE", KEY_META, "transform/canonical", "fnm:TR??",
+					 KEY_META, "transform/canonical/set", "1", KEY_END),
+			     keyNew ("user/tests/canonical/nomatch1", KEY_VALUE, "ENABLE", KEY_META, "transform/canonical", "fnm:TR??",
+				     KEY_META, "transform/canonical/set", "1", KEY_END),
+			     keyNew ("user/tests/canonical/match2", KEY_VALUE, "TRue", KEY_META, "transform/canonical", "fnm:TR??",
+				     KEY_META, "transform/canonical/set", "1", KEY_END),
+			     keyNew ("user/tests/canonical/nomatch2", KEY_VALUE, "ENAble", KEY_META, "transform/canonical", "fnm:TR??",
+				     KEY_META, "transform/canonical/set", "1", KEY_END),
 
 			     KS_END);
 
@@ -357,37 +330,31 @@ static void testFNMatchArray ()
 {
 	Key * parentKey = keyNew ("user/tests/canonical", KEY_VALUE, "", KEY_END);
 	KeySet * ks =
-		ksNew (20, keyNew ("user/tests/canonical/match1", KEY_VALUE, "TRUE", KEY_META, "transform/canonical/fnmatch", "#2",
-				   KEY_META, "transform/canonical/fnmatch/#0", "*UE", KEY_META, "transform/canonical/fnmatch/#0/canonical",
-				   "1true", KEY_META, "transform/canonical/fnmatch/#1", "?N", KEY_META,
-				   "transform/canonical/fnmatch/#1/canonical", "1on", KEY_META, "transform/canonical/fnmatch/#2", "??ABLE",
-				   KEY_META, "transform/canonical/fnmatch/#2/canonical", "1enable", KEY_END),
-		       keyNew ("user/tests/canonical/match2", KEY_VALUE, "ON", KEY_META, "transform/canonical/fnmatch", "#2", KEY_META,
-			       "transform/canonical/fnmatch/#0", "*UE", KEY_META, "transform/canonical/fnmatch/#0/canonical", "1true",
-			       KEY_META, "transform/canonical/fnmatch/#1", "?N", KEY_META, "transform/canonical/fnmatch/#1/canonical",
-			       "1on", KEY_META, "transform/canonical/fnmatch/#2", "??ABLE", KEY_META,
-			       "transform/canonical/fnmatch/#2/canonical", "1enable", KEY_END),
-		       keyNew ("user/tests/canonical/match3", KEY_VALUE, "ENABLE", KEY_META, "transform/canonical/fnmatch", "#2", KEY_META,
-			       "transform/canonical/fnmatch/#0", "*UE", KEY_META, "transform/canonical/fnmatch/#0/canonical", "1true",
-			       KEY_META, "transform/canonical/fnmatch/#1", "?N", KEY_META, "transform/canonical/fnmatch/#1/canonical",
-			       "1on", KEY_META, "transform/canonical/fnmatch/#2", "??ABLE", KEY_META,
-			       "transform/canonical/fnmatch/#2/canonical", "1enable", KEY_END),
+		ksNew (20, keyNew ("user/tests/canonical/match1", KEY_VALUE, "TRUE", KEY_META, "transform/canonical", "#2", KEY_META,
+				   "transform/canonical/#0", "fnm:*UE", KEY_META, "transform/canonical/#0/set", "1true", KEY_META,
+				   "transform/canonical/#1", "fnm:?N", KEY_META, "transform/canonical/#1/set", "1on", KEY_META,
+				   "transform/canonical/#2", "fnm:??ABLE", KEY_META, "transform/canonical/#2/set", "1enable", KEY_END),
+		       keyNew ("user/tests/canonical/match2", KEY_VALUE, "ON", KEY_META, "transform/canonical", "#2", KEY_META,
+			       "transform/canonical/#0", "fnm:*UE", KEY_META, "transform/canonical/#0/set", "1true", KEY_META,
+			       "transform/canonical/#1", "fnm:?N", KEY_META, "transform/canonical/#1/set", "1on", KEY_META,
+			       "transform/canonical/#2", "fnm:??ABLE", KEY_META, "transform/canonical/#2/set", "1enable", KEY_END),
+		       keyNew ("user/tests/canonical/match3", KEY_VALUE, "ENABLE", KEY_META, "transform/canonical", "#2", KEY_META,
+			       "transform/canonical/#0", "fnm:*UE", KEY_META, "transform/canonical/#0/set", "1true", KEY_META,
+			       "transform/canonical/#1", "fnm:?N", KEY_META, "transform/canonical/#1/set", "1on", KEY_META,
+			       "transform/canonical/#2", "fnm:??ABLE", KEY_META, "transform/canonical/#2/set", "1enable", KEY_END),
 
-		       keyNew ("user/tests/canonical/nomatch1", KEY_VALUE, "TRue", KEY_META, "transform/canonical/fnmatch", "#2", KEY_META,
-			       "transform/canonical/fnmatch/#0", "*UE", KEY_META, "transform/canonical/fnmatch/#0/canonical", "1true",
-			       KEY_META, "transform/canonical/fnmatch/#1", "?N", KEY_META, "transform/canonical/fnmatch/#1/canonical",
-			       "1on", KEY_META, "transform/canonical/fnmatch/#2", "??ABLE", KEY_META,
-			       "transform/canonical/fnmatch/#2/canonical", "1enable", KEY_END),
-		       keyNew ("user/tests/canonical/nomatch2", KEY_VALUE, "on", KEY_META, "transform/canonical/fnmatch", "#2", KEY_META,
-			       "transform/canonical/fnmatch/#0", "*UE", KEY_META, "transform/canonical/fnmatch/#0/canonical", "1true",
-			       KEY_META, "transform/canonical/fnmatch/#1", "?N", KEY_META, "transform/canonical/fnmatch/#1/canonical",
-			       "1on", KEY_META, "transform/canonical/fnmatch/#2", "??ABLE", KEY_META,
-			       "transform/canonical/fnmatch/#2/canonical", "1enable", KEY_END),
-		       keyNew ("user/tests/canonical/nomatch3", KEY_VALUE, "ENAble", KEY_META, "transform/canonical/fnmatch", "#2",
-			       KEY_META, "transform/canonical/fnmatch/#0", "*UE", KEY_META, "transform/canonical/fnmatch/#0/canonical",
-			       "1true", KEY_META, "transform/canonical/fnmatch/#1", "?N", KEY_META,
-			       "transform/canonical/fnmatch/#1/canonical", "1on", KEY_META, "transform/canonical/fnmatch/#2", "??ABLE",
-			       KEY_META, "transform/canonical/fnmatch/#2/canonical", "1enable", KEY_END),
+		       keyNew ("user/tests/canonical/nomatch1", KEY_VALUE, "TRue", KEY_META, "transform/canonical", "#2", KEY_META,
+			       "transform/canonical/#0", "fnm:*UE", KEY_META, "transform/canonical/#0/set", "1true", KEY_META,
+			       "transform/canonical/#1", "fnm:?N", KEY_META, "transform/canonical/#1/set", "1on", KEY_META,
+			       "transform/canonical/#2", "fnm:??ABLE", KEY_META, "transform/canonical/#2/set", "1enable", KEY_END),
+		       keyNew ("user/tests/canonical/nomatch2", KEY_VALUE, "on", KEY_META, "transform/canonical", "#2", KEY_META,
+			       "transform/canonical/#0", "fnm:*UE", KEY_META, "transform/canonical/#0/set", "1true", KEY_META,
+			       "transform/canonical/#1", "fnm:?N", KEY_META, "transform/canonical/#1/set", "1on", KEY_META,
+			       "transform/canonical/#2", "fnm:??ABLE", KEY_META, "transform/canonical/#2/set", "1enable", KEY_END),
+		       keyNew ("user/tests/canonical/nomatch3", KEY_VALUE, "ENAble", KEY_META, "transform/canonical", "#2", KEY_META,
+			       "transform/canonical/#0", "fnm:*UE", KEY_META, "transform/canonical/#0/set", "1true", KEY_META,
+			       "transform/canonical/#1", "fnm:?N", KEY_META, "transform/canonical/#1/set", "1on", KEY_META,
+			       "transform/canonical/#2", "fnm:??ABLE", KEY_META, "transform/canonical/#2/set", "1enable", KEY_END),
 		       KS_END);
 
 	KeySet * conf = ksNew (0, KS_END);
@@ -419,27 +386,24 @@ static void testFNMatchArray ()
 static void testTristateList ()
 {
 	Key * parentKey = keyNew ("user/tests/canonical", KEY_VALUE, "", KEY_END);
-	KeySet * ks = ksNew (
-		20, keyNew ("user/tests/canonical/TTrue", KEY_VALUE, "On", KEY_META, "transform/canonical/list/insensitive", "#2", KEY_META,
-			    "transform/canonical/list/insensitive/#0", "'TRUE','ON','OPEN','ENABLE'", KEY_META,
-			    "transform/canonical/list/insensitive/#0/canonical", "1", KEY_META, "transform/canonical/list/insensitive/#1",
-			    "'FALSE','OFF','CLOSED','DISABLE'", KEY_META, "transform/canonical/list/insensitive/#1/canonical", "0",
-			    KEY_META, "transform/canonical/list/insensitive/#2", "'OTHER','NONE',''", KEY_META,
-			    "transform/canonical/list/insensitive/#2/canonical", "2", KEY_END),
-		keyNew ("user/tests/canonical/TFalse", KEY_VALUE, "Disable", KEY_META, "transform/canonical/list/insensitive", "#2",
-			KEY_META, "transform/canonical/list/insensitive/#0", "'TRUE','ON','OPEN','ENABLE'", KEY_META,
-			"transform/canonical/list/insensitive/#0/canonical", "1", KEY_META, "transform/canonical/list/insensitive/#1",
-			"'FALSE','OFF','CLOSED','DISABLE'", KEY_META, "transform/canonical/list/insensitive/#1/canonical", "0", KEY_META,
-			"transform/canonical/list/insensitive/#2", "'OTHER','NONE',''", KEY_META,
-			"transform/canonical/list/insensitive/#2/canonical", "2", KEY_END),
-		keyNew ("user/tests/canonical/TOther", KEY_VALUE, "", KEY_META, "transform/canonical/list/insensitive", "#2", KEY_META,
-			"transform/canonical/list/insensitive/#0", "'TRUE','ON','OPEN','ENABLE'", KEY_META,
-			"transform/canonical/list/insensitive/#0/canonical", "1", KEY_META, "transform/canonical/list/insensitive/#1",
-			"'FALSE','OFF','CLOSED','DISABLE'", KEY_META, "transform/canonical/list/insensitive/#1/canonical", "0", KEY_META,
-			"transform/canonical/list/insensitive/#2", "'OTHER','NONE',''", KEY_META,
-			"transform/canonical/list/insensitive/#2/canonical", "2", KEY_END),
+	KeySet * ks =
+		ksNew (20, keyNew ("user/tests/canonical/TTrue", KEY_VALUE, "On", KEY_META, "transform/canonical", "#2", KEY_META,
+				   "transform/canonical/#0", "caselist:'TRUE','ON','OPEN','ENABLE'", KEY_META, "transform/canonical/#0/set",
+				   "1", KEY_META, "transform/canonical/#1", "caselist:'FALSE','OFF','CLOSED','DISABLE'", KEY_META,
+				   "transform/canonical/#1/set", "0", KEY_META, "transform/canonical/#2", "caselist:'OTHER','NONE',''",
+				   KEY_META, "transform/canonical/#2/set", "2", KEY_END),
+		       keyNew ("user/tests/canonical/TFalse", KEY_VALUE, "Disable", KEY_META, "transform/canonical", "#2", KEY_META,
+			       "transform/canonical/#0", "caselist:'TRUE','ON','OPEN','ENABLE'", KEY_META, "transform/canonical/#0/set",
+			       "1", KEY_META, "transform/canonical/#1", "caselist:'FALSE','OFF','CLOSED','DISABLE'", KEY_META,
+			       "transform/canonical/#1/set", "0", KEY_META, "transform/canonical/#2", "caselist:'OTHER','NONE',''",
+			       KEY_META, "transform/canonical/#2/set", "2", KEY_END),
+		       keyNew ("user/tests/canonical/TOther", KEY_VALUE, "", KEY_META, "transform/canonical", "#2", KEY_META,
+			       "transform/canonical/#0", "caselist:'TRUE','ON','OPEN','ENABLE'", KEY_META, "transform/canonical/#0/set",
+			       "1", KEY_META, "transform/canonical/#1", "caselist:'FALSE','OFF','CLOSED','DISABLE'", KEY_META,
+			       "transform/canonical/#1/set", "0", KEY_META, "transform/canonical/#2", "caselist:'OTHER','NONE',''",
+			       KEY_META, "transform/canonical/#2/set", "2", KEY_END),
 
-		KS_END);
+		       KS_END);
 
 	KeySet * conf = ksNew (0, KS_END);
 	PLUGIN_OPEN ("canonical");
@@ -460,21 +424,20 @@ static void testTristateList ()
 static void testTristateListToIndex ()
 {
 	Key * parentKey = keyNew ("user/tests/canonical", KEY_VALUE, "", KEY_END);
-	KeySet * ks = ksNew (20, keyNew ("user/tests/canonical/TTrue", KEY_VALUE, "On", KEY_META, "transform/canonical/list/insensitive",
-					 "#2", KEY_META, "transform/canonical/list/insensitive/#0", "'FALSE','OFF','CLOSED','DISABLE'",
-					 KEY_META, "transform/canonical/list/insensitive/#1", "'TRUE','ON','OPEN','ENABLE'", KEY_META,
-					 "transform/canonical/list/insensitive/#2", "'OTHER','NONE',''", KEY_END),
-			     keyNew ("user/tests/canonical/TFalse", KEY_VALUE, "Disable", KEY_META, "transform/canonical/list/insensitive",
-				     "#2", KEY_META, "transform/canonical/list/insensitive/#0", "'FALSE','OFF','CLOSED','DISABLE'",
-				     KEY_META, "transform/canonical/list/insensitive/#1", "'TRUE','ON','OPEN','ENABLE'", KEY_META,
-				     "transform/canonical/list/insensitive/#2", "'OTHER','NONE',''", KEY_END),
-			     keyNew ("user/tests/canonical/TOther", KEY_VALUE, "Other", KEY_META, "transform/canonical/list/insensitive",
-				     "#2", KEY_META, "transform/canonical/list/insensitive/#0", "'FALSE','OFF','CLOSED','DISABLE'",
-				     KEY_META, "transform/canonical/list/insensitive/#1", "'TRUE','ON','OPEN','ENABLE'", KEY_META,
-				     "transform/canonical/list/insensitive/#2", "'OTHER','NONE',''", KEY_END),
+	KeySet * ks = ksNew (
+		20,
+		keyNew ("user/tests/canonical/TTrue", KEY_VALUE, "On", KEY_META, "transform/canonical", "#2", KEY_META,
+			"transform/canonical/#0", "caselist:'FALSE','OFF','CLOSED','DISABLE'", KEY_META, "transform/canonical/#1",
+			"caselist:'TRUE','ON','OPEN','ENABLE'", KEY_META, "transform/canonical/#2", "caselist:'OTHER','NONE',''", KEY_END),
+		keyNew ("user/tests/canonical/TFalse", KEY_VALUE, "Disable", KEY_META, "transform/canonical", "#2", KEY_META,
+			"transform/canonical/#0", "caselist:'FALSE','OFF','CLOSED','DISABLE'", KEY_META, "transform/canonical/#1",
+			"caselist:'TRUE','ON','OPEN','ENABLE'", KEY_META, "transform/canonical/#2", "caselist:'OTHER','NONE',''", KEY_END),
+		keyNew ("user/tests/canonical/TOther", KEY_VALUE, "Other", KEY_META, "transform/canonical", "#2", KEY_META,
+			"transform/canonical/#0", "caselist:'FALSE','OFF','CLOSED','DISABLE'", KEY_META, "transform/canonical/#1",
+			"caselist:'TRUE','ON','OPEN','ENABLE'", KEY_META, "transform/canonical/#2", "caselist:'OTHER','NONE',''", KEY_END),
 
 
-			     KS_END);
+		KS_END);
 
 	KeySet * conf = ksNew (0, KS_END);
 	PLUGIN_OPEN ("canonical");
@@ -486,6 +449,36 @@ static void testTristateListToIndex ()
 	succeed_if (!strcmp (keyString (ksLookupByName (ks, "user/tests/canonical/TTrue", KDB_O_NONE)), "1"), "kdbGet failed on TTrue");
 	succeed_if (!strcmp (keyString (ksLookupByName (ks, "user/tests/canonical/TFalse", KDB_O_NONE)), "0"), "kdbGet failed on TFalse");
 	succeed_if (!strcmp (keyString (ksLookupByName (ks, "user/tests/canonical/TOther", KDB_O_NONE)), "2"), "kdbGet failed on match3");
+	ksDel (ks);
+
+	keyDel (parentKey);
+	PLUGIN_CLOSE ();
+}
+
+static void testMixedArray ()
+{
+	Key * parentKey = keyNew ("user/tests/canonical", KEY_VALUE, "", KEY_END);
+	KeySet * ks = ksNew (20, keyNew ("user/tests/canonical/match1", KEY_VALUE, "ABC", KEY_META, "transform/canonical", "#2", KEY_META,
+					 "transform/canonical/#0", "regex:[a-zA-Z]", KEY_META, "transform/canonical/#1", "fnm:??3",
+					 KEY_META, "transform/canonical/#2", "list:'+++','---','==='", KEY_END),
+			     keyNew ("user/tests/canonical/match2", KEY_VALUE, "123", KEY_META, "transform/canonical", "#2", KEY_META,
+				     "transform/canonical/#0", "regex:[a-zA-Z]", KEY_META, "transform/canonical/#1", "fnm:??3", KEY_META,
+				     "transform/canonical/#2", "list:'+++','---','==='", KEY_END),
+			     keyNew ("user/tests/canonical/match3", KEY_VALUE, "===", KEY_META, "transform/canonical", "#2", KEY_META,
+				     "transform/canonical/#0", "regex:[a-zA-Z]", KEY_META, "transform/canonical/#1", "fnm:??3", KEY_META,
+				     "transform/canonical/#2", "list:'+++','---','==='", KEY_END),
+			     KS_END);
+
+	KeySet * conf = ksNew (0, KS_END);
+	PLUGIN_OPEN ("canonical");
+
+	ksRewind (ks);
+
+	succeed_if (plugin->kdbGet (plugin, ks, parentKey) != (-1), "kdbGet failed");
+
+	succeed_if (!strcmp (keyString (ksLookupByName (ks, "user/tests/canonical/match1", KDB_O_NONE)), "0"), "kdbGet failed on TTrue");
+	succeed_if (!strcmp (keyString (ksLookupByName (ks, "user/tests/canonical/match2", KDB_O_NONE)), "1"), "kdbGet failed on TFalse");
+	succeed_if (!strcmp (keyString (ksLookupByName (ks, "user/tests/canonical/match3", KDB_O_NONE)), "2"), "kdbGet failed on match3");
 	ksDel (ks);
 
 	keyDel (parentKey);
@@ -509,6 +502,7 @@ int main (int argc, char ** argv)
 	testFNMatchArray ();
 	testTristateList ();
 	testTristateListToIndex ();
+	testMixedArray ();
 	printf ("\ntestmod_canonical RESULTS: %d test(s) done. %d error(s).\n", nbTest, nbError);
 
 	return nbError;

--- a/src/plugins/canonical/testmod_canonical.c
+++ b/src/plugins/canonical/testmod_canonical.c
@@ -1,0 +1,541 @@
+/**
+ * @file
+ *
+ * @brief Tests for canonical plugin
+ *
+ * @copyright BSD License (see LICENSE.md or https://www.libelektra.org)
+ *
+ */
+
+#include <stdlib.h>
+#include <string.h>
+
+#include <kdbconfig.h>
+
+#include <tests_plugin.h>
+
+static void testSensitiveListSingle ()
+{
+	Key * parentKey = keyNew ("user/tests/canonical", KEY_VALUE, "", KEY_END);
+	KeySet * ks = ksNew (
+		20, keyNew ("user/tests/canonical/match1", KEY_VALUE, "TRUE", KEY_META, "transform/canonical/list/sensitive",
+			    "  'TRUE' , 'true'  ,    'ON' ,'ENABLE'  , 'enable' ", KEY_META, "transform/canonical/list/sensitive/canonical",
+			    "1", KEY_END),
+		keyNew ("user/tests/canonical/match2", KEY_VALUE, "ENABLE", KEY_META, "transform/canonical/list/sensitive",
+			"'TRUE' ,  'true','ON','ENABLE','enable'", KEY_META, "transform/canonical/list/sensitive/canonical", "1", KEY_END),
+		keyNew ("user/tests/canonical/nomatch1", KEY_VALUE, "TRue", KEY_META, "transform/canonical/list/sensitive",
+			"'TRUE'  , 'true',  'ON' ,  'ENABLE' , 'enable' ", KEY_META, "transform/canonical/list/sensitive/canonical", "1",
+			KEY_END),
+		keyNew ("user/tests/canonical/nomatch2", KEY_VALUE, "ENAble", KEY_META, "transform/canonical/list/sensitive",
+			"'TRUE','true','ON','ENABLE','enable'", KEY_META, "transform/canonical/list/sensitive/canonical", "1", KEY_END),
+
+		KS_END);
+
+	KeySet * conf = ksNew (0, KS_END);
+	PLUGIN_OPEN ("canonical");
+
+	ksRewind (ks);
+
+	Key * cur;
+	while ((cur = ksNext (ks)) != NULL)
+	{
+		fprintf (stderr, "%s:(%s)\n", keyName (cur), keyString (cur));
+	}
+	ksRewind (ks);
+
+	succeed_if (plugin->kdbGet (plugin, ks, parentKey) != (-1), "kdbGet failed");
+
+	ksRewind (ks);
+	while ((cur = ksNext (ks)) != NULL)
+	{
+		fprintf (stderr, "%s:(%s)\n", keyName (cur), keyString (cur));
+	}
+
+	succeed_if (!strcmp (keyString (ksLookupByName (ks, "user/tests/canonical/match1", KDB_O_NONE)), "1"), "kdbGet failed on match1");
+	succeed_if (!strcmp (keyString (ksLookupByName (ks, "user/tests/canonical/match2", KDB_O_NONE)), "1"), "kdbGet failed on match2");
+
+	succeed_if (!strcmp (keyString (ksLookupByName (ks, "user/tests/canonical/nomatch1", KDB_O_NONE)), "TRue"),
+		    "kdbGet failed on nomatch1");
+	succeed_if (!strcmp (keyString (ksLookupByName (ks, "user/tests/canonical/nomatch2", KDB_O_NONE)), "ENAble"),
+		    "kdbGet failed on nomatch2");
+	ksDel (ks);
+
+	keyDel (parentKey);
+	PLUGIN_CLOSE ();
+}
+
+static void testInsensitiveListSingle ()
+{
+	Key * parentKey = keyNew ("user/tests/canonical", KEY_VALUE, "", KEY_END);
+	KeySet * ks = ksNew (
+		20,
+		keyNew ("user/tests/canonical/match1", KEY_VALUE, "TRUE", KEY_META, "transform/canonical/list/insensitive",
+			"'TRUE','true','ON','ENABLE','enable'", KEY_META, "transform/canonical/list/insensitive/canonical", "1", KEY_END),
+		keyNew ("user/tests/canonical/match2", KEY_VALUE, "ENABLE", KEY_META, "transform/canonical/list/insensitive",
+			"'TRUE','true','ON','ENABLE','enable'", KEY_META, "transform/canonical/list/insensitive/canonical", "1", KEY_END),
+		keyNew ("user/tests/canonical/match3", KEY_VALUE, "TRue", KEY_META, "transform/canonical/list/insensitive",
+			"'TRUE','true','ON','ENABLE','enable'", KEY_META, "transform/canonical/list/insensitive/canonical", "1", KEY_END),
+		keyNew ("user/tests/canonical/match4", KEY_VALUE, "ENAble", KEY_META, "transform/canonical/list/insensitive",
+			"'TRUE','true','ON','ENABLE','enable'", KEY_META, "transform/canonical/list/insensitive/canonical", "1", KEY_END),
+
+		KS_END);
+
+	KeySet * conf = ksNew (0, KS_END);
+	PLUGIN_OPEN ("canonical");
+
+	ksRewind (ks);
+
+	Key * cur;
+	while ((cur = ksNext (ks)) != NULL)
+	{
+		fprintf (stderr, "%s:(%s)\n", keyName (cur), keyString (cur));
+	}
+	ksRewind (ks);
+
+	succeed_if (plugin->kdbGet (plugin, ks, parentKey) != (-1), "kdbGet failed");
+
+	ksRewind (ks);
+	while ((cur = ksNext (ks)) != NULL)
+	{
+		fprintf (stderr, "%s:(%s)\n", keyName (cur), keyString (cur));
+	}
+
+	succeed_if (!strcmp (keyString (ksLookupByName (ks, "user/tests/canonical/match1", KDB_O_NONE)), "1"), "kdbGet failed on match1");
+	succeed_if (!strcmp (keyString (ksLookupByName (ks, "user/tests/canonical/match2", KDB_O_NONE)), "1"), "kdbGet failed on match2");
+
+	succeed_if (!strcmp (keyString (ksLookupByName (ks, "user/tests/canonical/match3", KDB_O_NONE)), "1"), "kdbGet failed on match3");
+	succeed_if (!strcmp (keyString (ksLookupByName (ks, "user/tests/canonical/match4", KDB_O_NONE)), "1"), "kdbGet failed on match4");
+	ksDel (ks);
+
+	keyDel (parentKey);
+	PLUGIN_CLOSE ();
+}
+
+
+static void testSensitiveListArray ()
+{
+	Key * parentKey = keyNew ("user/tests/canonical", KEY_VALUE, "", KEY_END);
+	KeySet * ks = ksNew (
+		20, keyNew ("user/tests/canonical/match1", KEY_VALUE, "TRUE", KEY_META, "transform/canonical/list/sensitive", "#2",
+			    KEY_META, "transform/canonical/list/sensitive/#0", "'TRUE','true'", KEY_META,
+			    "transform/canonical/list/sensitive/#0/canonical", "1true", KEY_META, "transform/canonical/list/sensitive/#1",
+			    "'ON'", KEY_META, "transform/canonical/list/sensitive/#1/canonical", "1on", KEY_META,
+			    "transform/canonical/list/sensitive/#2", "'enable','ENABLE'", KEY_META,
+			    "transform/canonical/list/sensitive/#2/canonical", "1enable", KEY_END),
+
+		keyNew ("user/tests/canonical/match2", KEY_VALUE, "ON", KEY_META, "transform/canonical/list/sensitive", "#2", KEY_META,
+			"transform/canonical/list/sensitive/#0", "'TRUE','true'", KEY_META,
+			"transform/canonical/list/sensitive/#0/canonical", "1true", KEY_META, "transform/canonical/list/sensitive/#1",
+			"'ON'", KEY_META, "transform/canonical/list/sensitive/#1/canonical", "1on", KEY_META,
+			"transform/canonical/list/sensitive/#2", "'enable','ENABLE'", KEY_META,
+			"transform/canonical/list/sensitive/#2/canonical", "1enable", KEY_END),
+		keyNew ("user/tests/canonical/match3", KEY_VALUE, "ENABLE", KEY_META, "transform/canonical/list/sensitive", "#2", KEY_META,
+			"transform/canonical/list/sensitive/#0", "'TRUE','true'", KEY_META,
+			"transform/canonical/list/sensitive/#0/canonical", "1true", KEY_META, "transform/canonical/list/sensitive/#1",
+			"'ON'", KEY_META, "transform/canonical/list/sensitive/#1/canonical", "1on", KEY_META,
+			"transform/canonical/list/sensitive/#2", "'enable','ENABLE'", KEY_META,
+			"transform/canonical/list/sensitive/#2/canonical", "1enable", KEY_END),
+
+		keyNew ("user/tests/canonical/nomatch1", KEY_VALUE, "TRue", KEY_META, "transform/canonical/list/sensitive", "#2", KEY_META,
+			"transform/canonical/list/sensitive/#0", "'TRUE','true'", KEY_META,
+			"transform/canonical/list/sensitive/#0/canonical", "1true", KEY_META, "transform/canonical/list/sensitive/#1",
+			"'ON'", KEY_META, "transform/canonical/list/sensitive/#1/canonical", "1on", KEY_META,
+			"transform/canonical/list/sensitive/#2", "'enable','ENABLE'", KEY_META,
+			"transform/canonical/list/sensitive/#2/canonical", "1enable", KEY_END),
+
+		keyNew ("user/tests/canonical/nomatch2", KEY_VALUE, "On", KEY_META, "transform/canonical/list/sensitive", "#2", KEY_META,
+			"transform/canonical/list/sensitive/#0", "'TRUE','true'", KEY_META,
+			"transform/canonical/list/sensitive/#0/canonical", "1true", KEY_META, "transform/canonical/list/sensitive/#1",
+			"'ON'", KEY_META, "transform/canonical/list/sensitive/#1/canonical", "1on", KEY_META,
+			"transform/canonical/list/sensitive/#2", "'enable','ENABLE'", KEY_META,
+			"transform/canonical/list/sensitive/#2/canonical", "1enable", KEY_END),
+		keyNew ("user/tests/canonical/nomatch3", KEY_VALUE, "ENAble", KEY_META, "transform/canonical/list/sensitive", "#2",
+			KEY_META, "transform/canonical/list/sensitive/#0", "'TRUE','true'", KEY_META,
+			"transform/canonical/list/sensitive/#0/canonical", "1true", KEY_META, "transform/canonical/list/sensitive/#1",
+			"'ON'", KEY_META, "transform/canonical/list/sensitive/#1/canonical", "1on", KEY_META,
+			"transform/canonical/list/sensitive/#2", "'enable','ENABLE'", KEY_META,
+			"transform/canonical/list/sensitive/#2/canonical", "1enable", KEY_END),
+
+		KS_END);
+
+	KeySet * conf = ksNew (0, KS_END);
+	PLUGIN_OPEN ("canonical");
+
+	ksRewind (ks);
+
+	Key * cur;
+	while ((cur = ksNext (ks)) != NULL)
+	{
+		fprintf (stderr, "%s:(%s)\n", keyName (cur), keyString (cur));
+	}
+	ksRewind (ks);
+
+	succeed_if (plugin->kdbGet (plugin, ks, parentKey) != (-1), "kdbGet failed");
+
+	ksRewind (ks);
+	while ((cur = ksNext (ks)) != NULL)
+	{
+		fprintf (stderr, "%s:(%s)\n", keyName (cur), keyString (cur));
+	}
+
+	succeed_if (!strcmp (keyString (ksLookupByName (ks, "user/tests/canonical/match1", KDB_O_NONE)), "1true"),
+		    "kdbGet failed on match1");
+	succeed_if (!strcmp (keyString (ksLookupByName (ks, "user/tests/canonical/match2", KDB_O_NONE)), "1on"), "kdbGet failed on match2");
+	succeed_if (!strcmp (keyString (ksLookupByName (ks, "user/tests/canonical/match3", KDB_O_NONE)), "1enable"),
+		    "kdbGet failed on match3");
+
+	succeed_if (!strcmp (keyString (ksLookupByName (ks, "user/tests/canonical/nomatch1", KDB_O_NONE)), "TRue"),
+		    "kdbGet failed on nomatch1");
+	succeed_if (!strcmp (keyString (ksLookupByName (ks, "user/tests/canonical/nomatch2", KDB_O_NONE)), "On"),
+		    "kdbGet failed on nomatch2");
+	succeed_if (!strcmp (keyString (ksLookupByName (ks, "user/tests/canonical/nomatch3", KDB_O_NONE)), "ENAble"),
+		    "kdbGet failed on nomatch3");
+	ksDel (ks);
+
+	keyDel (parentKey);
+	PLUGIN_CLOSE ();
+}
+
+static void testInsensitiveListArray ()
+{
+	Key * parentKey = keyNew ("user/tests/canonical", KEY_VALUE, "", KEY_END);
+	KeySet * ks = ksNew (
+		20, keyNew ("user/tests/canonical/match1", KEY_VALUE, "TRUE", KEY_META, "transform/canonical/list/insensitive", "#2",
+			    KEY_META, "transform/canonical/list/insensitive/#0", "'TRUE','true'", KEY_META,
+			    "transform/canonical/list/insensitive/#0/canonical", "1true", KEY_META,
+			    "transform/canonical/list/insensitive/#1", "'ON'", KEY_META,
+			    "transform/canonical/list/insensitive/#1/canonical", "1on", KEY_META, "transform/canonical/list/insensitive/#2",
+			    "'enable','ENABLE'", KEY_META, "transform/canonical/list/insensitive/#2/canonical", "1enable", KEY_END),
+
+		keyNew ("user/tests/canonical/match2", KEY_VALUE, "ON", KEY_META, "transform/canonical/list/insensitive", "#2", KEY_META,
+			"transform/canonical/list/insensitive/#0", "'TRUE','true'", KEY_META,
+			"transform/canonical/list/insensitive/#0/canonical", "1true", KEY_META, "transform/canonical/list/insensitive/#1",
+			"'ON'", KEY_META, "transform/canonical/list/insensitive/#1/canonical", "1on", KEY_META,
+			"transform/canonical/list/insensitive/#2", "'enable','ENABLE'", KEY_META,
+			"transform/canonical/list/insensitive/#2/canonical", "1enable", KEY_END),
+		keyNew ("user/tests/canonical/match3", KEY_VALUE, "ENABLE", KEY_META, "transform/canonical/list/insensitive", "#2",
+			KEY_META, "transform/canonical/list/insensitive/#0", "'TRUE','true'", KEY_META,
+			"transform/canonical/list/insensitive/#0/canonical", "1true", KEY_META, "transform/canonical/list/insensitive/#1",
+			"'ON'", KEY_META, "transform/canonical/list/insensitive/#1/canonical", "1on", KEY_META,
+			"transform/canonical/list/insensitive/#2", "'enable','ENABLE'", KEY_META,
+			"transform/canonical/list/insensitive/#2/canonical", "1enable", KEY_END),
+
+		keyNew ("user/tests/canonical/match4", KEY_VALUE, "TRue", KEY_META, "transform/canonical/list/insensitive", "#2", KEY_META,
+			"transform/canonical/list/insensitive/#0", "'TRUE','true'", KEY_META,
+			"transform/canonical/list/insensitive/#0/canonical", "1true", KEY_META, "transform/canonical/list/insensitive/#1",
+			"'ON'", KEY_META, "transform/canonical/list/insensitive/#1/canonical", "1on", KEY_META,
+			"transform/canonical/list/insensitive/#2", "'enable','ENABLE'", KEY_META,
+			"transform/canonical/list/insensitive/#2/canonical", "1enable", KEY_END),
+
+		keyNew ("user/tests/canonical/match5", KEY_VALUE, "On", KEY_META, "transform/canonical/list/insensitive", "#2", KEY_META,
+			"transform/canonical/list/insensitive/#0", "'TRUE','true'", KEY_META,
+			"transform/canonical/list/insensitive/#0/canonical", "1true", KEY_META, "transform/canonical/list/insensitive/#1",
+			"'ON'", KEY_META, "transform/canonical/list/insensitive/#1/canonical", "1on", KEY_META,
+			"transform/canonical/list/insensitive/#2", "'enable','ENABLE'", KEY_META,
+			"transform/canonical/list/insensitive/#2/canonical", "1enable", KEY_END),
+		keyNew ("user/tests/canonical/match6", KEY_VALUE, "ENAble", KEY_META, "transform/canonical/list/insensitive", "#2",
+			KEY_META, "transform/canonical/list/insensitive/#0", "'TRUE','true'", KEY_META,
+			"transform/canonical/list/insensitive/#0/canonical", "1true", KEY_META, "transform/canonical/list/insensitive/#1",
+			"'ON'", KEY_META, "transform/canonical/list/insensitive/#1/canonical", "1on", KEY_META,
+			"transform/canonical/list/insensitive/#2", "'enable','ENABLE'", KEY_META,
+			"transform/canonical/list/insensitive/#2/canonical", "1enable", KEY_END),
+
+		KS_END);
+
+	KeySet * conf = ksNew (0, KS_END);
+	PLUGIN_OPEN ("canonical");
+
+	ksRewind (ks);
+
+	Key * cur;
+	while ((cur = ksNext (ks)) != NULL)
+	{
+		fprintf (stderr, "%s:(%s)\n", keyName (cur), keyString (cur));
+	}
+	ksRewind (ks);
+
+	succeed_if (plugin->kdbGet (plugin, ks, parentKey) != (-1), "kdbGet failed");
+
+	ksRewind (ks);
+	while ((cur = ksNext (ks)) != NULL)
+	{
+		fprintf (stderr, "%s:(%s)\n", keyName (cur), keyString (cur));
+	}
+
+	succeed_if (!strcmp (keyString (ksLookupByName (ks, "user/tests/canonical/match1", KDB_O_NONE)), "1true"),
+		    "kdbGet failed on match1");
+	succeed_if (!strcmp (keyString (ksLookupByName (ks, "user/tests/canonical/match2", KDB_O_NONE)), "1on"), "kdbGet failed on match2");
+	succeed_if (!strcmp (keyString (ksLookupByName (ks, "user/tests/canonical/match3", KDB_O_NONE)), "1enable"),
+		    "kdbGet failed on match3");
+
+	succeed_if (!strcmp (keyString (ksLookupByName (ks, "user/tests/canonical/match4", KDB_O_NONE)), "1true"),
+		    "kdbGet failed on match4");
+	succeed_if (!strcmp (keyString (ksLookupByName (ks, "user/tests/canonical/match5", KDB_O_NONE)), "1on"), "kdbGet failed on match5");
+	succeed_if (!strcmp (keyString (ksLookupByName (ks, "user/tests/canonical/match6", KDB_O_NONE)), "1enable"),
+		    "kdbGet failed on match6");
+	ksDel (ks);
+
+	keyDel (parentKey);
+	PLUGIN_CLOSE ();
+}
+
+static void testRegexSingle ()
+{
+	Key * parentKey = keyNew ("user/tests/canonical", KEY_VALUE, "", KEY_END);
+	KeySet * ks = ksNew (20, keyNew ("user/tests/canonical/match1", KEY_VALUE, "TRUE", KEY_META, "transform/canonical/regex",
+					 "TR[uU][eE]", KEY_META, "transform/canonical/regex/canonical", "1", KEY_END),
+			     keyNew ("user/tests/canonical/nomatch1", KEY_VALUE, "ENABLE", KEY_META, "transform/canonical/regex",
+				     "TR[uU][eE]", KEY_META, "transform/canonical/regex/canonical", "1", KEY_END),
+			     keyNew ("user/tests/canonical/match2", KEY_VALUE, "TRue", KEY_META, "transform/canonical/regex", "TR[uU][eE]",
+				     KEY_META, "transform/canonical/regex/canonical", "1", KEY_END),
+			     keyNew ("user/tests/canonical/nomatch2", KEY_VALUE, "ENAble", KEY_META, "transform/canonical/regex",
+				     "TR[uU][eE]", KEY_META, "transform/canonical/regex/canonical", "1", KEY_END),
+
+			     KS_END);
+
+	KeySet * conf = ksNew (0, KS_END);
+	PLUGIN_OPEN ("canonical");
+
+	ksRewind (ks);
+
+	Key * cur;
+	while ((cur = ksNext (ks)) != NULL)
+	{
+		fprintf (stderr, "%s:(%s)\n", keyName (cur), keyString (cur));
+	}
+	ksRewind (ks);
+
+	succeed_if (plugin->kdbGet (plugin, ks, parentKey) != (-1), "kdbGet failed");
+
+	ksRewind (ks);
+	while ((cur = ksNext (ks)) != NULL)
+	{
+		fprintf (stderr, "%s:(%s)\n", keyName (cur), keyString (cur));
+	}
+
+	succeed_if (!strcmp (keyString (ksLookupByName (ks, "user/tests/canonical/match1", KDB_O_NONE)), "1"), "kdbGet failed on match1");
+	succeed_if (!strcmp (keyString (ksLookupByName (ks, "user/tests/canonical/match2", KDB_O_NONE)), "1"), "kdbGet failed on match2");
+
+	succeed_if (!strcmp (keyString (ksLookupByName (ks, "user/tests/canonical/nomatch1", KDB_O_NONE)), "ENABLE"),
+		    "kdbGet failed on nomatch1");
+	succeed_if (!strcmp (keyString (ksLookupByName (ks, "user/tests/canonical/nomatch2", KDB_O_NONE)), "ENAble"),
+		    "kdbGet failed on nomatch2");
+	ksDel (ks);
+
+	keyDel (parentKey);
+	PLUGIN_CLOSE ();
+}
+
+static void testRegexArray ()
+{
+	Key * parentKey = keyNew ("user/tests/canonical", KEY_VALUE, "", KEY_END);
+	KeySet * ks = ksNew (
+		20,
+		keyNew ("user/tests/canonical/match1", KEY_VALUE, "TRUE", KEY_META, "transform/canonical/regex", "#2", KEY_META,
+			"transform/canonical/regex/#0", "(TRUE|true)", KEY_META, "transform/canonical/regex/#0/canonical", "1true",
+			KEY_META, "transform/canonical/regex/#1", "ON", KEY_META, "transform/canonical/regex/#1/canonical", "1on", KEY_META,
+			"transform/canonical/regex/#2", ".*ABLE", KEY_META, "transform/canonical/regex/#2/canonical", "1enable", KEY_END),
+		keyNew ("user/tests/canonical/match2", KEY_VALUE, "ON", KEY_META, "transform/canonical/regex", "#2", KEY_META,
+			"transform/canonical/regex/#0", "(TRUE|true)", KEY_META, "transform/canonical/regex/#0/canonical", "1true",
+			KEY_META, "transform/canonical/regex/#1", "ON", KEY_META, "transform/canonical/regex/#1/canonical", "1on", KEY_META,
+			"transform/canonical/regex/#2", ".*ABLE", KEY_META, "transform/canonical/regex/#2/canonical", "1enable", KEY_END),
+		keyNew ("user/tests/canonical/match3", KEY_VALUE, "ENABLE", KEY_META, "transform/canonical/regex", "#2", KEY_META,
+			"transform/canonical/regex/#0", "(TRUE|true)", KEY_META, "transform/canonical/regex/#0/canonical", "1true",
+			KEY_META, "transform/canonical/regex/#1", "ON", KEY_META, "transform/canonical/regex/#1/canonical", "1on", KEY_META,
+			"transform/canonical/regex/#2", ".*ABLE", KEY_META, "transform/canonical/regex/#2/canonical", "1enable", KEY_END),
+
+		keyNew ("user/tests/canonical/nomatch1", KEY_VALUE, "TRue", KEY_META, "transform/canonical/regex", "#2", KEY_META,
+			"transform/canonical/regex/#0", "(TRUE|true)", KEY_META, "transform/canonical/regex/#0/canonical", "1true",
+			KEY_META, "transform/canonical/regex/#1", "ON", KEY_META, "transform/canonical/regex/#1/canonical", "1on", KEY_META,
+			"transform/canonical/regex/#2", ".*ABLE", KEY_META, "transform/canonical/regex/#2/canonical", "1enable", KEY_END),
+		keyNew ("user/tests/canonical/nomatch2", KEY_VALUE, "on", KEY_META, "transform/canonical/regex", "#2", KEY_META,
+			"transform/canonical/regex/#0", "(TRUE|true)", KEY_META, "transform/canonical/regex/#0/canonical", "1true",
+			KEY_META, "transform/canonical/regex/#1", "ON", KEY_META, "transform/canonical/regex/#1/canonical", "1on", KEY_META,
+			"transform/canonical/regex/#2", ".*ABLE", KEY_META, "transform/canonical/regex/#2/canonical", "1enable", KEY_END),
+		keyNew ("user/tests/canonical/nomatch3", KEY_VALUE, "ENAble", KEY_META, "transform/canonical/regex", "#2", KEY_META,
+			"transform/canonical/regex/#0", "(TRUE|true)", KEY_META, "transform/canonical/regex/#0/canonical", "1true",
+			KEY_META, "transform/canonical/regex/#1", "ON", KEY_META, "transform/canonical/regex/#1/canonical", "1on", KEY_META,
+			"transform/canonical/regex/#2", ".*ABLE", KEY_META, "transform/canonical/regex/#2/canonical", "1enable", KEY_END),
+		KS_END);
+
+	KeySet * conf = ksNew (0, KS_END);
+	PLUGIN_OPEN ("canonical");
+
+	ksRewind (ks);
+
+	Key * cur;
+	while ((cur = ksNext (ks)) != NULL)
+	{
+		fprintf (stderr, "%s:(%s)\n", keyName (cur), keyString (cur));
+	}
+	ksRewind (ks);
+
+	succeed_if (plugin->kdbGet (plugin, ks, parentKey) != (-1), "kdbGet failed");
+
+	ksRewind (ks);
+	while ((cur = ksNext (ks)) != NULL)
+	{
+		fprintf (stderr, "%s:(%s)\n", keyName (cur), keyString (cur));
+	}
+
+	succeed_if (!strcmp (keyString (ksLookupByName (ks, "user/tests/canonical/match1", KDB_O_NONE)), "1true"),
+		    "kdbGet failed on match1");
+	succeed_if (!strcmp (keyString (ksLookupByName (ks, "user/tests/canonical/match2", KDB_O_NONE)), "1on"), "kdbGet failed on match2");
+	succeed_if (!strcmp (keyString (ksLookupByName (ks, "user/tests/canonical/match3", KDB_O_NONE)), "1enable"),
+		    "kdbGet failed on match3");
+
+	succeed_if (!strcmp (keyString (ksLookupByName (ks, "user/tests/canonical/nomatch1", KDB_O_NONE)), "TRue"),
+		    "kdbGet failed on nomatch1");
+	succeed_if (!strcmp (keyString (ksLookupByName (ks, "user/tests/canonical/nomatch2", KDB_O_NONE)), "on"),
+		    "kdbGet failed on nomatch2");
+	succeed_if (!strcmp (keyString (ksLookupByName (ks, "user/tests/canonical/nomatch3", KDB_O_NONE)), "ENAble"),
+		    "kdbGet failed on nomatch3");
+	ksDel (ks);
+
+	keyDel (parentKey);
+	PLUGIN_CLOSE ();
+}
+
+
+static void testFNMatchSingle ()
+{
+	Key * parentKey = keyNew ("user/tests/canonical", KEY_VALUE, "", KEY_END);
+	KeySet * ks = ksNew (20, keyNew ("user/tests/canonical/match1", KEY_VALUE, "TRUE", KEY_META, "transform/canonical/fnmatch", "TR??",
+					 KEY_META, "transform/canonical/fnmatch/canonical", "1", KEY_END),
+			     keyNew ("user/tests/canonical/nomatch1", KEY_VALUE, "ENABLE", KEY_META, "transform/canonical/fnmatch", "TR??",
+				     KEY_META, "transform/canonical/fnmatch/canonical", "1", KEY_END),
+			     keyNew ("user/tests/canonical/match2", KEY_VALUE, "TRue", KEY_META, "transform/canonical/fnmatch", "TR??",
+				     KEY_META, "transform/canonical/fnmatch/canonical", "1", KEY_END),
+			     keyNew ("user/tests/canonical/nomatch2", KEY_VALUE, "ENAble", KEY_META, "transform/canonical/fnmatch", "TR??",
+				     KEY_META, "transform/canonical/fnmatch/canonical", "1", KEY_END),
+
+			     KS_END);
+
+	KeySet * conf = ksNew (0, KS_END);
+	PLUGIN_OPEN ("canonical");
+
+	ksRewind (ks);
+
+	Key * cur;
+	while ((cur = ksNext (ks)) != NULL)
+	{
+		fprintf (stderr, "%s:(%s)\n", keyName (cur), keyString (cur));
+	}
+	ksRewind (ks);
+
+	succeed_if (plugin->kdbGet (plugin, ks, parentKey) != (-1), "kdbGet failed");
+
+	ksRewind (ks);
+	while ((cur = ksNext (ks)) != NULL)
+	{
+		fprintf (stderr, "%s:(%s)\n", keyName (cur), keyString (cur));
+	}
+
+	succeed_if (!strcmp (keyString (ksLookupByName (ks, "user/tests/canonical/match1", KDB_O_NONE)), "1"), "kdbGet failed on match1");
+	succeed_if (!strcmp (keyString (ksLookupByName (ks, "user/tests/canonical/match2", KDB_O_NONE)), "1"), "kdbGet failed on match2");
+
+	succeed_if (!strcmp (keyString (ksLookupByName (ks, "user/tests/canonical/nomatch1", KDB_O_NONE)), "ENABLE"),
+		    "kdbGet failed on nomatch1");
+	succeed_if (!strcmp (keyString (ksLookupByName (ks, "user/tests/canonical/nomatch2", KDB_O_NONE)), "ENAble"),
+		    "kdbGet failed on nomatch2");
+	ksDel (ks);
+
+	keyDel (parentKey);
+	PLUGIN_CLOSE ();
+}
+
+static void testFNMatchArray ()
+{
+	Key * parentKey = keyNew ("user/tests/canonical", KEY_VALUE, "", KEY_END);
+	KeySet * ks =
+		ksNew (20, keyNew ("user/tests/canonical/match1", KEY_VALUE, "TRUE", KEY_META, "transform/canonical/fnmatch", "#2",
+				   KEY_META, "transform/canonical/fnmatch/#0", "*UE", KEY_META, "transform/canonical/fnmatch/#0/canonical",
+				   "1true", KEY_META, "transform/canonical/fnmatch/#1", "?N", KEY_META,
+				   "transform/canonical/fnmatch/#1/canonical", "1on", KEY_META, "transform/canonical/fnmatch/#2", "??ABLE",
+				   KEY_META, "transform/canonical/fnmatch/#2/canonical", "1enable", KEY_END),
+		       keyNew ("user/tests/canonical/match2", KEY_VALUE, "ON", KEY_META, "transform/canonical/fnmatch", "#2", KEY_META,
+			       "transform/canonical/fnmatch/#0", "*UE", KEY_META, "transform/canonical/fnmatch/#0/canonical", "1true",
+			       KEY_META, "transform/canonical/fnmatch/#1", "?N", KEY_META, "transform/canonical/fnmatch/#1/canonical",
+			       "1on", KEY_META, "transform/canonical/fnmatch/#2", "??ABLE", KEY_META,
+			       "transform/canonical/fnmatch/#2/canonical", "1enable", KEY_END),
+		       keyNew ("user/tests/canonical/match3", KEY_VALUE, "ENABLE", KEY_META, "transform/canonical/fnmatch", "#2", KEY_META,
+			       "transform/canonical/fnmatch/#0", "*UE", KEY_META, "transform/canonical/fnmatch/#0/canonical", "1true",
+			       KEY_META, "transform/canonical/fnmatch/#1", "?N", KEY_META, "transform/canonical/fnmatch/#1/canonical",
+			       "1on", KEY_META, "transform/canonical/fnmatch/#2", "??ABLE", KEY_META,
+			       "transform/canonical/fnmatch/#2/canonical", "1enable", KEY_END),
+
+		       keyNew ("user/tests/canonical/nomatch1", KEY_VALUE, "TRue", KEY_META, "transform/canonical/fnmatch", "#2", KEY_META,
+			       "transform/canonical/fnmatch/#0", "*UE", KEY_META, "transform/canonical/fnmatch/#0/canonical", "1true",
+			       KEY_META, "transform/canonical/fnmatch/#1", "?N", KEY_META, "transform/canonical/fnmatch/#1/canonical",
+			       "1on", KEY_META, "transform/canonical/fnmatch/#2", "??ABLE", KEY_META,
+			       "transform/canonical/fnmatch/#2/canonical", "1enable", KEY_END),
+		       keyNew ("user/tests/canonical/nomatch2", KEY_VALUE, "on", KEY_META, "transform/canonical/fnmatch", "#2", KEY_META,
+			       "transform/canonical/fnmatch/#0", "*UE", KEY_META, "transform/canonical/fnmatch/#0/canonical", "1true",
+			       KEY_META, "transform/canonical/fnmatch/#1", "?N", KEY_META, "transform/canonical/fnmatch/#1/canonical",
+			       "1on", KEY_META, "transform/canonical/fnmatch/#2", "??ABLE", KEY_META,
+			       "transform/canonical/fnmatch/#2/canonical", "1enable", KEY_END),
+		       keyNew ("user/tests/canonical/nomatch3", KEY_VALUE, "ENAble", KEY_META, "transform/canonical/fnmatch", "#2",
+			       KEY_META, "transform/canonical/fnmatch/#0", "*UE", KEY_META, "transform/canonical/fnmatch/#0/canonical",
+			       "1true", KEY_META, "transform/canonical/fnmatch/#1", "?N", KEY_META,
+			       "transform/canonical/fnmatch/#1/canonical", "1on", KEY_META, "transform/canonical/fnmatch/#2", "??ABLE",
+			       KEY_META, "transform/canonical/fnmatch/#2/canonical", "1enable", KEY_END),
+		       KS_END);
+
+	KeySet * conf = ksNew (0, KS_END);
+	PLUGIN_OPEN ("canonical");
+
+	ksRewind (ks);
+
+	Key * cur;
+	while ((cur = ksNext (ks)) != NULL)
+	{
+		fprintf (stderr, "%s:(%s)\n", keyName (cur), keyString (cur));
+	}
+	ksRewind (ks);
+
+	succeed_if (plugin->kdbGet (plugin, ks, parentKey) != (-1), "kdbGet failed");
+
+	ksRewind (ks);
+	while ((cur = ksNext (ks)) != NULL)
+	{
+		fprintf (stderr, "%s:(%s)\n", keyName (cur), keyString (cur));
+	}
+
+	succeed_if (!strcmp (keyString (ksLookupByName (ks, "user/tests/canonical/match1", KDB_O_NONE)), "1true"),
+		    "kdbGet failed on match1");
+	succeed_if (!strcmp (keyString (ksLookupByName (ks, "user/tests/canonical/match2", KDB_O_NONE)), "1on"), "kdbGet failed on match2");
+	succeed_if (!strcmp (keyString (ksLookupByName (ks, "user/tests/canonical/match3", KDB_O_NONE)), "1enable"),
+		    "kdbGet failed on match3");
+
+	succeed_if (!strcmp (keyString (ksLookupByName (ks, "user/tests/canonical/nomatch1", KDB_O_NONE)), "TRue"),
+		    "kdbGet failed on nomatch1");
+	succeed_if (!strcmp (keyString (ksLookupByName (ks, "user/tests/canonical/nomatch2", KDB_O_NONE)), "on"),
+		    "kdbGet failed on nomatch2");
+	succeed_if (!strcmp (keyString (ksLookupByName (ks, "user/tests/canonical/nomatch3", KDB_O_NONE)), "ENAble"),
+		    "kdbGet failed on nomatch3");
+	ksDel (ks);
+
+	keyDel (parentKey);
+	PLUGIN_CLOSE ();
+}
+
+
+int main (int argc, char ** argv)
+{
+	printf ("CANONICAL     TESTS\n");
+	printf ("==================\n\n");
+
+	init (argc, argv);
+
+	testSensitiveListSingle ();
+	testInsensitiveListSingle ();
+	testSensitiveListArray ();
+	testInsensitiveListArray ();
+	testRegexSingle ();
+	testRegexArray ();
+	testFNMatchSingle ();
+	testFNMatchArray ();
+	printf ("\ntestmod_canonical RESULTS: %d test(s) done. %d error(s).\n", nbTest, nbError);
+
+	return nbError;
+}

--- a/src/plugins/canonical/testmod_canonical.c
+++ b/src/plugins/canonical/testmod_canonical.c
@@ -36,20 +36,7 @@ static void testSensitiveListSingle ()
 
 	ksRewind (ks);
 
-	Key * cur;
-	while ((cur = ksNext (ks)) != NULL)
-	{
-		fprintf (stderr, "%s:(%s)\n", keyName (cur), keyString (cur));
-	}
-	ksRewind (ks);
-
 	succeed_if (plugin->kdbGet (plugin, ks, parentKey) != (-1), "kdbGet failed");
-
-	ksRewind (ks);
-	while ((cur = ksNext (ks)) != NULL)
-	{
-		fprintf (stderr, "%s:(%s)\n", keyName (cur), keyString (cur));
-	}
 
 	succeed_if (!strcmp (keyString (ksLookupByName (ks, "user/tests/canonical/match1", KDB_O_NONE)), "1"), "kdbGet failed on match1");
 	succeed_if (!strcmp (keyString (ksLookupByName (ks, "user/tests/canonical/match2", KDB_O_NONE)), "1"), "kdbGet failed on match2");
@@ -85,20 +72,7 @@ static void testInsensitiveListSingle ()
 
 	ksRewind (ks);
 
-	Key * cur;
-	while ((cur = ksNext (ks)) != NULL)
-	{
-		fprintf (stderr, "%s:(%s)\n", keyName (cur), keyString (cur));
-	}
-	ksRewind (ks);
-
 	succeed_if (plugin->kdbGet (plugin, ks, parentKey) != (-1), "kdbGet failed");
-
-	ksRewind (ks);
-	while ((cur = ksNext (ks)) != NULL)
-	{
-		fprintf (stderr, "%s:(%s)\n", keyName (cur), keyString (cur));
-	}
 
 	succeed_if (!strcmp (keyString (ksLookupByName (ks, "user/tests/canonical/match1", KDB_O_NONE)), "1"), "kdbGet failed on match1");
 	succeed_if (!strcmp (keyString (ksLookupByName (ks, "user/tests/canonical/match2", KDB_O_NONE)), "1"), "kdbGet failed on match2");
@@ -163,20 +137,7 @@ static void testSensitiveListArray ()
 
 	ksRewind (ks);
 
-	Key * cur;
-	while ((cur = ksNext (ks)) != NULL)
-	{
-		fprintf (stderr, "%s:(%s)\n", keyName (cur), keyString (cur));
-	}
-	ksRewind (ks);
-
 	succeed_if (plugin->kdbGet (plugin, ks, parentKey) != (-1), "kdbGet failed");
-
-	ksRewind (ks);
-	while ((cur = ksNext (ks)) != NULL)
-	{
-		fprintf (stderr, "%s:(%s)\n", keyName (cur), keyString (cur));
-	}
 
 	succeed_if (!strcmp (keyString (ksLookupByName (ks, "user/tests/canonical/match1", KDB_O_NONE)), "1true"),
 		    "kdbGet failed on match1");
@@ -247,20 +208,7 @@ static void testInsensitiveListArray ()
 
 	ksRewind (ks);
 
-	Key * cur;
-	while ((cur = ksNext (ks)) != NULL)
-	{
-		fprintf (stderr, "%s:(%s)\n", keyName (cur), keyString (cur));
-	}
-	ksRewind (ks);
-
 	succeed_if (plugin->kdbGet (plugin, ks, parentKey) != (-1), "kdbGet failed");
-
-	ksRewind (ks);
-	while ((cur = ksNext (ks)) != NULL)
-	{
-		fprintf (stderr, "%s:(%s)\n", keyName (cur), keyString (cur));
-	}
 
 	succeed_if (!strcmp (keyString (ksLookupByName (ks, "user/tests/canonical/match1", KDB_O_NONE)), "1true"),
 		    "kdbGet failed on match1");
@@ -298,20 +246,7 @@ static void testRegexSingle ()
 
 	ksRewind (ks);
 
-	Key * cur;
-	while ((cur = ksNext (ks)) != NULL)
-	{
-		fprintf (stderr, "%s:(%s)\n", keyName (cur), keyString (cur));
-	}
-	ksRewind (ks);
-
 	succeed_if (plugin->kdbGet (plugin, ks, parentKey) != (-1), "kdbGet failed");
-
-	ksRewind (ks);
-	while ((cur = ksNext (ks)) != NULL)
-	{
-		fprintf (stderr, "%s:(%s)\n", keyName (cur), keyString (cur));
-	}
 
 	succeed_if (!strcmp (keyString (ksLookupByName (ks, "user/tests/canonical/match1", KDB_O_NONE)), "1"), "kdbGet failed on match1");
 	succeed_if (!strcmp (keyString (ksLookupByName (ks, "user/tests/canonical/match2", KDB_O_NONE)), "1"), "kdbGet failed on match2");
@@ -363,20 +298,7 @@ static void testRegexArray ()
 
 	ksRewind (ks);
 
-	Key * cur;
-	while ((cur = ksNext (ks)) != NULL)
-	{
-		fprintf (stderr, "%s:(%s)\n", keyName (cur), keyString (cur));
-	}
-	ksRewind (ks);
-
 	succeed_if (plugin->kdbGet (plugin, ks, parentKey) != (-1), "kdbGet failed");
-
-	ksRewind (ks);
-	while ((cur = ksNext (ks)) != NULL)
-	{
-		fprintf (stderr, "%s:(%s)\n", keyName (cur), keyString (cur));
-	}
 
 	succeed_if (!strcmp (keyString (ksLookupByName (ks, "user/tests/canonical/match1", KDB_O_NONE)), "1true"),
 		    "kdbGet failed on match1");
@@ -416,20 +338,7 @@ static void testFNMatchSingle ()
 
 	ksRewind (ks);
 
-	Key * cur;
-	while ((cur = ksNext (ks)) != NULL)
-	{
-		fprintf (stderr, "%s:(%s)\n", keyName (cur), keyString (cur));
-	}
-	ksRewind (ks);
-
 	succeed_if (plugin->kdbGet (plugin, ks, parentKey) != (-1), "kdbGet failed");
-
-	ksRewind (ks);
-	while ((cur = ksNext (ks)) != NULL)
-	{
-		fprintf (stderr, "%s:(%s)\n", keyName (cur), keyString (cur));
-	}
 
 	succeed_if (!strcmp (keyString (ksLookupByName (ks, "user/tests/canonical/match1", KDB_O_NONE)), "1"), "kdbGet failed on match1");
 	succeed_if (!strcmp (keyString (ksLookupByName (ks, "user/tests/canonical/match2", KDB_O_NONE)), "1"), "kdbGet failed on match2");
@@ -486,20 +395,7 @@ static void testFNMatchArray ()
 
 	ksRewind (ks);
 
-	Key * cur;
-	while ((cur = ksNext (ks)) != NULL)
-	{
-		fprintf (stderr, "%s:(%s)\n", keyName (cur), keyString (cur));
-	}
-	ksRewind (ks);
-
 	succeed_if (plugin->kdbGet (plugin, ks, parentKey) != (-1), "kdbGet failed");
-
-	ksRewind (ks);
-	while ((cur = ksNext (ks)) != NULL)
-	{
-		fprintf (stderr, "%s:(%s)\n", keyName (cur), keyString (cur));
-	}
 
 	succeed_if (!strcmp (keyString (ksLookupByName (ks, "user/tests/canonical/match1", KDB_O_NONE)), "1true"),
 		    "kdbGet failed on match1");

--- a/src/plugins/canonical/testmod_canonical.c
+++ b/src/plugins/canonical/testmod_canonical.c
@@ -457,6 +457,40 @@ static void testTristateList ()
 	PLUGIN_CLOSE ();
 }
 
+static void testTristateListToIndex ()
+{
+	Key * parentKey = keyNew ("user/tests/canonical", KEY_VALUE, "", KEY_END);
+	KeySet * ks = ksNew (20, keyNew ("user/tests/canonical/TTrue", KEY_VALUE, "On", KEY_META, "transform/canonical/list/insensitive",
+					 "#2", KEY_META, "transform/canonical/list/insensitive/#0", "'FALSE','OFF','CLOSED','DISABLE'",
+					 KEY_META, "transform/canonical/list/insensitive/#1", "'TRUE','ON','OPEN','ENABLE'", KEY_META,
+					 "transform/canonical/list/insensitive/#2", "'OTHER','NONE',''", KEY_END),
+			     keyNew ("user/tests/canonical/TFalse", KEY_VALUE, "Disable", KEY_META, "transform/canonical/list/insensitive",
+				     "#2", KEY_META, "transform/canonical/list/insensitive/#0", "'FALSE','OFF','CLOSED','DISABLE'",
+				     KEY_META, "transform/canonical/list/insensitive/#1", "'TRUE','ON','OPEN','ENABLE'", KEY_META,
+				     "transform/canonical/list/insensitive/#2", "'OTHER','NONE',''", KEY_END),
+			     keyNew ("user/tests/canonical/TOther", KEY_VALUE, "Other", KEY_META, "transform/canonical/list/insensitive",
+				     "#2", KEY_META, "transform/canonical/list/insensitive/#0", "'FALSE','OFF','CLOSED','DISABLE'",
+				     KEY_META, "transform/canonical/list/insensitive/#1", "'TRUE','ON','OPEN','ENABLE'", KEY_META,
+				     "transform/canonical/list/insensitive/#2", "'OTHER','NONE',''", KEY_END),
+
+
+			     KS_END);
+
+	KeySet * conf = ksNew (0, KS_END);
+	PLUGIN_OPEN ("canonical");
+
+	ksRewind (ks);
+
+	succeed_if (plugin->kdbGet (plugin, ks, parentKey) != (-1), "kdbGet failed");
+
+	succeed_if (!strcmp (keyString (ksLookupByName (ks, "user/tests/canonical/TTrue", KDB_O_NONE)), "1"), "kdbGet failed on TTrue");
+	succeed_if (!strcmp (keyString (ksLookupByName (ks, "user/tests/canonical/TFalse", KDB_O_NONE)), "0"), "kdbGet failed on TFalse");
+	succeed_if (!strcmp (keyString (ksLookupByName (ks, "user/tests/canonical/TOther", KDB_O_NONE)), "2"), "kdbGet failed on match3");
+	ksDel (ks);
+
+	keyDel (parentKey);
+	PLUGIN_CLOSE ();
+}
 
 int main (int argc, char ** argv)
 {
@@ -474,6 +508,7 @@ int main (int argc, char ** argv)
 	testFNMatchSingle ();
 	testFNMatchArray ();
 	testTristateList ();
+	testTristateListToIndex ();
 	printf ("\ntestmod_canonical RESULTS: %d test(s) done. %d error(s).\n", nbTest, nbError);
 
 	return nbError;


### PR DESCRIPTION
# Purpose

Preview: Canonicalization plugin - matches keyvalue against either a list of values, posix extended regex or fnmatch and on a match brings the value to a canonical form

Some examples are in README.md

Pending decisions:
- move stringToArray helper function to a library ? 
- compilation variants for regex, lists and fnmatch ?
- per mountpoint configurations ? 

TODO:
- [ ] error handling
- [ ] cleanup
- [ ] Documentation


# Checklist

- [x] commit messages are fine (with references to issues)
- [x] I ran all tests and everything went fine
- [x] I added unit tests
- [ ] affected documentation is fixed
- [ ] I added code comments, logging, and assertions
- [ ] meta data is updated (e.g. README.md of plugins)


@markus2330 please review my pull request
