### PR TITLE
Travis: Test Additional Setups

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 notifications:
   email: travis@libelektra.org
 
-language: generic
+language: cpp
 
 #
 # Define the build matrix
@@ -10,12 +10,27 @@ matrix:
   include:
     - os: osx
       osx_image: xcode8.3
+      compiler: gcc
+
+    - os: osx
+      osx_image: xcode8.3
+      compiler: clang
+
     - os: osx
       osx_image: xcode7.3
+      compiler: clang
+
     - os: osx
       osx_image: xcode6.4
+      compiler: clang
+
     - os: linux
       dist: trusty
+      compiler: gcc
+
+    - os: linux
+      dist: trusty
+      compiler: clang
 
 before_install:
   - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,12 @@ before_install:
       rvm install 2.3.1;
       rvm use 2.3.1;
       gem install test-unit --no-document;
+      if [[ "$CC" == "gcc" ]]; then
+        brew install gcc;
+        brew link --overwrite gcc;
+        export CC=gcc-7;
+        export CXX=g++-7;
+      fi;
       brew install ninja;
       brew install checkbashisms;
       brew install swig;

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,6 +44,9 @@ before_install:
         brew link --overwrite gcc;
         export CC=gcc-7;
         export CXX=g++-7;
+      else
+        # Linking `crypto_botan` using `gcc` fails on macOS
+        brew install botan;
       fi;
       brew install ninja;
       brew install checkbashisms;
@@ -57,7 +60,7 @@ before_install:
       brew install dbus;
       brew install qt;
       brew install discount;
-      brew install openssl botan libgcrypt;
+      brew install openssl libgcrypt;
       brew install libgit2;
       brew install xerces-c;
       pip install cheetah; # Required by kdb-gen

--- a/src/plugins/ini/README.md
+++ b/src/plugins/ini/README.md
@@ -56,7 +56,7 @@ The ini plugin supports the use of comments. Comment lines start with
 a ';' or a '#'. Comments are put into the comment metadata of the key
 following the comment. This can be either a section key or a normal key.
 When creating new comments (e.g. via `kdb setmeta`) you can prefix
-your comment with the comment indicator for your choice (';' or '#')
+your comment with the comment indicator of your choice (';' or '#')
 which will be used when writing the comment to the file. If the comment
 is not prefixed with a comment indicator, the ini plugin will use the
 character defined by the `comment` option, or default to '#'.


### PR DESCRIPTION
# Purpose

This pull request adds additional Travis build jobs:

- Clang on Linux
- GCC on macOS

. I disabled `crypto_botan` in the build job that uses GCC on macOS, since linking the plugin produces the following [error message](https://travis-ci.org/sanssecours/libelektra/jobs/269100889#L2338):

```
Undefined symbols for architecture x86_64:
  "Botan::get_cipher(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, Botan::OctetString const&, Botan::OctetString const&, Botan::Cipher_Dir)", referenced from:
      _elektraCryptoBotanDecrypt in botan_operations.cpp.o
      _elektraCryptoBotanEncrypt in botan_operations.cpp.o
  "Botan::Pipe::read_all_as_string[abi:cxx11](unsigned long)", referenced from:
      _elektraCryptoBotanDecrypt in botan_operations.cpp.o
  "Botan::Pipe::write(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)", referenced from:
      _elektraCryptoBotanEncrypt in botan_operations.cpp.o
  "Botan::PBKDF::create(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)", referenced from:
      _elektraCryptoBotanDecrypt in botan_operations.cpp.o
      _elektraCryptoBotanEncrypt in botan_operations.cpp.o
  "Botan::PBKDF::pbkdf_iterations(unsigned long, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, unsigned char const*, unsigned long, unsigned long) const", referenced from:
      _elektraCryptoBotanDecrypt in botan_operations.cpp.o
      _elektraCryptoBotanEncrypt in botan_operations.cpp.o
ld: symbol(s) not found for architecture x86_64
collect2: error: ld returned 1 exit status
```

. If someone knows why that is the case, please comment below. More information about this problem would be quite helpful, since `yamlcpp` seems to have a [very similar same problem](https://travis-ci.org/sanssecours/libelektra/jobs/269100889#L2338).

# Checklist

- [x] I checked all commit messages.
- [x] I ran all tests and everything went fine.