### PR TITLE
Fix strict prototypes

### DIFF
--- a/benchmarks/benchmarks.c
+++ b/benchmarks/benchmarks.c
@@ -32,12 +32,12 @@ void timePrint (char * msg)
 	gettimeofday (&start, 0);
 }
 
-void benchmarkCreate ()
+void benchmarkCreate (void)
 {
 	large = ksNew (num_key * num_dir, KS_END);
 }
 
-void benchmarkFillup ()
+void benchmarkFillup (void)
 {
 	int i, j;
 	char name[KEY_NAME_LENGTH + 1];

--- a/benchmarks/benchmarks.h
+++ b/benchmarks/benchmarks.h
@@ -34,8 +34,8 @@
 void timeInit (void);
 void timePrint (char * msg);
 
-void benchmarkCreate ();
-void benchmarkFillup ();
+void benchmarkCreate (void);
+void benchmarkFillup (void);
 
 extern int num_dir; // default = NUM_DIR;
 extern int num_key; // default = NUM_KEY;

--- a/benchmarks/cmp.c
+++ b/benchmarks/cmp.c
@@ -81,7 +81,7 @@ int natcmp (const char * str1, const char * str2)
 }
 
 
-int main ()
+int main (void)
 {
 	long long nrIterations = 100000000;
 	const char str1[] = "some string to be compared with/some\\/more with a long common part, and only a bit different";

--- a/benchmarks/createkeys.c
+++ b/benchmarks/createkeys.c
@@ -8,12 +8,12 @@
 
 #include <benchmarks.h>
 
-void benchmarkDel ()
+void benchmarkDel (void)
 {
 	ksDel (large);
 }
 
-int benchmarkIterate ()
+int benchmarkIterate (void)
 {
 	ksRewind (large);
 	Key * cur;

--- a/benchmarks/large.c
+++ b/benchmarks/large.c
@@ -12,26 +12,26 @@ KDB * kdb;
 Key * key;
 KeySet * large;
 
-void benchmarkOpen ()
+void benchmarkOpen (void)
 {
 	kdb = kdbOpen (key);
 }
 
-void benchmarkInread ()
+void benchmarkInread (void)
 {
 	KeySet * n = ksNew (0, KS_END);
 	kdbGet (kdb, n, key);
 	ksDel (n);
 }
 
-void benchmarkReadin ()
+void benchmarkReadin (void)
 {
 	KeySet * n = ksNew (0, KS_END);
 	kdbGet (kdb, n, key);
 	ksDel (n);
 }
 
-void benchmarkLookupByName ()
+void benchmarkLookupByName (void)
 {
 	int i, j;
 	char name[KEY_NAME_LENGTH + 1];
@@ -48,33 +48,33 @@ void benchmarkLookupByName ()
 	}
 }
 
-void benchmarkReread ()
+void benchmarkReread (void)
 {
 	kdbGet (kdb, large, key);
 }
 
-void benchmarkInwrite ()
+void benchmarkInwrite (void)
 {
 	kdbSet (kdb, large, key);
 }
 
-void benchmarkRewrite ()
+void benchmarkRewrite (void)
 {
 	kdbSet (kdb, large, key);
 }
 
-void benchmarkWriteout ()
+void benchmarkWriteout (void)
 {
 	kdbSet (kdb, large, key);
 }
 
-void benchmarkClose ()
+void benchmarkClose (void)
 {
 	kdbClose (kdb, key);
 }
 
 
-int main ()
+int main (void)
 {
 	key = keyNew (KEY_ROOT, KEY_END);
 

--- a/cmake/ElektraCompiling.cmake
+++ b/cmake/ElektraCompiling.cmake
@@ -131,7 +131,7 @@ set (COMMON_FLAGS "${COMMON_FLAGS} -Wformat-security")
 set (COMMON_FLAGS "${COMMON_FLAGS} -Wshadow")
 set (COMMON_FLAGS "${COMMON_FLAGS} -Wcomments -Wtrigraphs -Wundef")
 set (COMMON_FLAGS "${COMMON_FLAGS} -Wuninitialized -Winit-self")
-#set (C_EXTRA_FLAGS "${C_EXTRA_FLAGS} -Wstrict-prototypes") # not yet fixed in code
+set (C_EXTRA_FLAGS "${C_EXTRA_FLAGS} -Wstrict-prototypes")
 
 # Not every compiler understands -Wmaybe-uninitialized
 check_c_compiler_flag(-Wmaybe-uninitialized HAS_CFLAG_MAYBE_UNINITIALIZED)

--- a/examples/basename.c
+++ b/examples/basename.c
@@ -10,7 +10,7 @@
 
 #include <stdio.h>
 
-int main ()
+int main (void)
 {
 	// clang-format off
 {

--- a/examples/cascading.c
+++ b/examples/cascading.c
@@ -16,7 +16,7 @@ void printError (char * what, Key const * parentKey)
 		keyString (keyGetMeta (parentKey, "error/number")), keyString (keyGetMeta (parentKey, "error/reason")));
 }
 
-int main ()
+int main (void)
 {
 	Key * parentKey = keyNew ("", KEY_CASCADING_NAME, KEY_END);
 	KDB * kdb = kdbOpen (parentKey);

--- a/examples/external/cmake/application.c
+++ b/examples/external/cmake/application.c
@@ -10,7 +10,7 @@
 
 #include <stdio.h>
 
-int main ()
+int main (void)
 {
 	KeySet * myConfig = ksNew (0, KS_END);
 	Key * key = keyNew ("system/test/myapp", KEY_END);

--- a/examples/external/pkgconfig/application.c
+++ b/examples/external/pkgconfig/application.c
@@ -10,7 +10,7 @@
 
 #include <stdio.h>
 
-int main ()
+int main (void)
 {
 	KeySet * myConfig = ksNew (0, KS_END);
 	Key * key = keyNew ("system/test/myapp", KEY_END);

--- a/examples/functional.c
+++ b/examples/functional.c
@@ -128,7 +128,7 @@ int find_80 (Key * check)
 	return n > 70 ? -1 : 1;
 }
 
-int main ()
+int main (void)
 {
 	KeySet * out;
 	KeySet * ks = ksNew (64, keyNew ("user/a/1", KEY_END), keyNew ("user/a/2", KEY_END), keyNew ("user/a/b/1", KEY_END),

--- a/examples/kdbget.c
+++ b/examples/kdbget.c
@@ -9,7 +9,7 @@
 #include <kdb.h>
 #include <stdio.h>
 
-int main ()
+int main (void)
 {
 	KeySet * myConfig = ksNew (0, KS_END);
 

--- a/examples/kdbget_error.c
+++ b/examples/kdbget_error.c
@@ -15,7 +15,7 @@ void printError (Key * key);
 void printWarnings (Key * key);
 void removeMetaData (Key * key, const char * searchfor);
 
-int main ()
+int main (void)
 {
 	KeySet * myConfig = ksNew (0, KS_END);
 	Key * key = keyNew ("/sw/MyApp", KEY_CASCADING_NAME, KEY_END);

--- a/examples/kdbintro.c
+++ b/examples/kdbintro.c
@@ -8,7 +8,7 @@
 
 #include <kdb.h>
 
-int main ()
+int main (void)
 {
 	KeySet * myConfig = ksNew (0, KS_END);
 	Key * parentKey = keyNew ("/sw/MyApp", KEY_CASCADING_NAME, KEY_END);

--- a/examples/kdbopen.c
+++ b/examples/kdbopen.c
@@ -9,14 +9,14 @@
 #include <kdb.h>
 
 //! [open]
-void thread1 ()
+void thread1 (void)
 {
 	Key * parent = keyNew ("/app/part1", KEY_CASCADING_NAME, KEY_END);
 	KDB * h = kdbOpen (parent);
 	// fetch keys and work with them
 	kdbClose (h, parent);
 }
-void thread2 ()
+void thread2 (void)
 {
 	Key * parent = keyNew ("/app/part2", KEY_CASCADING_NAME, KEY_END);
 	KDB * h = kdbOpen (parent);
@@ -25,7 +25,7 @@ void thread2 ()
 }
 //! [open]
 
-int main ()
+int main (void)
 {
 	thread1 ();
 	thread2 ();

--- a/examples/kdbset.c
+++ b/examples/kdbset.c
@@ -29,7 +29,7 @@ KeySet * doElektraMerge (KeySet * ours, KeySet * theirs, KeySet * base)
 }
 
 
-int main ()
+int main (void)
 {
 	// clang-format off
 //! [set]

--- a/examples/keyCopy.c
+++ b/examples/keyCopy.c
@@ -61,7 +61,7 @@ void i (Key * k)
 }
 //! [Individual Copy]
 
-int main ()
+int main (void)
 {
 	Key * k = keyNew ("user/hello", KEY_VALUE, "my content", KEY_END);
 

--- a/examples/keyMeta.c
+++ b/examples/keyMeta.c
@@ -44,7 +44,7 @@ void o (KeySet * ks)
 }
 //! [Shared Meta All]
 
-int main ()
+int main (void)
 {
 	Key * k = keyNew ("user/key", KEY_END);
 	c = keyNew ("user/copy", KEY_END);

--- a/examples/keyName.c
+++ b/examples/keyName.c
@@ -11,7 +11,7 @@
 
 #include <kdb.h>
 
-int main ()
+int main (void)
 {
 	// clang-format off
 //! [add name]

--- a/examples/keyNew.c
+++ b/examples/keyNew.c
@@ -11,7 +11,7 @@
 #include <kdb.h>
 #include <stdio.h>
 
-static void shortExamples()
+static void shortExamples(void)
 {
 {
 //! [Simple]
@@ -168,7 +168,7 @@ keyDel (k); // k is now deleted
 
 }
 
-int main()
+int main(void)
 {
 	shortExamples();
 }

--- a/examples/keyNewExample.c
+++ b/examples/keyNewExample.c
@@ -9,7 +9,7 @@
 #include <kdb.h>
 #include <stdio.h>
 
-int main ()
+int main (void)
 {
 	KeySet * ks = ksNew (0, KS_END);
 	Key * key = 0;

--- a/examples/keyset.c
+++ b/examples/keyset.c
@@ -38,7 +38,7 @@ void h (Key * k)
 
 // clang-format off
 
-void simpleAppend ()
+void simpleAppend (void)
 {
 //! [simple append]
 KeySet * ks = ksNew (1, KS_END);
@@ -49,7 +49,7 @@ ksDel (ks);
 }
 
 
-void refAppend ()
+void refAppend (void)
 {
 //! [ref append]
 KeySet * ks = ksNew (1, KS_END);
@@ -63,7 +63,7 @@ keyDel (k);
 //! [ref append]
 }
 
-void dupAppend ()
+void dupAppend (void)
 {
 //! [dup append]
 KeySet * ks = ksNew (1, KS_END);
@@ -75,7 +75,7 @@ keyDel (k);
 //! [dup append]
 }
 
-int main ()
+int main (void)
 {
 	Key * origKey;
 	KeySet * ks = ksNew (0, KS_END);

--- a/examples/ksCut.c
+++ b/examples/ksCut.c
@@ -19,7 +19,7 @@ void outputKeySet (KeySet * returned)
 	}
 }
 
-int main ()
+int main (void)
 {
 	// clang-format off
 	//! [cut]

--- a/examples/ksLookupPop.c
+++ b/examples/ksLookupPop.c
@@ -29,7 +29,7 @@ void f (KeySet * iterator, KeySet * lookup)
 }
 //! [f]
 
-int main ()
+int main (void)
 {
 	KeySet * ks1 = ksNew (20, KS_END);
 	KeySet * ks2 = ksNew (20, KS_END);

--- a/examples/ksNew.c
+++ b/examples/ksNew.c
@@ -11,7 +11,7 @@
 
 // clang-format off
 
-int main ()
+int main (void)
 {
 {
 //! [Simple]

--- a/examples/ksNewExample.c
+++ b/examples/ksNewExample.c
@@ -9,7 +9,7 @@
 #include <kdb.h>
 #include <stdio.h>
 
-int main ()
+int main (void)
 {
 	// clang-format off
 //! [Full Example]

--- a/examples/meta.c
+++ b/examples/meta.c
@@ -10,7 +10,7 @@
 
 #include <stdio.h>
 
-int main ()
+int main (void)
 {
 	Key * k;
 	Key * c;

--- a/examples/namespace.c
+++ b/examples/namespace.c
@@ -47,7 +47,7 @@ case KEY_NS_CASCADING:
 //! [namespace]
 }
 
-void loop ()
+void loop (void)
 {
 //! [loop]
 for (elektraNamespace ns = KEY_NS_FIRST; ns <= KEY_NS_LAST; ++ns)
@@ -58,7 +58,7 @@ for (elektraNamespace ns = KEY_NS_FIRST; ns <= KEY_NS_LAST; ++ns)
 //! [loop]
 }
 
-int main ()
+int main (void)
 {
 	char s[100];
 	fgets (s, 100, stdin);

--- a/examples/set_key.c
+++ b/examples/set_key.c
@@ -28,7 +28,7 @@ void print_warnings (Key * err)
 }
 
 /** After writing the key this function rereads the key and print it*/
-void check_key ()
+void check_key (void)
 {
 	Key * error_key = keyNew (0);
 	KDB * kdb_handle = kdbOpen (error_key);
@@ -51,7 +51,7 @@ void check_key ()
 }
 
 // typical usage of Elektra
-int main ()
+int main (void)
 {
 	Key * error_key = keyNew (0);
 	KDB * kdb_handle = kdbOpen (error_key);

--- a/src/bindings/glib/tests/testglib_kdb.c
+++ b/src/bindings/glib/tests/testglib_kdb.c
@@ -12,7 +12,7 @@
 
 #define TEST_NS "user/tests/glib"
 
-static void test_open_close ()
+static void test_open_close (void)
 {
 	GElektraKdb * kdb;
 	GElektraKey * error = gelektra_key_new (NULL);
@@ -37,7 +37,7 @@ static void test_open_close ()
 }
 
 
-static void test_get_set ()
+static void test_get_set (void)
 {
 	GElektraKdb * kdb;
 	GElektraKeySet * ks;

--- a/src/bindings/glib/tests/testglib_key.c
+++ b/src/bindings/glib/tests/testglib_key.c
@@ -10,7 +10,7 @@
 #include <glib-object.h>
 #include <tests.h>
 
-static void test_ctor ()
+static void test_ctor (void)
 {
 	GElektraKey * key;
 
@@ -80,7 +80,7 @@ static void test_ctor ()
 static GElektraKey * g_key = NULL;
 static GElektraKey * g_bkey = NULL;
 
-static void create_global_keys ()
+static void create_global_keys (void)
 {
 	g_key = gelektra_key_new ("user/key", GELEKTRA_KEY_VALUE, "value", GELEKTRA_KEY_OWNER, "myowner", GELEKTRA_KEY_COMMENT, "mycomment",
 				  GELEKTRA_KEY_UID, "123", GELEKTRA_KEY_GID, 456, GELEKTRA_KEY_MODE, 0644, GELEKTRA_KEY_ATIME, 123,
@@ -96,7 +96,7 @@ static void create_global_keys ()
 	succeed_if (gelektra_key_getref (g_bkey) == 1, "refcount should be 1");
 }
 
-static void test_props ()
+static void test_props (void)
 {
 	gchar *name, *basename, *fullname;
 	g_object_get (g_key, "name", &name, "basename", &basename, "fullname", &fullname, NULL);
@@ -116,7 +116,7 @@ static void test_props ()
 	g_object_unref (key);
 }
 
-static void test_basic ()
+static void test_basic (void)
 {
 	GElektraKey * key;
 
@@ -143,7 +143,7 @@ static void test_basic ()
 	g_object_unref (key);
 }
 
-static void test_operators ()
+static void test_operators (void)
 {
 	succeed_if (!gelektra_key_equal (g_key, g_bkey), "keys shouldn't be equal");
 	succeed_if (gelektra_key_cmp (g_key, g_bkey) != 0, "keys shouldn't be equal");
@@ -154,7 +154,7 @@ static void test_operators ()
 	g_object_unref (key);
 }
 
-static void test_name_manipulation ()
+static void test_name_manipulation (void)
 {
 	// TODO gelektra_key_addbasename
 	succeed_if (gelektra_key_getnamesize (g_key) == sizeof ("user/key"), "wrong size");
@@ -163,7 +163,7 @@ static void test_name_manipulation ()
 }
 
 
-static void test_value_operations ()
+static void test_value_operations (void)
 {
 	gchar * data;
 	void * bdata;
@@ -202,7 +202,7 @@ static void test_value_operations ()
 	g_free (bdata);
 }
 
-static void test_meta_data ()
+static void test_meta_data (void)
 {
 	GElektraKey *meta, *key;
 
@@ -248,7 +248,7 @@ static void test_meta_data ()
 	g_object_unref (key);
 }
 
-static void test_validating ()
+static void test_validating (void)
 {
 	succeed_if (!gelektra_key_isnull (g_key), "key is null");
 	succeed_if (gelektra_key_isvalid (g_key), "key is not valid");
@@ -271,7 +271,7 @@ static void test_validating ()
 	g_object_unref (key);
 }
 
-static void destroy_global_keys ()
+static void destroy_global_keys (void)
 {
 	g_object_unref (g_key);
 	g_object_unref (g_bkey);

--- a/src/bindings/glib/tests/testglib_keyset.c
+++ b/src/bindings/glib/tests/testglib_keyset.c
@@ -10,7 +10,7 @@
 #include <glib-object.h>
 #include <tests.h>
 
-static void test_ctor ()
+static void test_ctor (void)
 {
 	GElektraKeySet * ks;
 
@@ -29,7 +29,7 @@ static void test_ctor ()
 	g_object_unref (ks);
 }
 
-static void test_basic ()
+static void test_basic (void)
 {
 	GElektraKeySet *ks1, *ks2;
 	GElektraKey * key;
@@ -67,7 +67,7 @@ static void test_basic ()
 	g_object_unref (ks1);
 }
 
-static void test_searching ()
+static void test_searching (void)
 {
 	GElektraKeySet * ks;
 	GElektraKey *key1, *key2;
@@ -90,7 +90,7 @@ static void test_searching ()
 	g_object_unref (ks);
 }
 
-static void test_iterating ()
+static void test_iterating (void)
 {
 	GElektraKeySet * ks;
 	GElektraKey *key1, *key2, *tmpkey;

--- a/src/bindings/intercept/fs/intercept.c
+++ b/src/bindings/intercept/fs/intercept.c
@@ -109,7 +109,7 @@ static const char * genTemporaryFilename (void)
 
 static void init (void) __attribute__ ((constructor));
 static void cleanup (void) __attribute__ ((destructor));
-void init ()
+void init (void)
 {
 	char cwd[PATH_MAX];
 	getcwd (cwd, PATH_MAX);
@@ -192,7 +192,7 @@ CleanUp:
 }
 
 
-void cleanup ()
+void cleanup (void)
 {
 	Node * current = head;
 	while (current)

--- a/src/include/kdbversion.h.in
+++ b/src/include/kdbversion.h.in
@@ -19,7 +19,7 @@
 
 #include <kdb.h>
 
-static inline KeySet *elektraVersionKeySet ()
+static inline KeySet *elektraVersionKeySet (void)
 {
 	return ksNew (50, keyNew ("system/elektra/version",
 			KEY_VALUE, "Below are version information of the Elektra Library you are currently using", KEY_END),

--- a/src/libs/elektra/backend.c
+++ b/src/libs/elektra/backend.c
@@ -42,7 +42,7 @@
  *
  * @return 
  */
-static Backend * elektraBackendAllocate ()
+static Backend * elektraBackendAllocate (void)
 {
 	Backend * backend = elektraCalloc (sizeof (struct _Backend));
 

--- a/src/libs/elektra/key.c
+++ b/src/libs/elektra/key.c
@@ -80,7 +80,7 @@
  * Allocates and initializes a key
  * @returns 0 if allocation did not work, the key otherwise
  */
-static Key * elektraKeyMalloc ()
+static Key * elektraKeyMalloc (void)
 {
 	Key * key = (Key *)elektraMalloc (sizeof (Key));
 	if (!key) return 0;

--- a/src/libs/elektra/mount.c
+++ b/src/libs/elektra/mount.c
@@ -309,7 +309,7 @@ Plugin * elektraMountGlobalsLoadPlugin (KeySet * referencePlugins, Key * cur, Ke
 	return plugin;
 }
 
-KeySet * elektraDefaultGlobalConfig ()
+KeySet * elektraDefaultGlobalConfig (void)
 {
 	return ksNew (
 		18, keyNew ("system/elektra/globalplugins", KEY_VALUE, "", KEY_END),

--- a/src/plugins/augeas/testaugeas.c
+++ b/src/plugins/augeas/testaugeas.c
@@ -9,7 +9,7 @@
 #include <augeas.h>
 #include <stddef.h>
 
-int main ()
+int main (void)
 {
 	augeas * handle = aug_init (NULL, NULL, AUG_NONE);
 	aug_text_store (handle, "Hosts", "/raw/contentnode", "/raw/tree");

--- a/src/plugins/base64/testmod_base64.c
+++ b/src/plugins/base64/testmod_base64.c
@@ -23,12 +23,12 @@ static const char * decoded[] = { "", "f", "fo", "foo", "foob", "fooba", "foobar
 static const char * encoded[] = { "", "Zg==", "Zm8=", "Zm9v", "Zm9vYg==", "Zm9vYmE=", "Zm9vYmFy" };
 static const size_t testcaseCounter = sizeof (decoded) / sizeof (const char *);
 
-static inline KeySet * newPluginConfiguration ()
+static inline KeySet * newPluginConfiguration (void)
 {
 	return ksNew (0, KS_END);
 }
 
-static void test_init ()
+static void test_init (void)
 {
 	Plugin * plugin = NULL;
 	Key * parentKey = keyNew ("system", KEY_END);
@@ -61,7 +61,7 @@ static inline char testcase2char (size_t i)
 	return '0' + i + 1;
 }
 
-static void test_base64_encoding ()
+static void test_base64_encoding (void)
 {
 	char errorAlloc[] = "Encoding #.: Memory allocation failed";
 	char errorMismatch[] = "Encoding #.: returned unexpected result";
@@ -81,7 +81,7 @@ static void test_base64_encoding ()
 	}
 }
 
-static void test_base64_decoding ()
+static void test_base64_decoding (void)
 {
 	char errorFail[] = "Decoding #.: operation failed";
 	char errorMismatch[] = "Decoding #.: returned unexpected result vector";
@@ -121,7 +121,7 @@ static void test_base64_decoding ()
 	}
 }
 
-static void test_base64_plugin_regular ()
+static void test_base64_plugin_regular (void)
 {
 	Plugin * plugin = NULL;
 	Key * parentKey = keyNew ("system", KEY_END);
@@ -221,7 +221,7 @@ static void test_base64_plugin_regular ()
 	keyDel (parentKey);
 }
 
-static void test_base64_plugin_decoding_error ()
+static void test_base64_plugin_decoding_error (void)
 {
 	Plugin * plugin = NULL;
 	Key * parentKey = keyNew ("system", KEY_END);

--- a/src/plugins/blockresolver/blockresolver.c
+++ b/src/plugins/blockresolver/blockresolver.c
@@ -91,7 +91,7 @@ int elektraBlockresolverCheckFile (const char * filename ELEKTRA_UNUSED)
 	return 1;
 }
 
-static const char * genTempFilename ()
+static const char * genTempFilename (void)
 {
 	struct timeval tv;
 	gettimeofday (&tv, 0);

--- a/src/plugins/boolean/testmod_boolean.c
+++ b/src/plugins/boolean/testmod_boolean.c
@@ -15,7 +15,7 @@
 
 #include <tests_plugin.h>
 
-static void test_default ()
+static void test_default (void)
 {
 	Key * parentKey = keyNew ("user/tests/boolean", KEY_END);
 	KeySet * conf = ksNew (0, KS_END);
@@ -44,7 +44,7 @@ static void test_default ()
 	PLUGIN_CLOSE ();
 }
 
-static void test_defaultRestore ()
+static void test_defaultRestore (void)
 {
 	Key * parentKey = keyNew ("user/tests/boolean", KEY_END);
 	KeySet * conf = ksNew (0, KS_END);
@@ -64,7 +64,7 @@ static void test_defaultRestore ()
 	PLUGIN_CLOSE ();
 }
 
-static void test_defaultError ()
+static void test_defaultError (void)
 {
 	Key * parentKey = keyNew ("user/tests/boolean", KEY_END);
 	KeySet * conf = ksNew (0, KS_END);
@@ -85,7 +85,7 @@ static void test_defaultError ()
 	PLUGIN_CLOSE ();
 }
 
-static void test_userValue ()
+static void test_userValue (void)
 {
 	Key * parentKey = keyNew ("user/tests/boolean", KEY_END);
 	KeySet * conf = ksNew (10, keyNew ("system/on/true", KEY_VALUE, "7", KEY_END),

--- a/src/plugins/cachefilter/testmod_cachefilter.c
+++ b/src/plugins/cachefilter/testmod_cachefilter.c
@@ -17,49 +17,49 @@
 
 #include <tests_plugin.h>
 
-static KeySet * createTestKeysToCache ()
+static KeySet * createTestKeysToCache (void)
 {
 	return ksNew (3, keyNew ("user/tests/cachefilter/will/be/cached/key1", KEY_VALUE, "cached1", KEY_END),
 		      keyNew ("user/tests/cachefilter/will/be/cached/key2", KEY_VALUE, "cached2", KEY_END),
 		      keyNew ("user/tests/cachefilter/will/be/cached", KEY_VALUE, "cached", KEY_END), KS_END);
 }
 
-static KeySet * createTestKeysToCache2 ()
+static KeySet * createTestKeysToCache2 (void)
 {
 	return ksNew (3, keyNew ("user/tests/cachefilter/will/be/cached/key3", KEY_VALUE, "cached1", KEY_END),
 		      keyNew ("user/tests/cachefilter/will/be/cached/key4", KEY_VALUE, "cached2", KEY_END),
 		      keyNew ("user/tests/cachefilter/will/be/cached/key5", KEY_VALUE, "cached", KEY_END), KS_END);
 }
 
-static KeySet * createTestKeysToCache3 ()
+static KeySet * createTestKeysToCache3 (void)
 {
 	return ksNew (3, keyNew ("user/tests/cachefilter/will/be/cached/key6", KEY_VALUE, "cached1", KEY_END),
 		      keyNew ("user/tests/cachefilter/will/be/cached/key7", KEY_VALUE, "cached2", KEY_END),
 		      keyNew ("user/tests/cachefilter/will/be/cached/key8", KEY_VALUE, "cached", KEY_END), KS_END);
 }
 
-static KeySet * createTestKeysToNotCache ()
+static KeySet * createTestKeysToNotCache (void)
 {
 	return ksNew (3, keyNew ("user/tests/cachefilter/will/not/be/cached/key1", KEY_VALUE, "not-cached1", KEY_END),
 		      keyNew ("user/tests/cachefilter/will/not/be/cached/key2", KEY_VALUE, "not-cached2", KEY_END),
 		      keyNew ("user/tests/cachefilter/will/not/be/cached", KEY_VALUE, "not-cached", KEY_END), KS_END);
 }
 
-static KeySet * createTestKeysToNotCacheCascading ()
+static KeySet * createTestKeysToNotCacheCascading (void)
 {
 	return ksNew (3, keyNew ("user/tests/cachefilter/will/not/be/cached/with/directory/key1", KEY_END),
 		      keyNew ("user/tests/cachefilter/will/not/be/cached/with/directory/key2", KEY_END),
 		      keyNew ("user/tests/cachefilter/will/not/be/cached/with/directory/key3", KEY_END), KS_END);
 }
 
-static KeySet * createTestKeysToNotCacheSiblings ()
+static KeySet * createTestKeysToNotCacheSiblings (void)
 {
 	return ksNew (3, keyNew ("user/tests/cachefilter/will/not/be/cached/for/whatever/key1", KEY_END),
 		      keyNew ("user/tests/cachefilter/will/not/be/cached/for/whatever/key2", KEY_END),
 		      keyNew ("user/tests/cachefilter/will/not/be/cached/for/whatever/key3", KEY_END), KS_END);
 }
 
-static void test_successfulCache ()
+static void test_successfulCache (void)
 {
 	Key * parentKey = keyNew ("user/tests/cachefilter/will/not/be/cached", KEY_END);
 	KeySet * conf = ksNew (0, KS_END);
@@ -103,7 +103,7 @@ static void test_successfulCache ()
 	PLUGIN_CLOSE ();
 }
 
-static void test_successfulCacheLong ()
+static void test_successfulCacheLong (void)
 {
 	Key * parentKey = keyNew ("user/tests/cachefilter/will/not/be/cached", KEY_END);
 	KeySet * conf = ksNew (0, KS_END);
@@ -179,7 +179,7 @@ static void test_successfulCacheLong ()
 	PLUGIN_CLOSE ();
 }
 
-static void test_successfulGetSetGetSet ()
+static void test_successfulGetSetGetSet (void)
 {
 	Key * parentKey = keyNew ("user/tests/cachefilter/will/not/be/cached", KEY_END);
 	KeySet * conf = ksNew (0, KS_END);
@@ -247,7 +247,7 @@ static void test_successfulGetSetGetSet ()
 	PLUGIN_CLOSE ();
 }
 
-static void test_successfulGetGetGet ()
+static void test_successfulGetGetGet (void)
 {
 	Key * parentKey = keyNew ("user/tests/cachefilter/will/not/be/cached", KEY_END);
 	Key * parentKey2 = keyNew ("user/tests/cachefilter/will/not/be/cached/with", KEY_END);
@@ -317,7 +317,7 @@ static void test_successfulGetGetGet ()
 	PLUGIN_CLOSE ();
 }
 
-static void test_successfulSiblingGets ()
+static void test_successfulSiblingGets (void)
 {
 	Key * parentKey = keyNew ("user/tests/cachefilter/will/not/be/cached/with", KEY_END);
 	Key * parentKey2 = keyNew ("user/tests/cachefilter/will/not/be/cached/for", KEY_END);

--- a/src/plugins/ccode/testmod_ccode.c
+++ b/src/plugins/ccode/testmod_ccode.c
@@ -22,7 +22,7 @@
 
 #include <tests_internal.h>
 
-CCodeData * get_data ()
+CCodeData * get_data (void)
 {
 	CCodeData * d = calloc (1, sizeof (CCodeData));
 	d->escape = '\\';
@@ -47,7 +47,7 @@ const char encoded_string[] = "a\\wvalue\\nwith\\e\\s\\r\\wand\\w\\b\\witself";
 const char other_encoded_string[] = "a%wvalue%nwith%e%s%r%wand%w%b%witself";
 const char decoded_string[] = "a value\nwith=;# and \\ itself";
 
-void test_encode ()
+void test_encode (void)
 {
 	printf ("test encode\n");
 
@@ -63,7 +63,7 @@ void test_encode ()
 	keyDel (test);
 }
 
-void test_decode ()
+void test_decode (void)
 {
 	printf ("test decode\n");
 
@@ -97,7 +97,7 @@ void check_reversibility (const char * msg)
 	keyDel (encode);
 }
 
-void test_reversibility ()
+void test_reversibility (void)
 {
 	printf ("test reversibility\n");
 
@@ -114,7 +114,7 @@ void test_reversibility ()
 	check_reversibility ("\n\\");
 }
 
-void test_decodeescape ()
+void test_decodeescape (void)
 {
 	printf ("test decode escape\n");
 
@@ -132,7 +132,7 @@ void test_decodeescape ()
 	keyDel (test);
 }
 
-void test_config ()
+void test_config (void)
 {
 	printf ("test with config\n");
 
@@ -163,7 +163,7 @@ void test_config ()
 	elektraFree (p);
 }
 
-void test_otherescape ()
+void test_otherescape (void)
 {
 	printf ("test with config with other escape\n");
 

--- a/src/plugins/conditionals/testmod_conditionals.c
+++ b/src/plugins/conditionals/testmod_conditionals.c
@@ -14,7 +14,7 @@
 
 #include <tests_plugin.h>
 
-static void test_ifthenelseint ()
+static void test_ifthenelseint (void)
 {
 	Key * parentKey = keyNew ("user/tests/conditionals", KEY_VALUE, "", KEY_END);
 	KeySet * ks = ksNew (5, keyNew ("user/tests/conditionals/totest", KEY_VALUE, "153", KEY_META, "check/condition",
@@ -30,7 +30,7 @@ static void test_ifthenelseint ()
 	keyDel (parentKey);
 	PLUGIN_CLOSE ();
 }
-static void test_ifthenint ()
+static void test_ifthenint (void)
 {
 	Key * parentKey = keyNew ("user/tests/conditionals", KEY_VALUE, "", KEY_END);
 	KeySet * ks = ksNew (5, keyNew ("user/tests/conditionals/totest", KEY_VALUE, "153", KEY_META, "check/condition",
@@ -46,7 +46,7 @@ static void test_ifthenint ()
 	keyDel (parentKey);
 	PLUGIN_CLOSE ();
 }
-static void test_ifthenltint ()
+static void test_ifthenltint (void)
 {
 	Key * parentKey = keyNew ("user/tests/conditionals", KEY_VALUE, "", KEY_END);
 	KeySet * ks = ksNew (5, keyNew ("user/tests/conditionals/totest", KEY_VALUE, "153", KEY_META, "check/condition",
@@ -62,7 +62,7 @@ static void test_ifthenltint ()
 	keyDel (parentKey);
 	PLUGIN_CLOSE ();
 }
-static void test_ifthengtint ()
+static void test_ifthengtint (void)
 {
 	Key * parentKey = keyNew ("user/tests/conditionals", KEY_VALUE, "", KEY_END);
 	KeySet * ks = ksNew (5, keyNew ("user/tests/conditionals/totest", KEY_VALUE, "153", KEY_META, "check/condition",
@@ -79,7 +79,7 @@ static void test_ifthengtint ()
 	PLUGIN_CLOSE ();
 }
 
-static void test_ifthenkey ()
+static void test_ifthenkey (void)
 {
 	Key * parentKey = keyNew ("user/tests/conditionals", KEY_VALUE, "", KEY_END);
 	KeySet * ks = ksNew (5, keyNew ("user/tests/conditionals/totest", KEY_VALUE, "153", KEY_META, "check/condition",
@@ -97,7 +97,7 @@ static void test_ifthenkey ()
 }
 
 
-static void test_emptyisempty ()
+static void test_emptyisempty (void)
 {
 	Key * parentKey = keyNew ("user/tests/conditionals", KEY_VALUE, "", KEY_END);
 	KeySet * ks = ksNew (5, keyNew ("user/tests/conditionals/totest", KEY_VALUE, "", KEY_META, "check/condition",
@@ -115,7 +115,7 @@ static void test_emptyisempty ()
 }
 
 
-static void test_notempty ()
+static void test_notempty (void)
 {
 	Key * parentKey = keyNew ("user/tests/conditionals", KEY_VALUE, "", KEY_END);
 	KeySet * ks = ksNew (5, keyNew ("user/tests/conditionals/totest", KEY_VALUE, "153", KEY_META, "check/condition",
@@ -132,7 +132,7 @@ static void test_notempty ()
 	PLUGIN_CLOSE ();
 }
 
-static void test_ifsetthenval ()
+static void test_ifsetthenval (void)
 {
 	Key * parentKey = keyNew ("user/tests/conditionals", KEY_VALUE, "", KEY_END);
 	KeySet * ks = ksNew (5, keyNew ("user/tests/conditionals/totest", KEY_VALUE, "", KEY_META, "check/condition",
@@ -150,7 +150,7 @@ static void test_ifsetthenval ()
 	keyDel (parentKey);
 	PLUGIN_CLOSE ();
 }
-static void test_ifsetthenkey ()
+static void test_ifsetthenkey (void)
 {
 	Key * parentKey = keyNew ("user/tests/conditionals", KEY_VALUE, "", KEY_END);
 	KeySet * ks = ksNew (5, keyNew ("user/tests/conditionals/totest", KEY_VALUE, "", KEY_META, "check/condition",
@@ -168,7 +168,7 @@ static void test_ifsetthenkey ()
 	keyDel (parentKey);
 	PLUGIN_CLOSE ();
 }
-static void test_assignThen ()
+static void test_assignThen (void)
 {
 	Key * parentKey = keyNew ("user/tests/conditionals", KEY_VALUE, "", KEY_END);
 	KeySet * ks = ksNew (5, keyNew ("user/tests/conditionals/totest", KEY_VALUE, "Hello", KEY_META, "assign/condition",
@@ -184,7 +184,7 @@ static void test_assignThen ()
 	keyDel (parentKey);
 	PLUGIN_CLOSE ();
 }
-static void test_assignThen2 ()
+static void test_assignThen2 (void)
 {
 	Key * parentKey = keyNew ("user/tests/conditionals", KEY_VALUE, "", KEY_END);
 	KeySet * ks = ksNew (5, keyNew ("user/tests/conditionals/totest", KEY_VALUE, "Hello", KEY_META, "assign/condition",
@@ -200,7 +200,7 @@ static void test_assignThen2 ()
 	keyDel (parentKey);
 	PLUGIN_CLOSE ();
 }
-static void test_assignElse ()
+static void test_assignElse (void)
 {
 	Key * parentKey = keyNew ("user/tests/conditionals", KEY_VALUE, "", KEY_END);
 	KeySet * ks = ksNew (5, keyNew ("user/tests/conditionals/totest", KEY_VALUE, "Hello", KEY_META, "assign/condition",
@@ -217,7 +217,7 @@ static void test_assignElse ()
 	PLUGIN_CLOSE ();
 }
 
-static void test_assignKeyThen ()
+static void test_assignKeyThen (void)
 {
 	Key * parentKey = keyNew ("user/tests/conditionals", KEY_VALUE, "", KEY_END);
 	KeySet * ks = ksNew (5, keyNew ("user/tests/conditionals/totest", KEY_VALUE, "Hello", KEY_META, "assign/condition",
@@ -235,7 +235,7 @@ static void test_assignKeyThen ()
 	PLUGIN_CLOSE ();
 }
 
-static void test_assignKeyElse ()
+static void test_assignKeyElse (void)
 {
 	Key * parentKey = keyNew ("user/tests/conditionals", KEY_VALUE, "", KEY_END);
 	KeySet * ks = ksNew (5, keyNew ("user/tests/conditionals/totest", KEY_VALUE, "Hello", KEY_META, "assign/condition",
@@ -253,7 +253,7 @@ static void test_assignKeyElse ()
 	PLUGIN_CLOSE ();
 }
 
-static void test_doesntExistSuccess ()
+static void test_doesntExistSuccess (void)
 {
 	Key * parentKey = keyNew ("user/tests/conditionals", KEY_VALUE, "", KEY_END);
 	KeySet * ks = ksNew (5, keyNew ("user/tests/conditionals/totest", KEY_VALUE, "5", KEY_META, "check/condition",
@@ -272,7 +272,7 @@ static void test_doesntExistSuccess ()
 	PLUGIN_CLOSE ();
 }
 
-static void test_doesntExistFail ()
+static void test_doesntExistFail (void)
 {
 	Key * parentKey = keyNew ("user/tests/conditionals", KEY_VALUE, "", KEY_END);
 	KeySet * ks = ksNew (5, keyNew ("user/tests/conditionals/totest", KEY_VALUE, "5", KEY_META, "check/condition",
@@ -291,7 +291,7 @@ static void test_doesntExistFail ()
 	PLUGIN_CLOSE ();
 }
 
-static void test_nested1Success ()
+static void test_nested1Success (void)
 {
 	Key * parentKey = keyNew ("user/tests/conditionals", KEY_VALUE, "", KEY_END);
 	KeySet * ks =
@@ -311,7 +311,7 @@ static void test_nested1Success ()
 	PLUGIN_CLOSE ();
 }
 
-static void test_nested1Fail ()
+static void test_nested1Fail (void)
 {
 	Key * parentKey = keyNew ("user/tests/conditionals", KEY_VALUE, "", KEY_END);
 	KeySet * ks =
@@ -331,7 +331,7 @@ static void test_nested1Fail ()
 }
 
 
-static void test_nested2Success ()
+static void test_nested2Success (void)
 {
 	Key * parentKey = keyNew ("user/tests/conditionals", KEY_VALUE, "", KEY_END);
 	KeySet * ks = ksNew (5, keyNew ("user/tests/conditionals/totest", KEY_VALUE, "5", KEY_META, "check/condition",
@@ -352,7 +352,7 @@ static void test_nested2Success ()
 	PLUGIN_CLOSE ();
 }
 
-static void test_nested2Fail ()
+static void test_nested2Fail (void)
 {
 	Key * parentKey = keyNew ("user/tests/conditionals", KEY_VALUE, "", KEY_END);
 	KeySet * ks = ksNew (5, keyNew ("user/tests/conditionals/totest", KEY_VALUE, "5", KEY_META, "check/condition",
@@ -372,7 +372,7 @@ static void test_nested2Fail ()
 	PLUGIN_CLOSE ();
 }
 
-static void test_suffix ()
+static void test_suffix (void)
 {
 	Key * parentKey = keyNew ("user/tests/conditionals", KEY_VALUE, "", KEY_END);
 	KeySet * ks = ksNew (5, keyNew ("user/tests/conditionals/totest", KEY_VALUE, "2%", KEY_META, "check/condition",
@@ -390,7 +390,7 @@ static void test_suffix ()
 	PLUGIN_CLOSE ();
 }
 
-static void test_elseWhitespace ()
+static void test_elseWhitespace (void)
 {
 	Key * parentKey = keyNew ("user/tests/conditionals", KEY_VALUE, "", KEY_END);
 	KeySet * ks = ksNew (5, keyNew ("user/tests/conditionals/totest", KEY_VALUE, "2", KEY_META, "check/condition",
@@ -407,7 +407,7 @@ static void test_elseWhitespace ()
 	PLUGIN_CLOSE ();
 }
 
-static void test_elseWhitespace2 ()
+static void test_elseWhitespace2 (void)
 {
 	Key * parentKey = keyNew ("user/tests/conditionals", KEY_VALUE, "", KEY_END);
 	KeySet * ks = ksNew (5, keyNew ("user/tests/conditionals/totest", KEY_VALUE, "2", KEY_META, "check/condition",
@@ -424,7 +424,7 @@ static void test_elseWhitespace2 ()
 	PLUGIN_CLOSE ();
 }
 
-static void test_elseWhitespace3 ()
+static void test_elseWhitespace3 (void)
 {
 	Key * parentKey = keyNew ("user/tests/conditionals", KEY_VALUE, "", KEY_END);
 	KeySet * ks = ksNew (5, keyNew ("user/tests/conditionals/totest", KEY_VALUE, "2", KEY_META, "check/condition",
@@ -441,7 +441,7 @@ static void test_elseWhitespace3 ()
 	PLUGIN_CLOSE ();
 }
 
-static void test_doubleUp ()
+static void test_doubleUp (void)
 {
 	Key * parentKey = keyNew ("user/tests/conditionals", KEY_VALUE, "", KEY_END);
 	KeySet * ks =
@@ -463,7 +463,7 @@ static void test_doubleUp ()
 }
 
 
-static void test_multiCondAny ()
+static void test_multiCondAny (void)
 {
 	Key * parentKey = keyNew ("user/tests/conditionals", KEY_VALUE, "", KEY_END);
 	KeySet * ks = ksNew (5, keyNew ("user/tests/conditionals/compare", KEY_VALUE, "Sun", KEY_END),
@@ -481,7 +481,7 @@ static void test_multiCondAny ()
 	PLUGIN_CLOSE ();
 }
 
-static void test_multiCond2Any ()
+static void test_multiCond2Any (void)
 {
 	Key * parentKey = keyNew ("user/tests/conditionals", KEY_VALUE, "", KEY_END);
 	KeySet * ks = ksNew (5, keyNew ("user/tests/conditionals/compare", KEY_VALUE, "Moon", KEY_END),
@@ -499,7 +499,7 @@ static void test_multiCond2Any ()
 	PLUGIN_CLOSE ();
 }
 
-static void test_multiCondAll ()
+static void test_multiCondAll (void)
 {
 	Key * parentKey = keyNew ("user/tests/conditionals", KEY_VALUE, "", KEY_END);
 	KeySet * ks = ksNew (5, keyNew ("user/tests/conditionals/compare", KEY_VALUE, "Sun", KEY_END),
@@ -517,7 +517,7 @@ static void test_multiCondAll ()
 	PLUGIN_CLOSE ();
 }
 
-static void test_multiCond2All ()
+static void test_multiCond2All (void)
 {
 	Key * parentKey = keyNew ("user/tests/conditionals", KEY_VALUE, "", KEY_END);
 	KeySet * ks = ksNew (5, keyNew ("user/tests/conditionals/compare", KEY_VALUE, "Moon", KEY_END),
@@ -535,7 +535,7 @@ static void test_multiCond2All ()
 	PLUGIN_CLOSE ();
 }
 
-static void test_multiCondNoFail ()
+static void test_multiCondNoFail (void)
 {
 	Key * parentKey = keyNew ("user/tests/conditionals", KEY_VALUE, "", KEY_END);
 	KeySet * ks = ksNew (5, keyNew ("user/tests/conditionals/compare", KEY_VALUE, "Sun", KEY_END),
@@ -553,7 +553,7 @@ static void test_multiCondNoFail ()
 	PLUGIN_CLOSE ();
 }
 
-static void test_multiCond2NoFail ()
+static void test_multiCond2NoFail (void)
 {
 	Key * parentKey = keyNew ("user/tests/conditionals", KEY_VALUE, "", KEY_END);
 	KeySet * ks = ksNew (5, keyNew ("user/tests/conditionals/compare", KEY_VALUE, "Moon", KEY_END),
@@ -570,7 +570,7 @@ static void test_multiCond2NoFail ()
 	keyDel (parentKey);
 	PLUGIN_CLOSE ();
 }
-static void test_multiAssign ()
+static void test_multiAssign (void)
 {
 	Key * parentKey = keyNew ("user/tests/conditionals", KEY_VALUE, "", KEY_END);
 	KeySet * ks = ksNew (5, keyNew ("user/tests/conditionals/totest", KEY_VALUE, "Hello", KEY_META, "assign/condition", "#1", KEY_META,
@@ -589,7 +589,7 @@ static void test_multiAssign ()
 	PLUGIN_CLOSE ();
 }
 
-static void test_multiAssign2 ()
+static void test_multiAssign2 (void)
 {
 	Key * parentKey = keyNew ("user/tests/conditionals", KEY_VALUE, "", KEY_END);
 	KeySet * ks = ksNew (5, keyNew ("user/tests/conditionals/totest", KEY_VALUE, "Bye", KEY_META, "assign/condition", "#1", KEY_META,
@@ -608,7 +608,7 @@ static void test_multiAssign2 ()
 	PLUGIN_CLOSE ();
 }
 
-static void test_multiAssign3 ()
+static void test_multiAssign3 (void)
 {
 	Key * parentKey = keyNew ("user/tests/conditionals", KEY_VALUE, "", KEY_END);
 	KeySet * ks = ksNew (5, keyNew ("user/tests/conditionals/totest", KEY_VALUE, "Bye", KEY_META, "assign/condition", "#1", KEY_META,

--- a/src/plugins/crypto/compile_gcrypt.c
+++ b/src/plugins/crypto/compile_gcrypt.c
@@ -9,7 +9,7 @@
 
 #include <gcrypt.h>
 
-int main ()
+int main (void)
 {
 	gcry_cipher_hd_t elektraCryptoHandle;
 	return 0;

--- a/src/plugins/crypto/compile_openssl.c
+++ b/src/plugins/crypto/compile_openssl.c
@@ -9,7 +9,7 @@
 
 #include <openssl/evp.h>
 
-int main ()
+int main (void)
 {
 	EVP_CIPHER_CTX * opensslSpecificType;
 	return 0;

--- a/src/plugins/crypto/crypto.c
+++ b/src/plugins/crypto/crypto.c
@@ -90,7 +90,7 @@ static int elektraCryptoInit (Key * errorKey ELEKTRA_UNUSED)
  *
  * Some libraries may need extra code for cleaning up the environment.
  */
-static void elektraCryptoTeardown ()
+static void elektraCryptoTeardown (void)
 {
 }
 

--- a/src/plugins/crypto/test_internals.h
+++ b/src/plugins/crypto/test_internals.h
@@ -55,7 +55,7 @@ static int isMarkedForEncryption (const Key * k)
 /**
  * @brief create a new KeySet holding sample data for encryption and decryption.
  */
-static KeySet * newTestdataKeySet ()
+static KeySet * newTestdataKeySet (void)
 {
 	Key * kUnchanged1 = keyNew ("user/crypto/test/nochange", KEY_END);
 	Key * kUnchanged2 = keyNew ("user/crypto/test/nochange2", KEY_END);
@@ -98,7 +98,7 @@ static inline void setPluginShutdown (KeySet * config)
 	ksAppendKey (config, keyNew (ELEKTRA_CRYPTO_PARAM_SHUTDOWN, KEY_VALUE, "1", 0));
 }
 
-static KeySet * newPluginConfiguration ()
+static KeySet * newPluginConfiguration (void)
 {
 	return ksNew (2, keyNew (ELEKTRA_RECIPIENT_KEY, KEY_VALUE, TEST_KEY_ID, KEY_END),
 		      keyNew (ELEKTRA_CRYPTO_PARAM_GPG_UNIT_TEST, KEY_VALUE, "1", KEY_END), KS_END);

--- a/src/plugins/doc/doc.c
+++ b/src/plugins/doc/doc.c
@@ -244,7 +244,7 @@ int elektraPluginSet (Plugin * plugin ELEKTRA_UNUSED, KeySet * returned, Key * p
 //![set full]
 
 
-void elektraUsercodeUselessSymbol ()
+void elektraUsercodeUselessSymbol (void)
 {
 	usercode (0, 0, 0);
 }

--- a/src/plugins/dump/testmod_dump.c
+++ b/src/plugins/dump/testmod_dump.c
@@ -20,7 +20,7 @@
 
 #include <tests.h>
 
-KeySet * get_dump ()
+KeySet * get_dump (void)
 {
 	Key *k1, *k2;
 	// clang-format off

--- a/src/plugins/enum/testmod_enum.c
+++ b/src/plugins/enum/testmod_enum.c
@@ -17,7 +17,7 @@
 #include <tests_plugin.h>
 
 
-static void test ()
+static void test (void)
 {
 	Key * parentKey = keyNew ("user/tests/enum", KEY_VALUE, "", KEY_END);
 	Key * k1 = keyNew ("user/tests/enum/valid1", KEY_VALUE, "TRUE", KEY_META, "check/enum", "'TRUE',  'FALSE'", KEY_END);
@@ -56,7 +56,7 @@ static void test ()
 	PLUGIN_CLOSE ();
 }
 
-static void testArray ()
+static void testArray (void)
 {
 	Key * parentKey = keyNew ("user/tests/enum", KEY_VALUE, "", KEY_END);
 	Key * k1 = keyNew ("user/tests/enum/valid1", KEY_VALUE, "LOW", KEY_META, "check/enum", "#1", KEY_META, "check/enum/#0", "LOW",
@@ -102,7 +102,7 @@ static void testArray ()
 	PLUGIN_CLOSE ();
 }
 
-static void testMultiList ()
+static void testMultiList (void)
 {
 	Key * parentKey = keyNew ("user/tests/enum", KEY_VALUE, "", KEY_END);
 	Key * k1 = keyNew ("user/tests/enum/valid1", KEY_VALUE, "LOW", KEY_META, "check/enum/multi", "_", KEY_META, "check/enum",

--- a/src/plugins/fcrypt/testmod_fcrypt.c
+++ b/src/plugins/fcrypt/testmod_fcrypt.c
@@ -25,7 +25,7 @@
 
 static const kdb_octet_t testContent[] = { 0x01, 0x02, 0xCA, 0xFE, 0xBA, 0xBE, 0x03, 0x04 };
 
-static KeySet * newPluginConfiguration ()
+static KeySet * newPluginConfiguration (void)
 {
 	// clang-format off
 	return ksNew (3,
@@ -101,7 +101,7 @@ static int isTestFileCorrect (const char * file)
 	return returnValue;
 }
 
-static void test_init ()
+static void test_init (void)
 {
 	Plugin * plugin = NULL;
 	Key * parentKey = keyNew ("system", KEY_END);
@@ -131,7 +131,7 @@ static void test_init ()
 	keyDel (parentKey);
 }
 
-static void test_gpg ()
+static void test_gpg (void)
 {
 	// Plugin configuration
 	KeySet * conf = newPluginConfiguration ();
@@ -150,7 +150,7 @@ static void test_gpg ()
 	ksDel (conf);
 }
 
-static void test_file_crypto_operations ()
+static void test_file_crypto_operations (void)
 {
 	Plugin * plugin = NULL;
 	Key * parentKey = keyNew ("system", KEY_END);
@@ -194,7 +194,7 @@ static void test_file_crypto_operations ()
 	keyDel (parentKey);
 }
 
-static void test_file_signature_operations ()
+static void test_file_signature_operations (void)
 {
 	Plugin * plugin = NULL;
 	Key * parentKey = keyNew ("system", KEY_END);

--- a/src/plugins/fstab/fstab.h
+++ b/src/plugins/fstab/fstab.h
@@ -18,7 +18,6 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <stdio.h>
-#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>

--- a/src/plugins/fstab/testmntent.c
+++ b/src/plugins/fstab/testmntent.c
@@ -9,7 +9,7 @@
 #include <mntent.h>
 #include <stdio.h>
 
-int main ()
+int main (void)
 {
 	struct mntent * m;
 	FILE * f;

--- a/src/plugins/gitresolver/gitresolver_test.c
+++ b/src/plugins/gitresolver/gitresolver_test.c
@@ -1,5 +1,5 @@
 #include <git2.h>
-void main ()
+void main (void)
 {
 	git_libgit2_init ();
 	git_index_add_frombuffer (NULL, NULL, NULL, (size_t)NULL);

--- a/src/plugins/glob/testmod_glob.c
+++ b/src/plugins/glob/testmod_glob.c
@@ -20,7 +20,7 @@
 
 #define NR_KEYS 1
 
-void test_match ()
+void test_match (void)
 {
 	succeed_if (fnmatch ("user/*/to/key", "user/path/to/key", FNM_PATHNAME) == 0, "could not do simple fnmatch");
 }
@@ -51,14 +51,14 @@ void testKeys (KeySet * ks)
 	succeed_if (strcmp ("testvalue2", keyValue (metaKey)) == 0, "value of metakey testmetakey2 not correct");
 }
 
-KeySet * createKeys ()
+KeySet * createKeys (void)
 {
 	KeySet * ks = ksNew (30, keyNew ("user/tests/glob/test1", KEY_END), keyNew ("user/tests/glob/test2/subtest1", KEY_END),
 			     keyNew ("user/tests/glob/test3", KEY_END), KS_END);
 	return ks;
 }
 
-void test_zeroMatchFlags ()
+void test_zeroMatchFlags (void)
 {
 	Key * parentKey = keyNew ("user/tests/glob", KEY_END);
 	KeySet * conf = ksNew (20, keyNew ("user/glob/#1", KEY_VALUE, "*test1", KEY_META, "testmetakey1", "testvalue1", KEY_END),
@@ -94,7 +94,7 @@ void test_zeroMatchFlags ()
 	PLUGIN_CLOSE ();
 }
 
-void test_setGlobalMatch ()
+void test_setGlobalMatch (void)
 {
 	Key * parentKey = keyNew ("user/tests/glob", KEY_END);
 	// clang-format off
@@ -120,7 +120,7 @@ void test_setGlobalMatch ()
 	PLUGIN_CLOSE ();
 }
 
-void test_getGlobalMatch ()
+void test_getGlobalMatch (void)
 {
 	Key * parentKey = keyNew ("user/tests/glob", KEY_END);
 	// clang-format off
@@ -146,7 +146,7 @@ void test_getGlobalMatch ()
 	PLUGIN_CLOSE ();
 }
 
-void test_getDirectionMatch ()
+void test_getDirectionMatch (void)
 {
 	Key * parentKey = keyNew ("user/tests/glob", KEY_END);
 	// clang-format off
@@ -176,7 +176,7 @@ void test_getDirectionMatch ()
 	PLUGIN_CLOSE ();
 }
 
-void test_setDirectionMatch ()
+void test_setDirectionMatch (void)
 {
 	Key * parentKey = keyNew ("user/tests/glob", KEY_END);
 	// clang-format off
@@ -206,7 +206,7 @@ void test_setDirectionMatch ()
 	PLUGIN_CLOSE ();
 }
 
-void test_namedMatchFlags ()
+void test_namedMatchFlags (void)
 {
 	Key * parentKey = keyNew ("user/tests/glob", KEY_END);
 	KeySet * conf = ksNew (20, keyNew ("user/glob/#1", KEY_VALUE, "user/tests/glob/*", KEY_META, "testmetakey1", "testvalue1", KEY_END),
@@ -240,7 +240,7 @@ void test_namedMatchFlags ()
 	PLUGIN_CLOSE ();
 }
 
-void test_onlyFirstMatchIsApplied ()
+void test_onlyFirstMatchIsApplied (void)
 {
 	Key * parentKey = keyNew ("user/tests/glob", KEY_END);
 	// clang-format off

--- a/src/plugins/hexcode/testmod_hexcode.c
+++ b/src/plugins/hexcode/testmod_hexcode.c
@@ -25,7 +25,7 @@
 const char encoded_string[] = "a\\20value\\20with\\3D\\3B\\23\\20and\\20\\5C\\20itself";
 const char decoded_string[] = "a value with=;# and \\ itself";
 
-void test_encode ()
+void test_encode (void)
 {
 	printf ("test encode\n");
 
@@ -50,7 +50,7 @@ void test_encode ()
 	keyDel (test);
 }
 
-void test_decode ()
+void test_decode (void)
 {
 	printf ("test decode\n");
 
@@ -96,7 +96,7 @@ void check_reversibility (const char * msg)
 	keyDel (encode);
 }
 
-void test_reversibility ()
+void test_reversibility (void)
 {
 	printf ("test reversibility\n");
 
@@ -113,7 +113,7 @@ void test_reversibility ()
 	check_reversibility ("\n\\");
 }
 
-void test_config ()
+void test_config (void)
 {
 	KeySet * config =
 		ksNew (20, keyNew ("user/chars", KEY_END), keyNew ("user/chars/20", KEY_END), keyNew ("user/chars/23", KEY_END),

--- a/src/plugins/iconv/testmod_iconv.c
+++ b/src/plugins/iconv/testmod_iconv.c
@@ -26,7 +26,7 @@
 
 #define NR_KEYS 1
 
-void test_latin1_to_utf8 ()
+void test_latin1_to_utf8 (void)
 {
 	KeySet * latin1 = 0;
 	KeySet * utf8 = 0;
@@ -66,7 +66,7 @@ void test_latin1_to_utf8 ()
 	ksDel (modules);
 }
 
-void test_utf8_to_latin1 ()
+void test_utf8_to_latin1 (void)
 {
 	KeySet * latin1 = 0;
 	KeySet * utf8 = 0;
@@ -107,7 +107,7 @@ void test_utf8_to_latin1 ()
 	ksDel (modules);
 }
 
-void test_utf8_needed ()
+void test_utf8_needed (void)
 {
 	printf ("Test if utf8 conversation is needed\n");
 	KeySet * modules = ksNew (0, KS_END);
@@ -147,7 +147,7 @@ static void set_str (char ** str, size_t * len, char * newstr)
 	strcpy (*str, newstr);
 }
 
-void test_utf8_conversation ()
+void test_utf8_conversation (void)
 {
 	KeySet * modules = ksNew (0, KS_END);
 	elektraModulesInit (modules, 0);

--- a/src/plugins/ini/contract.h
+++ b/src/plugins/ini/contract.h
@@ -10,7 +10,7 @@
 #define CONTRACT_H_
 
 
-static inline KeySet * getPluginContract ()
+static inline KeySet * getPluginContract (void)
 {
 	// clang-formater off
 	return ksNew (30, keyNew ("system/elektra/modules/ini", KEY_VALUE, "Ini plugin waits for your orders", KEY_END),

--- a/src/plugins/ini/testmod_ini.c
+++ b/src/plugins/ini/testmod_ini.c
@@ -251,7 +251,7 @@ static void test_multilineIniWrite (char * fileName)
 
 	PLUGIN_CLOSE ();
 }
-static void test_multilineIniInvalidConfigWrite ()
+static void test_multilineIniInvalidConfigWrite (void)
 {
 	Key * parentKey = keyNew ("user/tests/ini-multiline-write", KEY_VALUE, elektraFilename (), KEY_END);
 	KeySet * conf = ksNew (30, keyNew ("system/multiline", KEY_VALUE, "0", KEY_END),

--- a/src/plugins/iterate/testmod_iterate.c
+++ b/src/plugins/iterate/testmod_iterate.c
@@ -14,7 +14,7 @@
 
 #include <tests_plugin.h>
 
-static void test_basics ()
+static void test_basics (void)
 {
 	printf ("test basics\n");
 

--- a/src/plugins/jni/testmod_jni.c
+++ b/src/plugins/jni/testmod_jni.c
@@ -22,7 +22,7 @@
 #include <testmod_jni.h>
 #include <tests_plugin.h>
 
-static void test_helloWorld ()
+static void test_helloWorld (void)
 {
 	Key * parentKey = keyNew ("user/tests/jni", KEY_VALUE, "", KEY_END);
 	KeySet * conf =

--- a/src/plugins/keytometa/testmod_keytometa.c
+++ b/src/plugins/keytometa/testmod_keytometa.c
@@ -42,7 +42,7 @@ static Key * createMergingKey (int i)
 }
 
 // clang-format off
-static KeySet* createSimpleTestKeys()
+static KeySet* createSimpleTestKeys(void)
 {
 	/* the keys to be converted are simply appended to the next
 	 * or the previous key.
@@ -77,7 +77,7 @@ static KeySet* createSimpleTestKeys()
 			KS_END);
 }
 
-static KeySet* createMergeTestkeys()
+static KeySet* createMergeTestkeys(void)
 {
 	/* the keys to be converted are merged together
 	 * into a single metadata
@@ -104,7 +104,7 @@ static KeySet* createMergeTestkeys()
 	return ks;
 }
 
-static KeySet* createSkipMergeTestKeys()
+static KeySet* createSkipMergeTestKeys(void)
 {
 	/* the keys to be converted are interweaved with keys
 	 * of the other directio
@@ -142,7 +142,7 @@ static KeySet* createSkipMergeTestKeys()
 			KS_END);
 }
 
-static KeySet *createParentTestKeys()
+static KeySet *createParentTestKeys(void)
 {
 
 	/* all keys to be converted are appended to the
@@ -194,7 +194,7 @@ static KeySet *createParentTestKeys()
 			KS_END);
 }
 
-static KeySet* createDifferentMetaNameTestKeys()
+static KeySet* createDifferentMetaNameTestKeys(void)
 {
 	return ksNew (20,
 			keyNew ("user/convertkey1",
@@ -215,7 +215,7 @@ static KeySet* createDifferentMetaNameTestKeys()
 			KS_END);
 }
 
-static KeySet* createSameLevelTestKeys()
+static KeySet* createSameLevelTestKeys(void)
 {
 	return ksNew (20,
 			keyNew ("user/levelkey1",
@@ -245,7 +245,7 @@ static KeySet* createSameLevelTestKeys()
 }
 // clang-format on
 
-void test_parentAppendMode ()
+void test_parentAppendMode (void)
 {
 	Key * parentKey = keyNew ("user/tests/keytometa", KEY_END);
 	KeySet * conf = ksNew (0, KS_END);
@@ -308,7 +308,7 @@ void test_parentAppendMode ()
 }
 
 
-void test_simpleAppendModes ()
+void test_simpleAppendModes (void)
 {
 	Key * parentKey = keyNew ("user/tests/keytometa", KEY_END);
 	KeySet * conf = ksNew (0, KS_END);
@@ -356,7 +356,7 @@ void test_simpleAppendModes ()
 }
 
 
-void test_metaMerging ()
+void test_metaMerging (void)
 {
 	Key * parentKey = keyNew ("user/tests/keytometa", KEY_END);
 	KeySet * conf = ksNew (0, KS_END);
@@ -407,7 +407,7 @@ void test_metaMerging ()
 	PLUGIN_CLOSE ();
 }
 
-void test_metaSkipMerge ()
+void test_metaSkipMerge (void)
 {
 	Key * parentKey = keyNew ("user/tests/keytometa", KEY_END);
 	KeySet * conf = ksNew (0, KS_END);
@@ -439,7 +439,7 @@ void test_metaSkipMerge ()
 	PLUGIN_CLOSE ();
 }
 
-void test_differentMetaNames ()
+void test_differentMetaNames (void)
 {
 	Key * parentKey = keyNew ("user/tests/keytometa", KEY_END);
 	KeySet * conf = ksNew (0, KS_END);
@@ -468,7 +468,7 @@ void test_differentMetaNames ()
 	PLUGIN_CLOSE ();
 }
 
-void test_appendSameLevel ()
+void test_appendSameLevel (void)
 {
 	Key * parentKey = keyNew ("user/tests/keytometa", KEY_END);
 	KeySet * conf = ksNew (0, KS_END);
@@ -502,7 +502,7 @@ void test_appendSameLevel ()
 	PLUGIN_CLOSE ();
 }
 
-void test_restoreOnSet ()
+void test_restoreOnSet (void)
 {
 	Key * parentKey = keyNew ("user/tests/keytometa", KEY_END);
 	KeySet * conf = ksNew (0, KS_END);

--- a/src/plugins/line/line.c
+++ b/src/plugins/line/line.c
@@ -22,7 +22,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-static inline KeySet * elektraLineContract ()
+static inline KeySet * elektraLineContract (void)
 {
 	return ksNew (30, keyNew ("system/elektra/modules/line", KEY_VALUE, "line plugin waits for your orders", KEY_END),
 		      keyNew ("system/elektra/modules/line/exports", KEY_END),

--- a/src/plugins/line/testmod_line.c
+++ b/src/plugins/line/testmod_line.c
@@ -20,7 +20,7 @@
 
 #include <tests_plugin.h>
 
-void test_readline ()
+void test_readline (void)
 {
 
 	char * filename = srcdir_file ("line/linetest");

--- a/src/plugins/list/testmod_list.c
+++ b/src/plugins/list/testmod_list.c
@@ -14,7 +14,7 @@
 
 #include <tests_plugin.h>
 
-static void doTest ()
+static void doTest (void)
 {
 	KeySet * ks = ksNew (5, keyNew ("user/tests/list/to/be/cut/key1", KEY_END), keyNew ("user/tests/list/to/be/cut/key2", KEY_END),
 			     keyNew ("user/tests/list/to/be/cut/meta1", KEY_END),

--- a/src/plugins/lua/testmod_lua.c
+++ b/src/plugins/lua/testmod_lua.c
@@ -15,7 +15,7 @@
 #include <tests_plugin.h>
 
 // test simple variable passing
-static void test_variable_passing ()
+static void test_variable_passing (void)
 {
 	printf ("Testing simple variable passing...\n");
 
@@ -38,7 +38,7 @@ static void test_variable_passing ()
 }
 
 // test loading lua twice
-static void test_two_scripts ()
+static void test_two_scripts (void)
 {
 	printf ("Testing loading of two active lua plugins...\n");
 
@@ -72,7 +72,7 @@ static void test_two_scripts ()
 }
 
 // simple return value test
-static void test_fail ()
+static void test_fail (void)
 {
 	printf ("Testing return values from lua functions...\n");
 
@@ -96,7 +96,7 @@ static void test_fail ()
 }
 
 // test script with syntax error
-static void test_wrong ()
+static void test_wrong (void)
 {
 	printf ("Testing lua script with syntax error...\n");
 

--- a/src/plugins/mathcheck/testmod_mathcheck.c
+++ b/src/plugins/mathcheck/testmod_mathcheck.c
@@ -46,7 +46,7 @@ static KeySet * create_ks (const char * res, const char * meta)
 		      keyNew ("user/tests/mathcheck/bla/val3", KEY_VALUE, "3", KEY_END), KS_END);
 }
 
-static void test_multiUp ()
+static void test_multiUp (void)
 {
 	Key * parentKey = keyNew ("user/tests/mathcheck", KEY_VALUE, "", KEY_END);
 	KeySet * conf = ksNew (0, KS_END);

--- a/src/plugins/mini/mini.c
+++ b/src/plugins/mini/mini.c
@@ -58,7 +58,7 @@
  *
  * @return A contract describing the functionality of this plugin.
  */
-static inline KeySet * elektraMiniContract ()
+static inline KeySet * elektraMiniContract (void)
 {
 	return ksNew (30, keyNew ("system/elektra/modules/mini", KEY_VALUE, "mini plugin waits for your orders", KEY_END),
 		      keyNew ("system/elektra/modules/mini/exports", KEY_END),

--- a/src/plugins/mini/testmod_mini.c
+++ b/src/plugins/mini/testmod_mini.c
@@ -22,7 +22,7 @@
 
 /* -- Functions ------------------------------------------------------------------------------------------------------------------------- */
 
-static void test_basics ()
+static void test_basics (void)
 {
 	printf ("• Test basic functionality of plugin\n");
 
@@ -38,7 +38,7 @@ static void test_basics ()
 	PLUGIN_CLOSE ();
 }
 
-static void test_get ()
+static void test_get (void)
 {
 	char const * const fileName = "mini/read.ini";
 	printf ("• Parse file “%s”\n", fileName);
@@ -81,7 +81,7 @@ static void test_get ()
 	PLUGIN_CLOSE ();
 }
 
-static void test_set ()
+static void test_set (void)
 {
 	printf ("• Write configuration data\n");
 

--- a/src/plugins/network/testmod_network.c
+++ b/src/plugins/network/testmod_network.c
@@ -17,7 +17,7 @@
 #include <tests.h>
 
 
-void test_addr ()
+void test_addr (void)
 {
 	// clang-format off
 	Key * k = keyNew ("user/anything",

--- a/src/plugins/ni/nickel-1.1.0/src/hash.c
+++ b/src/plugins/ni/nickel-1.1.0/src/hash.c
@@ -1089,7 +1089,7 @@ elektraNi_PRIVATE uint32_t Hash (const void * restrict key, size_t length, uint3
 #ifdef SELF_TEST
 
 /* used for timings */
-void driver1 ()
+void driver1 (void)
 {
 	uint8_t buf[256];
 	uint32_t i;
@@ -1112,7 +1112,7 @@ void driver1 ()
 #define HASHLEN 1
 #define MAXPAIR 60
 #define MAXLEN 70
-void driver2 ()
+void driver2 (void)
 {
 	uint8_t qa[MAXLEN + 1], qb[MAXLEN + 2], *a = &qa[0], *b = &qb[1];
 	uint32_t c[HASHSTATE], d[HASHSTATE], i = 0, j = 0, k, l, m = 0, z;
@@ -1184,7 +1184,7 @@ void driver2 ()
 }
 
 /* Check for reading beyond the end of the buffer and alignment problems */
-void driver3 ()
+void driver3 (void)
 {
 	uint8_t buf[MAXLEN + 20], *b;
 	uint32_t len;
@@ -1264,7 +1264,7 @@ void driver3 ()
 }
 
 /* check for problems with nulls */
-void driver4 ()
+void driver4 (void)
 {
 	uint8_t buf[1];
 	uint32_t h, i, state[HASHSTATE];
@@ -1282,7 +1282,7 @@ void driver4 ()
 }
 
 
-int main ()
+int main (void)
 {
 	driver1 (); /* test that the key is hashed: used for timings */
 	driver2 (); /* test that whole key is hashed thoroughly */

--- a/src/plugins/noresolver/noresolver.c
+++ b/src/plugins/noresolver/noresolver.c
@@ -26,7 +26,7 @@ int elektraNoresolverCheckFile (const char * filename)
 	return 1;
 }
 
-static KeySet * elektraNoresolverModules ()
+static KeySet * elektraNoresolverModules (void)
 {
 	return ksNew (
 		50, keyNew ("system/elektra/modules/" ELEKTRA_PLUGIN_NAME "", KEY_VALUE,

--- a/src/plugins/passwd/testmod_passwd.c
+++ b/src/plugins/passwd/testmod_passwd.c
@@ -14,7 +14,7 @@
 
 #include <tests_plugin.h>
 
-void test_read ()
+void test_read (void)
 {
 	Key * parentKey = keyNew ("user/tests/passwd-read", KEY_VALUE, srcdir_file ("passwd/passwd_in"), KEY_END);
 	KeySet * conf = ksNew (10, keyNew ("system/index", KEY_VALUE, "name", KEY_END), KS_END);
@@ -29,7 +29,7 @@ void test_read ()
 	PLUGIN_CLOSE ();
 }
 
-void test_write ()
+void test_write (void)
 {
 	Key * parentKey = keyNew ("user/tests/passwd-write", KEY_VALUE, elektraFilename (), KEY_END);
 	KeySet * conf = ksNew (30, keyNew ("system/index", KEY_VALUE, "name", KEY_END), KS_END);
@@ -48,7 +48,7 @@ void test_write ()
 	PLUGIN_CLOSE ();
 }
 
-void test_read_write ()
+void test_read_write (void)
 {
 	Key * parentKeyRead = keyNew ("user/tests/passwd-write", KEY_VALUE, srcdir_file ("passwd/passwd_in"), KEY_END);
 	Key * parentKeyWrite = keyNew ("user/tests/passwd-write", KEY_VALUE, elektraFilename (), KEY_END);

--- a/src/plugins/python/testmod_python.c
+++ b/src/plugins/python/testmod_python.c
@@ -17,7 +17,7 @@
 
 #include <tests_plugin.h>
 
-static void init_env ()
+static void init_env (void)
 {
 	setenv ("PYTHONDONTWRITEBYTECODE", "1", 1);
 	setenv ("PYTHONPATH", ".", 1);
@@ -47,7 +47,7 @@ static char * python_file (const char * filename)
 }
 
 // test simple variable passing
-static void test_variable_passing ()
+static void test_variable_passing (void)
 {
 	printf ("Testing simple variable passing...\n");
 
@@ -68,7 +68,7 @@ static void test_variable_passing ()
 }
 
 // test loading python twice
-static void test_two_scripts ()
+static void test_two_scripts (void)
 {
 	printf ("Testing loading of two active python plugins...\n");
 
@@ -102,7 +102,7 @@ static void test_two_scripts ()
 }
 
 // simple return value test
-static void test_fail ()
+static void test_fail (void)
 {
 	printf ("Testing return values from python functions...\n");
 
@@ -124,7 +124,7 @@ static void test_fail ()
 }
 
 // test script with wrong class name
-static void test_wrong ()
+static void test_wrong (void)
 {
 	printf ("Testing python script with wrong class name...\n");
 

--- a/src/plugins/rename/testmod_rename.c
+++ b/src/plugins/rename/testmod_rename.c
@@ -25,7 +25,7 @@
 #include <tests_plugin.h>
 
 
-static KeySet * createSimpleTestKeys ()
+static KeySet * createSimpleTestKeys (void)
 {
 	return ksNew (20, keyNew ("user/tests/rename/will/be/stripped/key1", KEY_VALUE, "value1", KEY_END),
 		      keyNew ("user/tests/rename/will/be/stripped/key2", KEY_VALUE, "value2", KEY_END),
@@ -33,7 +33,7 @@ static KeySet * createSimpleTestKeys ()
 		      keyNew ("user/tests/rename/will/not/be/stripped/key4", KEY_VALUE, "value4", KEY_END), KS_END);
 }
 
-static KeySet * createSimpleMetaTestKeys ()
+static KeySet * createSimpleMetaTestKeys (void)
 {
 	// clang-format off
 	return ksNew (20,
@@ -80,7 +80,7 @@ static void compareKeySets (KeySet * ks, KeySet * expected)
 	}
 }
 
-static void test_simpleCutOnGet ()
+static void test_simpleCutOnGet (void)
 {
 	Key * parentKey = keyNew ("user/tests/rename", KEY_END);
 	KeySet * conf = ksNew (20, keyNew ("system/cut", KEY_VALUE, "will/be/stripped", KEY_END), KS_END);
@@ -106,7 +106,7 @@ static void test_simpleCutOnGet ()
 }
 
 
-static void test_metaCutOnGet ()
+static void test_metaCutOnGet (void)
 {
 	Key * parentKey = keyNew ("user/tests/rename", KEY_END);
 	KeySet * conf = ksNew (0, KS_END);
@@ -126,7 +126,7 @@ static void test_metaCutOnGet ()
 	PLUGIN_CLOSE ();
 }
 
-static void test_simpleCutRestoreOnSet ()
+static void test_simpleCutRestoreOnSet (void)
 {
 	Key * parentKey = keyNew ("user/tests/rename", KEY_END);
 	Key * parentKeyCopy = keyDup (parentKey);
@@ -165,7 +165,7 @@ static void test_simpleCutRestoreOnSet ()
 	PLUGIN_CLOSE ();
 }
 
-static void test_withoutConfig ()
+static void test_withoutConfig (void)
 {
 	Key * parentKey = keyNew ("user/tests/rename", KEY_END);
 	Key * parentKeyCopy = keyDup (parentKey);
@@ -190,7 +190,7 @@ static void test_withoutConfig ()
 	PLUGIN_CLOSE ();
 }
 
-static void test_metaConfigTakesPrecedence ()
+static void test_metaConfigTakesPrecedence (void)
 {
 	Key * parentKey = keyNew ("user/tests/rename", KEY_END);
 	KeySet * conf = ksNew (20, keyNew ("system/cut", KEY_VALUE, "will/be", KEY_END), KS_END);
@@ -222,7 +222,7 @@ static void test_metaConfigTakesPrecedence ()
 	PLUGIN_CLOSE ();
 }
 
-static void test_keyCutNamePart ()
+static void test_keyCutNamePart (void)
 {
 	Key * parentKey = keyNew ("user/tests/rename", KEY_END);
 	Key * result = elektraKeyCreateNewName (parentKey, parentKey, "wont/cut/this", NULL, NULL, NULL, 0);
@@ -252,7 +252,7 @@ static void test_keyCutNamePart ()
 	keyDel (parentKey);
 }
 
-static void test_rebaseOfNewKeys ()
+static void test_rebaseOfNewKeys (void)
 {
 	Key * parentKey = keyNew ("user/tests/rename", KEY_END);
 	KeySet * conf = ksNew (20, keyNew ("system/cut", KEY_VALUE, "new/base", KEY_END), KS_END);
@@ -287,7 +287,7 @@ static void test_rebaseOfNewKeys ()
 	PLUGIN_CLOSE ();
 }
 
-static void test_addNewBaseToParentKey ()
+static void test_addNewBaseToParentKey (void)
 {
 	Key * parentKey = keyNew ("user/tests/rename", KEY_END);
 	KeySet * conf = ksNew (20, keyNew ("system/cut", KEY_VALUE, "new/base", KEY_END), KS_END);
@@ -311,7 +311,7 @@ static void test_addNewBaseToParentKey ()
 	PLUGIN_CLOSE ();
 }
 
-static void test_replaceString ()
+static void test_replaceString (void)
 {
 	Key * parentKey = keyNew ("user/tests/rename", KEY_END);
 	KeySet * conf = ksNew (20, keyNew ("system/cut", KEY_VALUE, "will/be/stripped", KEY_END),
@@ -335,7 +335,7 @@ static void test_replaceString ()
 	PLUGIN_CLOSE ();
 }
 
-static void test_toUpper ()
+static void test_toUpper (void)
 {
 	Key * parentKey = keyNew ("user/tests/rename", KEY_END);
 	KeySet * conf = ksNew (20, keyNew ("system/toupper", KEY_VALUE, "0", KEY_END), KS_END);
@@ -355,7 +355,7 @@ static void test_toUpper ()
 	PLUGIN_CLOSE ();
 }
 
-static void test_toLower ()
+static void test_toLower (void)
 {
 	Key * parentKey = keyNew ("user/tests/rename", KEY_END);
 	KeySet * conf = ksNew (20, keyNew ("system/tolower", KEY_VALUE, "0", KEY_END), KS_END);
@@ -374,7 +374,7 @@ static void test_toLower ()
 	PLUGIN_CLOSE ();
 }
 
-static void test_mixCase ()
+static void test_mixCase (void)
 {
 	Key * parentKey = keyNew ("user/tests/rename", KEY_END);
 	KeySet * conf =
@@ -395,7 +395,7 @@ static void test_mixCase ()
 	PLUGIN_CLOSE ();
 }
 
-static void test_write ()
+static void test_write (void)
 {
 	Key * parentKey = keyNew ("user/tests/rename", KEY_END);
 	KeySet * conf =
@@ -415,7 +415,7 @@ static void test_write ()
 	PLUGIN_CLOSE ();
 }
 
-static void test_write2 ()
+static void test_write2 (void)
 {
 	Key * parentKey = keyNew ("user/tests/rename", KEY_END);
 	KeySet * conf =

--- a/src/plugins/resolver/testmod_resolver.c
+++ b/src/plugins/resolver/testmod_resolver.c
@@ -14,14 +14,14 @@
 
 #include "resolver.h"
 
-KeySet * set_pluginconf ()
+KeySet * set_pluginconf (void)
 {
 	return ksNew (10, keyNew ("system/path", KEY_VALUE, KDB_DB_FILE, KEY_END), keyNew ("user/path", KEY_VALUE, "elektra.ecf", KEY_END),
 		      KS_END);
 }
 
 
-void test_resolve ()
+void test_resolve (void)
 {
 	int pathLen = tempHomeLen + 1 + strlen (KDB_DB_USER) + 12 + 1;
 	char * path = elektraMalloc (pathLen);
@@ -75,7 +75,7 @@ void test_resolve ()
 	elektraFree (path);
 }
 
-void test_name ()
+void test_name (void)
 {
 	printf ("Resolve Name\n");
 
@@ -112,7 +112,7 @@ void test_name ()
 	ksDel (modules);
 }
 
-void test_lockname ()
+void test_lockname (void)
 {
 	printf ("Resolve Dirname\n");
 
@@ -149,7 +149,7 @@ void test_lockname ()
 	ksDel (modules);
 }
 
-void test_tempname ()
+void test_tempname (void)
 {
 	printf ("Resolve Tempname\n");
 
@@ -187,7 +187,7 @@ void test_tempname ()
 	ksDel (modules);
 }
 
-void test_checkfile ()
+void test_checkfile (void)
 {
 	printf ("Check file\n");
 
@@ -239,7 +239,7 @@ void test_checkfile ()
 	ksDel (modules);
 }
 
-static void check_xdg ()
+static void check_xdg (void)
 {
 	KeySet * modules = ksNew (0, KS_END);
 	elektraModulesInit (modules, 0);

--- a/src/plugins/semlock/testmod_semlock.c
+++ b/src/plugins/semlock/testmod_semlock.c
@@ -14,7 +14,7 @@
 
 #include <tests_plugin.h>
 
-static void test_OpenClose ()
+static void test_OpenClose (void)
 {
 	printf ("test Open & Close\n");
 
@@ -26,7 +26,7 @@ static void test_OpenClose ()
 	PLUGIN_CLOSE ();
 }
 
-static void test_GetSet ()
+static void test_GetSet (void)
 {
 	printf ("test Get & Set\n");
 

--- a/src/plugins/simpleini/testmod_simpleini.c
+++ b/src/plugins/simpleini/testmod_simpleini.c
@@ -76,7 +76,7 @@ static void test_formatNotAccepted (const char * format)
 }
 
 
-static void test_readDefaultFormat ()
+static void test_readDefaultFormat (void)
 {
 	const char * expected_keys[] = { "key1", "key2", "key3", "key4" };
 	const char * expected_values[] = { "value1", "value2", "value3", "value4 " };
@@ -89,7 +89,7 @@ static void test_readDefaultFormat ()
 			 4, expected_keys, expected_values);
 }
 
-static void test_readFormat_wo_space ()
+static void test_readFormat_wo_space (void)
 {
 
 	const char * expected_keys[] = { "key1", "key2", "key3", "key4" };
@@ -103,7 +103,7 @@ static void test_readFormat_wo_space ()
 			 4, expected_keys, expected_values);
 }
 
-static void test_readFormat_special1 ()
+static void test_readFormat_special1 (void)
 {
 
 	const char * expected_keys[] = { "key1", "key2", "key3", "key4" };

--- a/src/plugins/template/testmod_template.c
+++ b/src/plugins/template/testmod_template.c
@@ -14,7 +14,7 @@
 
 #include <tests_plugin.h>
 
-static void test_basics ()
+static void test_basics (void)
 {
 	printf ("test basics\n");
 

--- a/src/plugins/uname/testmod_uname.c
+++ b/src/plugins/uname/testmod_uname.c
@@ -20,7 +20,7 @@
 
 #include <tests_plugin.h>
 
-void test_structure ()
+void test_structure (void)
 {
 	printf ("Test structure of keys returned from uname plugin");
 

--- a/src/plugins/uname/testuname.c
+++ b/src/plugins/uname/testuname.c
@@ -8,7 +8,7 @@
 
 #include <sys/utsname.h>
 
-int main ()
+int main (void)
 {
 	struct utsname buf;
 

--- a/src/plugins/validation/testmod_validation.c
+++ b/src/plugins/validation/testmod_validation.c
@@ -31,7 +31,7 @@
 
 #define NR_KEYS 4
 
-void test_lookupre ()
+void test_lookupre (void)
 {
 	KeySet * ks = ksNew (5, keyNew ("user/a", KEY_VALUE, "a", KEY_COMMENT, "does not match", KEY_END),
 			     keyNew ("user/b", KEY_VALUE, "  a  ", KEY_COMMENT, "does not match", KEY_END),
@@ -57,7 +57,7 @@ void test_lookupre ()
 	ksDel (ks);
 }
 
-void test_extended ()
+void test_extended (void)
 {
 	KeySet * ks = ksNew (5, keyNew ("user/a", KEY_VALUE, "la", KEY_COMMENT, "match", KEY_END),
 			     keyNew ("user/b", KEY_VALUE, "lalala", KEY_COMMENT, "match", KEY_END),
@@ -86,7 +86,7 @@ void test_extended ()
 	ksDel (ks);
 }
 
-void word_test ()
+void word_test (void)
 {
 	Key * parentKey = keyNew ("user/tests/validation", KEY_VALUE, "", KEY_END);
 	Key * k1 = keyNew ("user/tests/validation/valid1", KEY_VALUE, "word", KEY_META, "check/validation", "word", KEY_META,
@@ -130,7 +130,7 @@ void word_test ()
 	PLUGIN_CLOSE ();
 }
 
-void line_test ()
+void line_test (void)
 {
 	Key * parentKey = keyNew ("user/tests/validation", KEY_VALUE, "", KEY_END);
 	Key * k1 = keyNew ("user/tests/validation/valid1", KEY_VALUE, "line", KEY_META, "check/validation", "line", KEY_META,
@@ -174,7 +174,7 @@ void line_test ()
 	PLUGIN_CLOSE ();
 }
 
-void invert_test ()
+void invert_test (void)
 {
 	Key * parentKey = keyNew ("user/tests/validation", KEY_VALUE, "", KEY_END);
 	Key * k1 = keyNew ("user/tests/validation/valid1", KEY_VALUE, "word", KEY_META, "check/validation", "word", KEY_META,
@@ -218,7 +218,7 @@ void invert_test ()
 	PLUGIN_CLOSE ();
 }
 
-void icase_test ()
+void icase_test (void)
 {
 	Key * parentKey = keyNew ("user/tests/validation", KEY_VALUE, "", KEY_END);
 	Key * k1 = keyNew ("user/tests/validation/valid1", KEY_VALUE, "WORD", KEY_META, "check/validation", "word", KEY_META,

--- a/src/plugins/xerces/testmod_xerces.c
+++ b/src/plugins/xerces/testmod_xerces.c
@@ -15,7 +15,7 @@
 
 #define ELEKTRA_XERCES_ORIGINAL_ROOT_NAME "xerces/rootname"
 
-static void test_basics ()
+static void test_basics (void)
 {
 	printf ("test basics\n");
 	fflush (stdout);
@@ -49,7 +49,7 @@ static void test_basics ()
 	fflush (stdout);
 }
 
-static void test_simple_read ()
+static void test_simple_read (void)
 {
 	printf ("test simple read\n");
 	fflush (stdout);
@@ -164,7 +164,7 @@ static void test_simple_read ()
 	fflush (stdout);
 }
 
-static void test_simple_write ()
+static void test_simple_write (void)
 {
 	printf ("test simple write\n");
 	fflush (stdout);
@@ -211,7 +211,7 @@ static void test_simple_write ()
 	fflush (stdout);
 }
 
-static void test_maven_pom ()
+static void test_maven_pom (void)
 {
 	printf ("test maven pom\n");
 	fflush (stdout);
@@ -248,7 +248,7 @@ static void test_maven_pom ()
 	fflush (stdout);
 }
 
-static void test_jenkins_config ()
+static void test_jenkins_config (void)
 {
 	printf ("test jenkins config\n");
 	fflush (stdout);

--- a/src/plugins/xmltool/testmod_xmltool.c
+++ b/src/plugins/xmltool/testmod_xmltool.c
@@ -13,7 +13,7 @@
 
 #include <unistd.h>
 
-void test_readwrite ()
+void test_readwrite (void)
 {
 	KeySet * ks;
 	FILE * fout;
@@ -32,7 +32,7 @@ void test_readwrite ()
 	ksDel (ks);
 }
 
-void test_readwrite_hier ()
+void test_readwrite_hier (void)
 {
 	KeySet * ks;
 	FILE * fout;
@@ -52,7 +52,7 @@ void test_readwrite_hier ()
 }
 
 
-void test_key ()
+void test_key (void)
 {
 	KeySet * ks;
 	Key * cur;
@@ -154,7 +154,7 @@ void test_key ()
 	ksDel (ks);
 }
 
-void test_keyset ()
+void test_keyset (void)
 {
 	KeySet * ks;
 	Key * cur;
@@ -221,7 +221,7 @@ void test_keyset ()
 
 #define MAX_SIZE 200
 
-static void test_ksCommonParentName ()
+static void test_ksCommonParentName (void)
 {
 	char ret[MAX_SIZE + 1];
 	KeySet * ks =

--- a/src/plugins/yajl/testmod_yajl.c
+++ b/src/plugins/yajl/testmod_yajl.c
@@ -21,7 +21,7 @@
 #include <tests_internal.h>
 
 // clang-format off
-KeySet *getEmptyKeys()
+KeySet *getEmptyKeys(void)
 {
 	return ksNew(1,
 			keyNew("user/tests/yajl",
@@ -30,7 +30,7 @@ KeySet *getEmptyKeys()
 			);
 }
 
-KeySet *getNullKeys()
+KeySet *getNullKeys(void)
 {
 	Key *k1, *k2;
 	KeySet *ks = ksNew(10,
@@ -51,7 +51,7 @@ KeySet *getNullKeys()
 	return ks;
 }
 
-KeySet *getBelowKeys()
+KeySet *getBelowKeys(void)
 {
 	KeySet *ks = ksNew(10,
 			keyNew("user/tests/yajl",
@@ -84,7 +84,7 @@ KeySet *getBelowKeys()
 }
 
 /*
-KeySet *getBelowKeys()
+KeySet *getBelowKeys(void)
 {
 	KeySet *ks = ksNew(10,
 			keyNew("user/tests/yajl",
@@ -111,7 +111,7 @@ KeySet *getBelowKeys()
 }
 */
 
-KeySet *getBooleanKeys()
+KeySet *getBooleanKeys(void)
 {
 	KeySet *ks = ksNew(10,
 			keyNew("user/tests/yajl",
@@ -131,7 +131,7 @@ KeySet *getBooleanKeys()
 	return ks;
 }
 
-KeySet *getNumberKeys()
+KeySet *getNumberKeys(void)
 {
 	KeySet *ks = ksNew(10,
 			keyNew("user/tests/yajl",
@@ -154,7 +154,7 @@ KeySet *getNumberKeys()
 	return ks;
 }
 
-KeySet *getStringKeys()
+KeySet *getStringKeys(void)
 {
 	KeySet *ks = ksNew(10,
 			keyNew("user/tests/yajl",
@@ -174,7 +174,7 @@ KeySet *getStringKeys()
 	return ks;
 }
 
-KeySet *getMapKeys ()
+KeySet *getMapKeys (void)
 {
 	KeySet *ks = ksNew(10,
 			keyNew("user/tests/yajl",
@@ -215,7 +215,7 @@ KeySet *getMapKeys ()
 	return ks;
 }
 
-KeySet *getArrayKeys()
+KeySet *getArrayKeys(void)
 {
 	KeySet *ks = ksNew(30,
 			keyNew("user/tests/yajl",
@@ -287,7 +287,7 @@ KeySet *getArrayKeys()
 	return ks;
 }
 
-KeySet *getOpenICCKeys()
+KeySet *getOpenICCKeys(void)
 {
 	KeySet *ks = ksNew(60,
 			keyNew("user/tests/yajl",
@@ -438,7 +438,7 @@ keyNew("user/tests/yajl/org/freedesktop/openicc/device/monitor/#1/EDID_date",
 	return ks;
 }
 
-KeySet *getSomeBelowKeys()
+KeySet *getSomeBelowKeys(void)
 {
 	return ksNew(10,
 			keyNew("user/some/path/below",
@@ -542,7 +542,7 @@ void test_readWrite (const char * fileName, KeySet * conf)
 // TODO: make nicer and put to test framework
 #define succeed_if_equal(x, y) succeed_if (!strcmp (x, y), x)
 
-void test_nextNotBelow ()
+void test_nextNotBelow (void)
 {
 	printf ("Test next not below\n");
 
@@ -593,7 +593,7 @@ void test_nextNotBelow ()
 	ksDel (ks);
 }
 
-void test_reverseLevel ()
+void test_reverseLevel (void)
 {
 	Key * k = keyNew ("user/abc/defghi/jkl", KEY_END);
 	int level = 0;
@@ -663,7 +663,7 @@ void test_reverseLevel ()
 	keyDel (k);
 }
 
-void test_countLevel ()
+void test_countLevel (void)
 {
 	Key * k = keyNew ("user///", KEY_END);
 	succeed_if (elektraKeyCountLevel (k) == 1, "count level wrong");
@@ -697,7 +697,7 @@ void test_countLevel ()
 	keyDel (k2);
 }
 
-void test_writing ()
+void test_writing (void)
 {
 	KeySet * conf = ksNew (0, KS_END);
 	Key * parentKey = keyNew ("user/tests/yajl", KEY_VALUE, "/proc/self/fd/1", KEY_END);

--- a/src/plugins/yajl/yajl_parse.c
+++ b/src/plugins/yajl/yajl_parse.c
@@ -285,7 +285,7 @@ static void elektraYajlParseSuppressEmpty (KeySet * returned, Key * parentKey)
 	}
 }
 
-static inline KeySet * elektraGetModuleConfig ()
+static inline KeySet * elektraGetModuleConfig (void)
 {
 	return ksNew (30, keyNew ("system/elektra/modules/yajl", KEY_VALUE, "yajl plugin waits for your orders", KEY_END),
 		      keyNew ("system/elektra/modules/yajl/exports", KEY_END),

--- a/src/plugins/yaml/testmod_yaml.c
+++ b/src/plugins/yaml/testmod_yaml.c
@@ -22,7 +22,7 @@
 
 /* -- Functions ------------------------------------------------------------------------------------------------------------------------- */
 
-static void test_basics ()
+static void test_basics (void)
 {
 	printf ("• Test basic functionality of plugin\n");
 
@@ -39,7 +39,7 @@ static void test_basics ()
 	PLUGIN_CLOSE ();
 }
 
-static void test_get ()
+static void test_get (void)
 {
 	char const * const fileName = "yaml/simple.yaml";
 	printf ("• Parse file “%s”\n", fileName);

--- a/src/plugins/yaml/yaml.c
+++ b/src/plugins/yaml/yaml.c
@@ -690,7 +690,7 @@ static int parseFile (KeySet * returned ELEKTRA_UNUSED, Key * parentKey)
  *
  * @return A contract describing the functionality of this plugin.
  */
-static KeySet * contractYaml ()
+static KeySet * contractYaml (void)
 {
 	return ksNew (30, keyNew ("system/elektra/modules/yaml", KEY_VALUE, "yaml plugin waits for your orders", KEY_END),
 		      keyNew ("system/elektra/modules/yaml/exports", KEY_END),

--- a/src/tools/gen/template/genopt.c
+++ b/src/tools/gen/template/genopt.c
@@ -46,7 +46,7 @@ extern "C"
 {
 #endif
 
-const char *elektraGenHelpText()
+const char *elektraGenHelpText(void)
 {
 	return
 @for $key, $info in $parameters.items()

--- a/tests/abi/testabi_key.c
+++ b/tests/abi/testabi_key.c
@@ -92,7 +92,7 @@ struct test tstKeyName[] = {
 	}
 };
 
-static void test_keyNewSpecial ()
+static void test_keyNewSpecial (void)
 {
 	printf ("Test special key creation\n");
 
@@ -128,7 +128,7 @@ static void test_keyNewSpecial ()
 	keyDel (k);
 }
 
-static void test_keyNewSystem ()
+static void test_keyNewSystem (void)
 {
 	Key * key;
 	char array[] = "here is some data stored";
@@ -219,7 +219,7 @@ static void test_keyNewSystem ()
 	succeed_if (keyDel (k3) == 0, "keyDel: Unable to delete key with name + value");
 }
 
-static void test_keyNewUser ()
+static void test_keyNewUser (void)
 {
 	Key * k1;
 	Key * k2;
@@ -253,7 +253,7 @@ static void test_keyNewUser ()
 	keyDel (k1);
 }
 
-static void test_keyReference ()
+static void test_keyReference (void)
 {
 	printf ("Test key reference\n");
 
@@ -374,7 +374,7 @@ static void test_keyReference ()
 	keyDel (key);
 }
 
-static void test_keyName ()
+static void test_keyName (void)
 {
 	Key * key;
 	char ret[1000];
@@ -604,7 +604,7 @@ static void test_keyName ()
 }
 
 
-static void test_keyNameSlashes ()
+static void test_keyNameSlashes (void)
 {
 	printf ("Test Slashes in Key Name\n");
 	size_t size;
@@ -884,7 +884,7 @@ static void test_keyNameSlashes ()
 }
 
 
-static void test_keyValue ()
+static void test_keyValue (void)
 {
 	Key * key;
 	char ret[1000];
@@ -1200,7 +1200,7 @@ static void test_keyBinary (void)
 	keyDel (key);
 }
 
-static void test_keyInactive ()
+static void test_keyInactive (void)
 {
 	Key * key = keyNew (0);
 
@@ -1255,7 +1255,7 @@ static void test_keyInactive ()
 	keyDel (key);
 }
 
-static void test_keyBelow ()
+static void test_keyBelow (void)
 {
 	Key * key1 = keyNew (0);
 	Key * key2 = keyNew (0);
@@ -1503,7 +1503,7 @@ static void test_keyBelow ()
 	keyDel (key2);
 }
 
-static void test_keyDup ()
+static void test_keyDup (void)
 {
 	Key *orig, *copy;
 
@@ -1553,7 +1553,7 @@ static void test_keyDup ()
 	keyDel (copy);
 }
 
-static void test_keyCopy ()
+static void test_keyCopy (void)
 {
 	Key *orig, *copy;
 
@@ -1632,11 +1632,11 @@ static void test_keyCopy ()
 
 
 typedef void (*fun_t) ();
-static void fun ()
+static void fun (void)
 {
 }
 
-static void test_binary ()
+static void test_binary (void)
 {
 	printf ("Test binary values\n");
 
@@ -1733,7 +1733,7 @@ static void test_binary ()
 	keyDel (k);
 }
 
-static void test_keyBelowOrSame ()
+static void test_keyBelowOrSame (void)
 {
 	Key * key1 = keyNew (0);
 	Key * key2 = keyNew (0);
@@ -1818,7 +1818,7 @@ static void test_keyBelowOrSame ()
 	keyDel (key2);
 }
 
-static void test_keyNameSpecial ()
+static void test_keyNameSpecial (void)
 {
 	printf ("Test special keynames\n");
 	Key * k = keyNew (0);
@@ -1913,7 +1913,7 @@ static void test_keyNameSpecial ()
 	keyDel (k);
 }
 
-static void test_keyClear ()
+static void test_keyClear (void)
 {
 	printf ("Test clear of key\n");
 
@@ -1978,7 +1978,7 @@ static void test_keyClear ()
 	keyDel (k1);
 }
 
-static void test_keyBaseName ()
+static void test_keyBaseName (void)
 {
 	printf ("Test basename\n");
 	Key * k = keyNew ("user:yl///foo\\///bar\\/foo_bar\\/", KEY_END);
@@ -2042,7 +2042,7 @@ static void test_keyBaseName ()
 	keyDel (k);
 }
 
-static void test_keySetBaseName ()
+static void test_keySetBaseName (void)
 {
 	printf ("Test set basename\n");
 
@@ -2272,7 +2272,7 @@ static void test_keySetBaseName ()
 	keyDel (k);
 }
 
-static void test_keyAddBaseName ()
+static void test_keyAddBaseName (void)
 {
 	printf ("Test add basename\n");
 
@@ -2348,7 +2348,7 @@ static void test_keyAddBaseName ()
 	keyDel (k);
 }
 
-static void test_keyDirectBelow ()
+static void test_keyDirectBelow (void)
 {
 	printf ("Test direct below check\n");
 
@@ -2400,7 +2400,7 @@ static void test_keyDirectBelow ()
 	keyDel (k2);
 }
 
-static void test_keyEscape ()
+static void test_keyEscape (void)
 {
 	printf ("test escape in basename\n");
 
@@ -2482,7 +2482,7 @@ static void test_keyEscape ()
 	keyDel (k);
 }
 
-static void test_keyAdd ()
+static void test_keyAdd (void)
 {
 	printf ("test keyAdd\n");
 
@@ -2529,7 +2529,7 @@ static void test_keyAdd ()
 	keyDel (k);
 }
 
-void test_keyCascading ()
+void test_keyCascading (void)
 {
 	printf ("test cascading\n");
 
@@ -2610,7 +2610,7 @@ void test_keyCascading ()
 	keyDel (k);
 }
 
-static void test_keyUnescapedName ()
+static void test_keyUnescapedName (void)
 {
 	printf ("test keyUnescapedName\n");
 
@@ -2679,7 +2679,7 @@ static void test_keyUnescapedName ()
 	keyDel (k);
 }
 
-static void test_keyCanonify ()
+static void test_keyCanonify (void)
 {
 	printf ("test canonify\n");
 

--- a/tests/abi/testabi_key.c
+++ b/tests/abi/testabi_key.c
@@ -1631,7 +1631,7 @@ static void test_keyCopy (void)
 }
 
 
-typedef void (*fun_t) ();
+typedef void (*fun_t) (void);
 static void fun (void)
 {
 }
@@ -1659,7 +1659,7 @@ static void test_binary (void)
 
 
 	union {
-		void (*f) ();
+		void (*f) (void);
 		void * v;
 	} conversation;
 
@@ -1669,7 +1669,7 @@ static void test_binary (void)
 
 	conversation.v = 0;
 	conversation.f = 0;
-	void (*g) () = 0;
+	void (*g) (void) = 0;
 	succeed_if (keyGetBinary (k, &conversation.v, sizeof (conversation)) == sizeof (conversation), "could not get binary");
 	g = conversation.f;
 	succeed_if (g == fun, "pointers to functions are not equal");

--- a/tests/abi/testabi_ks.c
+++ b/tests/abi/testabi_ks.c
@@ -12,7 +12,7 @@
 
 char * namespaces[] = { "spec", "proc", "dir", "user", "system", 0 };
 
-static void test_ksNew ()
+static void test_ksNew (void)
 {
 	KeySet * ks = 0;
 	KeySet * keys = ksNew (15, KS_END);
@@ -87,7 +87,7 @@ static void test_ksNew ()
 	ksDel (ks_c);
 }
 
-static void test_ksEmpty ()
+static void test_ksEmpty (void)
 {
 	printf ("Test empty keysets\n");
 	KeySet * ks;
@@ -159,7 +159,7 @@ static void test_ksEmpty ()
 
 #define NR_KEYSETS 10
 
-static void test_ksReference ()
+static void test_ksReference (void)
 {
 	KeySet * ks = 0;
 	KeySet * ks1;
@@ -265,7 +265,7 @@ static void test_ksReference ()
 	}
 }
 
-static void test_ksDup ()
+static void test_ksDup (void)
 {
 	KeySet * ks = 0;
 	KeySet * other = 0;
@@ -325,7 +325,7 @@ static void test_ksDup ()
 	ksDel (ks);
 }
 
-static void test_ksCopy ()
+static void test_ksCopy (void)
 {
 	KeySet * ks = 0;
 	KeySet * other = 0;
@@ -421,7 +421,7 @@ static void test_ksCopy ()
 	ksDel (ks);
 }
 
-static void test_ksIterate ()
+static void test_ksIterate (void)
 {
 	KeySet * ks = ksNew (0, KS_END);
 	KeySet * other = ksNew (0, KS_END);
@@ -504,7 +504,7 @@ static void test_ksIterate ()
 	ksDel (other);
 }
 
-static void test_ksCursor ()
+static void test_ksCursor (void)
 {
 	KeySet * ks = ksNew (0, KS_END);
 	Key * key;
@@ -599,7 +599,7 @@ static void test_ksCursor ()
 	ksDel (ks);
 }
 
-static void test_ksAtCursor ()
+static void test_ksAtCursor (void)
 {
 	KeySet * ks;
 	Key * current;
@@ -660,7 +660,7 @@ static void test_ksAtCursor ()
 	ksDel (ks);
 }
 
-static void test_ksSort ()
+static void test_ksSort (void)
 {
 	KeySet * ks;
 	Key *key, *k1, *k2;
@@ -968,7 +968,7 @@ static void ksUnsort (KeySet * ks)
 	ksDel (tempks);
 }
 
-static void test_ksLookup ()
+static void test_ksLookup (void)
 {
 	printf ("Test lookup\n");
 
@@ -1059,7 +1059,7 @@ static void test_ksLookup ()
 	ksDel (lookupKeys);
 }
 
-static void test_ksLookupByName ()
+static void test_ksLookupByName (void)
 {
 	printf ("Test lookup by name\n");
 
@@ -1135,7 +1135,7 @@ static void test_ksLookupByName ()
 }
 
 
-static void test_ksLookupName ()
+static void test_ksLookupName (void)
 {
 	Key * found;
 	KeySet * ks = ksNew (0, KS_END);
@@ -1249,7 +1249,7 @@ static void test_ksLookupName ()
 	ksDel (ks);
 }
 
-static void test_ksLookupNameCascading ()
+static void test_ksLookupNameCascading (void)
 {
 	Key * found;
 	KeySet * ks = ksNew (0, KS_END);
@@ -1412,7 +1412,7 @@ static void test_ksLookupNameCascading ()
 	ksDel (ks);
 }
 
-static void test_ksLookupNameDomain ()
+static void test_ksLookupNameDomain (void)
 {
 	Key * found;
 	KeySet * ks = ksNew (0, KS_END);
@@ -1446,7 +1446,7 @@ static void test_ksLookupNameDomain ()
 	ksDel (ks);
 }
 
-static void test_ksLookupNameAll ()
+static void test_ksLookupNameAll (void)
 {
 	Key * found;
 	cursor_t cursor;
@@ -1588,7 +1588,7 @@ static void test_ksLookupNameAll ()
 }
 
 /*
-static void test_ksLookupValue()
+static void test_ksLookupValue(void)
 {
 	KeySet *ks = ksNew(0, KS_END);
 	Key *found;
@@ -1671,7 +1671,7 @@ static void test_ksLookupValue()
 }
 */
 
-static void test_ksExample ()
+static void test_ksExample (void)
 {
 	KeySet * ks = ksNew (0, KS_END);
 	Key * key;
@@ -1732,7 +1732,7 @@ static void test_ksExample ()
 	ksDel (ks);
 }
 
-static void test_ksAppend ()
+static void test_ksAppend (void)
 {
 	int i;
 
@@ -1929,7 +1929,7 @@ int find_80 (Key * check)
 	return n > 70 ? -1 : 1;
 }
 
-static void test_ksFunctional ()
+static void test_ksFunctional (void)
 {
 	Key * found;
 	Key * current;
@@ -1992,7 +1992,7 @@ static void test_ksFunctional ()
 	ksDel (values_below_30);
 }
 
-static void test_ksLookupPop ()
+static void test_ksLookupPop (void)
 {
 	printf ("Test ksLookup with KDB_O_POP\n");
 
@@ -2209,7 +2209,7 @@ static void test_ksLookupPop ()
 	ksDel (ks);
 }
 
-static void test_ksSync ()
+static void test_ksSync (void)
 {
 	printf ("Test sync flag of KeySet\n");
 
@@ -2251,7 +2251,7 @@ static void test_ksSync ()
 	ksDel (ks);
 }
 
-static void test_ksDoubleFree ()
+static void test_ksDoubleFree (void)
 {
 	/* Valgrind only test */
 	KeySet * ks1 = ksNew (5, keyNew ("user/abc1", KEY_VALUE, "abc1", KEY_END), keyNew ("user/abc2", KEY_VALUE, "abc1", KEY_END),
@@ -2271,7 +2271,7 @@ static void test_ksDoubleFree ()
 	ksDel (ks2);
 }
 
-static void test_ksDoubleAppend ()
+static void test_ksDoubleAppend (void)
 {
 	printf ("Test double appending\n");
 
@@ -2289,7 +2289,7 @@ static void test_ksDoubleAppend ()
 	ksDel (ks2);
 }
 
-static void test_ksDoubleAppendKey ()
+static void test_ksDoubleAppendKey (void)
 {
 	printf ("Test double appending of key\n");
 
@@ -2316,7 +2316,7 @@ static void test_ksDoubleAppendKey ()
 	// don't free key here!!
 }
 
-static void test_ksAppendKey ()
+static void test_ksAppendKey (void)
 {
 	printf ("Test cursor after appending key\n");
 	KeySet * ks = 0;
@@ -2372,7 +2372,7 @@ static void test_ksAppendKey ()
 	ksDel (ks);
 }
 
-static void test_ksModifyKey ()
+static void test_ksModifyKey (void)
 {
 	printf ("Test modify key after insertion\n");
 
@@ -2391,7 +2391,7 @@ static void test_ksModifyKey ()
 	ksDel (ks);
 }
 
-static void test_ksOrder ()
+static void test_ksOrder (void)
 {
 	KeySet * ks = ksNew (20, keyNew ("user/test/test", KEY_END), keyNew ("user/test/test/bar", KEY_END),
 			     keyNew ("user/test/test/foo", KEY_END), keyNew ("user/test/test-foo", KEY_END), KS_END);
@@ -2477,7 +2477,7 @@ KeySet * fill_vaargs (size_t size, ...)
 	return ks;
 }
 
-static void test_keyVNew ()
+static void test_keyVNew (void)
 {
 	printf ("Test keyVNew\n");
 
@@ -2503,7 +2503,7 @@ static void test_keyVNew ()
 }
 
 
-static KeySet * set_a ()
+static KeySet * set_a (void)
 {
 	return ksNew (16, keyNew ("user/0", KEY_END), keyNew ("user/a", KEY_END), keyNew ("user/a/a", KEY_END),
 		      keyNew ("user/a/a/a", KEY_END), keyNew ("user/a/a/b", KEY_END), keyNew ("user/a/b", KEY_END),
@@ -2513,7 +2513,7 @@ static KeySet * set_a ()
 		      keyNew ("user/x", KEY_END), KS_END);
 }
 
-static KeySet * set_oa ()
+static KeySet * set_oa (void)
 {
 	return ksNew (14, keyNew ("user/a", KEY_END), keyNew ("user/a/a", KEY_END), keyNew ("user/a/a/a", KEY_END),
 		      keyNew ("user/a/a/b", KEY_END), keyNew ("user/a/b", KEY_END), keyNew ("user/a/b/a", KEY_END),
@@ -2523,7 +2523,7 @@ static KeySet * set_oa ()
 }
 
 
-static void test_cut ()
+static void test_cut (void)
 {
 	printf ("Testing operation cut\n");
 
@@ -2576,7 +2576,7 @@ static void test_cut ()
 	}
 }
 
-static void test_cutpoint ()
+static void test_cutpoint (void)
 {
 	printf ("Testing operation cut point\n");
 
@@ -2606,7 +2606,7 @@ static void test_cutpoint ()
 	ksDel (cmp_part);
 }
 
-static void test_cascadingCutpoint ()
+static void test_cascadingCutpoint (void)
 {
 	printf ("Testing operation cascading cut point\n");
 
@@ -2659,7 +2659,7 @@ static void test_cascadingCutpoint ()
 	keyDel (cutpoint);
 }
 
-static void test_cascadingRootCutpoint ()
+static void test_cascadingRootCutpoint (void)
 {
 	printf ("Testing operation cascading root cut point\n");
 
@@ -2687,7 +2687,7 @@ static void test_cascadingRootCutpoint ()
 	keyDel (cutpoint);
 }
 
-static void test_cutpointRoot ()
+static void test_cutpointRoot (void)
 {
 	printf ("Testing operation cut root point\n");
 
@@ -2718,7 +2718,7 @@ static void test_cutpointRoot ()
 }
 
 
-static void test_cutpoint_1 ()
+static void test_cutpoint_1 (void)
 {
 	printf ("Testing operation cut point 1\n");
 
@@ -2750,7 +2750,7 @@ static void test_cutpoint_1 ()
 	ksDel (cmp_part);
 }
 
-static void test_unique_cutpoint ()
+static void test_unique_cutpoint (void)
 {
 	printf ("Testing operation cut with unique cutpoint\n");
 
@@ -2774,7 +2774,7 @@ static void test_unique_cutpoint ()
 	keyDel (cutpoint);
 }
 
-static void test_cutbelow ()
+static void test_cutbelow (void)
 {
 	printf ("Testing cutting below some keys\n");
 
@@ -2833,7 +2833,7 @@ KeySet * set_simple ()
 		      keyNew ("system/elektra/mountpoints/simple/setplugins/#1tracer", KEY_VALUE, "tracer", KEY_END), KS_END);
 }
 
-static void test_simple ()
+static void test_simple (void)
 {
 	KeySet * config = set_simple ();
 	KeySet * result_res = ksNew (16, keyNew ("system/elektra/mountpoints/simple/config", KEY_END),
@@ -2867,7 +2867,7 @@ static void test_simple ()
 	ksDel (config);
 }
 
-static void test_cursor ()
+static void test_cursor (void)
 {
 	printf ("test cut cursor\n");
 
@@ -2930,7 +2930,7 @@ static void test_cursor ()
 	ksDel (res);
 }
 
-static void test_morecut ()
+static void test_morecut (void)
 {
 	printf ("More cut test cases\n");
 
@@ -2964,7 +2964,7 @@ static void test_morecut ()
 	ksDel (split2);
 }
 
-static void test_cutafter ()
+static void test_cutafter (void)
 {
 	printf ("More cut after\n");
 
@@ -3005,7 +3005,7 @@ static void test_cutafter ()
 	ksDel (split2);
 }
 
-static void test_simpleLookup ()
+static void test_simpleLookup (void)
 {
 	printf ("Test simple lookup\n");
 
@@ -3031,7 +3031,7 @@ static void test_simpleLookup ()
 	ksDel (ks);
 }
 
-static void test_nsLookup ()
+static void test_nsLookup (void)
 {
 	printf ("Test lookup in all namespaces\n");
 
@@ -3081,7 +3081,7 @@ static void test_nsLookup ()
 	ksDel (ks);
 }
 
-static void test_ksAppend2 ()
+static void test_ksAppend2 (void)
 {
 	printf ("Test more involved appending\n");
 
@@ -3159,7 +3159,7 @@ static void test_ksAppend2 ()
 	ksDel (ks);
 }
 
-static void test_ksAppend3 ()
+static void test_ksAppend3 (void)
 {
 	printf ("Test appending same key\n");
 

--- a/tests/abi/testabi_ks.c
+++ b/tests/abi/testabi_ks.c
@@ -2807,7 +2807,7 @@ static void test_cutbelow (void)
 	keyDel (cutpoint);
 }
 
-KeySet * set_simple ()
+KeySet * set_simple (void)
 {
 	return ksNew (50, keyNew ("system/elektra/mountpoints/simple", KEY_END),
 

--- a/tests/abi/testabi_meta.c
+++ b/tests/abi/testabi_meta.c
@@ -8,7 +8,7 @@
 
 #include <tests.h>
 
-static void test_basic ()
+static void test_basic (void)
 {
 	Key * key;
 	key = keyNew ("user/key_with_meta", KEY_END);
@@ -59,7 +59,7 @@ static void test_basic ()
 	keyDel (key);
 }
 
-static void test_iterate ()
+static void test_iterate (void)
 {
 	Key * key;
 
@@ -86,7 +86,7 @@ static void test_iterate ()
 	keyDel (key);
 }
 
-static void test_size ()
+static void test_size (void)
 {
 	Key * key;
 	char * buffer;
@@ -171,7 +171,7 @@ static void test_size ()
 	keyDel (key);
 }
 
-static void test_dup ()
+static void test_dup (void)
 {
 	Key * key;
 	Key * dup;
@@ -218,7 +218,7 @@ static void l (Key * k)
 	// with the metadata "type" from g_c
 }
 
-static void test_examples ()
+static void test_examples (void)
 {
 	Key * key;
 	key = keyNew (0);
@@ -258,7 +258,7 @@ static void test_examples ()
 	keyDel (g_c);
 }
 
-static void test_copy ()
+static void test_copy (void)
 {
 	printf ("Test key meta copy\n");
 
@@ -380,7 +380,7 @@ static void test_copy ()
 	keyDel (c);
 }
 
-static void test_new ()
+static void test_new (void)
 {
 	Key * key;
 	// clang-format off
@@ -433,7 +433,7 @@ static void test_new ()
 }
 
 
-static void test_copyall ()
+static void test_copyall (void)
 {
 	printf ("Test key meta copy all\n");
 
@@ -530,7 +530,7 @@ static void test_copyall ()
 	keyDel (c);
 }
 
-static void test_type ()
+static void test_type (void)
 {
 	Key * key;
 

--- a/tests/abi/testabi_rel.c
+++ b/tests/abi/testabi_rel.c
@@ -8,7 +8,7 @@
 
 #include <tests.h>
 
-static void test_keyCmp ()
+static void test_keyCmp (void)
 {
 	printf ("check keyCmp\n");
 
@@ -110,7 +110,7 @@ static void test_keyCmp ()
 	keyDel (k2);
 }
 
-static void test_directbelow ()
+static void test_directbelow (void)
 {
 	printf ("check if direct below\n");
 	Key * k1 = keyNew (0);
@@ -157,7 +157,7 @@ static void test_directbelow ()
 	keyDel (k2);
 }
 
-static void test_below ()
+static void test_below (void)
 {
 	printf ("check if below\n");
 	Key * k1 = keyNew (0);
@@ -197,7 +197,7 @@ static void test_below ()
 	keyDel (k2);
 }
 
-static void test_examples ()
+static void test_examples (void)
 {
 	printf ("check examples\n");
 	Key * key = keyNew (0);
@@ -229,7 +229,7 @@ static void test_examples ()
 	keyDel (check);
 }
 
-static void test_hierarchy ()
+static void test_hierarchy (void)
 {
 	printf ("check hierarchy\n");
 	Key * key = keyNew (0);
@@ -255,7 +255,7 @@ static void test_hierarchy ()
 	keyDel (check);
 }
 
-static void test_null ()
+static void test_null (void)
 {
 	printf ("check invalid keys or null ptr\n");
 	Key * key = keyNew (0);

--- a/tests/cframework/tests.c
+++ b/tests/cframework/tests.c
@@ -34,7 +34,7 @@ char file[KDB_MAX_PATH_LENGTH];
 char srcdir[KDB_MAX_PATH_LENGTH];
 
 #ifdef HAVE_CLEARENV
-int clearenv ();
+int clearenv (void);
 #endif
 
 char * tmpfilename;
@@ -248,7 +248,7 @@ char * srcdir_file (const char * fileName)
 	return file;
 }
 
-const char * elektraFilename ()
+const char * elektraFilename (void)
 {
 	return tmpfilename;
 }

--- a/tests/cframework/tests.h
+++ b/tests/cframework/tests.h
@@ -273,7 +273,7 @@ int compare_files (const char * filename);
 int compare_line_files (const char * filename, const char * genfilename);
 
 char * srcdir_file (const char * fileName);
-const char * elektraFilename ();
+const char * elektraFilename (void);
 void elektraUnlink (const char * filename);
 
 Key * create_root_key (const char * backendName);

--- a/tests/ctest/test_array.c
+++ b/tests/ctest/test_array.c
@@ -10,7 +10,7 @@
 
 #include "tests.h"
 
-static void test_array ()
+static void test_array (void)
 {
 	printf ("Test array\n");
 
@@ -94,7 +94,7 @@ static void test_array ()
 	keyDel (k);
 }
 
-static void test_noArray ()
+static void test_noArray (void)
 {
 	printf ("Test no array\n");
 	Key * k = keyNew ("user/noarray", KEY_END);
@@ -105,7 +105,7 @@ static void test_noArray ()
 	keyDel (k);
 }
 
-static void test_startArray ()
+static void test_startArray (void)
 {
 	printf ("Test start array\n");
 	Key * k = keyNew ("user/startarray/#", KEY_END);
@@ -118,7 +118,7 @@ static void test_startArray ()
 	keyDel (k);
 }
 
-static void test_getArray ()
+static void test_getArray (void)
 {
 	printf ("Test get array");
 
@@ -141,7 +141,7 @@ static void test_getArray ()
 }
 
 
-static void test_getArrayNext ()
+static void test_getArrayNext (void)
 {
 	printf ("Test get array next");
 

--- a/tests/ctest/test_backend.c
+++ b/tests/ctest/test_backend.c
@@ -10,7 +10,7 @@
 #include <tests_internal.h>
 
 
-KeySet * set_simple ()
+KeySet * set_simple (void)
 {
 	return ksNew (50, keyNew ("system/elektra/mountpoints/simple", KEY_END),
 
@@ -43,7 +43,7 @@ KeySet * set_simple ()
 		      keyNew ("system/elektra/mountpoints/simple/errorplugins/#1" KDB_DEFAULT_STORAGE, KEY_END), KS_END);
 }
 
-KeySet * set_pluginconf ()
+KeySet * set_pluginconf (void)
 {
 	return ksNew (10, keyNew ("system/anything", KEY_VALUE, "backend", KEY_END), keyNew ("system/more", KEY_END),
 		      keyNew ("system/more/config", KEY_END), keyNew ("system/more/config/below", KEY_END), keyNew ("system/path", KEY_END),
@@ -52,7 +52,7 @@ KeySet * set_pluginconf ()
 		      KS_END);
 }
 
-static void test_simple ()
+static void test_simple (void)
 {
 	printf ("Test simple building of backend\n");
 
@@ -115,7 +115,7 @@ static void test_simple ()
 	ksDel (modules);
 }
 
-static void test_default ()
+static void test_default (void)
 {
 	printf ("Test default " KDB_DEFAULT_STORAGE "\n");
 
@@ -150,7 +150,7 @@ static void test_default ()
 }
 
 
-KeySet * set_backref ()
+KeySet * set_backref (void)
 {
 	return ksNew (
 		50, keyNew ("system/elektra/mountpoints/backref", KEY_END),
@@ -192,7 +192,7 @@ KeySet * set_backref ()
 		KS_END);
 }
 
-static void test_backref ()
+static void test_backref (void)
 {
 	printf ("Test back references\n");
 

--- a/tests/ctest/test_internal.c
+++ b/tests/ctest/test_internal.c
@@ -8,7 +8,7 @@
 
 #include <tests_internal.h>
 
-static void test_elektraMalloc ()
+static void test_elektraMalloc (void)
 {
 	char * buffer = 0;
 	buffer = elektraMalloc (50);
@@ -41,7 +41,7 @@ static void test_elektraMalloc ()
 	elektraFree (dup);
 }
 
-static void test_elektraStrLen ()
+static void test_elektraStrLen (void)
 {
 	char charSeq[5];
 
@@ -63,7 +63,7 @@ static void test_elektraStrLen ()
 
 #define TEST_VALIDATE_NAME_NOK(NAME, MSG) succeed_if (!elektraValidateKeyName (NAME, sizeof (NAME)), MSG " not ok");
 
-static void test_elektraValidateKeyName ()
+static void test_elektraValidateKeyName (void)
 {
 	printf ("test validate key name\n");
 
@@ -80,7 +80,7 @@ static void test_elektraValidateKeyName ()
 	TEST_VALIDATE_NAME_NOK ("tanglingKey\\\\\\\\\\\\\\", "tangling escape");
 }
 
-static void test_elektraEscapeKeyNamePart ()
+static void test_elektraEscapeKeyNamePart (void)
 {
 	printf ("test escape key name part\n");
 
@@ -113,7 +113,7 @@ static void test_elektraEscapeKeyNamePart ()
 	succeed_if_same_string (elektraEscapeKeyNamePart ("\\\\\\", dest), "\\\\\\\\\\\\");       // 3 -> 6
 }
 
-static void test_elektraUnescapeKeyName ()
+static void test_elektraUnescapeKeyName (void)
 {
 	printf ("test unescape key name \n");
 
@@ -237,7 +237,7 @@ static void test_elektraUnescapeKeyName ()
 	succeed_if_same_string ("bar/foo_bar/", p);
 }
 
-static void test_keyNameGetOneLevel ()
+static void test_keyNameGetOneLevel (void)
 {
 	printf ("test keyNameGetOneLevel\n");
 

--- a/tests/ctest/test_key.c
+++ b/tests/ctest/test_key.c
@@ -12,7 +12,7 @@
 #include <time.h>
 #endif
 
-static void test_keyRefcounter ()
+static void test_keyRefcounter (void)
 {
 	Key * key = keyNew (0);
 	key->ksReference = 5;
@@ -28,7 +28,7 @@ static void test_keyRefcounter ()
 	keyDel (key);
 }
 
-static void test_keyHelpers ()
+static void test_keyHelpers (void)
 {
 	char * name = "user/abc/defghi/jkl";
 	char * p;
@@ -457,7 +457,7 @@ static void test_keyHelpers ()
 	keyDel (k2);
 }
 
-static void test_keyPlugin ()
+static void test_keyPlugin (void)
 {
 	Plugin * plug = (Plugin *)1222243;
 
@@ -483,7 +483,7 @@ static void test_keyPlugin ()
 	} while (0)
 
 
-static void test_keyNameEscape ()
+static void test_keyNameEscape (void)
 {
 	char buffer[500];
 	char buffer2[500];
@@ -531,7 +531,7 @@ static void test_keyNameEscape ()
 	keyDel (k);
 }
 
-static void test_keyNameUnescape ()
+static void test_keyNameUnescape (void)
 {
 	char buffer[500];
 
@@ -611,7 +611,7 @@ static void test_keyNameUnescape ()
 	*/
 }
 
-static void test_keyCompare ()
+static void test_keyCompare (void)
 {
 	printf ("test keyCompare\n");
 	Key * key1 = keyNew (0);
@@ -659,7 +659,7 @@ static void test_keyCompare ()
 	keyDel (key2);
 }
 
-static void test_keyNewExtensions ()
+static void test_keyNewExtensions (void)
 {
 	printf ("test keyNewExtensions\n");
 
@@ -688,7 +688,7 @@ static void test_keyNewExtensions ()
 	succeed_if (keyDel (key) == 0, "keyDel: Unable to delete key with name + mode");
 }
 
-static void test_owner ()
+static void test_owner (void)
 {
 	printf ("test owner\n");
 
@@ -800,7 +800,7 @@ static void test_owner ()
 	succeed_if (keySetOwner (0, "") == -1, "null pointer");
 }
 
-static void test_keyComment ()
+static void test_keyComment (void)
 {
 	Key * key;
 	char ret[1000];
@@ -893,7 +893,7 @@ static void test_keyComment ()
 	keyDel (key);
 }
 
-static void test_keyOwner ()
+static void test_keyOwner (void)
 {
 	Key * key;
 	char ret[1000];
@@ -986,7 +986,7 @@ static void test_keyDir (void)
 	keyDel (key);
 }
 
-static void test_keyTime ()
+static void test_keyTime (void)
 {
 	Key * key = keyNew (0);
 	time_t now = time (0);
@@ -1121,7 +1121,7 @@ static void test_keyMeta (void)
 	keyDel (key);
 }
 
-static void test_elektraKeySetName ()
+static void test_elektraKeySetName (void)
 {
 	printf ("test elektraKeySetName\n");
 
@@ -1293,7 +1293,7 @@ static void test_elektraKeySetName ()
 	keyDel (key);
 }
 
-static void test_keyLock ()
+static void test_keyLock (void)
 {
 	printf ("Test locking\n");
 
@@ -1346,7 +1346,7 @@ static void test_keyLock ()
 }
 
 
-static void test_keyAddName ()
+static void test_keyAddName (void)
 {
 	Key * k = keyNew ("user", KEY_END);
 	keyAddName (k, "something");
@@ -1499,7 +1499,7 @@ static void test_keyAddName ()
 	keyDel (k);
 }
 
-static void test_keyNeedSync ()
+static void test_keyNeedSync (void)
 {
 	printf ("Test key need sync\n");
 
@@ -1579,7 +1579,7 @@ static void test_keyNeedSync ()
 	keyDel (k);
 }
 
-static void test_keyCopy ()
+static void test_keyCopy (void)
 {
 	printf ("test copy key\n");
 	Key * k = keyNew ("", KEY_END);
@@ -1598,7 +1598,7 @@ static void test_keyCopy ()
 	keyDel (c);
 }
 
-static void test_keyFixedNew ()
+static void test_keyFixedNew (void)
 {
 	printf ("test fixed new\n");
 	Key * k1 = keyNew (0);
@@ -1620,7 +1620,7 @@ static void test_keyFixedNew ()
 	keyDel (k2);
 }
 
-static void test_keyFlags ()
+static void test_keyFlags (void)
 {
 	printf ("Test KEY_FLAGS\n");
 

--- a/tests/ctest/test_keyname.c
+++ b/tests/ctest/test_keyname.c
@@ -22,7 +22,7 @@
 		succeed_if (strcmp (result, expected) == 0, error);                                                                        \
 	}
 
-static void test_relative_root ()
+static void test_relative_root (void)
 {
 	printf ("Get relative name of key with backend mounted at `/`\n");
 
@@ -40,7 +40,7 @@ static void test_relative_root ()
 	keyDel (parent);
 }
 
-static void test_relative_cascading ()
+static void test_relative_cascading (void)
 {
 	printf ("Get relative name of key with cascading mountpoint\n");
 
@@ -63,7 +63,7 @@ static void test_relative_cascading ()
 	keyDel (parent);
 }
 
-static void test_relative_generic ()
+static void test_relative_generic (void)
 {
 	printf ("Get relative name of key with generic mountpoint\n");
 
@@ -87,7 +87,7 @@ static void test_relative_generic ()
 	keyDel (parent);
 }
 
-static void test_relative_equal ()
+static void test_relative_equal (void)
 {
 	printf ("Get relative name of key which is the same as the parent key\n");
 

--- a/tests/ctest/test_ks.c
+++ b/tests/ctest/test_ks.c
@@ -10,7 +10,7 @@
 
 ssize_t ksCopyInternal (KeySet * ks, size_t to, size_t from);
 
-static void test_elektraRenameKeys ()
+static void test_elektraRenameKeys (void)
 {
 	printf ("test rename keys\n");
 	KeySet * ks = ksNew (20, keyNew ("system/some/common/prefix", KEY_END), keyNew ("system/some/common/prefix/dir", KEY_END),
@@ -35,7 +35,7 @@ static void test_elektraRenameKeys ()
 	ksDel (ks);
 }
 
-static void test_elektraEmptyKeys ()
+static void test_elektraEmptyKeys (void)
 {
 	printf ("test empty keys\n");
 	Key * key = keyNew ("", KEY_END);
@@ -51,7 +51,7 @@ static void test_elektraEmptyKeys ()
 	ksDel (ks);
 }
 
-static void test_cascadingLookup ()
+static void test_cascadingLookup (void)
 {
 	printf ("test cascading lookup\n");
 	Key * k0;
@@ -80,7 +80,7 @@ static void test_cascadingLookup ()
 	ksDel (ks);
 }
 
-static void test_creatingLookup ()
+static void test_creatingLookup (void)
 {
 	printf ("Test creating lookup\n");
 

--- a/tests/ctest/test_meta.c
+++ b/tests/ctest/test_meta.c
@@ -9,7 +9,7 @@
 #include <kdbproposal.h>
 #include <tests_internal.h>
 
-static void test_ro ()
+static void test_ro (void)
 {
 	Key * key;
 
@@ -28,7 +28,7 @@ static void test_ro ()
 	keyDel (key);
 }
 
-static void test_uid ()
+static void test_uid (void)
 {
 	Key * key;
 
@@ -83,7 +83,7 @@ static void test_uid ()
 }
 
 
-static void test_comment ()
+static void test_comment (void)
 {
 	Key * key;
 	char ret[10];
@@ -120,7 +120,7 @@ static void test_comment ()
 	succeed_if (keyDel (key) == 0, "could not delete key");
 }
 
-static void test_owner ()
+static void test_owner (void)
 {
 	Key * key;
 
@@ -164,7 +164,7 @@ static void test_owner ()
 	succeed_if (keyDel (key) == 0, "could not delete key with env");
 }
 
-static void test_mode ()
+static void test_mode (void)
 {
 	Key * key;
 
@@ -223,7 +223,7 @@ static void test_mode ()
 	keyDel (key);
 }
 
-static void test_metaKeySet ()
+static void test_metaKeySet (void)
 {
 	Key * key = keyNew ("user/test", KEY_END);
 	keySetMeta (key, "meta/test1", "value1");
@@ -266,7 +266,7 @@ static void test_metaKeySet ()
 	keyDel (key);
 }
 
-static void test_metaArrayToKS ()
+static void test_metaArrayToKS (void)
 {
 	Key * test = keyNew ("/a", KEY_META, "dep", "#1", KEY_META, "dep/#0", "/b", KEY_META, "dep/#1", "/c", KEY_END);
 	KeySet * ks = elektraMetaArrayToKS (test, "dep");
@@ -340,13 +340,13 @@ static void checkTopOrder3 (Key ** array)
 	succeed_if_top (2, "/c");
 	succeed_if_top (3, "/a");
 }
-uint64_t rdtsc ()
+uint64_t rdtsc (void)
 {
 	unsigned int lo, hi;
 	__asm__ __volatile__("rdtsc" : "=a"(lo), "=d"(hi));
 	return ((uint64_t)hi << 32) | lo;
 }
-static void test_top ()
+static void test_top (void)
 {
 	KeySet * test0 = ksNew (10, keyNew ("/a", KEY_VALUE, "whatever", KEY_END), KS_END);
 	KeySet * test1 = ksNew (

--- a/tests/ctest/test_mount.c
+++ b/tests/ctest/test_mount.c
@@ -12,7 +12,7 @@
 #include <../../src/libs/elektra/trie.c>
 #include <tests_internal.h>
 
-KDB * kdb_new ()
+KDB * kdb_new (void)
 {
 	KDB * kdb = elektraCalloc (sizeof (KDB));
 	kdb->split = splitNew ();
@@ -43,7 +43,7 @@ static void kdb_del (KDB * kdb)
 	elektraFree (kdb);
 }
 
-static void test_mount ()
+static void test_mount (void)
 {
 	printf ("test mount backend\n");
 
@@ -87,7 +87,7 @@ KeySet * minimal_config (void)
 }
 
 
-static void test_minimaltrie ()
+static void test_minimaltrie (void)
 {
 	printf ("Test minimal mount\n");
 
@@ -112,7 +112,7 @@ KeySet * simple_config (void)
 		      keyNew ("system/elektra/mountpoints/simple/mountpoint", KEY_VALUE, "user/tests/simple", KEY_END), KS_END);
 }
 
-static void test_simple ()
+static void test_simple (void)
 {
 	printf ("Test simple mount\n");
 
@@ -158,7 +158,7 @@ static void test_simple ()
 	kdb_del (kdb);
 }
 
-KeySet * set_simple ()
+KeySet * set_simple (void)
 {
 	return ksNew (50, keyNew ("system/elektra/mountpoints/simple", KEY_END),
 
@@ -192,7 +192,7 @@ KeySet * set_simple ()
 }
 
 
-KeySet * set_pluginconf ()
+KeySet * set_pluginconf (void)
 {
 	return ksNew (10, keyNew ("system/anything", KEY_VALUE, "backend", KEY_END), keyNew ("system/more", KEY_END),
 		      keyNew ("system/more/config", KEY_END), keyNew ("system/more/config/below", KEY_END), keyNew ("system/path", KEY_END),
@@ -201,7 +201,7 @@ KeySet * set_pluginconf ()
 		      KS_END);
 }
 
-static void test_simpletrie ()
+static void test_simpletrie (void)
 {
 	printf ("Test simple mount with plugins\n");
 
@@ -257,7 +257,7 @@ static void test_simpletrie ()
 }
 
 
-KeySet * set_two ()
+KeySet * set_two (void)
 {
 	return ksNew (50, keyNew ("system/elektra/mountpoints", KEY_END), keyNew ("system/elektra/mountpoints/simple", KEY_END),
 
@@ -310,7 +310,7 @@ KeySet * set_two ()
 		      keyNew ("system/elektra/mountpoints/two/setplugins/#2" KDB_DEFAULT_STORAGE, KEY_END), KS_END);
 }
 
-static void test_two ()
+static void test_two (void)
 {
 	printf ("Test two mounts\n");
 
@@ -370,7 +370,7 @@ static void test_two ()
 }
 
 
-KeySet * set_us ()
+KeySet * set_us (void)
 {
 	return ksNew (50, keyNew ("system/elektra/mountpoints", KEY_END), keyNew ("system/elektra/mountpoints/user", KEY_END),
 		      keyNew ("system/elektra/mountpoints/user/mountpoint", KEY_VALUE, "user", KEY_END),
@@ -378,7 +378,7 @@ KeySet * set_us ()
 		      keyNew ("system/elektra/mountpoints/system/mountpoint", KEY_VALUE, "system", KEY_END), KS_END);
 }
 
-static void test_us ()
+static void test_us (void)
 {
 	printf ("Test mounting of user and system backends\n");
 
@@ -441,7 +441,7 @@ KeySet * endings_config (void)
 		      keyNew ("system/elektra/mountpoints/endings/mountpoint", KEY_VALUE, "user/endings\200", KEY_END), KS_END);
 }
 
-static void test_endings ()
+static void test_endings (void)
 {
 	printf ("Test mounting with different endings\n");
 
@@ -542,7 +542,7 @@ KeySet * oldroot_config (void)
 		      keyNew ("system/elektra/mountpoints/simple/mountpoint", KEY_VALUE, "user/tests/simple", KEY_END), KS_END);
 }
 
-static void test_oldroot ()
+static void test_oldroot (void)
 {
 	printf ("Test mounting with old root\n");
 
@@ -598,7 +598,7 @@ KeySet * cascading_config (void)
 		      keyNew ("system/elektra/mountpoints/simple/mountpoint", KEY_VALUE, "/tests/simple", KEY_END), KS_END);
 }
 
-static void test_cascading ()
+static void test_cascading (void)
 {
 	printf ("Test simple mount with cascading\n");
 
@@ -680,7 +680,7 @@ KeySet * root_config (void)
 		      keyNew ("system/elektra/mountpoints/simple/mountpoint", KEY_VALUE, "user/tests/simple", KEY_END), KS_END);
 }
 
-static void test_root ()
+static void test_root (void)
 {
 	printf ("Test mounting with root\n");
 
@@ -735,7 +735,7 @@ static void test_root ()
 	ksDel (modules);
 }
 
-static void test_default ()
+static void test_default (void)
 {
 	printf ("Test mounting with default\n");
 
@@ -807,7 +807,7 @@ static void test_default ()
 	ksDel (modules);
 }
 
-static void test_init ()
+static void test_init (void)
 {
 	printf ("Test mounting with init (no config)\n");
 
@@ -875,7 +875,7 @@ static void test_init ()
 	ksDel (modules);
 }
 
-static void test_rootInit ()
+static void test_rootInit (void)
 {
 	printf ("Test mounting with root and init\n");
 
@@ -959,7 +959,7 @@ static void test_rootInit ()
 	ksDel (modules);
 }
 
-static void test_modules ()
+static void test_modules (void)
 {
 	printf ("Test mounting with modules\n");
 

--- a/tests/ctest/test_mountsplit.c
+++ b/tests/ctest/test_mountsplit.c
@@ -12,7 +12,7 @@
 #include <../../src/libs/elektra/trie.c>
 #include <tests_internal.h>
 
-KDB * kdb_new ()
+KDB * kdb_new (void)
 {
 	KDB * kdb = elektraCalloc (sizeof (KDB));
 	kdb->split = splitNew ();
@@ -39,7 +39,7 @@ static void kdb_del (KDB * kdb)
 	elektraFree (kdb);
 }
 
-static void test_mount ()
+static void test_mount (void)
 {
 	printf ("test mount backend\n");
 
@@ -86,7 +86,7 @@ KeySet * minimal_config (void)
 }
 
 
-static void test_minimaltrie ()
+static void test_minimaltrie (void)
 {
 	printf ("Test minimal mount\n");
 
@@ -112,7 +112,7 @@ KeySet * simple_config (void)
 		      keyNew ("system/elektra/mountpoints/simple/mountpoint", KEY_VALUE, "user/tests/simple", KEY_END), KS_END);
 }
 
-static void test_simple ()
+static void test_simple (void)
 {
 	printf ("Test simple mount\n");
 
@@ -162,7 +162,7 @@ static void test_simple ()
 	kdb_del (kdb);
 }
 
-KeySet * set_us ()
+KeySet * set_us (void)
 {
 	return ksNew (50, keyNew ("system/elektra/mountpoints", KEY_END), keyNew ("system/elektra/mountpoints/user", KEY_END),
 		      keyNew ("system/elektra/mountpoints/user/mountpoint", KEY_VALUE, "user", KEY_END),
@@ -170,7 +170,7 @@ KeySet * set_us ()
 		      keyNew ("system/elektra/mountpoints/system/mountpoint", KEY_VALUE, "system", KEY_END), KS_END);
 }
 
-static void test_us ()
+static void test_us (void)
 {
 	printf ("Test mounting of user and system backends\n");
 
@@ -232,7 +232,7 @@ KeySet * cascading_config (void)
 		      keyNew ("system/elektra/mountpoints/simple/mountpoint", KEY_VALUE, "/tests/simple", KEY_END), KS_END);
 }
 
-static void test_cascading ()
+static void test_cascading (void)
 {
 	printf ("Test simple mount with cascading\n");
 
@@ -328,7 +328,7 @@ KeySet * root_config (void)
 		      keyNew ("system/elektra/mountpoints/simple/mountpoint", KEY_VALUE, "user/tests/simple", KEY_END), KS_END);
 }
 
-static void test_root ()
+static void test_root (void)
 {
 	printf ("Test mounting with root\n");
 
@@ -399,7 +399,7 @@ static void test_root ()
 	ksDel (modules);
 }
 
-static void test_default ()
+static void test_default (void)
 {
 	printf ("Test mounting with default\n");
 
@@ -492,7 +492,7 @@ static void test_default ()
 	ksDel (modules);
 }
 
-static void test_modules ()
+static void test_modules (void)
 {
 	printf ("Test mounting with modules\n");
 
@@ -604,7 +604,7 @@ static void test_modules ()
 	ksDel (modules);
 }
 
-static void test_defaultonly ()
+static void test_defaultonly (void)
 {
 	printf ("Test mounting with default only\n");
 

--- a/tests/ctest/test_namespace.c
+++ b/tests/ctest/test_namespace.c
@@ -8,7 +8,7 @@
 
 #include <tests_internal.h>
 
-static void test_keyNamespace ()
+static void test_keyNamespace (void)
 {
 	Key * key;
 

--- a/tests/ctest/test_operation.c
+++ b/tests/ctest/test_operation.c
@@ -8,7 +8,7 @@
 
 #include <tests_internal.h>
 
-static void test_cmpOrder ()
+static void test_cmpOrder (void)
 {
 	Key * k1 = keyNew ("user/a", KEY_META, "order", "20", KEY_END);
 	Key * k2 = keyNew ("user/b", KEY_META, "order", "10", KEY_END);
@@ -36,7 +36,7 @@ static void test_cmpOrder ()
 	keyDel (k2);
 }
 
-static KeySet * set_a ()
+static KeySet * set_a (void)
 {
 	return ksNew (16, keyNew ("user/0", KEY_END), keyNew ("user/a", KEY_END), keyNew ("user/a/a", KEY_END),
 		      keyNew ("user/a/a/a", KEY_END), keyNew ("user/a/a/b", KEY_END), keyNew ("user/a/b", KEY_END),
@@ -46,7 +46,7 @@ static KeySet * set_a ()
 		      keyNew ("user/x", KEY_END), KS_END);
 }
 
-static void test_search ()
+static void test_search (void)
 {
 	printf ("Testing operation search (internal)\n");
 
@@ -141,7 +141,7 @@ static void test_search ()
 	ksDel (a);
 }
 
-static void test_format ()
+static void test_format (void)
 {
 	printf ("Test key format\n");
 

--- a/tests/ctest/test_order.c
+++ b/tests/ctest/test_order.c
@@ -8,7 +8,7 @@
 
 #include <tests_internal.h>
 
-static void test_ksNew ()
+static void test_ksNew (void)
 {
 	KeySet * ks = 0;
 	KeySet * keys = ksNew (15, KS_END);
@@ -75,7 +75,7 @@ static void test_ksNew ()
 	succeed_if (ksDel (ks2) == 0, "could not delete keyset");
 }
 
-static void test_ksDuplicate ()
+static void test_ksDuplicate (void)
 {
 	printf ("Test bug duplicate\n");
 	KeySet * ks = ksNew (0, KS_END);
@@ -89,7 +89,7 @@ static void test_ksDuplicate ()
 	ksDel (ks);
 }
 
-static void test_ksHole ()
+static void test_ksHole (void)
 {
 	printf ("Test holes in keysets\n");
 	KeySet * ks = ksNew (0, KS_END);
@@ -137,7 +137,7 @@ static void per (int k, Key ** pool, Key ** result)
 	result[size - 1] = 0;
 }
 
-static void test_append ()
+static void test_append (void)
 {
 	printf ("Test if keyset is sorted after appending\n");
 
@@ -315,7 +315,7 @@ static void test_append ()
 	keyDel (s3);
 }
 
-static void test_equal ()
+static void test_equal (void)
 {
 	Key * k1 = keyNew (0);
 	Key * k2 = keyNew (0);
@@ -343,7 +343,7 @@ static void test_equal ()
 	keyDel (k2);
 }
 
-static void test_cmp ()
+static void test_cmp (void)
 {
 	printf ("Compare two keys\n");
 
@@ -381,7 +381,7 @@ static void test_cmp ()
 	keyDel (k2);
 }
 
-static void test_appendowner ()
+static void test_appendowner (void)
 {
 	Key *key, *s1, *s2, *s3;
 	KeySet * ks;
@@ -423,7 +423,7 @@ static void test_appendowner ()
 	ksDel (ks);
 }
 
-static void test_ksLookupCase ()
+static void test_ksLookupCase (void)
 {
 	printf ("Test bug lookup with case\n");
 	KeySet * ks = ksNew (32, keyNew ("system/ay/key", KEY_VALUE, "aykey", KEY_END),
@@ -435,7 +435,7 @@ static void test_ksLookupCase ()
 	ksDel (ks);
 }
 
-static void test_ksLookupOwner ()
+static void test_ksLookupOwner (void)
 {
 	printf ("Test bug lookup with owner\n");
 	Key * found = 0;

--- a/tests/ctest/test_plugin.c
+++ b/tests/ctest/test_plugin.c
@@ -113,7 +113,7 @@ static void test_process (void)
 	keyDel (k);
 }
 
-KeySet * set_pluginconf ()
+KeySet * set_pluginconf (void)
 {
 	return ksNew (10, keyNew ("system/anything", KEY_VALUE, "backend", KEY_END), keyNew ("system/more", KEY_END),
 		      keyNew ("system/more/config", KEY_END), keyNew ("system/more/config/below", KEY_END), keyNew ("system/path", KEY_END),
@@ -122,7 +122,7 @@ KeySet * set_pluginconf ()
 		      KS_END);
 }
 
-static void test_simple ()
+static void test_simple (void)
 {
 	printf ("Test plugin\n");
 
@@ -146,7 +146,7 @@ static void test_simple ()
 	ksDel (modules);
 }
 
-static void test_name ()
+static void test_name (void)
 {
 	printf ("Test name\n");
 	KeySet * modules = ksNew (0, KS_END);

--- a/tests/ctest/test_proposal.c
+++ b/tests/ctest/test_proposal.c
@@ -8,7 +8,7 @@
 
 #include <tests_internal.h>
 
-static void test_ksPopAtCursor ()
+static void test_ksPopAtCursor (void)
 {
 	KeySet * ks = ksNew (5, keyNew ("user/valid/key1", KEY_END), keyNew ("user/valid/key2", KEY_END),
 			     keyNew ("system/valid/key1", KEY_END), keyNew ("system/valid/key2", KEY_END), KS_END);
@@ -26,7 +26,7 @@ static void test_ksPopAtCursor ()
 	ksDel (ks_c);
 }
 
-static void test_ksToArray ()
+static void test_ksToArray (void)
 {
 	KeySet * ks = ksNew (5, keyNew ("user/test1", KEY_END), keyNew ("user/test2", KEY_END), keyNew ("user/test3", KEY_END), KS_END);
 
@@ -54,7 +54,7 @@ static void test_ksToArray ()
 	ksDel (ks);
 }
 
-static void test_keyAsCascading ()
+static void test_keyAsCascading (void)
 {
 	printf ("test keyAsCascading\n");
 	Key * system = keyNew ("system", KEY_END);
@@ -80,7 +80,7 @@ static void test_keyAsCascading ()
 	keyDel (cascadingKey);
 }
 
-static void test_keyGetLevelsBelow ()
+static void test_keyGetLevelsBelow (void)
 {
 	printf ("test keyGetLevelsBelow\n");
 	Key * parent = keyNew ("system/parent", KEY_END);
@@ -97,7 +97,7 @@ static void test_keyGetLevelsBelow ()
 	keyDel (threeLvl);
 }
 
-static void test_keyRel2 ()
+static void test_keyRel2 (void)
 {
 	printf ("test keyRel2\n");
 

--- a/tests/ctest/test_size.c
+++ b/tests/ctest/test_size.c
@@ -10,7 +10,7 @@
 
 #define NAME_SIZE 250
 
-static void test_ksResize ()
+static void test_ksResize (void)
 {
 	int i;
 	KeySet * ks = 0;

--- a/tests/ctest/test_spec.c
+++ b/tests/ctest/test_spec.c
@@ -10,7 +10,7 @@
 
 #include <kdbproposal.h>
 
-static void test_lookupSingle ()
+static void test_lookupSingle (void)
 {
 	printf ("Test lookup single\n");
 
@@ -31,7 +31,7 @@ static void test_lookupSingle ()
 	ksDel (ks);
 }
 
-static void test_lookupChain ()
+static void test_lookupChain (void)
 {
 	printf ("Test lookup chain\n");
 
@@ -59,7 +59,7 @@ static void test_lookupChain ()
 	ksDel (ks);
 }
 
-static void test_lookupChainLast ()
+static void test_lookupChainLast (void)
 {
 	printf ("Test lookup chain last\n");
 
@@ -97,7 +97,7 @@ static void test_lookupChainLast ()
 }
 
 
-static void test_lookupChainRealWorld ()
+static void test_lookupChainRealWorld (void)
 {
 	printf ("Test lookup chain real world\n");
 
@@ -134,7 +134,7 @@ static void test_lookupChainRealWorld ()
 	ksDel (ks);
 }
 
-static void test_lookupNoOverride ()
+static void test_lookupNoOverride (void)
 {
 	printf ("Test lookup with override not found\n");
 
@@ -165,7 +165,7 @@ static void test_lookupNoOverride ()
 	keyDel (dup);
 }
 
-static void test_lookupDefault ()
+static void test_lookupDefault (void)
 {
 	printf ("Test lookup default\n");
 
@@ -194,7 +194,7 @@ static void test_lookupDefault ()
 	ksDel (ks);
 }
 
-static void test_lookupNoascading ()
+static void test_lookupNoascading (void)
 {
 	printf ("Test lookup without cascading\n");
 
@@ -242,7 +242,7 @@ static void test_lookupNoascading ()
 	keyDel (specKey);
 }
 
-static void test_lookupDefaultCascading ()
+static void test_lookupDefaultCascading (void)
 {
 	printf ("Test lookup default with cascading\n");
 
@@ -270,7 +270,7 @@ static void test_lookupDefaultCascading ()
 	ksDel (ks);
 }
 
-static void test_lookupLongChain ()
+static void test_lookupLongChain (void)
 {
 	printf ("Test lookup long chain\n");
 
@@ -318,7 +318,7 @@ static void test_lookupLongChain ()
 	ksDel (ks);
 }
 
-static void test_lookupCascading ()
+static void test_lookupCascading (void)
 {
 	printf ("Test lookup cascading\n");
 
@@ -341,7 +341,7 @@ static void test_lookupCascading ()
 	ksDel (ks);
 }
 
-static void test_lookupNamespace ()
+static void test_lookupNamespace (void)
 {
 	printf ("Test lookup namespace\n");
 
@@ -378,7 +378,7 @@ static void test_lookupNamespace ()
 	keyDel (specKey);
 }
 
-static void test_lookupIndirect ()
+static void test_lookupIndirect (void)
 {
 	printf ("Test lookup by indirect spec\n");
 
@@ -431,7 +431,7 @@ static void test_lookupIndirect ()
 	ksDel (ks);
 }
 
-static void test_lookupDoubleIndirect ()
+static void test_lookupDoubleIndirect (void)
 {
 	printf ("Test lookup by double indirect spec\n");
 
@@ -475,7 +475,7 @@ static void test_lookupDoubleIndirect ()
 	ksDel (ks);
 }
 
-static void test_lookupDoubleIndirectDefault ()
+static void test_lookupDoubleIndirectDefault (void)
 {
 	printf ("Test lookup by double indirect spec with default\n");
 

--- a/tests/ctest/test_split.c
+++ b/tests/ctest/test_split.c
@@ -27,7 +27,7 @@ KeySet * simple_config (void)
 }
 
 
-KeySet * set_us ()
+KeySet * set_us (void)
 {
 	return ksNew (50, keyNew ("system/elektra/mountpoints", KEY_END), keyNew ("system/elektra/mountpoints/user", KEY_END),
 		      keyNew ("system/elektra/mountpoints/user/mountpoint", KEY_VALUE, "user", KEY_END),
@@ -43,7 +43,7 @@ KeySet * root_config (void)
 }
 
 
-static void test_create ()
+static void test_create (void)
 {
 	printf ("Test create split\n");
 
@@ -64,7 +64,7 @@ static void test_create ()
 	splitDel (split);
 }
 
-static void test_resize ()
+static void test_resize (void)
 {
 	printf ("Test resize split\n");
 
@@ -87,7 +87,7 @@ static void test_resize ()
 	splitDel (split);
 }
 
-static void test_append ()
+static void test_append (void)
 {
 	printf ("Test append split\n");
 
@@ -114,7 +114,7 @@ static void test_append ()
 	splitDel (split);
 }
 
-static void test_remove ()
+static void test_remove (void)
 {
 	printf ("Test remove from split\n");
 

--- a/tests/ctest/test_splitget.c
+++ b/tests/ctest/test_splitget.c
@@ -34,7 +34,7 @@ KeySet * simple_cascading (void)
 }
 
 
-KeySet * set_realworld ()
+KeySet * set_realworld (void)
 {
 	return ksNew (50, keyNew ("system/elektra/mountpoints", KEY_END), keyNew ("system/elektra/mountpoints/root", KEY_END),
 		      keyNew ("system/elektra/mountpoints/root/mountpoint", KEY_VALUE, "/", KEY_END),
@@ -53,7 +53,7 @@ KeySet * set_realworld ()
 }
 
 
-static void test_simple ()
+static void test_simple (void)
 {
 	printf ("Test simple trie\n");
 
@@ -127,7 +127,7 @@ static void test_simple ()
 }
 
 
-static void test_cascading ()
+static void test_cascading (void)
 {
 	// TODO: test not fully done
 	printf ("Test simple cascading\n");
@@ -207,7 +207,7 @@ static void test_cascading ()
 }
 
 
-static void test_get ()
+static void test_get (void)
 {
 	printf ("Test basic get\n");
 	KDB * handle = elektraCalloc (sizeof (struct _KDB));
@@ -305,7 +305,7 @@ static void test_get ()
 	ksDel (modules);
 }
 
-static void test_limit ()
+static void test_limit (void)
 {
 	printf ("Test limit\n");
 	KDB * handle = elektraCalloc (sizeof (struct _KDB));
@@ -382,7 +382,7 @@ static void test_limit ()
 }
 
 
-static void test_nobackend ()
+static void test_nobackend (void)
 {
 	printf ("Test keys without backends in split\n");
 
@@ -439,7 +439,7 @@ static void test_nobackend ()
 }
 
 
-static void test_sizes ()
+static void test_sizes (void)
 {
 	printf ("Test sizes\n");
 	KDB * handle = elektraCalloc (sizeof (struct _KDB));
@@ -531,7 +531,7 @@ static void test_sizes ()
 }
 
 
-static void test_triesizes ()
+static void test_triesizes (void)
 {
 	printf ("Test sizes in backends with trie\n");
 
@@ -627,7 +627,7 @@ static void test_triesizes ()
 }
 
 
-static void test_merge ()
+static void test_merge (void)
 {
 	printf ("Test sizes in backends with trie\n");
 
@@ -719,7 +719,7 @@ static void test_merge ()
 }
 
 
-static void test_realworld ()
+static void test_realworld (void)
 {
 	printf ("Test real world example\n");
 

--- a/tests/ctest/test_splitset.c
+++ b/tests/ctest/test_splitset.c
@@ -12,7 +12,7 @@
 #include <../../src/libs/elektra/trie.c>
 #include <tests_internal.h>
 
-KeySet * set_us ()
+KeySet * set_us (void)
 {
 	return ksNew (50, keyNew ("system/elektra/mountpoints", KEY_END), keyNew ("system/elektra/mountpoints/user", KEY_END),
 		      keyNew ("system/elektra/mountpoints/user/mountpoint", KEY_VALUE, "user", KEY_END),
@@ -21,7 +21,7 @@ KeySet * set_us ()
 }
 
 
-KeySet * set_three ()
+KeySet * set_three (void)
 {
 	return ksNew (50, keyNew ("system/elektra/mountpoints", KEY_END), keyNew ("system/elektra/mountpoints/system", KEY_END),
 		      keyNew ("system/elektra/mountpoints/system/mountpoint", KEY_VALUE, "system", KEY_END),
@@ -32,7 +32,7 @@ KeySet * set_three ()
 }
 
 
-KeySet * set_realworld ()
+KeySet * set_realworld (void)
 {
 	return ksNew (50, keyNew ("system/elektra/mountpoints", KEY_END), keyNew ("system/elektra/mountpoints/root", KEY_END),
 		      keyNew ("system/elektra/mountpoints/root/mountpoint", KEY_VALUE, "/", KEY_END),
@@ -52,7 +52,7 @@ KeySet * set_realworld ()
 		      keyNew ("system/elektra/mountpoints/app2/mountpoint", KEY_VALUE, "user/sw/apps/app2", KEY_END), KS_END);
 }
 
-KDB * kdb_open ()
+KDB * kdb_open (void)
 {
 	KDB * handle = elektraCalloc (sizeof (struct _KDB));
 	handle->split = splitNew ();
@@ -78,7 +78,7 @@ void simulateGet (Split * split)
 }
 
 
-static void test_needsync ()
+static void test_needsync (void)
 {
 	printf ("Test needs sync\n");
 
@@ -146,7 +146,7 @@ static void test_needsync ()
 }
 
 
-static void test_mount ()
+static void test_mount (void)
 {
 	printf ("Test mount split\n");
 
@@ -249,7 +249,7 @@ static void test_mount ()
 	kdb_close (handle);
 }
 
-static void test_easyparent ()
+static void test_easyparent (void)
 {
 	printf ("Test parent separation of user and system (default Backend)\n");
 
@@ -308,7 +308,7 @@ static void test_easyparent ()
 	kdb_close (handle);
 }
 
-static void test_optimize ()
+static void test_optimize (void)
 {
 	printf ("Test optimization split (user, system in trie)\n");
 
@@ -415,7 +415,7 @@ static void test_optimize ()
 	kdb_close (handle);
 }
 
-static void test_three ()
+static void test_three (void)
 {
 	printf ("Test three mountpoints\n");
 
@@ -496,7 +496,7 @@ static void test_three ()
 	kdb_close (handle);
 }
 
-static void test_userremove ()
+static void test_userremove (void)
 {
 	printf ("Test user removing\n");
 	Key * parent = 0;
@@ -644,7 +644,7 @@ static void test_userremove ()
 }
 
 
-static void test_systemremove ()
+static void test_systemremove (void)
 {
 	printf ("Test system removing\n");
 	Key * parent = 0;
@@ -793,7 +793,7 @@ static void test_systemremove ()
 }
 
 
-static void test_emptyremove ()
+static void test_emptyremove (void)
 {
 	printf ("Test empty removing\n");
 
@@ -879,7 +879,7 @@ static void test_emptyremove ()
 	keyDel (parent);
 }
 
-static void test_realworld ()
+static void test_realworld (void)
 {
 	printf ("Test real world example\n");
 
@@ -1144,7 +1144,7 @@ static void test_realworld ()
 }
 
 
-static void test_emptysplit ()
+static void test_emptysplit (void)
 {
 	printf ("Test empty split\n");
 
@@ -1205,7 +1205,7 @@ static void test_emptysplit ()
 	kdb_close (handle);
 }
 
-static void test_nothingsync ()
+static void test_nothingsync (void)
 {
 	printf ("Test buildup with nothing to sync\n");
 	KDB * handle = kdb_open ();
@@ -1237,7 +1237,7 @@ static void test_nothingsync ()
 	kdb_close (handle);
 }
 
-static void test_state ()
+static void test_state (void)
 {
 	printf ("Test state conflicts\n");
 	KDB * handle = kdb_open ();

--- a/tests/ctest/test_trie.c
+++ b/tests/ctest/test_trie.c
@@ -21,7 +21,7 @@ Trie * test_insert (Trie * trie, char * name, char * value)
 }
 
 
-static void test_minimaltrie ()
+static void test_minimaltrie (void)
 {
 	printf ("Test minimal trie\n");
 
@@ -55,7 +55,7 @@ KeySet * simple_config (void)
 		      keyNew ("system/elektra/mountpoints/simple/mountpoint", KEY_VALUE, "user/tests/simple", KEY_END), KS_END);
 }
 
-static void test_simple ()
+static void test_simple (void)
 {
 	printf ("Test simple trie\n");
 
@@ -106,7 +106,7 @@ static void collect_mountpoints (Trie * trie, KeySet * mountpoints)
 	}
 }
 
-static void test_iterate ()
+static void test_iterate (void)
 {
 	printf ("Test iterate trie\n");
 
@@ -175,7 +175,7 @@ static void test_iterate ()
 	keyDel (searchKey);
 }
 
-static void test_reviterate ()
+static void test_reviterate (void)
 {
 	printf ("Test reviterate trie\n");
 
@@ -272,7 +272,7 @@ KeySet * set_mountpoints (void)
 		      keyNew ("system/tests/hosts/below", KEY_VALUE, "sysbelow", KEY_END), KS_END);
 }
 
-static void test_moreiterate ()
+static void test_moreiterate (void)
 {
 	printf ("Test moreiterate trie\n");
 
@@ -367,7 +367,7 @@ static void test_moreiterate ()
 	keyDel (searchKey);
 }
 
-static void test_revmoreiterate ()
+static void test_revmoreiterate (void)
 {
 	printf ("Test revmoreiterate trie\n");
 
@@ -519,7 +519,7 @@ static void test_revmoreiterate ()
 }
 
 
-static void test_umlauts ()
+static void test_umlauts (void)
 {
 	printf ("Test umlauts trie\n");
 
@@ -574,7 +574,7 @@ static void test_umlauts ()
 	keyDel (searchKey);
 }
 
-static void test_endings ()
+static void test_endings (void)
 {
 	printf ("Test endings trie\n");
 
@@ -690,7 +690,7 @@ static void test_endings ()
 	}
 }
 
-static void test_root ()
+static void test_root (void)
 {
 	printf ("Test trie with root\n");
 
@@ -735,7 +735,7 @@ static void test_root ()
 	keyDel (searchKey);
 }
 
-static void test_double ()
+static void test_double (void)
 {
 	printf ("Test double insertion\n");
 
@@ -767,7 +767,7 @@ static void test_double ()
 	trieClose (trie, 0);
 }
 
-static void test_emptyvalues ()
+static void test_emptyvalues (void)
 {
 	printf ("Test empty values in trie\n");
 

--- a/tests/ctest/test_utility.c
+++ b/tests/ctest/test_utility.c
@@ -12,7 +12,7 @@
 
 #define MAX_LENGTH 100
 
-static void test_elektraLskip ()
+static void test_elektraLskip (void)
 {
 	printf ("Test elektraLskip\n");
 
@@ -23,7 +23,7 @@ static void test_elektraLskip ()
 	succeed_if_same_string (elektraLskip (" \tLeading And Trailing Whitespace\t\n "), "Leading And Trailing Whitespace\t\n ");
 }
 
-static void test_elektraRstrip ()
+static void test_elektraRstrip (void)
 {
 	printf ("Test elektraRstrip\n");
 
@@ -74,7 +74,7 @@ static void test_elektraRstrip ()
 	succeed_if_same_string (last, "g");
 }
 
-static void test_elektraStrip ()
+static void test_elektraStrip (void)
 {
 	printf ("Test elektraStrip\n");
 	char text[MAX_LENGTH];
@@ -86,7 +86,7 @@ static void test_elektraStrip ()
 	succeed_if_same_string (elektraStrip (text), "Leading And Trailing Whitespace\n\tSecond Line");
 }
 
-static void test_elektraReplace ()
+static void test_elektraReplace (void)
 {
 	printf ("Test elektraReplace\n");
 	char * text;


### PR DESCRIPTION
# Purpose

fix the warnings by -Wstrict-prototypes

# Checklist

- [X] commit messages are fine (with references to issues)
- [X] I ran all tests and everything went fine
- [ ] I added unit tests
- [ ] affected documentation is fixed
- [ ] I added code comments, logging, and assertions
- [ ] meta data is updated (e.g. README.md of plugins)

@markus2330 I've enabled the -Wstrict-prototypes flag in general now so we have it in the future
