### PR TITLE
Fix compiler warnings (#1579 )

### DIFF
--- a/src/plugins/crypto/botan_operations.cpp
+++ b/src/plugins/crypto/botan_operations.cpp
@@ -275,7 +275,11 @@ int elektraCryptoBotanDecrypt (KeySet * pluginConfig, Key * k, Key * errorKey, K
 		if (decryptor.remaining () > 0)
 		{
 			// decode the "header" flags
-			decryptor.read (static_cast<byte *> (&flags), sizeof (kdb_octet_t));
+			const size_t flagLength = decryptor.read (static_cast<byte *> (&flags), sizeof (kdb_octet_t));
+			if (flagLength != sizeof (kdb_octet_t))
+			{
+				throw std::length_error ("Failed to restore the original data type of the value.");
+			}
 		}
 
 		const size_t msgLength = decryptor.remaining ();

--- a/src/plugins/crypto/gpg.c
+++ b/src/plugins/crypto/gpg.c
@@ -787,7 +787,7 @@ int CRYPTO_PLUGIN_FUNCTION (gpgCall) (KeySet * conf, Key * errorKey, Key * msgKe
 			if (dup (pipe_stdin[0]) < 0)
 			{
 				ELEKTRA_SET_ERROR (ELEKTRA_ERROR_CRYPTO_GPG, errorKey, "failed to redirect stdin.");
-				return -2;
+				exit (42);
 			}
 		}
 		close (pipe_stdin[0]);
@@ -797,7 +797,7 @@ int CRYPTO_PLUGIN_FUNCTION (gpgCall) (KeySet * conf, Key * errorKey, Key * msgKe
 		if (dup (pipe_stdout[1]) < 0)
 		{
 			ELEKTRA_SET_ERROR (ELEKTRA_ERROR_CRYPTO_GPG, errorKey, "failed to redirect the stdout.");
-			return -2;
+			exit (42);
 		}
 		close (pipe_stdout[1]);
 
@@ -806,7 +806,7 @@ int CRYPTO_PLUGIN_FUNCTION (gpgCall) (KeySet * conf, Key * errorKey, Key * msgKe
 		if (dup (pipe_stderr[1]) < 0)
 		{
 			ELEKTRA_SET_ERROR (ELEKTRA_ERROR_CRYPTO_GPG, errorKey, "failed to redirect stderr.");
-			return -2;
+			exit (42);
 		}
 		close (pipe_stderr[1]);
 
@@ -814,7 +814,7 @@ int CRYPTO_PLUGIN_FUNCTION (gpgCall) (KeySet * conf, Key * errorKey, Key * msgKe
 		if (execv (argv[0], argv) < 0)
 		{
 			ELEKTRA_SET_ERRORF (ELEKTRA_ERROR_CRYPTO_GPG, errorKey, "failed to start the gpg binary: %s", argv[0]);
-			return -2;
+			exit (42);
 		}
 		// end of the child process
 	}
@@ -863,7 +863,7 @@ int CRYPTO_PLUGIN_FUNCTION (gpgCall) (KeySet * conf, Key * errorKey, Key * msgKe
 		ELEKTRA_SET_ERROR (ELEKTRA_ERROR_CRYPTO_GPG, errorKey, "GPG reported a bad signature");
 		break;
 
-	case -2:
+	case 42:
 		// error has been set to errorKey by the child process
 		break;
 

--- a/src/plugins/fcrypt/fcrypt.c
+++ b/src/plugins/fcrypt/fcrypt.c
@@ -102,7 +102,6 @@ error:
  */
 static int shredTemporaryFile (int fd, Key * errorKey)
 {
-	kdb_octet_t error = 0;
 	kdb_octet_t buffer[512] = { 0 };
 	struct stat tmpStat;
 
@@ -121,15 +120,9 @@ static int shredTemporaryFile (int fd, Key * errorKey)
 	{
 		if (write (fd, buffer, sizeof (buffer)) != sizeof (buffer))
 		{
-			// save the error state but keep on writing in the hope that further writes wont't fail
-			error = 1;
+			goto error;
 		}
 	}
-	if (error)
-	{
-		goto error;
-	}
-
 	return 1;
 
 error:


### PR DESCRIPTION
# Purpose

Fix compiler warnings from #1579 in the `crypto` and `fcrypt` plugin.

# Checklist

Please only check relevant points.
For docu fixes, spell checking and similar nothing
needs to be checked.

- [x] commit messages are fine (with references to issues)
- [x] I ran all tests and everything went fine
- [ ] I added unit tests
- [ ] affected documentation is fixed
- [ ] I added code comments, logging, and assertions
- [ ] meta data is updated (e.g. README.md of plugins)

@markus2330 please review my pull request
