### PR TITLE
YAML Plugin: First Version

### DIFF
--- a/.oclint
+++ b/.oclint
@@ -1,3 +1,5 @@
 rule-configurations:
   - key: LONG_LINE
     value: 140
+disable-rules:
+  - GotoStatement

--- a/doc/decisions/validation.md
+++ b/doc/decisions/validation.md
@@ -2,15 +2,15 @@
 
 ## Issue
 
-Validation plugins operate as indenpendent blackboxes. 
-For every backend each mounted validation plugin iterates 
-over the whole keyset, checks every key for its trigger metakey, 
+Validation plugins operate as indenpendent blackboxes.
+For every backend each mounted validation plugin iterates
+over the whole keyset, checks every key for its trigger metakey,
 and validates the key.
 
-Currently all needed validation plugins need to be specified at 
-mount-time - if additional validation is required, the backend 
-has to be remounted with the required plugins and plugin 
-configuration. 
+Currently all needed validation plugins need to be specified at
+mount-time - if additional validation is required, the backend
+has to be remounted with the required plugins and plugin
+configuration.
 
 If validation of a key fails, each plugin decides on its own
 how to handle the issue and proceed in ways that might be
@@ -21,7 +21,7 @@ different than what is expected or desired.
 
 ## Assumptions
 
-While plugins should always fail and return an error if validation 
+While plugins should always fail and return an error if validation
 fails on kdbSet, there are be can be several different requirements
 for what should happen on kdbGet and handle problems e.g.
 
@@ -36,7 +36,7 @@ for what should happen on kdbGet and handle problems e.g.
 
   we want to read the whole configuration, but drop invalid keys
 
-  invalid keys might be replaced by default values, requested 
+  invalid keys might be replaced by default values, requested
   from the user, ...
 
 - fail with error
@@ -47,15 +47,15 @@ for what should happen on kdbGet and handle problems e.g.
 
 ## Considered Alternatives
 
-- Extend validation plugins to allow us to specify what should happen 
+- Extend validation plugins to allow us to specify what should happen
   if a key fails to validate
-- Export a validation function that allows us to use an additional plugin 
+- Export a validation function that allows us to use an additional plugin
   to decide what should be done
 
 
 ## Decision
 
-Use a wapper plugin to iterate over the keyset and delegate the validation 
+Use a wapper plugin to iterate over the keyset and delegate the validation
 of each key to the corresponding validation plugin.
 
 ## Argument
@@ -66,9 +66,9 @@ of each key to the corresponding validation plugin.
 
 ## Implications
 
-validation plugins have to export their validation routine 
+validation plugins have to export their validation routine
 
-`static int validateKey(const Key * key, const Key * errorKey)` 
+`static int validateKey(const Key * key, const Key * errorKey)`
 
 returning 1 if validation succeeded, 0 on failure
 

--- a/doc/decisions/validation.md
+++ b/doc/decisions/validation.md
@@ -2,7 +2,7 @@
 
 ## Issue
 
-Validation plugins operate as indenpendent blackboxes.
+Validation plugins operate as independent blackboxes.
 For every backend each mounted validation plugin iterates
 over the whole keyset, checks every key for its trigger metakey,
 and validates the key.
@@ -55,7 +55,7 @@ for what should happen on kdbGet and handle problems e.g.
 
 ## Decision
 
-Use a wapper plugin to iterate over the keyset and delegate the validation
+Use a wrapper plugin to iterate over the keyset and delegate the validation
 of each key to the corresponding validation plugin.
 
 ## Argument

