### PR TITLE
Run All: Use Non-Buffered Output

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -65,6 +65,6 @@ before_script:
 
 script:
   - ninja
-  - travis_wait 30 ninja run_all
+  - ninja run_all
   - ninja install
-  - travis_wait 30 ninja run_all
+  - ninja run_all

--- a/doc/old/NEWS.md
+++ b/doc/old/NEWS.md
@@ -529,7 +529,7 @@ From this release on, Elektra has full read and write capabilities
 towards the world of json. json is a very popular serialization format
 which is originated in Javascript.
 It is very similar to the already existing tcl plugin, which also works
-like a parser without intermediate datastructures. But unlike the tcl
+like a parser without intermediate data structures. But unlike the tcl
 plugin, where a grammar was written, the blazing fast yajl library was
 used.
 

--- a/src/bindings/cpp/examples/cpp_example_ordering.cpp
+++ b/src/bindings/cpp/examples/cpp_example_ordering.cpp
@@ -1,7 +1,7 @@
 /**
  * @file
  *
- * @brief example how easy it is to put keys in different datastructures
+ * @brief example how easy it is to put keys in different data structures
  *
  * - * They might even have complete other properties than KeySet, e.g. in
  * this case:

--- a/src/libs/elektra/key.c
+++ b/src/libs/elektra/key.c
@@ -68,7 +68,7 @@
  *
  * @par
  * As you can imagine this refcounting allows you to put the Key in your
- * own datastructures.
+ * own data structures.
  * It can be a very powerful feature, e.g. if you need your own-defined
  * ordering or different Models of your configuration.
  */

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -35,10 +35,15 @@ macro (do_test source)
 			)
 endmacro (do_test)
 
+if (NOT CMAKE_VERSION VERSION_LESS 3.2)
+	set (USES_TERMINAL USES_TERMINAL)
+endif (NOT CMAKE_VERSION VERSION_LESS 3.2)
+
 add_custom_target(run_all
 	COMMAND "${CMAKE_SOURCE_DIR}/scripts/run_all"
 	"$<CONFIGURATION>"
-	WORKING_DIRECTORY "${CMAKE_BINARY_DIR}")
+	WORKING_DIRECTORY "${CMAKE_BINARY_DIR}"
+	${USES_TERMINAL})
 
 add_custom_target(run_nokdbtests
 	COMMAND "${CMAKE_SOURCE_DIR}/scripts/run_nokdbtests"


### PR DESCRIPTION
# Purpose

Currently the output of `ninja run_all` is buffered. Consequently we do not see which sub-command causes problems if we terminated the script before it finishes. This behaviour is especially problematic, if Travis kills the script cause it runs for too long.

# Checklist

- [x] I checked all commit messages twice.
- [x] I ran all tests and everything went fine.