### PR TITLE
Travis: Add Basic Linux Build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,6 +56,8 @@ before_install:
 #
 before_script:
   - cd $TRAVIS_BUILD_DIR/..
+  - INSTALL_DIR="$PWD/install"
+  - SYSTEM_DIR="$PWD/kdbsystem"
   - mkdir build && cd build
   - CMAKE_OPT=()
   - echo $PATH
@@ -78,11 +80,12 @@ before_script:
     -DBINDINGS=ALL
     -DTOOLS=ALL
     -DINSTALL_SYSTEM_FILES=OFF
-    -DCMAKE_INSTALL_PREFIX=$TRAVIS_BUILD_DIR/../install
-    -DKDB_DB_SYSTEM=$TRAVIS_BUILD_DIR/../kdbsystem
+    -DCMAKE_INSTALL_PREFIX="$INSTALL_DIR"
+    -DKDB_DB_SYSTEM="$SYSTEM_DIR"
     ${CMAKE_OPT[@]}
     $TRAVIS_BUILD_DIR
-  - PATH=$PATH:$(ruby -e "puts File.expand_path('$TRAVIS_BUILD_DIR/../install/bin')")
+  - export PATH=$PATH:"$INSTALL_DIR/bin"
+  - export LD_LIBRARY_PATH="$INSTALL_DIR/lib"
 
 script:
   - ninja

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,8 @@ matrix:
       osx_image: xcode7.3
     - os: osx
       osx_image: xcode6.4
+    - os: linux
+      dist: trusty
 
 before_install:
   - |
@@ -41,6 +43,12 @@ before_install:
       export Qt5_DIR=/usr/local/opt/qt5;
       brew config;
     fi
+  - |
+    if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
+      sudo apt-get -qq update;
+      sudo apt-get install clang-format-3.8;
+      sudo apt-get install ninja-build;
+    fi
 
 #
 # Source is checked out in $TRAVIS_BUILD_DIR
@@ -51,6 +59,7 @@ before_script:
   - mkdir build && cd build
   - CMAKE_OPT=()
   - echo $PATH
+  - plugins="ALL;-jni";
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
       python2_ver=$(python2 -c 'import sys; print(".".join(map(str, sys.version_info[:2])))') &&
       CMAKE_OPT+=("-DPYTHON2_INCLUDE_DIR:PATH=$(python2-config --prefix)/include/python${python2_ver}") &&
@@ -58,11 +67,13 @@ before_script:
       python3_ver=$(python3 -c 'import sys; print(".".join(map(str, sys.version_info[:2])))') &&
       CMAKE_OPT+=("-DPYTHON_INCLUDE_DIR:PATH=$(python3-config --prefix)/include/python${python3_ver}m") &&
       CMAKE_OPT+=("-DPYTHON_LIBRARY:FILEPATH=$(python3-config --prefix)/lib/libpython${python3_ver}.dylib");
-      plugins="ALL;-jni";
       if [[ $(uname -r | cut -d "." -f 1) == 15 ]]; then plugins="${plugins};-CRYPTO"; fi;
       ln -s /usr/local/opt/openssl/include/openssl/ /usr/local/include/openssl;
     fi
-  - cmake -GNinja -DBUILD_STATIC=OFF -DPLUGINS="${plugins:-ALL}" -DBINDINGS=ALL -DTOOLS=ALL -DKDB_DB_SYSTEM=$TRAVIS_BUILD_DIR/../kdbsystem ${CMAKE_OPT[@]} $TRAVIS_BUILD_DIR
+  - >
+    cmake -GNinja -DBUILD_STATIC=OFF -DPLUGINS="${plugins:-ALL}" -DBINDINGS=ALL -DTOOLS=ALL -DINSTALL_SYSTEM_FILES=OFF
+    -DCMAKE_INSTALL_PREFIX=$TRAVIS_BUILD_DIR/../install -DKDB_DB_SYSTEM=$TRAVIS_BUILD_DIR/../kdbsystem ${CMAKE_OPT[@]} $TRAVIS_BUILD_DIR
+  - PATH=$PATH:$(ruby -e "puts File.expand_path('$TRAVIS_BUILD_DIR/../install/bin')")
 
 script:
   - ninja

--- a/.travis.yml
+++ b/.travis.yml
@@ -71,8 +71,17 @@ before_script:
       ln -s /usr/local/opt/openssl/include/openssl/ /usr/local/include/openssl;
     fi
   - >
-    cmake -GNinja -DBUILD_STATIC=OFF -DPLUGINS="${plugins:-ALL}" -DBINDINGS=ALL -DTOOLS=ALL -DINSTALL_SYSTEM_FILES=OFF
-    -DCMAKE_INSTALL_PREFIX=$TRAVIS_BUILD_DIR/../install -DKDB_DB_SYSTEM=$TRAVIS_BUILD_DIR/../kdbsystem ${CMAKE_OPT[@]} $TRAVIS_BUILD_DIR
+    cmake
+    -GNinja
+    -DBUILD_STATIC=OFF
+    -DPLUGINS="${plugins:-ALL}"
+    -DBINDINGS=ALL
+    -DTOOLS=ALL
+    -DINSTALL_SYSTEM_FILES=OFF
+    -DCMAKE_INSTALL_PREFIX=$TRAVIS_BUILD_DIR/../install
+    -DKDB_DB_SYSTEM=$TRAVIS_BUILD_DIR/../kdbsystem
+    ${CMAKE_OPT[@]}
+    $TRAVIS_BUILD_DIR
   - PATH=$PATH:$(ruby -e "puts File.expand_path('$TRAVIS_BUILD_DIR/../install/bin')")
 
 script:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,7 @@ project (Elektra)
 
 #fix macOS RPATH issues
 set(CMAKE_MACOSX_RPATH 1)
+SET(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib")
 
 #additional modules for loading libraries
 set (CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/Modules/")


### PR DESCRIPTION
# Purpose

This update adds a basic Linux build for Travis. While we already [test multiple variations of Elektra on Linux](https://build.libelektra.org/jenkins), adding an additional build still has some merits:

1. Travis also [tests updates on forks](https://travis-ci.org/sanssecours/libelektra) of this repo
2. Since Travis uses Ubuntu instead of Debian there might be slight differences in the OS, which allow us to [discover new problems](https://github.com/ElektraInitiative/libelektra/issues/1579)
3. Travis still works if someone [compromises the build server](https://github.com/ElektraInitiative/libelektra/issues/1505)

.

# Checklist

- [x] I checked all commit messages.
- [x] I ran all tests and [everything went fine](https://travis-ci.org/sanssecours/libelektra/builds/266210248).