### PR TITLE
Macros: Add `ELEKTRA_NOT_NULL` and `ELEKTRA_MALLOC_ERROR`

### DIFF
--- a/src/include/kdbassert.h
+++ b/src/include/kdbassert.h
@@ -43,4 +43,5 @@ void elektraAbort (const char * expression, const char * function, const char * 
 #else
 #define ELEKTRA_ASSERT(EXPR, ...)
 #endif
+#define ELEKTRA_NOT_NULL(argument) ELEKTRA_ASSERT (argument, "The variable `" #argument "` contains `NULL`.")
 #endif

--- a/src/include/kdbmacros.h
+++ b/src/include/kdbmacros.h
@@ -43,6 +43,8 @@
 			ELEKTRA_SET_ERROR (75, parentKey, strerror (errno));                                                               \
 	} while (0)
 
+#define ELEKTRA_MALLOC_ERROR(key, size) ELEKTRA_SET_ERRORF (ELEKTRA_ERROR_MALLOC, key, "Unable to allocate %zu bytes.", size);
+
 /**
  * @brief Sets error 84 if info != returned
  *

--- a/src/plugins/file/file.c
+++ b/src/plugins/file/file.c
@@ -156,7 +156,7 @@ int elektraFileSet (Plugin * handle ELEKTRA_UNUSED, KeySet * returned ELEKTRA_UN
 	unsigned char * value = elektraMalloc (valueSize);
 	if (!value)
 	{
-		ELEKTRA_SET_ERRORF (ELEKTRA_ERROR_MALLOC, parentKey, "failed to allocate buffer of %zd bytes", valueSize);
+		ELEKTRA_MALLOC_ERROR (parentKey, valueSize);
 		fclose (fp);
 		return -1;
 	}

--- a/src/plugins/mini/mini.c
+++ b/src/plugins/mini/mini.c
@@ -36,8 +36,8 @@
  */
 #define CLOSE_FILE(file, errorNumber, parentKey, ERROR_FUNCTION)                                                                           \
 	{                                                                                                                                  \
-		ELEKTRA_ASSERT (file, "The Parameter `file` contains `NULL` instead of a valid file handle.");                             \
-		ELEKTRA_ASSERT (parentKey, "The Parameter `parentKey` contains `NULL` instead of a valid key.");                           \
+		ELEKTRA_NOT_NULL (file);                                                                                                   \
+		ELEKTRA_NOT_NULL (parentKey);                                                                                              \
                                                                                                                                            \
 		if (fclose (file) != 0)                                                                                                    \
 		{                                                                                                                          \
@@ -89,7 +89,7 @@ static inline KeySet * elektraMiniContract (void)
  */
 static inline char * stripComment (char * line)
 {
-	ELEKTRA_ASSERT (line != NULL, "The Parameter `line` contains `NULL` instead of a valid string.");
+	ELEKTRA_NOT_NULL (line);
 
 	char * current = line;
 	char * before = NULL;
@@ -118,7 +118,7 @@ static inline char * stripComment (char * line)
  */
 static inline char * findUnescapedEquals (char * text)
 {
-	ELEKTRA_ASSERT (text != NULL, "The Parameter `text` contains `NULL` instead of a valid string.");
+	ELEKTRA_NOT_NULL (text);
 
 	char * equals = text;
 	char * before = NULL;
@@ -152,9 +152,9 @@ static inline char * findUnescapedEquals (char * text)
  */
 static inline void parseLine (char * line, size_t lineNumber, KeySet * keySet, Key * parentKey)
 {
-	ELEKTRA_ASSERT (line != NULL, "The Parameter `line` contains `NULL` instead of a valid string.");
-	ELEKTRA_ASSERT (keySet != NULL, "The Parameter `keySet` contains `NULL` instead of a valid key set.");
-	ELEKTRA_ASSERT (parentKey != NULL, "The Parameter `parentKey` contains `NULL` instead of a valid key.");
+	ELEKTRA_NOT_NULL (line);
+	ELEKTRA_NOT_NULL (keySet);
+	ELEKTRA_NOT_NULL (parentKey);
 
 	char * pair = elektraStrip (stripComment (line));
 
@@ -202,9 +202,9 @@ static inline void parseLine (char * line, size_t lineNumber, KeySet * keySet, K
  */
 static int parseINI (FILE * file, KeySet * keySet, Key * parentKey)
 {
-	ELEKTRA_ASSERT (file != NULL, "The Parameter `file` contains `NULL` instead of a valid file handle.");
-	ELEKTRA_ASSERT (keySet != NULL, "The Parameter `keySet` contains `NULL` instead of a valid key set.");
-	ELEKTRA_ASSERT (parentKey != NULL, "The Parameter `parentKey` contains `NULL` instead of a valid key.");
+	ELEKTRA_NOT_NULL (file);
+	ELEKTRA_NOT_NULL (keySet);
+	ELEKTRA_NOT_NULL (parentKey);
 
 	char * line = NULL;
 	size_t capacity = 0;
@@ -246,8 +246,8 @@ static int parseINI (FILE * file, KeySet * keySet, Key * parentKey)
  */
 static int parseFile (KeySet * returned, Key * parentKey)
 {
-	ELEKTRA_ASSERT (returned != NULL, "The Parameter `returned` contains `NULL` instead of a valid key set.");
-	ELEKTRA_ASSERT (parentKey != NULL, "The Parameter `parentKey` contains `NULL` instead of a valid key.");
+	ELEKTRA_NOT_NULL (returned);
+	ELEKTRA_NOT_NULL (parentKey);
 
 	ELEKTRA_LOG ("Read configuration data");
 	int errorNumber = errno;
@@ -285,7 +285,7 @@ static int parseFile (KeySet * returned, Key * parentKey)
  */
 static inline int checkWrite (int status, int errorNumber, Key * parentKey)
 {
-	ELEKTRA_ASSERT (parentKey != NULL, "The Parameter `parentKey` contains `NULL` instead of a valid key.");
+	ELEKTRA_NOT_NULL (parentKey);
 
 	if (status < 0)
 	{
@@ -313,9 +313,9 @@ static inline int checkWrite (int status, int errorNumber, Key * parentKey)
  */
 static inline int writeFile (FILE * file, KeySet * keySet, Key * parentKey)
 {
-	ELEKTRA_ASSERT (file != NULL, "The Parameter `file` contains `NULL` instead of a valid file handle.");
-	ELEKTRA_ASSERT (keySet != NULL, "The Parameter `keySet` contains `NULL` instead of a valid key set.");
-	ELEKTRA_ASSERT (parentKey != NULL, "The Parameter `parentKey` contains `NULL` instead of a valid key.");
+	ELEKTRA_NOT_NULL (file);
+	ELEKTRA_NOT_NULL (keySet);
+	ELEKTRA_NOT_NULL (parentKey);
 
 	int status = 0;
 	int errorNumber = errno;

--- a/src/plugins/yaml/yaml.c
+++ b/src/plugins/yaml/yaml.c
@@ -87,8 +87,6 @@ typedef struct
 	ELEKTRA_SET_ERRORF (ELEKTRA_ERROR_PARSE, data->parentKey, "%s:%lu:%lu: " message, keyString (data->parentKey), data->line,         \
 			    data->column, __VA_ARGS__);
 
-#define SET_ERROR_MALLOC(data, size) ELEKTRA_SET_ERRORF (ELEKTRA_ERROR_MALLOC, data->parentKey, "Unable to allocate %lu bytes", size);
-
 #define RET_NOK(function)                                                                                                                  \
 	if (function->status != OK)                                                                                                        \
 	{                                                                                                                                  \
@@ -135,7 +133,7 @@ static parserType * setErrorMalloc (parserType * const parser, size_t size)
 {
 	ELEKTRA_NOT_NULL (parser);
 
-	SET_ERROR_MALLOC (parser, size);
+	ELEKTRA_MALLOC_ERROR (parser->parentKey, size);
 	parser->status = ERROR_PARSE;
 	return parser;
 }

--- a/src/plugins/yaml/yaml.c
+++ b/src/plugins/yaml/yaml.c
@@ -95,8 +95,6 @@ typedef struct
 		return parser; /* Requires that the name of the parsing structure is `parser`! */                                          \
 	}
 
-#define ASSERT_NOT_NULL(argument) ELEKTRA_ASSERT (argument, "The variable `" #argument "` contains `NULL`.")
-
 /* -- Functions ------------------------------------------------------------------------------------------------------------------------- */
 
 // ========
@@ -115,7 +113,7 @@ typedef struct
  */
 static parserType * setErrorErrno (parserType * const parser, statusType status)
 {
-	ASSERT_NOT_NULL (parser);
+	ELEKTRA_NOT_NULL (parser);
 
 	SET_ERROR_PARSE (parser, "%s", strerror (errno));
 	errno = parser->errorNumber;
@@ -135,7 +133,7 @@ static parserType * setErrorErrno (parserType * const parser, statusType status)
  */
 static parserType * setErrorMalloc (parserType * const parser, size_t size)
 {
-	ASSERT_NOT_NULL (parser);
+	ELEKTRA_NOT_NULL (parser);
 
 	SET_ERROR_MALLOC (parser, size);
 	parser->status = ERROR_PARSE;
@@ -159,8 +157,8 @@ static parserType * setErrorMalloc (parserType * const parser, size_t size)
  */
 static parserType * bufferChar (parserType * const parser)
 {
-	ASSERT_NOT_NULL (parser);
-	ASSERT_NOT_NULL (parser->file);
+	ELEKTRA_NOT_NULL (parser);
+	ELEKTRA_NOT_NULL (parser->file);
 
 	char * line = NULL;
 	size_t capacity;
@@ -200,8 +198,8 @@ static parserType * bufferChar (parserType * const parser)
  */
 static parserType * getNextChar (parserType * parser)
 {
-	ASSERT_NOT_NULL (parser);
-	ASSERT_NOT_NULL (parser->file);
+	ELEKTRA_NOT_NULL (parser);
+	ELEKTRA_NOT_NULL (parser->file);
 
 	RET_NOK (bufferChar (parser));
 
@@ -239,8 +237,8 @@ static parserType * getNextChar (parserType * parser)
  */
 static parserType * putBackChar (parserType * parser)
 {
-	ASSERT_NOT_NULL (parser);
-	ASSERT_NOT_NULL (parser->buffer);
+	ELEKTRA_NOT_NULL (parser);
+	ELEKTRA_NOT_NULL (parser->buffer);
 	ELEKTRA_ASSERT (parser->buffer - 1 >= parser->bufferBase, "Can not put back more characters than available");
 
 	// We assume that we never put back the newline character
@@ -269,9 +267,9 @@ static parserType * putBackChar (parserType * parser)
  */
 static parserType * acceptChars (parserType * const parser, char const * const characters)
 {
-	ASSERT_NOT_NULL (parser);
-	ASSERT_NOT_NULL (parser->file);
-	ASSERT_NOT_NULL (characters);
+	ELEKTRA_NOT_NULL (parser);
+	ELEKTRA_NOT_NULL (parser->file);
+	ELEKTRA_NOT_NULL (characters);
 
 	if (getNextChar (parser)->status != OK || !parser->match) return parser;
 
@@ -305,9 +303,9 @@ static parserType * acceptChars (parserType * const parser, char const * const c
  */
 static parserType * expect (parserType * const parser, char const * const characters)
 {
-	ASSERT_NOT_NULL (parser);
-	ASSERT_NOT_NULL (parser->file);
-	ASSERT_NOT_NULL (characters);
+	ELEKTRA_NOT_NULL (parser);
+	ELEKTRA_NOT_NULL (parser->file);
+	ELEKTRA_NOT_NULL (characters);
 
 	RET_NOK (acceptChars (parser, characters));
 
@@ -341,8 +339,8 @@ static parserType * expect (parserType * const parser, char const * const charac
  */
 static parserType * whitespace (parserType * const parser)
 {
-	ASSERT_NOT_NULL (parser);
-	ASSERT_NOT_NULL (parser->file);
+	ELEKTRA_NOT_NULL (parser);
+	ELEKTRA_NOT_NULL (parser->file);
 
 	while (acceptChars (parser, " \t\n")->status == OK && parser->match)
 		; //! OCLINT
@@ -363,9 +361,9 @@ static parserType * whitespace (parserType * const parser)
  */
 static parserType * content (parserType * const parser)
 {
-	ASSERT_NOT_NULL (parser);
-	ASSERT_NOT_NULL (parser->file);
-	ASSERT_NOT_NULL (parser->buffer);
+	ELEKTRA_NOT_NULL (parser);
+	ELEKTRA_NOT_NULL (parser->file);
+	ELEKTRA_NOT_NULL (parser->buffer);
 
 	char * previous = parser->buffer;
 	size_t numberCharsRead = 0;
@@ -406,8 +404,8 @@ static parserType * content (parserType * const parser)
  */
 static parserType * doubleQuoted (parserType * const parser)
 {
-	ASSERT_NOT_NULL (parser);
-	ASSERT_NOT_NULL (parser->file);
+	ELEKTRA_NOT_NULL (parser);
+	ELEKTRA_NOT_NULL (parser->file);
 
 	RET_NOK (expect (parser, "\""));
 	RET_NOK (content (parser));
@@ -433,8 +431,8 @@ static parserType * doubleQuoted (parserType * const parser)
  */
 static parserType * doubleQuotedSpace (parserType * const parser)
 {
-	ASSERT_NOT_NULL (parser);
-	ASSERT_NOT_NULL (parser->file);
+	ELEKTRA_NOT_NULL (parser);
+	ELEKTRA_NOT_NULL (parser->file);
 
 	RET_NOK (whitespace (parser));
 	RET_NOK (doubleQuoted (parser));
@@ -459,11 +457,11 @@ static parserType * doubleQuotedSpace (parserType * const parser)
  */
 static parserType * saveText (parserType * const parser, char ** location)
 {
-	ASSERT_NOT_NULL (parser);
-	ASSERT_NOT_NULL (parser->match);
-	ASSERT_NOT_NULL (parser->end);
+	ELEKTRA_NOT_NULL (parser);
+	ELEKTRA_NOT_NULL (parser->match);
+	ELEKTRA_NOT_NULL (parser->end);
 	ELEKTRA_ASSERT (parser->end - parser->match >= -1, "The string specified via parser->match and parser->end has negative length");
-	ASSERT_NOT_NULL (location);
+	ELEKTRA_NOT_NULL (location);
 
 	size_t length = parser->end - parser->match + 1;
 	if (*location) elektraFree (*location);
@@ -489,8 +487,8 @@ static parserType * saveText (parserType * const parser, char ** location)
  */
 static parserType * key (parserType * const parser)
 {
-	ASSERT_NOT_NULL (parser);
-	ASSERT_NOT_NULL (parser->file);
+	ELEKTRA_NOT_NULL (parser);
+	ELEKTRA_NOT_NULL (parser->file);
 
 	RET_NOK (doubleQuotedSpace (parser));
 	return saveText (parser, &parser->key);
@@ -509,8 +507,8 @@ static parserType * key (parserType * const parser)
  */
 static parserType * value (parserType * const parser)
 {
-	ASSERT_NOT_NULL (parser);
-	ASSERT_NOT_NULL (parser->file);
+	ELEKTRA_NOT_NULL (parser);
+	ELEKTRA_NOT_NULL (parser->file);
 
 	RET_NOK (doubleQuotedSpace (parser));
 	return saveText (parser, &parser->value);
@@ -529,8 +527,8 @@ static parserType * value (parserType * const parser)
  */
 static parserType * pair (parserType * const parser)
 {
-	ASSERT_NOT_NULL (parser);
-	ASSERT_NOT_NULL (parser->file);
+	ELEKTRA_NOT_NULL (parser);
+	ELEKTRA_NOT_NULL (parser->file);
 
 	RET_NOK (key (parser));
 	LOG_PARSE (parser, "Read key “%s”", parser->key);
@@ -562,8 +560,8 @@ static parserType * pair (parserType * const parser)
  */
 static parserType * optionalAdditionalPairs (parserType * const parser)
 {
-	ASSERT_NOT_NULL (parser);
-	ASSERT_NOT_NULL (parser->file);
+	ELEKTRA_NOT_NULL (parser);
+	ELEKTRA_NOT_NULL (parser->file);
 
 	while (acceptChars (parser, ",")->status == OK && parser->match)
 	{
@@ -585,8 +583,8 @@ static parserType * optionalAdditionalPairs (parserType * const parser)
  */
 static parserType * pairs (parserType * const parser)
 {
-	ASSERT_NOT_NULL (parser);
-	ASSERT_NOT_NULL (parser->file);
+	ELEKTRA_NOT_NULL (parser);
+	ELEKTRA_NOT_NULL (parser->file);
 
 	RET_NOK (whitespace (parser));
 	RET_NOK (expect (parser, "{"));
@@ -617,8 +615,8 @@ static parserType * pairs (parserType * const parser)
  */
 static parserType * openFile (parserType * const parser)
 {
-	ASSERT_NOT_NULL (parser);
-	ASSERT_NOT_NULL (parser->parentKey);
+	ELEKTRA_NOT_NULL (parser);
+	ELEKTRA_NOT_NULL (parser->parentKey);
 
 	parser->file = fopen (keyString (parser->parentKey), "r");
 
@@ -639,7 +637,7 @@ static parserType * openFile (parserType * const parser)
  */
 static parserType * cleanup (parserType * const parser)
 {
-	ASSERT_NOT_NULL (parser);
+	ELEKTRA_NOT_NULL (parser);
 
 	if (parser->file && fclose (parser->file) != 0) setErrorErrno (parser, ERROR_FILE_CLOSE);
 	if (parser->bufferBase) elektraFree (parser->bufferBase);
@@ -662,8 +660,8 @@ static parserType * cleanup (parserType * const parser)
  */
 static int parseFile (KeySet * returned ELEKTRA_UNUSED, Key * parentKey)
 {
-	ASSERT_NOT_NULL (returned);
-	ASSERT_NOT_NULL (parentKey);
+	ELEKTRA_NOT_NULL (returned);
+	ELEKTRA_NOT_NULL (parentKey);
 
 	ELEKTRA_LOG ("Read configuration data");
 
@@ -712,9 +710,9 @@ static KeySet * contractYaml (void)
  */
 static int writeFile (FILE * file, KeySet * keySet, Key * parentKey)
 {
-	ASSERT_NOT_NULL (file);
-	ASSERT_NOT_NULL (keySet);
-	ASSERT_NOT_NULL (parentKey);
+	ELEKTRA_NOT_NULL (file);
+	ELEKTRA_NOT_NULL (keySet);
+	ELEKTRA_NOT_NULL (parentKey);
 
 	ksRewind (keySet);
 


### PR DESCRIPTION
# Purpose

This pull request adds two simple macros:

- `ELEKTRA_NOT_NULL` and
- `ELEKTRA_MALLOC_ERROR`

.

# Checklist

- [x] I checked all commit messages.
- [x] I ran all tests and everything went fine.