--- a/doc/tutorials/validation.md
+++ b/doc/tutorials/validation.md
@@ -182,7 +182,7 @@ Particularly a _Specfile_ contains metadata that defines
 
 Let us create an example _Specfile_ in the dump format, which supports metadata
 (altough the specfile is stored in the dump format, we can still create it using
-the human readable [ni format](/doc/src/plugins/ni/README.md) by using `kdb import`):
+the human readable [ni format](/src/plugins/ni/README.md) by using `kdb import`):
 ```sh
 kdb mount tutorial.dump spec/tutorial dump
 cat << HERE | kdb import spec/tutorial ni

--- a/src/error/specification
+++ b/src/error/specification
@@ -528,7 +528,7 @@ number:87
 description:memory allocation error
 severity:error
 ingroup:plugin
-macro:MALLOC_ERROR
+macro:MALLOC
 
 number:88
 description:could not sync directory

--- a/src/include/kdbassert.h
+++ b/src/include/kdbassert.h
@@ -15,12 +15,12 @@ extern "C" {
 
 void elektraAbort (const char * expression, const char * function, const char * file, const int line, const char * msg, ...)
 #ifdef __GNUC__
-	__attribute__ ((format (printf, 5, 6)))
-#endif
-
-// For scan-build / clang analyzer to detect our assertions abort
+	__attribute__ ((format (printf, 5, 6))) __attribute__ ((__noreturn__))
+#else
 #ifdef __clang_analyzer__
+	// For scan-build / clang analyzer to detect our assertions abort
 	__attribute__ ((analyzer_noreturn))
+#endif
 #endif
 	;
 

--- a/src/plugins/README.md
+++ b/src/plugins/README.md
@@ -112,6 +112,7 @@ productive use:
 - [mozprefs](mozprefs/) for Mozilla preference files
 - [c](c/) writes Elektra C-structures (`ksNew(.. keyNew(...`)
 - [file](file/) reads and writes a file from/to a single key
+- [yaml](yaml/) reads and writes a very limited subset of [YAML](http://www.yaml.org)
 
 ### System Information
 

--- a/src/plugins/file/file.c
+++ b/src/plugins/file/file.c
@@ -63,8 +63,7 @@ int elektraFileGet (Plugin * handle ELEKTRA_UNUSED, KeySet * returned ELEKTRA_UN
 
 	if (!buffer)
 	{
-		ELEKTRA_SET_ERRORF (ELEKTRA_ERROR_MALLOC_ERROR, parentKey, "failed to allocate buffer of %lld bytes for %s", fileSize,
-				    fileName);
+		ELEKTRA_SET_ERRORF (ELEKTRA_ERROR_MALLOC, parentKey, "failed to allocate buffer of %lld bytes for %s", fileSize, fileName);
 		return -1;
 	}
 
@@ -157,7 +156,7 @@ int elektraFileSet (Plugin * handle ELEKTRA_UNUSED, KeySet * returned ELEKTRA_UN
 	unsigned char * value = elektraMalloc (valueSize);
 	if (!value)
 	{
-		ELEKTRA_SET_ERRORF (ELEKTRA_ERROR_MALLOC_ERROR, parentKey, "failed to allocate buffer of %zd bytes", valueSize);
+		ELEKTRA_SET_ERRORF (ELEKTRA_ERROR_MALLOC, parentKey, "failed to allocate buffer of %zd bytes", valueSize);
 		fclose (fp);
 		return -1;
 	}

--- a/src/plugins/mini/mini.c
+++ b/src/plugins/mini/mini.c
@@ -360,7 +360,7 @@ int elektraMiniSet (Plugin * handle ELEKTRA_UNUSED, KeySet * returned, Key * par
 	if (!destination)
 	{
 		ELEKTRA_LOG_WARNING ("Could not open file “%s” for writing: %s", keyString (parentKey), strerror (errno));
-		ELEKTRA_SET_ERROR_GET (parentKey);
+		ELEKTRA_SET_ERROR_SET (parentKey);
 		errno = errorNumber;
 		return ELEKTRA_PLUGIN_STATUS_ERROR;
 	}

--- a/src/plugins/yaml/CMakeLists.txt
+++ b/src/plugins/yaml/CMakeLists.txt
@@ -4,5 +4,7 @@ add_plugin (yaml
 	SOURCES
 		yaml.h
 		yaml.c
+	LINK_ELEKTRA
+		elektra-ease
 	ADD_TEST
 	)

--- a/src/plugins/yaml/CMakeLists.txt
+++ b/src/plugins/yaml/CMakeLists.txt
@@ -1,0 +1,8 @@
+include (LibAddMacros)
+
+add_plugin (yaml
+	SOURCES
+		yaml.h
+		yaml.c
+	ADD_TEST
+	)

--- a/src/plugins/yaml/README.md
+++ b/src/plugins/yaml/README.md
@@ -1,0 +1,18 @@
+- infos = Information about the yaml plugin is in keys below
+- infos/author = René Schwaiger <sanssecours@me.com>
+- infos/licence = BSD
+- infos/needs =
+- infos/provides =
+- infos/recommends =
+- infos/placements =
+- infos/status = maintained preview experimental unfinished concept discouraged
+- infos/metadata =
+- infos/description = A very basic plugin that reads and writes a very small subset of YAML
+
+## Introduction
+
+This plugin reads and writes configuration data in the data serialization language [YAML](http://www.yaml.org).
+
+## Limitations
+
+Currently this plugin **does not offer any functionality**.

--- a/src/plugins/yaml/README.md
+++ b/src/plugins/yaml/README.md
@@ -25,9 +25,14 @@ kdb set /examples/yaml/key value
 kdb get /examples/yaml/key
 #> value
 
+kdb set /examples/yaml/kittens "warm & fuzzy"
+kdb get /examples/yaml/kittens
+#> warm & fuzzy
+
 kdb export /examples/yaml yaml
 #> {
 #>   "key" : "value"
+#> , "kittens" : "warm & fuzzy"
 #> }
 
 kdb rm -r /examples/yaml

--- a/src/plugins/yaml/README.md
+++ b/src/plugins/yaml/README.md
@@ -29,9 +29,12 @@ kdb set /examples/yaml/kittens "warm & fuzzy"
 kdb get /examples/yaml/kittens
 #> warm & fuzzy
 
+kdb set /examples/yaml/empty ""
+
 kdb export /examples/yaml yaml
 #> {
-#>   "key" : "value"
+#>   "empty" : ""
+#> , "key" : "value"
 #> , "kittens" : "warm & fuzzy"
 #> }
 

--- a/src/plugins/yaml/README.md
+++ b/src/plugins/yaml/README.md
@@ -30,6 +30,7 @@ kdb export /examples/yaml yaml
 #>   "key" : "value"
 #> }
 
+kdb rm -r /examples/yaml
 kdb umount /examples/yaml
 ```
 

--- a/src/plugins/yaml/README.md
+++ b/src/plugins/yaml/README.md
@@ -18,7 +18,7 @@ This plugin reads configuration data specified in a **very limited** subset of  
 ### Basic Usage
 
 ```sh
-# Mount mini plugin to cascading namespace `/examples/yaml`
+# Mount yaml plugin to cascading namespace `/examples/yaml`
 kdb mount config.yaml /examples/yaml yaml
 
 kdb set /examples/yaml/key value

--- a/src/plugins/yaml/README.md
+++ b/src/plugins/yaml/README.md
@@ -11,8 +11,19 @@
 
 ## Introduction
 
-This plugin reads and writes configuration data in the data serialization language [YAML](http://www.yaml.org).
+This plugin reads configuration data specified in a **very limited** subset of  the data serialization language [YAML](http://www.yaml.org).
+
+## Examples
+
+### Basic Usage
+
+```sh
+# Mount mini plugin to cascading namespace `/examples/yaml`
+kdb mount config.yaml /examples/yaml yaml
+
+kdb umount /examples/yaml
+```
 
 ## Limitations
 
-Currently this plugin **does not offer any functionality**.
+Currently this plugin **should not be used by anyone**.

--- a/src/plugins/yaml/README.md
+++ b/src/plugins/yaml/README.md
@@ -21,6 +21,15 @@ This plugin reads configuration data specified in a **very limited** subset of  
 # Mount mini plugin to cascading namespace `/examples/yaml`
 kdb mount config.yaml /examples/yaml yaml
 
+kdb set /examples/yaml/key value
+kdb get /examples/yaml/key
+#> value
+
+kdb export /examples/yaml yaml
+#> {
+#>   "key" : "value"
+#> }
+
 kdb umount /examples/yaml
 ```
 

--- a/src/plugins/yaml/testmod_yaml.c
+++ b/src/plugins/yaml/testmod_yaml.c
@@ -1,0 +1,48 @@
+/**
+ * @file
+ *
+ * @brief Tests for yaml plugin
+ *
+ * @copyright BSD License (see doc/LICENSE.md or https://www.libelektra.org)
+ *
+ */
+
+#include <stdlib.h>
+#include <string.h>
+
+#include <kdbconfig.h>
+
+#include <tests_plugin.h>
+
+static void test_basics ()
+{
+	printf ("• Test basic functionality of plugin\n");
+
+	Key * parentKey = keyNew ("user/tests/yaml", KEY_END);
+	KeySet * conf = ksNew (0, KS_END);
+	PLUGIN_OPEN ("yaml");
+
+	KeySet * ks = ksNew (0, KS_END);
+
+	succeed_if (plugin->kdbGet (plugin, ks, parentKey) == ELEKTRA_PLUGIN_STATUS_NO_UPDATE, "Call of kdbGet was not successful");
+	succeed_if (plugin->kdbSet (plugin, ks, parentKey) == ELEKTRA_PLUGIN_STATUS_NO_UPDATE, "Call of kdbSet was not successful");
+
+	keyDel (parentKey);
+	ksDel (ks);
+	PLUGIN_CLOSE ();
+}
+
+
+int main (int argc, char ** argv)
+{
+	printf ("🐪 YAML Tests\n");
+	printf ("==============\n\n");
+
+	init (argc, argv);
+
+	test_basics ();
+
+	printf ("\nResults: %d Test%s done — %d error%s.\n", nbTest, nbTest != 1 ? "s" : "", nbError, nbError != 1 ? "s" : "");
+
+	return nbError;
+}

--- a/src/plugins/yaml/testmod_yaml.c
+++ b/src/plugins/yaml/testmod_yaml.c
@@ -35,6 +35,28 @@ static void test_basics ()
 	PLUGIN_CLOSE ();
 }
 
+static void test_get ()
+{
+	char const * const fileName = "yaml/simple.yaml";
+	printf ("• Parse file “%s”\n", fileName);
+
+	char const * const prefix = "user/yaml/tests/read";
+	Key * parentKey = keyNew (prefix, KEY_VALUE, srcdir_file (fileName), KEY_END);
+	KeySet * conf = ksNew (0, KS_END);
+	PLUGIN_OPEN ("yaml");
+
+	KeySet * keySet = ksNew (0, KS_END);
+
+	int status = plugin->kdbGet (plugin, keySet, parentKey);
+
+	succeed_if (status == ELEKTRA_PLUGIN_STATUS_SUCCESS || status == ELEKTRA_PLUGIN_STATUS_NO_UPDATE, "Unable to open or parse file");
+	succeed_if (output_error (parentKey), "Received unexpected error while reading the configuration");
+
+	keyDel (parentKey);
+	ksDel (keySet);
+	PLUGIN_CLOSE ();
+}
+
 // ========
 // = Main =
 // ========
@@ -47,6 +69,7 @@ int main (int argc, char ** argv)
 	init (argc, argv);
 
 	test_basics ();
+	test_get ();
 
 	printf ("\nResults: %d Test%s done — %d error%s.\n", nbTest, nbTest != 1 ? "s" : "", nbError, nbError != 1 ? "s" : "");
 

--- a/src/plugins/yaml/testmod_yaml.c
+++ b/src/plugins/yaml/testmod_yaml.c
@@ -16,6 +16,10 @@
 
 #include <tests_plugin.h>
 
+/* -- Macros ---------------------------------------------------------------------------------------------------------------------------- */
+
+#define MAX_LENGTH_TEXT 500
+
 /* -- Functions ------------------------------------------------------------------------------------------------------------------------- */
 
 static void test_basics ()
@@ -51,6 +55,25 @@ static void test_get ()
 
 	succeed_if (status == ELEKTRA_PLUGIN_STATUS_SUCCESS || status == ELEKTRA_PLUGIN_STATUS_NO_UPDATE, "Unable to open or parse file");
 	succeed_if (output_error (parentKey), "Received unexpected error while reading the configuration");
+
+	char keyValues[][2][50] = {
+		{ "hello", "world" },
+	};
+
+	Key * key;
+	char text[MAX_LENGTH_TEXT];
+	for (size_t pair = 0; pair < sizeof (keyValues) / sizeof (keyValues[0]); pair++)
+	{
+		char * name = keyValues[pair][0];
+		char * value = keyValues[pair][1];
+		snprintf (text, MAX_LENGTH_TEXT, "%s/%s", prefix, name);
+		key = ksLookupByName (keySet, text, KDB_O_NONE);
+
+		snprintf (text, MAX_LENGTH_TEXT, "Key “%s” not found", name);
+		exit_if_fail (key, text);
+
+		succeed_if_same_string (keyString (key), value);
+	}
 
 	keyDel (parentKey);
 	ksDel (keySet);

--- a/src/plugins/yaml/testmod_yaml.c
+++ b/src/plugins/yaml/testmod_yaml.c
@@ -22,14 +22,13 @@ static void test_basics ()
 {
 	printf ("• Test basic functionality of plugin\n");
 
-	Key * parentKey = keyNew ("user/tests/yaml", KEY_END);
+	Key * parentKey = keyNew ("system/elektra/modules/yaml", KEY_END);
 	KeySet * conf = ksNew (0, KS_END);
 	PLUGIN_OPEN ("yaml");
 
 	KeySet * ks = ksNew (0, KS_END);
 
-	succeed_if (plugin->kdbGet (plugin, ks, parentKey) == ELEKTRA_PLUGIN_STATUS_NO_UPDATE, "Call of kdbGet was not successful");
-	succeed_if (plugin->kdbSet (plugin, ks, parentKey) == ELEKTRA_PLUGIN_STATUS_NO_UPDATE, "Call of kdbSet was not successful");
+	succeed_if (plugin->kdbGet (plugin, ks, parentKey) == ELEKTRA_PLUGIN_STATUS_SUCCESS, "Could not retrieve plugin contract");
 
 	keyDel (parentKey);
 	ksDel (ks);

--- a/src/plugins/yaml/testmod_yaml.c
+++ b/src/plugins/yaml/testmod_yaml.c
@@ -7,12 +7,16 @@
  *
  */
 
+/* -- Imports --------------------------------------------------------------------------------------------------------------------------- */
+
 #include <stdlib.h>
 #include <string.h>
 
 #include <kdbconfig.h>
 
 #include <tests_plugin.h>
+
+/* -- Functions ------------------------------------------------------------------------------------------------------------------------- */
 
 static void test_basics ()
 {
@@ -32,6 +36,9 @@ static void test_basics ()
 	PLUGIN_CLOSE ();
 }
 
+// ========
+// = Main =
+// ========
 
 int main (int argc, char ** argv)
 {

--- a/src/plugins/yaml/yaml.c
+++ b/src/plugins/yaml/yaml.c
@@ -89,9 +89,9 @@ typedef struct
 
 /* -- Functions ------------------------------------------------------------------------------------------------------------------------- */
 
-// ===========
-// = Private =
-// ===========
+// ========
+// = Misc =
+// ========
 
 static parserType * setError (parserType * const parser, statusType status)
 {
@@ -103,62 +103,9 @@ static parserType * setError (parserType * const parser, statusType status)
 	return parser;
 }
 
-/**
- * @brief Open a file for reading
- *
- * @pre The parameters `parser` and `parser->parentKey` must not be `NULL`
- *
- * @param parser Saves the filename of the file this function opens
- *
- * @retval The updated parsing structure. If there were any errors opening the file, then this function sets the type of the parsing
- * 	   structure to `ERROR_FILE_OPEN`.
- */
-static parserType * openFile (parserType * const parser)
-{
-	ASSERT_NOT_NULL (parser);
-	ASSERT_NOT_NULL (parser->parentKey);
-
-	parser->file = fopen (keyString (parser->parentKey), "r");
-
-	if (!parser->file) setError (parser, ERROR_FILE_OPEN);
-
-	return parser;
-}
-
-/**
- * @brief Free allocated resources
- *
- * @pre The parameter `parser` must not be `NULL`
- *
- * @param parser Contains resources this function frees
- *
- * @retval The updated parsing structure. If there were any errors closing the file specified via `parser`, then this function sets the
- *         type of the parsing structure to `ERROR_FILE_CLOSE`.
- */
-static parserType * cleanup (parserType * const parser)
-{
-	ASSERT_NOT_NULL (parser);
-
-	if (parser->file && fclose (parser->file) != 0) setError (parser, ERROR_FILE_CLOSE);
-	if (parser->bufferBase) free (parser->bufferBase);
-
-	return parser;
-}
-
-/**
- * @brief This function returns a key set containing the contract of this plugin.
- *
- * @return A contract describing the functionality of this plugin.
- */
-static KeySet * contractYaml ()
-{
-	return ksNew (30, keyNew ("system/elektra/modules/yaml", KEY_VALUE, "yaml plugin waits for your orders", KEY_END),
-		      keyNew ("system/elektra/modules/yaml/exports", KEY_END),
-		      keyNew ("system/elektra/modules/yaml/exports/get", KEY_FUNC, elektraYamlGet, KEY_END),
-		      keyNew ("system/elektra/modules/yaml/exports/set", KEY_FUNC, elektraYamlSet, KEY_END),
-#include ELEKTRA_README (yaml)
-		      keyNew ("system/elektra/modules/yaml/infos/version", KEY_VALUE, PLUGINVERSION, KEY_END), KS_END);
-}
+// ===========
+// = Parsing =
+// ===========
 
 static parserType * assertNumberCharsAvailable (parserType * const parser, size_t numberChars)
 {
@@ -328,6 +275,52 @@ static parserType * pair (parserType * const parser)
 	return parser;
 }
 
+// =====================
+// = Resource Handling =
+// =====================
+
+/**
+ * @brief Open a file for reading
+ *
+ * @pre The parameters `parser` and `parser->parentKey` must not be `NULL`
+ *
+ * @param parser Saves the filename of the file this function opens
+ *
+ * @retval The updated parsing structure. If there were any errors opening the file, then this function sets the type of the parsing
+ * 	   structure to `ERROR_FILE_OPEN`.
+ */
+static parserType * openFile (parserType * const parser)
+{
+	ASSERT_NOT_NULL (parser);
+	ASSERT_NOT_NULL (parser->parentKey);
+
+	parser->file = fopen (keyString (parser->parentKey), "r");
+
+	if (!parser->file) setError (parser, ERROR_FILE_OPEN);
+
+	return parser;
+}
+
+/**
+ * @brief Free allocated resources
+ *
+ * @pre The parameter `parser` must not be `NULL`
+ *
+ * @param parser Contains resources this function frees
+ *
+ * @retval The updated parsing structure. If there were any errors closing the file specified via `parser`, then this function sets the
+ *         type of the parsing structure to `ERROR_FILE_CLOSE`.
+ */
+static parserType * cleanup (parserType * const parser)
+{
+	ASSERT_NOT_NULL (parser);
+
+	if (parser->file && fclose (parser->file) != 0) setError (parser, ERROR_FILE_CLOSE);
+	if (parser->bufferBase) free (parser->bufferBase);
+
+	return parser;
+}
+
 /**
  * @brief Parse a file containing data specified in a very basic subset of YAML and store the obtained data in a given key set.
  *
@@ -362,6 +355,21 @@ static int parseFile (KeySet * returned ELEKTRA_UNUSED, Key * parentKey)
 	cleanup (parser);
 
 	return parser->status == OK ? ELEKTRA_PLUGIN_STATUS_SUCCESS : ELEKTRA_PLUGIN_STATUS_ERROR;
+}
+
+/**
+ * @brief This function returns a key set containing the contract of this plugin.
+ *
+ * @return A contract describing the functionality of this plugin.
+ */
+static KeySet * contractYaml ()
+{
+	return ksNew (30, keyNew ("system/elektra/modules/yaml", KEY_VALUE, "yaml plugin waits for your orders", KEY_END),
+		      keyNew ("system/elektra/modules/yaml/exports", KEY_END),
+		      keyNew ("system/elektra/modules/yaml/exports/get", KEY_FUNC, elektraYamlGet, KEY_END),
+		      keyNew ("system/elektra/modules/yaml/exports/set", KEY_FUNC, elektraYamlSet, KEY_END),
+#include ELEKTRA_README (yaml)
+		      keyNew ("system/elektra/modules/yaml/infos/version", KEY_VALUE, PLUGINVERSION, KEY_END), KS_END);
 }
 
 // ====================

--- a/src/plugins/yaml/yaml.c
+++ b/src/plugins/yaml/yaml.c
@@ -151,6 +151,7 @@ static parserType * getNextChar (parserType * parser)
 static parserType * putBackChars (parserType * parser, size_t numberChars)
 {
 	ASSERT_NOT_NULL (parser);
+	ELEKTRA_ASSERT (parser->buffer - numberChars >= parser->bufferBase, "Can not put back more characters than available.");
 
 	parser->bufferCharsAvailable += numberChars;
 	parser->buffer -= numberChars;

--- a/src/plugins/yaml/yaml.c
+++ b/src/plugins/yaml/yaml.c
@@ -139,7 +139,7 @@ static parserType * getNextChar (parserType * parser)
 {
 	ASSERT_NOT_NULL (parser);
 
-	if (assertNumberCharsAvailable (parser, 1)->status != OK) return parser;
+	RET_NOK (assertNumberCharsAvailable (parser, 1));
 
 	parser->bufferCharsAvailable--;
 	parser->text = parser->buffer;
@@ -164,7 +164,7 @@ static bool acceptChars (parserType * const parser, char const * const character
 	ASSERT_NOT_NULL (parser->file);
 	ASSERT_NOT_NULL (characters);
 
-	if (getNextChar (parser)->status != OK) return parser;
+	RET_NOK (getNextChar (parser));
 
 	for (size_t charIndex = 0; charIndex < numberCharacters; charIndex++)
 	{
@@ -193,10 +193,7 @@ static parserType * expect (parserType * const parser, char const character)
 	ASSERT_NOT_NULL (parser);
 
 	bool found = acceptChar (parser, character);
-	if (parser->status != OK)
-	{
-		return parser;
-	}
+	RET_NOK (parser);
 
 	if (!found)
 	{
@@ -239,11 +236,7 @@ static parserType * readUntilDoubleQuote (parserType * const parser)
 		LOG_PARSE (parser, "Read character “%c”", *parser->text);
 		previous = parser->text;
 	}
-
-	if (parser->status != OK)
-	{
-		return parser;
-	}
+	RET_NOK (parser);
 
 	*parser->text = '\0';
 	parser->text = text;

--- a/src/plugins/yaml/yaml.c
+++ b/src/plugins/yaml/yaml.c
@@ -245,7 +245,7 @@ static parserType * whitespace (parserType * const parser)
 	ASSERT_NOT_NULL (parser);
 	ASSERT_NOT_NULL (parser->file);
 
-	while (acceptChars (parser, " \t")->status == OK && parser->text)
+	while (acceptChars (parser, " \t\n")->status == OK && parser->text)
 		; //! OCLINT
 
 	return parser;

--- a/src/plugins/yaml/yaml.c
+++ b/src/plugins/yaml/yaml.c
@@ -202,7 +202,15 @@ static parserType * acceptChars (parserType * const parser, char const * const c
 	{
 		LOG_PARSE (parser, "Accepted character “%c”", *lastCharacter);
 		parser->text = lastCharacter;
-		parser->column++;
+		if (*lastCharacter == '\n')
+		{
+			parser->line++;
+			parser->column = 1;
+		}
+		else
+		{
+			parser->column++;
+		}
 		return parser;
 	}
 	LOG_PARSE (parser, "Put back character “%c”", *lastCharacter);

--- a/src/plugins/yaml/yaml.c
+++ b/src/plugins/yaml/yaml.c
@@ -318,6 +318,14 @@ static parserType * pair (parserType * const parser)
 	RET_NOK (expect (parser, "}"));
 	LOG_PARSE (parser, "“%s: %s”", parser->key, parser->value);
 
+	Key * key = keyNew (keyName (parser->parentKey), KEY_END);
+	keyAddName (key, parser->key);
+	keySetString (key, parser->value);
+	ELEKTRA_LOG_DEBUG ("Name:  “%s”", keyName (key));
+	ELEKTRA_LOG_DEBUG ("Value: “%s”", keyString (key));
+
+	ksAppendKey (parser->keySet, key);
+
 	return parser;
 }
 

--- a/src/plugins/yaml/yaml.c
+++ b/src/plugins/yaml/yaml.c
@@ -136,14 +136,16 @@ static parserType * readNumberChars (parserType * const parser, size_t numberCha
 
 	while (parser->bufferCharsAvailable < numberChars && (numberCharsRead = getline (&line, &capacity, parser->file)) != -1)
 	{
+		size_t bufferOffset = parser->buffer - parser->bufferBase;
 		size_t bufferCharsAvailable = parser->bufferCharsAvailable + numberCharsRead;
-		if ((parser->bufferBase == 0 && (parser->bufferBase = elektraMalloc (bufferCharsAvailable)) == NULL) ||
-		    ((elektraRealloc ((void **)&parser->bufferBase, bufferCharsAvailable + 1) < 0)))
+		size_t bufferSize = bufferOffset + bufferCharsAvailable + 1;
+		if ((parser->bufferBase == 0 && (parser->bufferBase = elektraMalloc (bufferSize)) == NULL) ||
+		    ((elektraRealloc ((void **)&parser->bufferBase, bufferSize) < 0)))
 		{
-			return setErrorMalloc (parser, bufferCharsAvailable + 1);
+			return setErrorMalloc (parser, bufferSize);
 		}
-		strncpy (parser->bufferBase + parser->bufferCharsAvailable, line, numberCharsRead + 1);
-		if (!parser->buffer) parser->buffer = parser->bufferBase;
+		strncpy (parser->bufferBase + bufferOffset, line, numberCharsRead + 1);
+		parser->buffer = parser->bufferBase + bufferOffset;
 		free (line);
 
 		parser->bufferCharsAvailable = bufferCharsAvailable;

--- a/src/plugins/yaml/yaml.c
+++ b/src/plugins/yaml/yaml.c
@@ -74,12 +74,7 @@ typedef struct
 /* -- Macros ---------------------------------------------------------------------------------------------------------------------------- */
 
 #define LOG_PARSE(data, message, ...)                                                                                                      \
-	{                                                                                                                                  \
-		char filename[MAXPATHLEN];                                                                                                 \
-		basename_r (keyString (data->parentKey), filename);                                                                        \
-		ELEKTRA_LOG_DEBUG ("%s:%lu:%lu: " message, filename, data->line, data->column, __VA_ARGS__);                               \
-	}
-
+	ELEKTRA_LOG_DEBUG ("%s:%lu:%lu: " message, strrchr (keyString (data->parentKey), '/') + 1, data->line, data->column, __VA_ARGS__);
 #define SET_ERROR_PARSE(data, message, ...)                                                                                                \
 	ELEKTRA_SET_ERRORF (ELEKTRA_ERROR_PARSE, data->parentKey, "%s:%lu:%lu: " message, keyString (data->parentKey), data->line,         \
 			    data->column, __VA_ARGS__);

--- a/src/plugins/yaml/yaml.c
+++ b/src/plugins/yaml/yaml.c
@@ -124,9 +124,5 @@ int elektraYamlSet (Plugin * handle ELEKTRA_UNUSED, KeySet * returned ELEKTRA_UN
 
 Plugin * ELEKTRA_PLUGIN_EXPORT (yaml)
 {
-	// clang-format off
-	return elektraPluginExport ("yaml",
-		ELEKTRA_PLUGIN_GET,	&elektraYamlGet,
-		ELEKTRA_PLUGIN_SET,	&elektraYamlSet,
-		ELEKTRA_PLUGIN_END);
+	return elektraPluginExport ("yaml", ELEKTRA_PLUGIN_GET, &elektraYamlGet, ELEKTRA_PLUGIN_SET, &elektraYamlSet, ELEKTRA_PLUGIN_END);
 }

--- a/src/plugins/yaml/yaml.c
+++ b/src/plugins/yaml/yaml.c
@@ -167,6 +167,16 @@ static parserType * getNextChar (parserType * parser)
 		return parser;
 	}
 
+	if (*parser->buffer == '\n')
+	{
+		parser->line++;
+		parser->column = 1;
+	}
+	else
+	{
+		parser->column++;
+	}
+
 	parser->bufferCharsAvailable--;
 	parser->text = parser->buffer;
 	parser->buffer++;
@@ -179,6 +189,9 @@ static parserType * putBackChar (parserType * parser)
 	ASSERT_NOT_NULL (parser);
 	ELEKTRA_ASSERT (parser->buffer - 1 >= parser->bufferBase, "Can not put back more characters than available.");
 
+	// We assume that we never put back the newline character
+	ELEKTRA_ASSERT (*(parser->buffer - 1) != '\n', "Tried to put back newline character.");
+	parser->column--;
 	parser->bufferCharsAvailable++;
 	parser->buffer--;
 
@@ -200,15 +213,6 @@ static parserType * acceptChars (parserType * const parser, char const * const c
 	{
 		LOG_PARSE (parser, "Accepted character “%c”", *lastCharacter);
 		parser->text = lastCharacter;
-		if (*lastCharacter == '\n')
-		{
-			parser->line++;
-			parser->column = 1;
-		}
-		else
-		{
-			parser->column++;
-		}
 		return parser;
 	}
 	LOG_PARSE (parser, "Put back character “%c”", *lastCharacter);

--- a/src/plugins/yaml/yaml.c
+++ b/src/plugins/yaml/yaml.c
@@ -513,16 +513,15 @@ int elektraYamlSet (Plugin * handle ELEKTRA_UNUSED, KeySet * returned ELEKTRA_UN
 	int errorNumber = errno;
 	FILE * destination = fopen (keyString (parentKey), "w");
 
-	if (!destination) goto error;
 	// The bitwise or in the next line is correct, since we need to close the file even if writing fails
-	if ((writeFile (destination, returned, parentKey) < 0) | (fclose (destination) == EOF)) goto error; //! OCLint
+	if (!destination || (writeFile (destination, returned, parentKey) < 0) | (fclose (destination) == EOF)) //! OCLint
+	{
+		ELEKTRA_SET_ERROR_SET (parentKey);
+		errno = errorNumber;
+		return ELEKTRA_PLUGIN_STATUS_ERROR;
+	}
 
 	return ELEKTRA_PLUGIN_STATUS_SUCCESS;
-
-error:
-	ELEKTRA_SET_ERROR_SET (parentKey);
-	errno = errorNumber;
-	return ELEKTRA_PLUGIN_STATUS_ERROR;
 }
 
 Plugin * ELEKTRA_PLUGIN_EXPORT (yaml)

--- a/src/plugins/yaml/yaml.c
+++ b/src/plugins/yaml/yaml.c
@@ -466,6 +466,7 @@ static parserType * saveText (parserType * const parser, char ** location)
 	ASSERT_NOT_NULL (location);
 
 	size_t length = parser->end - parser->match + 1;
+	if (*location) free (*location);
 	*location = elektraMalloc (length + 1);
 	if (!*location) return setErrorMalloc (parser, length + 1);
 

--- a/src/plugins/yaml/yaml.c
+++ b/src/plugins/yaml/yaml.c
@@ -269,7 +269,7 @@ static parserType * content (parserType * const parser)
 		previous = parser->match;
 	}
 	RET_NOK (parser);
-	if (parser->match && *parser->match == '"')
+	if (*(parser->buffer - 1) == '"')
 	{
 		putBackChar (parser);
 		numberCharsRead--;
@@ -326,15 +326,13 @@ static parserType * saveText (parserType * const parser, char ** location)
 static parserType * key (parserType * const parser)
 {
 	RET_NOK (doubleQuotedSpace (parser));
-	RET_NOK (saveText (parser, &parser->key));
-	return parser;
+	return saveText (parser, &parser->key);
 }
 
 static parserType * value (parserType * const parser)
 {
 	RET_NOK (doubleQuotedSpace (parser));
-	RET_NOK (saveText (parser, &parser->value));
-	return parser;
+	return saveText (parser, &parser->value);
 }
 
 static parserType * pair (parserType * const parser)

--- a/src/plugins/yaml/yaml.c
+++ b/src/plugins/yaml/yaml.c
@@ -10,9 +10,30 @@
 /* -- Imports --------------------------------------------------------------------------------------------------------------------------- */
 
 #include "yaml.h"
+
 #include <kdbhelper.h>
+#include <kdblogger.h>
 
 /* -- Functions ------------------------------------------------------------------------------------------------------------------------- */
+
+// ===========
+// = Private =
+// ===========
+
+/**
+ * @brief This function returns a key set containing the contract of this plugin.
+ *
+ * @return A contract describing the functionality of this plugin.
+ */
+static inline KeySet * contractYaml ()
+{
+	return ksNew (30, keyNew ("system/elektra/modules/yaml", KEY_VALUE, "yaml plugin waits for your orders", KEY_END),
+		      keyNew ("system/elektra/modules/yaml/exports", KEY_END),
+		      keyNew ("system/elektra/modules/yaml/exports/get", KEY_FUNC, elektraYamlGet, KEY_END),
+		      keyNew ("system/elektra/modules/yaml/exports/set", KEY_FUNC, elektraYamlSet, KEY_END),
+#include ELEKTRA_README (yaml)
+		      keyNew ("system/elektra/modules/yaml/infos/version", KEY_VALUE, PLUGINVERSION, KEY_END), KS_END);
+}
 
 // ====================
 // = Plugin Interface =
@@ -23,13 +44,8 @@ int elektraYamlGet (Plugin * handle ELEKTRA_UNUSED, KeySet * returned ELEKTRA_UN
 {
 	if (!elektraStrCmp (keyName (parentKey), "system/elektra/modules/yaml"))
 	{
-		KeySet * contract =
-			ksNew (30, keyNew ("system/elektra/modules/yaml", KEY_VALUE, "yaml plugin waits for your orders", KEY_END),
-			       keyNew ("system/elektra/modules/yaml/exports", KEY_END),
-			       keyNew ("system/elektra/modules/yaml/exports/get", KEY_FUNC, elektraYamlGet, KEY_END),
-			       keyNew ("system/elektra/modules/yaml/exports/set", KEY_FUNC, elektraYamlSet, KEY_END),
-#include ELEKTRA_README (yaml)
-			       keyNew ("system/elektra/modules/yaml/infos/version", KEY_VALUE, PLUGINVERSION, KEY_END), KS_END);
+		ELEKTRA_LOG_DEBUG ("Retrieve plugin contract");
+		KeySet * contract = contractYaml ();
 		ksAppend (returned, contract);
 		ksDel (contract);
 

--- a/src/plugins/yaml/yaml.c
+++ b/src/plugins/yaml/yaml.c
@@ -1,0 +1,46 @@
+/**
+ * @file
+ *
+ * @brief Source for yaml plugin
+ *
+ * @copyright BSD License (see doc/LICENSE.md or https://www.libelektra.org)
+ *
+ */
+
+#include "yaml.h"
+
+#include <kdbhelper.h>
+
+int elektraYamlGet (Plugin * handle ELEKTRA_UNUSED, KeySet * returned ELEKTRA_UNUSED, Key * parentKey ELEKTRA_UNUSED)
+{
+	if (!elektraStrCmp (keyName (parentKey), "system/elektra/modules/yaml"))
+	{
+		KeySet * contract =
+			ksNew (30, keyNew ("system/elektra/modules/yaml", KEY_VALUE, "yaml plugin waits for your orders", KEY_END),
+			       keyNew ("system/elektra/modules/yaml/exports", KEY_END),
+			       keyNew ("system/elektra/modules/yaml/exports/get", KEY_FUNC, elektraYamlGet, KEY_END),
+			       keyNew ("system/elektra/modules/yaml/exports/set", KEY_FUNC, elektraYamlSet, KEY_END),
+#include ELEKTRA_README (yaml)
+			       keyNew ("system/elektra/modules/yaml/infos/version", KEY_VALUE, PLUGINVERSION, KEY_END), KS_END);
+		ksAppend (returned, contract);
+		ksDel (contract);
+
+		return ELEKTRA_PLUGIN_STATUS_SUCCESS;
+	}
+
+	return ELEKTRA_PLUGIN_STATUS_NO_UPDATE;
+}
+
+int elektraYamlSet (Plugin * handle ELEKTRA_UNUSED, KeySet * returned ELEKTRA_UNUSED, Key * parentKey ELEKTRA_UNUSED)
+{
+	return ELEKTRA_PLUGIN_STATUS_NO_UPDATE;
+}
+
+Plugin * ELEKTRA_PLUGIN_EXPORT (yaml)
+{
+	// clang-format off
+	return elektraPluginExport ("yaml",
+		ELEKTRA_PLUGIN_GET,	&elektraYamlGet,
+		ELEKTRA_PLUGIN_SET,	&elektraYamlSet,
+		ELEKTRA_PLUGIN_END);
+}

--- a/src/plugins/yaml/yaml.c
+++ b/src/plugins/yaml/yaml.c
@@ -187,10 +187,10 @@ static parserType * getNextChar (parserType * parser)
 static parserType * putBackChar (parserType * parser)
 {
 	ASSERT_NOT_NULL (parser);
-	ELEKTRA_ASSERT (parser->buffer - 1 >= parser->bufferBase, "Can not put back more characters than available.");
+	ELEKTRA_ASSERT (parser->buffer - 1 >= parser->bufferBase, "Can not put back more characters than available");
 
 	// We assume that we never put back the newline character
-	ELEKTRA_ASSERT (*(parser->buffer - 1) != '\n', "Tried to put back newline character.");
+	ELEKTRA_ASSERT (*(parser->buffer - 1) != '\n', "Tried to put back newline character");
 	parser->column--;
 	parser->bufferCharsAvailable++;
 	parser->buffer--;

--- a/src/plugins/yaml/yaml.c
+++ b/src/plugins/yaml/yaml.c
@@ -178,6 +178,8 @@ static parserType * putBackChars (parserType * parser, size_t numberChars)
 	ASSERT_NOT_NULL (parser);
 	ELEKTRA_ASSERT (parser->buffer - numberChars >= parser->bufferBase, "Can not put back more characters than available.");
 
+	LOG_PARSE (parser, "Put back %lu characters", numberChars);
+
 	parser->bufferCharsAvailable += numberChars;
 	parser->buffer -= numberChars;
 

--- a/src/plugins/yaml/yaml.c
+++ b/src/plugins/yaml/yaml.c
@@ -297,7 +297,7 @@ static parserType * readUntilDoubleQuote (parserType * const parser)
 		return parser;
 	}
 
-	*(parser->text + 1) = '\0';
+	*parser->text = '\0';
 	parser->text = text;
 
 	return parser;

--- a/src/plugins/yaml/yaml.c
+++ b/src/plugins/yaml/yaml.c
@@ -225,7 +225,7 @@ static parserType * whitespace (parserType * const parser)
 	return parser;
 }
 
-static parserType * readUntilDoubleQuote (parserType * const parser)
+static parserType * content (parserType * const parser)
 {
 	ASSERT_NOT_NULL (parser);
 
@@ -254,7 +254,7 @@ static parserType * doubleQuoted (parserType * const parser)
 	ASSERT_NOT_NULL (parser);
 
 	RET_NOK (expect (parser, "\""));
-	RET_NOK (readUntilDoubleQuote (parser));
+	RET_NOK (content (parser));
 	char * text = parser->text;
 	RET_NOK (expect (parser, "\""));
 	parser->text = text;

--- a/src/plugins/yaml/yaml.c
+++ b/src/plugins/yaml/yaml.c
@@ -7,10 +7,18 @@
  *
  */
 
-#include "yaml.h"
+/* -- Imports --------------------------------------------------------------------------------------------------------------------------- */
 
+#include "yaml.h"
 #include <kdbhelper.h>
 
+/* -- Functions ------------------------------------------------------------------------------------------------------------------------- */
+
+// ====================
+// = Plugin Interface =
+// ====================
+
+/** @see elektraDocGet */
 int elektraYamlGet (Plugin * handle ELEKTRA_UNUSED, KeySet * returned ELEKTRA_UNUSED, Key * parentKey ELEKTRA_UNUSED)
 {
 	if (!elektraStrCmp (keyName (parentKey), "system/elektra/modules/yaml"))
@@ -31,6 +39,7 @@ int elektraYamlGet (Plugin * handle ELEKTRA_UNUSED, KeySet * returned ELEKTRA_UN
 	return ELEKTRA_PLUGIN_STATUS_NO_UPDATE;
 }
 
+/** @see elektraDocSet */
 int elektraYamlSet (Plugin * handle ELEKTRA_UNUSED, KeySet * returned ELEKTRA_UNUSED, Key * parentKey ELEKTRA_UNUSED)
 {
 	return ELEKTRA_PLUGIN_STATUS_NO_UPDATE;

--- a/src/plugins/yaml/yaml.c
+++ b/src/plugins/yaml/yaml.c
@@ -492,7 +492,7 @@ static int writeFile (FILE * file, KeySet * keySet, Key * parentKey)
 	for (Key * key; status >= 0 && (key = ksNext (keySet)) != 0;)
 	{
 		const char * name = elektraKeyGetRelativeName (key, parentKey);
-		ELEKTRA_LOG_DEBUG ("Write mapping “\"%s\" : \"%s\"", name, keyString (key));
+		ELEKTRA_LOG_DEBUG ("Write mapping “\"%s\" : \"%s\"”", name, keyString (key));
 		status = fprintf (file, "  \"%s\" : \"%s\"\n", name, keyString (key));
 	}
 	return status < 0 ? status : fprintf (file, "}");

--- a/src/plugins/yaml/yaml.c
+++ b/src/plugins/yaml/yaml.c
@@ -75,10 +75,10 @@ typedef struct
 
 #define LOG_PARSE(data, message, ...)                                                                                                      \
 	ELEKTRA_LOG_DEBUG ("%s:%lu:%lu: " message, strrchr (keyString (data->parentKey), '/') + 1, data->line, data->column, __VA_ARGS__);
+
 #define SET_ERROR_PARSE(data, message, ...)                                                                                                \
 	ELEKTRA_SET_ERRORF (ELEKTRA_ERROR_PARSE, data->parentKey, "%s:%lu:%lu: " message, keyString (data->parentKey), data->line,         \
 			    data->column, __VA_ARGS__);
-
 #define RET_NOK(function)                                                                                                                  \
 	if (function->status != OK)                                                                                                        \
 	{                                                                                                                                  \
@@ -352,10 +352,8 @@ static int parseFile (KeySet * returned ELEKTRA_UNUSED, Key * parentKey)
 					     .parentKey = parentKey,
 					     .keySet = returned,
 					     .errorNumber = errno };
-	if (openFile (parser)->status == OK)
-	{
-		pair (parser);
-	}
+
+	if (openFile (parser)->status == OK) pair (parser);
 	cleanup (parser);
 
 	return parser->status == OK ? ELEKTRA_PLUGIN_STATUS_SUCCESS : ELEKTRA_PLUGIN_STATUS_ERROR;

--- a/src/plugins/yaml/yaml.c
+++ b/src/plugins/yaml/yaml.c
@@ -126,7 +126,7 @@ static parserType * setErrorMalloc (parserType * const parser, size_t size)
 // = Parsing =
 // ===========
 
-static parserType * readNumberChars (parserType * const parser, size_t numberChars)
+static parserType * bufferChar (parserType * const parser)
 {
 	ASSERT_NOT_NULL (parser);
 
@@ -134,7 +134,7 @@ static parserType * readNumberChars (parserType * const parser, size_t numberCha
 	size_t capacity;
 	ssize_t numberCharsRead;
 
-	while (parser->bufferCharsAvailable < numberChars && (numberCharsRead = getline (&line, &capacity, parser->file)) != -1)
+	while (parser->bufferCharsAvailable < 1 && (numberCharsRead = getline (&line, &capacity, parser->file)) != -1)
 	{
 		size_t bufferOffset = parser->buffer - parser->bufferBase;
 		size_t bufferCharsAvailable = parser->bufferCharsAvailable + numberCharsRead;
@@ -159,7 +159,7 @@ static parserType * getNextChar (parserType * parser)
 {
 	ASSERT_NOT_NULL (parser);
 
-	RET_NOK (readNumberChars (parser, 1));
+	RET_NOK (bufferChar (parser));
 
 	if (parser->bufferCharsAvailable < 1)
 	{

--- a/src/plugins/yaml/yaml.c
+++ b/src/plugins/yaml/yaml.c
@@ -607,7 +607,7 @@ static parserType * pairs (parserType * const parser)
 /**
  * @brief Open a file for reading
  *
- * @pre The parameters `parser` and `parser->parentKey` must not be `NULL`
+ * @pre The variables `parser` and `parser->parentKey` must not be `NULL`
  *
  * @param parser Saves the filename of the file this function opens
  *

--- a/src/plugins/yaml/yaml.c
+++ b/src/plugins/yaml/yaml.c
@@ -40,7 +40,7 @@ static inline KeySet * contractYaml ()
 // ====================
 
 /** @see elektraDocGet */
-int elektraYamlGet (Plugin * handle ELEKTRA_UNUSED, KeySet * returned ELEKTRA_UNUSED, Key * parentKey ELEKTRA_UNUSED)
+int elektraYamlGet (Plugin * handle ELEKTRA_UNUSED, KeySet * returned, Key * parentKey)
 {
 	if (!elektraStrCmp (keyName (parentKey), "system/elektra/modules/yaml"))
 	{

--- a/src/plugins/yaml/yaml.c
+++ b/src/plugins/yaml/yaml.c
@@ -79,10 +79,10 @@ typedef struct
 	ELEKTRA_SET_ERRORF (ELEKTRA_ERROR_PARSE, data->parentKey, "%s:%lu:%lu: " message, keyString (data->parentKey), data->line,         \
 			    data->column, __VA_ARGS__);
 
-#define PARSE(parser, data)                                                                                                                \
-	if (parser->status != OK)                                                                                                          \
+#define RET_NOK(function)                                                                                                                  \
+	if (function->status != OK)                                                                                                        \
 	{                                                                                                                                  \
-		return data;                                                                                                               \
+		return parser; /* Requires that the name of the parsing structure is `parser`! */                                          \
 	}
 
 /* -- Functions ------------------------------------------------------------------------------------------------------------------------- */
@@ -305,9 +305,9 @@ static parserType * readUntilDoubleQuote (parserType * const parser)
 
 static parserType * key (parserType * const parser)
 {
-	PARSE (whitespace (parser), parser);
-	PARSE (expect (parser, '"'), parser);
-	PARSE (readUntilDoubleQuote (parser), parser);
+	RET_NOK (whitespace (parser));
+	RET_NOK (expect (parser, '"'));
+	RET_NOK (readUntilDoubleQuote (parser));
 
 	LOG_PARSE (parser, "Read key value “%s”", parser->text);
 
@@ -316,9 +316,9 @@ static parserType * key (parserType * const parser)
 
 static parserType * pair (parserType * const parser)
 {
-	PARSE (whitespace (parser), parser);
-	PARSE (expect (parser, '{'), parser);
-	PARSE (key (parser), parser);
+	RET_NOK (whitespace (parser));
+	RET_NOK (expect (parser, '{'));
+	RET_NOK (key (parser));
 
 	return parser;
 }

--- a/src/plugins/yaml/yaml.c
+++ b/src/plugins/yaml/yaml.c
@@ -116,13 +116,8 @@ static parserType * openFile (parserType * const parser)
 
 	parser->file = fopen (keyString (parser->parentKey), "r");
 
-	if (!parser->file)
-	{
-		ELEKTRA_LOG_WARNING ("Could not open file “%s” for reading: %s", keyString (parser->parentKey), strerror (errno));
-		ELEKTRA_SET_ERROR_GET (parser->parentKey);
-		errno = parser->errorNumber;
-		parser->status = ERROR_FILE_OPEN;
-	}
+	if (!parser->file) setError (parser, ERROR_FILE_OPEN);
+
 	return parser;
 }
 

--- a/src/plugins/yaml/yaml.c
+++ b/src/plugins/yaml/yaml.c
@@ -137,16 +137,15 @@ static parserType * readNumberChars (parserType * const parser, size_t numberCha
 	while (parser->bufferCharsAvailable < numberChars && (numberCharsRead = getline (&line, &capacity, parser->file)) != -1)
 	{
 		size_t bufferCharsAvailable = parser->bufferCharsAvailable + numberCharsRead;
-		char * newBuffer = elektraMalloc (bufferCharsAvailable + 1);
-
-		if (!newBuffer) return setErrorMalloc (parser, bufferCharsAvailable + 1);
-		strncpy (newBuffer, parser->buffer, parser->bufferCharsAvailable);
-		strncpy (newBuffer + parser->bufferCharsAvailable, line, bufferCharsAvailable + 1);
-
-		elektraFree (parser->bufferBase);
+		if ((parser->bufferBase == 0 && (parser->bufferBase = elektraMalloc (bufferCharsAvailable)) == NULL) ||
+		    ((elektraRealloc ((void **)&parser->bufferBase, bufferCharsAvailable + 1) < 0)))
+		{
+			return setErrorMalloc (parser, bufferCharsAvailable + 1);
+		}
+		strncpy (parser->bufferBase + parser->bufferCharsAvailable, line, numberCharsRead + 1);
+		if (!parser->buffer) parser->buffer = parser->bufferBase;
 		free (line);
 
-		parser->bufferBase = parser->buffer = newBuffer;
 		parser->bufferCharsAvailable = bufferCharsAvailable;
 	}
 

--- a/src/plugins/yaml/yaml.c
+++ b/src/plugins/yaml/yaml.c
@@ -85,6 +85,8 @@ typedef struct
 		return parser; /* Requires that the name of the parsing structure is `parser`! */                                          \
 	}
 
+#define ASSERT_NOT_NULL(argument) ELEKTRA_ASSERT (argument, "The variable `" #argument "` contains `NULL`.")
+
 /* -- Functions ------------------------------------------------------------------------------------------------------------------------- */
 
 // ===========
@@ -93,6 +95,8 @@ typedef struct
 
 static parserType * setError (parserType * const parser, statusType status)
 {
+	ASSERT_NOT_NULL (parser);
+
 	SET_ERROR_PARSE (parser, "%s", strerror (errno));
 	errno = parser->errorNumber;
 	parser->status = status;
@@ -111,8 +115,8 @@ static parserType * setError (parserType * const parser, statusType status)
  */
 static parserType * openFile (parserType * const parser)
 {
-	ELEKTRA_ASSERT (parser, "The Parameter `parser` contains `NULL`.");
-	ELEKTRA_ASSERT (parser->parentKey, "The Parameter `parentKey` contains `NULL`.");
+	ASSERT_NOT_NULL (parser);
+	ASSERT_NOT_NULL (parser->parentKey);
 
 	parser->file = fopen (keyString (parser->parentKey), "r");
 
@@ -133,7 +137,7 @@ static parserType * openFile (parserType * const parser)
  */
 static parserType * cleanup (parserType * const parser)
 {
-	ELEKTRA_ASSERT (parser, "The Parameter `parser` contains `NULL`.");
+	ASSERT_NOT_NULL (parser);
 
 	if (parser->file && fclose (parser->file) != 0) setError (parser, ERROR_FILE_CLOSE);
 	if (parser->bufferBase) free (parser->bufferBase);
@@ -158,7 +162,7 @@ static KeySet * contractYaml ()
 
 static parserType * assertNumberCharsAvailable (parserType * const parser, size_t numberChars)
 {
-	ELEKTRA_ASSERT (parser, "The parameter `parser` contains `NULL`.");
+	ASSERT_NOT_NULL (parser);
 
 	char * line = NULL;
 	size_t capacity;
@@ -186,7 +190,7 @@ static parserType * assertNumberCharsAvailable (parserType * const parser, size_
 
 static parserType * getNextChar (parserType * parser)
 {
-	ELEKTRA_ASSERT (parser && parser->file, "The Parameter `parser` contains `NULL`.");
+	ASSERT_NOT_NULL (parser);
 
 	if (assertNumberCharsAvailable (parser, 1)->status != OK) return parser;
 
@@ -199,7 +203,7 @@ static parserType * getNextChar (parserType * parser)
 
 static parserType * putBackChars (parserType * parser, size_t numberChars)
 {
-	ELEKTRA_ASSERT (parser, "The Parameter `parser` contains `NULL`.");
+	ASSERT_NOT_NULL (parser);
 
 	parser->bufferCharsAvailable += numberChars;
 	parser->buffer -= numberChars;
@@ -209,9 +213,9 @@ static parserType * putBackChars (parserType * parser, size_t numberChars)
 
 static bool acceptChars (parserType * const parser, char const * const characters, size_t numberCharacters)
 {
-	ELEKTRA_ASSERT (parser, "The Parameter `parser` contains `NULL`.");
-	ELEKTRA_ASSERT (parser->file, "The Parameter `parser→file` contains `NULL`.");
-	ELEKTRA_ASSERT (characters, "The Parameter `characters` contains `NULL`.");
+	ASSERT_NOT_NULL (parser);
+	ASSERT_NOT_NULL (parser->file);
+	ASSERT_NOT_NULL (characters);
 
 	if (getNextChar (parser)->status != OK) return parser;
 
@@ -232,14 +236,14 @@ static bool acceptChars (parserType * const parser, char const * const character
 
 static bool acceptChar (parserType * const parser, char const character)
 {
-	ELEKTRA_ASSERT (parser, "The Parameter `parser` contains `NULL`.");
+	ASSERT_NOT_NULL (parser);
 
 	return acceptChars (parser, (char[]){ character }, 1);
 }
 
 static parserType * expect (parserType * const parser, char const character)
 {
-	ELEKTRA_ASSERT (parser, "The Parameter `parser` contains `NULL`.");
+	ASSERT_NOT_NULL (parser);
 
 	bool found = acceptChar (parser, character);
 	if (parser->status != OK)
@@ -258,8 +262,8 @@ static parserType * expect (parserType * const parser, char const character)
 
 static parserType * whitespace (parserType * const parser)
 {
-	ELEKTRA_ASSERT (parser, "The Parameter `parser` contains `NULL`.");
-	ELEKTRA_ASSERT (parser->file, "The Parameter `file` contains `NULL`.");
+	ASSERT_NOT_NULL (parser);
+	ASSERT_NOT_NULL (parser->file);
 
 	bool found;
 	do
@@ -276,13 +280,10 @@ static parserType * whitespace (parserType * const parser)
 
 static parserType * readUntilDoubleQuote (parserType * const parser)
 {
-	ELEKTRA_ASSERT (parser, "The Parameter `parser` contains `NULL`.");
-	ELEKTRA_ASSERT (parser->file, "The Parameter `parser→file` contains `NULL`.");
+	ASSERT_NOT_NULL (parser);
 
 	char * previous = NULL;
-
 	size_t numberOfChars = 0;
-
 	char * text = parser->buffer;
 
 	while (getNextChar (parser)->status == OK && (*parser->text != '"' || (previous && *previous == '\\')))
@@ -305,6 +306,8 @@ static parserType * readUntilDoubleQuote (parserType * const parser)
 
 static parserType * key (parserType * const parser)
 {
+	ASSERT_NOT_NULL (parser);
+
 	RET_NOK (whitespace (parser));
 	RET_NOK (expect (parser, '"'));
 	RET_NOK (readUntilDoubleQuote (parser));
@@ -316,6 +319,8 @@ static parserType * key (parserType * const parser)
 
 static parserType * pair (parserType * const parser)
 {
+	ASSERT_NOT_NULL (parser);
+
 	RET_NOK (whitespace (parser));
 	RET_NOK (expect (parser, '{'));
 	RET_NOK (key (parser));
@@ -336,8 +341,8 @@ static parserType * pair (parserType * const parser)
  */
 static int parseFile (KeySet * returned ELEKTRA_UNUSED, Key * parentKey)
 {
-	ELEKTRA_ASSERT (returned, "The Parameter `returned` contains `NULL` instead of a valid key set.");
-	ELEKTRA_ASSERT (parentKey, "The Parameter `parentKey` contains `NULL` instead of a valid key.");
+	ASSERT_NOT_NULL (returned);
+	ASSERT_NOT_NULL (parentKey);
 
 	ELEKTRA_LOG ("Read configuration data");
 

--- a/src/plugins/yaml/yaml.c
+++ b/src/plugins/yaml/yaml.c
@@ -129,6 +129,7 @@ static parserType * setErrorMalloc (parserType * const parser, size_t size)
 static parserType * bufferChar (parserType * const parser)
 {
 	ASSERT_NOT_NULL (parser);
+	ASSERT_NOT_NULL (parser->file);
 
 	char * line = NULL;
 	size_t capacity;
@@ -158,6 +159,7 @@ static parserType * bufferChar (parserType * const parser)
 static parserType * getNextChar (parserType * parser)
 {
 	ASSERT_NOT_NULL (parser);
+	ASSERT_NOT_NULL (parser->file);
 
 	RET_NOK (bufferChar (parser));
 
@@ -187,6 +189,7 @@ static parserType * getNextChar (parserType * parser)
 static parserType * putBackChar (parserType * parser)
 {
 	ASSERT_NOT_NULL (parser);
+	ASSERT_NOT_NULL (parser->buffer);
 	ELEKTRA_ASSERT (parser->buffer - 1 >= parser->bufferBase, "Can not put back more characters than available");
 
 	// We assume that we never put back the newline character
@@ -222,6 +225,8 @@ static parserType * acceptChars (parserType * const parser, char const * const c
 static parserType * expect (parserType * const parser, char const * const characters)
 {
 	ASSERT_NOT_NULL (parser);
+	ASSERT_NOT_NULL (parser->file);
+	ASSERT_NOT_NULL (characters);
 
 	RET_NOK (acceptChars (parser, characters));
 
@@ -256,6 +261,7 @@ static parserType * whitespace (parserType * const parser)
 static parserType * content (parserType * const parser)
 {
 	ASSERT_NOT_NULL (parser);
+	ASSERT_NOT_NULL (parser->file);
 	ASSERT_NOT_NULL (parser->buffer);
 
 	char * previous = parser->buffer;
@@ -285,6 +291,7 @@ static parserType * content (parserType * const parser)
 static parserType * doubleQuoted (parserType * const parser)
 {
 	ASSERT_NOT_NULL (parser);
+	ASSERT_NOT_NULL (parser->file);
 
 	RET_NOK (expect (parser, "\""));
 	RET_NOK (content (parser));
@@ -298,6 +305,7 @@ static parserType * doubleQuoted (parserType * const parser)
 static parserType * doubleQuotedSpace (parserType * const parser)
 {
 	ASSERT_NOT_NULL (parser);
+	ASSERT_NOT_NULL (parser->file);
 
 	RET_NOK (whitespace (parser));
 	RET_NOK (doubleQuoted (parser));
@@ -311,6 +319,9 @@ static parserType * doubleQuotedSpace (parserType * const parser)
 static parserType * saveText (parserType * const parser, char ** location)
 {
 	ASSERT_NOT_NULL (parser);
+	ASSERT_NOT_NULL (parser->match);
+	ASSERT_NOT_NULL (parser->end);
+	ELEKTRA_ASSERT (parser->end - parser->match >= -1, "The string specified via parser->match and parser->end has negative length");
 	ASSERT_NOT_NULL (location);
 
 	size_t length = parser->end - parser->match + 1;
@@ -325,18 +336,27 @@ static parserType * saveText (parserType * const parser, char ** location)
 
 static parserType * key (parserType * const parser)
 {
+	ASSERT_NOT_NULL (parser);
+	ASSERT_NOT_NULL (parser->file);
+
 	RET_NOK (doubleQuotedSpace (parser));
 	return saveText (parser, &parser->key);
 }
 
 static parserType * value (parserType * const parser)
 {
+	ASSERT_NOT_NULL (parser);
+	ASSERT_NOT_NULL (parser->file);
+
 	RET_NOK (doubleQuotedSpace (parser));
 	return saveText (parser, &parser->value);
 }
 
 static parserType * pair (parserType * const parser)
 {
+	ASSERT_NOT_NULL (parser);
+	ASSERT_NOT_NULL (parser->file);
+
 	RET_NOK (key (parser));
 	LOG_PARSE (parser, "Read key “%s”", parser->key);
 
@@ -356,6 +376,9 @@ static parserType * pair (parserType * const parser)
 
 static parserType * optionalAdditionalPairs (parserType * const parser)
 {
+	ASSERT_NOT_NULL (parser);
+	ASSERT_NOT_NULL (parser->file);
+
 	while (acceptChars (parser, ",")->status == OK && parser->match)
 	{
 		RET_NOK (pair (parser));
@@ -366,6 +389,7 @@ static parserType * optionalAdditionalPairs (parserType * const parser)
 static parserType * pairs (parserType * const parser)
 {
 	ASSERT_NOT_NULL (parser);
+	ASSERT_NOT_NULL (parser->file);
 
 	RET_NOK (whitespace (parser));
 	RET_NOK (expect (parser, "{"));

--- a/src/plugins/yaml/yaml.c
+++ b/src/plugins/yaml/yaml.c
@@ -174,15 +174,13 @@ static parserType * getNextChar (parserType * parser)
 	return parser;
 }
 
-static parserType * putBackChars (parserType * parser, size_t numberChars)
+static parserType * putBackChar (parserType * parser)
 {
 	ASSERT_NOT_NULL (parser);
-	ELEKTRA_ASSERT (parser->buffer - numberChars >= parser->bufferBase, "Can not put back more characters than available.");
+	ELEKTRA_ASSERT (parser->buffer - 1 >= parser->bufferBase, "Can not put back more characters than available.");
 
-	LOG_PARSE (parser, "Put back %lu characters", numberChars);
-
-	parser->bufferCharsAvailable += numberChars;
-	parser->buffer -= numberChars;
+	parser->bufferCharsAvailable++;
+	parser->buffer--;
 
 	return parser;
 }
@@ -214,7 +212,7 @@ static parserType * acceptChars (parserType * const parser, char const * const c
 		return parser;
 	}
 	LOG_PARSE (parser, "Put back character “%c”", *lastCharacter);
-	return putBackChars (parser, 1);
+	return putBackChar (parser);
 }
 
 static parserType * expect (parserType * const parser, char const * const characters)
@@ -269,7 +267,7 @@ static parserType * content (parserType * const parser)
 	RET_NOK (parser);
 	if (parser->text && *parser->text == '"')
 	{
-		putBackChars (parser, 1);
+		putBackChar (parser);
 		numberCharsRead--;
 	}
 

--- a/src/plugins/yaml/yaml.c
+++ b/src/plugins/yaml/yaml.c
@@ -666,17 +666,17 @@ static int parseFile (KeySet * returned ELEKTRA_UNUSED, Key * parentKey)
 
 	ELEKTRA_LOG ("Read configuration data");
 
-	parserType * parser = &(parserType){ .status = OK,
-					     .line = 1,
-					     .column = 1,
-					     .file = NULL,
-					     .match = NULL,
-					     .bufferBase = NULL,
-					     .buffer = NULL,
-					     .bufferCharsAvailable = 0,
-					     .parentKey = parentKey,
-					     .keySet = returned,
-					     .errorNumber = errno };
+	parserType * parser = &(parserType){.status = OK,
+					    .line = 1,
+					    .column = 1,
+					    .file = NULL,
+					    .match = NULL,
+					    .bufferBase = NULL,
+					    .buffer = NULL,
+					    .bufferCharsAvailable = 0,
+					    .parentKey = parentKey,
+					    .keySet = returned,
+					    .errorNumber = errno };
 
 	if (openFile (parser)->status == OK) pairs (parser);
 	cleanup (parser);

--- a/src/plugins/yaml/yaml.h
+++ b/src/plugins/yaml/yaml.h
@@ -1,0 +1,20 @@
+/**
+ * @file
+ *
+ * @brief Header for yaml plugin
+ *
+ * @copyright BSD License (see doc/LICENSE.md or https://www.libelektra.org)
+ *
+ */
+
+#ifndef ELEKTRA_PLUGIN_YAML_H
+#define ELEKTRA_PLUGIN_YAML_H
+
+#include <kdbplugin.h>
+
+int elektraYamlGet (Plugin * handle, KeySet * ks, Key * parentKey);
+int elektraYamlSet (Plugin * handle, KeySet * ks, Key * parentKey);
+
+Plugin * ELEKTRA_PLUGIN_EXPORT (yaml);
+
+#endif

--- a/src/plugins/yaml/yaml/simple.yaml
+++ b/src/plugins/yaml/yaml/simple.yaml
@@ -1,3 +1,3 @@
-  	{ "hello" :
+  {	 "hello" :
 		"world" ,
 		"key": "value"}

--- a/src/plugins/yaml/yaml/simple.yaml
+++ b/src/plugins/yaml/yaml/simple.yaml
@@ -1,1 +1,2 @@
-  	{ "hello" : "world" }
+  	{ "hello" :
+		"world" }

--- a/src/plugins/yaml/yaml/simple.yaml
+++ b/src/plugins/yaml/yaml/simple.yaml
@@ -1,2 +1,3 @@
   	{ "hello" :
-		"world" }
+		"world" ,
+		"key": "value"}

--- a/src/plugins/yaml/yaml/simple.yaml
+++ b/src/plugins/yaml/yaml/simple.yaml
@@ -1,0 +1,1 @@
+  	{ "hello" : "world" }

--- a/src/plugins/yaml/yaml/yaml.abnf
+++ b/src/plugins/yaml/yaml/yaml.abnf
@@ -14,7 +14,8 @@ printable =/ %xe00-fffd
 ; All Unicode Character Starting from the Supplementary Multilingual Plain
 printable =/ %x10000-10ffff
 
-pairs = *WSLF "{" pair "}" *WSLF
+pairs = *WSLF "{" pair optionalAdditionalPairs "}" *WSLF
+optionalAdditionalPairs = *("," pair)
 pair = key ":" value
 key = doubleQuotedSpace
 value = doubleQuotedSpace

--- a/src/plugins/yaml/yaml/yaml.abnf
+++ b/src/plugins/yaml/yaml/yaml.abnf
@@ -17,4 +17,5 @@ pair = *WSP "{" key ":" value "}" *WSP
 key = doubleQuotedSpace
 value = doubleQuotedSpace
 doubleQuotedSpace =  *WSP doubleQuoted *WSP
-doubleQuoted = DQUOTE *printable DQUOTE
+doubleQuoted = DQUOTE content DQUOTE
+content = *printable

--- a/src/plugins/yaml/yaml/yaml.abnf
+++ b/src/plugins/yaml/yaml/yaml.abnf
@@ -13,7 +13,8 @@ printable =/ %xe00-fffd
 ; All Unicode Character Starting from the Supplementary Multilingual Plain
 printable =/ %x10000-10ffff
 
-pair = *WSP "{" key ":" value "}" *WSP
+pairs = *WSP "{" pair "}" *WSP
+pair =  key ":" value
 key = doubleQuotedSpace
 value = doubleQuotedSpace
 doubleQuotedSpace =  *WSP doubleQuoted *WSP

--- a/src/plugins/yaml/yaml/yaml.abnf
+++ b/src/plugins/yaml/yaml/yaml.abnf
@@ -1,4 +1,5 @@
 NEL = %x85
+WSLF = WSP / LF
 
 ; Printable characters from C0 set
 printable =  HTAB / LF / CR
@@ -13,10 +14,10 @@ printable =/ %xe00-fffd
 ; All Unicode Character Starting from the Supplementary Multilingual Plain
 printable =/ %x10000-10ffff
 
-pairs = *WSP "{" pair "}" *WSP
+pairs = *WSLF "{" pair "}" *WSLF
 pair =  key ":" value
 key = doubleQuotedSpace
 value = doubleQuotedSpace
-doubleQuotedSpace =  *WSP doubleQuoted *WSP
+doubleQuotedSpace =  *WSLF doubleQuoted *WSLF
 doubleQuoted = DQUOTE content DQUOTE
 content = *printable

--- a/src/plugins/yaml/yaml/yaml.abnf
+++ b/src/plugins/yaml/yaml/yaml.abnf
@@ -2,7 +2,7 @@ NEL = %x85
 WSLF = WSP / LF
 
 ; Printable characters from C0 set
-printable =  HTAB / LF / CR
+printable = HTAB / LF / CR
 ; Printable ASCII
 printable =/ %x20-7e
 ; Next Line from C1 set
@@ -15,9 +15,9 @@ printable =/ %xe00-fffd
 printable =/ %x10000-10ffff
 
 pairs = *WSLF "{" pair "}" *WSLF
-pair =  key ":" value
+pair = key ":" value
 key = doubleQuotedSpace
 value = doubleQuotedSpace
-doubleQuotedSpace =  *WSLF doubleQuoted *WSLF
+doubleQuotedSpace = *WSLF doubleQuoted *WSLF
 doubleQuoted = DQUOTE content DQUOTE
 content = *printable

--- a/src/plugins/yaml/yaml/yaml.abnf
+++ b/src/plugins/yaml/yaml/yaml.abnf
@@ -1,0 +1,20 @@
+NEL = %x85
+
+; Printable characters from C0 set
+printable =  HTAB / LF / CR
+; Printable ASCII
+printable =/ %x20-7e
+; Next Line from C1 set
+printable =/ NEL
+; Characters after C1 set – Surrogate pairs
+printable =/ %xa0-d7ff
+; Private use characters – Replacement character
+printable =/ %xe00-fffd
+; All Unicode Character Starting from the Supplementary Multilingual Plain
+printable =/ %x10000-10ffff
+
+pair = *WSP "{" key ":" value "}" *WSP
+key = doubleQuotedSpace
+value = doubleQuotedSpace
+doubleQuotedSpace =  *WSP doubleQuoted *WSP
+doubleQuoted = DQUOTE *printable DQUOTE

--- a/tests/shell/shell_recorder/tutorial_wrapper/CMakeLists.txt
+++ b/tests/shell/shell_recorder/tutorial_wrapper/CMakeLists.txt
@@ -30,6 +30,7 @@ add_plugin_shell_test (mozprefs)
 add_plugin_shell_test (xerces)
 add_plugin_shell_test (range)
 add_plugin_shell_test (type)
+add_plugin_shell_test (yaml)
 
 # Only works with super user privileges, since it writes to `/etc/hosts`:
 # add_s_test (tutorial_mount "${CMAKE_SOURCE_DIR}/doc/tutorials/mount.md")


### PR DESCRIPTION
# Purpose

This pull request adds a **very basic** YAML plugin. I wrote the parsing code myself, since I wanted to learn how to “properly” write a recursive descent parser. While the code should not be too hard to extend (see commit commit 17aa7a6 for an example), I do not think that it makes sense to continue with the development of this parser, since it currently has multiple issues that I listed below.

- **No Scanner:**  While I prefer a scanner-less parser (no distinction between lexing and parsing), this decision might be problematic. I assume that some advanced YAML features require a lookahead of one symbol and a one character (byte) lookahead is not enough. 
- **Ignores Whitespace:** This is problematic since YAML’s block style uses additional leading spaces to denote child nodes.
- **Error Handling:** A lot of the code currently consists of checks for errors. Unfortunately C does not support exceptions which would make the code much cleaner.

Anyway, I guess I will remove most of the parsing code later and just use [libyaml](http://pyyaml.org/wiki/LibYAML) or something similar for my example of a hand-written parser.

# Checklist

- [x] Not a single one of the included commits closes an open issue :o).
- [x] I ran all tests and only the usual test cases:
   - `testjna_maven`,
   - `test_kdb.lua`,
   - `test_key.lua`,
   - `test_keyset.lua`
  failed, since I enabled the address sanitizer.
- [x] I added unit tests.
- [x] I added code comments, logging, and assertions.
- [x] Commit 2a0f94b includes a minor update to the specification.