### PR TITLE
Fcrypt improvements

### DIFF
--- a/src/error/specification
+++ b/src/error/specification
@@ -1111,3 +1111,10 @@ severity:warning
 ingroup:plugin
 macro:FCRYPT_CLOSE
 module:fcrypt
+
+number:180
+description:Failed to unlink a temporary file. WARNING: unencrypted data may leak! Please try to delete the file manually.
+severity:warning
+ingroup:plugin
+macro:FCRYPT_UNLINK
+module:fcrypt

--- a/src/error/specification
+++ b/src/error/specification
@@ -1104,3 +1104,10 @@ severity:error
 ingroup:plugin
 macro:FCRYPT_STATE
 module:fcrypt
+
+number:179
+description:Failed to close a file descriptor.
+severity:warning
+ingroup:plugin
+macro:FCRYPT_CLOSE
+module:fcrypt

--- a/src/plugins/fcrypt/README.md
+++ b/src/plugins/fcrypt/README.md
@@ -66,15 +66,15 @@ Please refer to [crypto](../crypto/).
 
 You can mount the plugin with encryption enabled like this:
 
-	kdb mount test.ecf /t fcrypt encrypt/key=DDEBEF9EE2DC931701338212DAF635B17F230E8D
+	kdb mount test.ecf /t fcrypt "encrypt/key=DDEBEF9EE2DC931701338212DAF635B17F230E8D"
 
 If you only want to sign the configuration file, you can mount the plugin like this:
 
-	kdb mount test.ecf /t fcrypt sign/key=DDEBEF9EE2DC931701338212DAF635B17F230E8D
+	kdb mount test.ecf /t fcrypt "sign/key=DDEBEF9EE2DC931701338212DAF635B17F230E8D"
 
 Both options `encrypt/key` and `sign/key` can be combined:
 
-	kdb mount test.ecf /t fcrypt encrypt/key=DDEBEF9EE2DC931701338212DAF635B17F230E8D sign/key=DDEBEF9EE2DC931701338212DAF635B17F230E8D
+	kdb mount test.ecf /t fcrypt "encrypt/key=DDEBEF9EE2DC931701338212DAF635B17F230E8D,sign/key=DDEBEF9EE2DC931701338212DAF635B17F230E8D"
 
 If you create a key under `/t`
 
@@ -110,3 +110,12 @@ However, you can simply display the plain text content of the file by using GPG:
 ### GPG Configuration
 
 The GPG Configuration is described in [crypto](../crypto/).
+
+### Textmode
+
+`fcrypt` operates in textmode per default. In textmode `fcrypt` uses the `--armor` option of GPG, thus the
+output of `fcrypt` is ASCII armored. If no encryption key is provided (i.e. only signature is requested)
+`fcrypt` uses the `--clearsign` option of GPG.
+
+Textmode can be disabled by setting `fcrypt/textmode` to `0` in the plugin configuration.
+

--- a/src/plugins/fcrypt/fcrypt.c
+++ b/src/plugins/fcrypt/fcrypt.c
@@ -186,7 +186,11 @@ static int fcryptGpgCallAndCleanup (Key * parentKey, KeySet * pluginConfig, char
 	{
 		// if anything went wrong above the temporary file is shredded and removed
 		shredTemporaryFile (tmpFileFd, parentKey);
-		unlink (tmpFile);
+		if (unlink (tmpFile))
+		{
+			ELEKTRA_ADD_WARNINGF (ELEKTRA_WARNING_FCRYPT_UNLINK, parentKey, "Affected file: %s, error description: %s", tmpFile,
+					      strerror (errno));
+		}
 	}
 
 	if (parentKeyFd >= 0 && close (parentKeyFd))
@@ -416,7 +420,11 @@ static int fcryptDecrypt (KeySet * pluginConfig, Key * parentKey, fcryptState * 
 	{
 		// if anything went wrong above the temporary file is shredded and removed
 		shredTemporaryFile (tmpFileFd, parentKey);
-		unlink (tmpFile);
+		if (unlink (tmpFile))
+		{
+			ELEKTRA_ADD_WARNINGF (ELEKTRA_WARNING_FCRYPT_UNLINK, parentKey, "Affected file: %s, error description: %s", tmpFile,
+					      strerror (errno));
+		}
 		if (close (tmpFileFd))
 		{
 			ELEKTRA_ADD_WARNINGF (ELEKTRA_WARNING_FCRYPT_CLOSE, parentKey, "%s", strerror (errno));
@@ -526,7 +534,11 @@ int ELEKTRA_PLUGIN_FUNCTION (ELEKTRA_PLUGIN_NAME, get) (Plugin * handle, KeySet 
 				ELEKTRA_ADD_WARNINGF (ELEKTRA_WARNING_FCRYPT_CLOSE, parentKey, "%s", strerror (errno));
 			}
 			s->tmpFileFd = -1;
-			unlink (s->tmpFilePath);
+			if (unlink (s->tmpFilePath))
+			{
+				ELEKTRA_ADD_WARNINGF (ELEKTRA_WARNING_FCRYPT_UNLINK, parentKey, "Affected file: %s, error description: %s",
+						      s->tmpFilePath, strerror (errno));
+			}
 			elektraFree (s->tmpFilePath);
 			s->tmpFilePath = NULL;
 		}

--- a/src/plugins/fcrypt/fcrypt.h
+++ b/src/plugins/fcrypt/fcrypt.h
@@ -19,4 +19,6 @@ int ELEKTRA_PLUGIN_FUNCTION (ELEKTRA_PLUGIN_NAME, checkconf) (Key * errorKey, Ke
 
 Plugin * ELEKTRA_PLUGIN_EXPORT (crypto);
 
+#define ELEKTRA_FCRYPT_CONFIG_TEXTMODE "/fcrypt/textmode"
+
 #endif

--- a/src/plugins/fcrypt/testmod_fcrypt.c
+++ b/src/plugins/fcrypt/testmod_fcrypt.c
@@ -18,6 +18,8 @@
 #include <gpg.h>
 #include <test_key.h>
 
+#include "fcrypt.h"
+
 #define PLUGIN_NAME "fcrypt"
 #define TEST_KEY_ID "DDEBEF9EE2DC931701338212DAF635B17F230E8D"
 #define TEST_FILE "fcrypt_testfile"
@@ -32,6 +34,7 @@ static KeySet * newPluginConfiguration (void)
 		keyNew (ELEKTRA_RECIPIENT_KEY, KEY_VALUE, TEST_KEY_ID, KEY_END),
 		keyNew (ELEKTRA_CRYPTO_PARAM_GPG_UNIT_TEST, KEY_VALUE, "1", KEY_END),
 		keyNew (ELEKTRA_SIGNATURE_KEY, KEY_VALUE, TEST_KEY_ID, KEY_END),
+		keyNew (ELEKTRA_FCRYPT_CONFIG_TEXTMODE, KEY_VALUE, "0", KEY_END),
 		KS_END);
 	// clang-format on
 }


### PR DESCRIPTION
# Purpose

- text mode (see `README.md`)
- error handling for `unlink()` and `close()` calls

Closes #1543 .

# Checklist

Please only check relevant points.
For docu fixes, spell checking and similar nothing
needs to be checked.

- [x] commit messages are fine (with references to issues)
- [x] I ran all tests and everything went fine
- [ ] I added unit tests
- [x] affected documentation is fixed
- [x] I added code comments, logging, and assertions
- [ ] meta data is updated (e.g. README.md of plugins)

@markus2330 please review my pull request
