### PR TITLE
crypto: introduce payload version

### DIFF
--- a/src/error/specification
+++ b/src/error/specification
@@ -1118,3 +1118,17 @@ severity:warning
 ingroup:plugin
 macro:FCRYPT_UNLINK
 module:fcrypt
+
+number:181
+description:The provided data could not be recognized as valid cryptographic payload. The data is possibly corrupted.
+severity:error
+ingroup:plugin
+macro:CRYPTO_PAYLOAD
+module:crypto
+
+number:182
+description:The version of the cryptographic payload is not compatible with the version of the plugin.
+severity:error
+ingroup:plugin
+macro:CRYPTO_VERSION
+module:crypto

--- a/src/plugins/crypto/botan_operations.cpp
+++ b/src/plugins/crypto/botan_operations.cpp
@@ -214,10 +214,16 @@ int elektraCryptoBotanEncrypt (KeySet * pluginConfig, Key * k, Key * errorKey, K
 		const size_t msgLength = encryptor.remaining ();
 		if (msgLength > 0)
 		{
-			auto buffer = unique_ptr<byte[]>{ new byte[msgLength + sizeof (kdb_unsigned_long_t) + saltLen] };
+			auto buffer = unique_ptr<byte[]>{
+				new byte[msgLength + ELEKTRA_CRYPTO_MAGIC_NUMBER_LEN + sizeof (kdb_unsigned_long_t) + saltLen]
+			};
+			size_t bufferIndex = 0;
 
-			memcpy (&buffer[0], &saltLen, sizeof (kdb_unsigned_long_t));
-			memcpy (&buffer[sizeof (kdb_unsigned_long_t)], salt, saltLen);
+			memcpy (&buffer[bufferIndex], ELEKTRA_CRYPTO_MAGIC_NUMBER, ELEKTRA_CRYPTO_MAGIC_NUMBER_LEN);
+			bufferIndex += ELEKTRA_CRYPTO_MAGIC_NUMBER_LEN;
+			memcpy (&buffer[bufferIndex], &saltLen, sizeof (kdb_unsigned_long_t));
+			bufferIndex += sizeof (kdb_unsigned_long_t);
+			memcpy (&buffer[bufferIndex], salt, saltLen);
 
 			const size_t buffered = encryptor.read (&buffer[sizeof (kdb_unsigned_long_t) + saltLen], msgLength);
 			keySetBinary (k, &buffer[0], buffered + sizeof (kdb_unsigned_long_t) + saltLen);
@@ -253,8 +259,8 @@ int elektraCryptoBotanDecrypt (KeySet * pluginConfig, Key * k, Key * errorKey, K
 	saltLen += sizeof (kdb_unsigned_long_t);
 
 	// set payload pointer
-	const byte * payload = reinterpret_cast<const byte *> (keyValue (k)) + saltLen;
-	const size_t payloadLen = keyGetValueSize (k) - saltLen;
+	const byte * payload = reinterpret_cast<const byte *> (keyValue (k)) + saltLen + ELEKTRA_CRYPTO_MAGIC_NUMBER_LEN;
+	const size_t payloadLen = keyGetValueSize (k) - saltLen - ELEKTRA_CRYPTO_MAGIC_NUMBER_LEN;
 
 	try
 	{

--- a/src/plugins/crypto/botan_operations.cpp
+++ b/src/plugins/crypto/botan_operations.cpp
@@ -224,9 +224,10 @@ int elektraCryptoBotanEncrypt (KeySet * pluginConfig, Key * k, Key * errorKey, K
 			memcpy (&buffer[bufferIndex], &saltLen, sizeof (kdb_unsigned_long_t));
 			bufferIndex += sizeof (kdb_unsigned_long_t);
 			memcpy (&buffer[bufferIndex], salt, saltLen);
+			bufferIndex += saltLen;
 
-			const size_t buffered = encryptor.read (&buffer[sizeof (kdb_unsigned_long_t) + saltLen], msgLength);
-			keySetBinary (k, &buffer[0], buffered + sizeof (kdb_unsigned_long_t) + saltLen);
+			const size_t buffered = encryptor.read (&buffer[bufferIndex], msgLength);
+			keySetBinary (k, &buffer[0], buffered + bufferIndex);
 		}
 	}
 	catch (std::exception & e)

--- a/src/plugins/crypto/crypto.h
+++ b/src/plugins/crypto/crypto.h
@@ -26,6 +26,29 @@ enum ElektraCryptoOperation
 	ELEKTRA_CRYPTO_DECRYPT = 1
 };
 
+/*
+ * A NOTE ABOUT THE CRYPTOGRAPHIC PAYLOAD
+ *
+ * Every compilation variant shall keep to the following format when writing encrypted payload to Keys.
+ *
+ * The following header is stored before the encrypted data.
+ *
+ * +----+-------------------------------------------+---------+--------+-----------------------+-----------+
+ * |    | Element                                   |  Offset | Length | Data Type             | Encrypted |
+ * +----+-------------------------------------------+---------+--------+-----------------------+-----------+
+ * |    | magic number #!crypto                     |       0 |    8 B | char                  | NO        |
+ * |    | crypto payload version                    |       8 |    2 B | char                  | NO        |
+ * | Ls | length of the salt                        |      10 |    4 B | unsigned long integer | NO        |
+ * | S  | salt                                      |      14 |   Ls B | byte                  | NO        |
+ * | T  | original data type (string, binary, null) | 14 + Ls |    1 B | byte                  | YES       |
+ * | Lc | original content length                   | 15 + Ls |    4 B | unsigned long integer | YES       |
+ * +----+-------------------------------------------+---------+--------+-----------------------+-----------+
+ *
+ */
+#define ELEKTRA_CRYPTO_PAYLOAD_VERSION "00"
+#define ELEKTRA_CRYPTO_MAGIC_NUMBER "#!crypto" ELEKTRA_CRYPTO_PAYLOAD_VERSION
+#define ELEKTRA_CRYPTO_MAGIC_NUMBER_LEN (sizeof (ELEKTRA_CRYPTO_MAGIC_NUMBER) - 1)
+
 // plugin defaults
 #define ELEKTRA_CRYPTO_DEFAULT_MASTER_PWD_LENGTH (30)
 #define ELEKTRA_CRYPTO_DEFAULT_ITERATION_COUNT (15000)

--- a/src/plugins/crypto/gcrypt_operations.c
+++ b/src/plugins/crypto/gcrypt_operations.c
@@ -322,7 +322,8 @@ int elektraCryptoGcryEncrypt (elektraCryptoHandle * handle, Key * k, Key * error
 	current += ELEKTRA_CRYPTO_GCRY_BLOCKSIZE;
 
 	// encrypt the value using gcrypt's in-place encryption
-	const size_t dataLen = outputLen - ELEKTRA_CRYPTO_GCRY_BLOCKSIZE - sizeof (kdb_unsigned_long_t) - saltLen;
+	const size_t dataLen =
+		outputLen - ELEKTRA_CRYPTO_GCRY_BLOCKSIZE - sizeof (kdb_unsigned_long_t) - saltLen - ELEKTRA_CRYPTO_MAGIC_NUMBER_LEN;
 	memcpy (current, content, contentLen);
 	gcry_err = gcry_cipher_encrypt (*handle, current, dataLen, NULL, 0);
 	if (gcry_err != 0)

--- a/src/plugins/crypto/helper.c
+++ b/src/plugins/crypto/helper.c
@@ -61,9 +61,7 @@ int CRYPTO_PLUGIN_FUNCTION (getSaltFromMetakey) (Key * errorKey, Key * k, kdb_oc
 int CRYPTO_PLUGIN_FUNCTION (getSaltFromPayload) (Key * errorKey, Key * k, kdb_octet_t ** salt, kdb_unsigned_long_t * saltLen)
 {
 	static const size_t headerLen = sizeof (kdb_unsigned_long_t);
-	const ssize_t payloadLen = keyGetValueSize (k);
-	const kdb_octet_t * payload = (kdb_octet_t *)keyValue (k);
-	kdb_unsigned_long_t restoredSaltLen = 0;
+	const ssize_t payloadLen = keyGetValueSize (k) - ELEKTRA_CRYPTO_MAGIC_NUMBER_LEN;
 
 	// validate payload length
 	if ((size_t)payloadLen < sizeof (size_t) || payloadLen < 0)
@@ -73,6 +71,10 @@ int CRYPTO_PLUGIN_FUNCTION (getSaltFromPayload) (Key * errorKey, Key * k, kdb_oc
 		if (salt) *salt = NULL;
 		return -1;
 	}
+
+	const kdb_octet_t * value = (kdb_octet_t *)keyValue (k);
+	const kdb_octet_t * payload = &value[ELEKTRA_CRYPTO_MAGIC_NUMBER_LEN];
+	kdb_unsigned_long_t restoredSaltLen = 0;
 
 	// restore salt length
 	memcpy (&restoredSaltLen, payload, headerLen);

--- a/src/plugins/crypto/openssl_operations.c
+++ b/src/plugins/crypto/openssl_operations.c
@@ -304,6 +304,9 @@ int elektraCryptoOpenSSLEncrypt (elektraCryptoHandle * handle, Key * k, Key * er
 		return -1;
 	}
 
+	// write out the magic number
+	BIO_write (encrypted, ELEKTRA_CRYPTO_MAGIC_NUMBER, ELEKTRA_CRYPTO_MAGIC_NUMBER_LEN);
+
 	// encode the salt into the payload
 	BIO_write (encrypted, &saltLen, sizeof (saltLen));
 	BIO_write (encrypted, salt, saltLen);
@@ -401,8 +404,8 @@ int elektraCryptoOpenSSLDecrypt (elektraCryptoHandle * handle, Key * k, Key * er
 	saltLen += sizeof (kdb_unsigned_long_t);
 
 	// set payload pointer
-	const kdb_octet_t * payload = ((kdb_octet_t *)keyValue (k)) + saltLen;
-	const size_t payloadLen = keyGetValueSize (k) - saltLen;
+	const kdb_octet_t * payload = ((kdb_octet_t *)keyValue (k)) + saltLen + ELEKTRA_CRYPTO_MAGIC_NUMBER_LEN;
+	const size_t payloadLen = keyGetValueSize (k) - saltLen - ELEKTRA_CRYPTO_MAGIC_NUMBER_LEN;
 
 	// initialize crypto header data
 	kdb_unsigned_long_t contentLen = 0;


### PR DESCRIPTION
# Purpose

The `crypto` plugin adds a magic number and version hint about the version of the payload.

The prefix is `#!crypto00` where `00` refers to the version.
The version is defined in `crypto.h`.

Closes #1575 .

# Checklist

Please only check relevant points.
For docu fixes, spell checking and similar nothing
needs to be checked.

- [x] commit messages are fine (with references to issues)
- [x] I ran all tests and everything went fine
- [ ] I added unit tests
- [ ] affected documentation is fixed
- [ ] I added code comments, logging, and assertions
- [ ] meta data is updated (e.g. README.md of plugins)

@markus2330 please review my pull request
