### PR TITLE
haskell-bindings-fix-tests

### DIFF
--- a/cmake/Modules/LibAddHaskellPlugin.cmake
+++ b/cmake/Modules/LibAddHaskellPlugin.cmake
@@ -122,10 +122,10 @@ macro (add_haskell_plugin target)
 			# GHC's structure differs between OSX and Linux
 			# On OSX we need to link iconv and Cffi additionally
 			if (APPLE)
-				find_library (GHC_FFI_LIB "Cffi" PATHS "${GHC_LIB_DIR}/rts")
+				find_library (GHC_FFI_LIB Cffi PATHS "${GHC_LIB_DIR}/rts")
 				if (GHC_FFI_LIB)
-					set (GHC_LIB_DIRS
-						${GHC_LIB_DIRS}
+					set (GHC_LIBS
+						${GHC_LIBS}
 						${GHC_FFI_LIB}
 						iconv
 					)
@@ -177,6 +177,13 @@ macro (add_haskell_plugin target)
 				"${CMAKE_SOURCE_DIR}/src/plugins/haskell/Elektra/Haskell.hs"
 			)
 			add_custom_target (${target} DEPENDS ${PLUGIN_HASKELL_NAME})
+			if (BUILD_SHARED)
+				add_custom_command(TARGET ${target} POST_BUILD
+			    	COMMAND ${CMAKE_COMMAND} -E copy
+			    		"${PLUGIN_HASKELL_NAME}"
+	    				"${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/"
+				)
+			endif (BUILD_SHARED)
 
 			else (GHC_PRIM_LIB)
 				remove_plugin (${target} "GHC_PRIM_LIB not found")

--- a/cmake/Modules/LibAddHaskellPlugin.cmake
+++ b/cmake/Modules/LibAddHaskellPlugin.cmake
@@ -51,47 +51,78 @@ macro (add_haskell_plugin target)
 				${GHC_LIB_DIR}/include # for HsFFI.h
 			)
 
+			set (CABAL_OPTS "--prefix=${CMAKE_INSTALL_PREFIX}")
+			if (BUILD_SHARED)
+				# shared variants of ghc libraries have the ghc version as a suffix
+				set (GHC_DYNAMIC_SUFFIX "-ghc${GHC_VERSION}")
+				if (APPLE)
+					set (GHC_DYNAMIC_ENDING ".dylib")
+				else (APPLE)
+					set (GHC_DYNAMIC_ENDING ".so")
+				endif (APPLE)
+				set (CABAL_OPTS "${CABAL_OPTS};--enable-shared")
+			else (BUILD_SHARED)
+				set (GHC_DYNAMIC_ENDING ".a")
+			endif (BUILD_SHARED)
+
 			# since we want to continue to use our cmake add_plugin macro
 			# we compile via the c compiler instead of ghc
 			# so we must feed it with the ghc library paths manually
 			# inspired by https://github.com/jarrett/cpphs/blob/master/Makefile
 			# use HSrts_thr for the threaded version of the rts
-			find_library (GHC_RTS_LIB HSrts PATHS ${GHC_LIB_DIR}/rts)
+			find_library (
+				GHC_RTS_LIB "HSrts${GHC_DYNAMIC_SUFFIX}"
+				PATHS "${GHC_LIB_DIR}/rts"
+			)
+
 			execute_process (
 				COMMAND ${GHC-PKG_EXECUTABLE} latest base
 				OUTPUT_VARIABLE GHC_BASE_NAME OUTPUT_STRIP_TRAILING_WHITESPACE
 			)
-			find_library (GHC_BASE_LIB "HS${GHC_BASE_NAME}" ${GHC_LIB_DIR}/${GHC_BASE_NAME})
+			find_library (
+				GHC_BASE_LIB "HS${GHC_BASE_NAME}${GHC_DYNAMIC_SUFFIX}"
+				PATHS "${GHC_LIB_DIR}/${GHC_BASE_NAME}"
+			)
+
 			execute_process (
 				COMMAND ${GHC-PKG_EXECUTABLE} latest integer-gmp
 				OUTPUT_VARIABLE GHC_GMP_NAME OUTPUT_STRIP_TRAILING_WHITESPACE
 			)
-			find_library (GHC_GMP_LIB "HS${GHC_GMP_NAME}" ${GHC_LIB_DIR}/${GHC_GMP_NAME})
+			find_library (
+				GHC_GMP_LIB "HS${GHC_GMP_NAME}${GHC_DYNAMIC_SUFFIX}"
+				PATHS "${GHC_LIB_DIR}/${GHC_GMP_NAME}"
+			)
+
 			execute_process (
 				COMMAND ${GHC-PKG_EXECUTABLE} latest ghc-prim
 				OUTPUT_VARIABLE GHC_PRIM_NAME OUTPUT_STRIP_TRAILING_WHITESPACE
 			)
-			find_library (GHC_PRIM_LIB "HS${GHC_PRIM_NAME}" ${GHC_LIB_DIR}/${GHC_PRIM_NAME})
+			find_library (
+				GHC_PRIM_LIB "HS${GHC_PRIM_NAME}${GHC_DYNAMIC_SUFFIX}"
+				PATHS "${GHC_LIB_DIR}/${GHC_PRIM_NAME}"
+			)
 
 			if (GHC_RTS_LIB)
 			if (GHC_BASE_LIB)
 			if (GHC_GMP_LIB)
 			if (GHC_PRIM_LIB)
 
-			set (GHC_LIB_DIRS
-				"${CMAKE_CURRENT_BINARY_DIR}/dist/build/libHS${target}.a"
-				"${CMAKE_BINARY_DIR}/src/bindings/haskell/dist/build/libHSlibelektra-haskell-${KDB_VERSION}.a"
+			set (PLUGIN_HASKELL_NAME "${CMAKE_CURRENT_BINARY_DIR}/dist/build/libHS${target}${GHC_DYNAMIC_SUFFIX}${GHC_DYNAMIC_ENDING}")
+
+			set (GHC_LIBS
+				${PLUGIN_HASKELL_NAME}
+				"${CMAKE_BINARY_DIR}/src/bindings/haskell/dist/build/libHSlibelektra-haskell-${KDB_VERSION}${GHC_DYNAMIC_SUFFIX}${GHC_DYNAMIC_ENDING}"
 				${GHC_RTS_LIB}
 				${GHC_BASE_LIB}
 				${GHC_GMP_LIB}
-				${GHC_PRIM_LIB}
 				gmp
+				${GHC_PRIM_LIB}
 			)
 
 			# GHC's structure differs between OSX and Linux
 			# On OSX we need to link iconv and Cffi additionally
 			if (APPLE)
-				find_library (GHC_FFI_LIB Cffi PATHS ${GHC_LIB_DIR}/rts)
+				find_library (GHC_FFI_LIB "Cffi" PATHS "${GHC_LIB_DIR}/rts")
 				if (GHC_FFI_LIB)
 					set (GHC_LIB_DIRS
 						${GHC_LIB_DIRS}
@@ -102,7 +133,7 @@ macro (add_haskell_plugin target)
 					remove_plugin (${target} "GHC_FFI_LIB not found")
 				endif (GHC_FFI_LIB)
 			endif (APPLE)
-
+			
 			# configure include paths
 			configure_file (
 				"${CMAKE_CURRENT_SOURCE_DIR}/${target}.cabal.in"
@@ -136,16 +167,16 @@ macro (add_haskell_plugin target)
 				DEPENDS c2hs_haskell
 			)
 			add_custom_command (
-				OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/dist/build/libHS${target}.a
+				OUTPUT ${PLUGIN_HASKELL_NAME}
 				# this way it will generate predictable output filenames
 				# and compile the haskell part of this plugin with cabal
-				COMMAND ${CABAL_EXECUTABLE} --ipid=${target} --enable-shared configure
+				COMMAND ${CABAL_EXECUTABLE} --ipid=${target} ${CABAL_OPTS} configure
 				COMMAND ${CABAL_EXECUTABLE} build
 				WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
 				DEPENDS "${CMAKE_BINARY_DIR}/src/bindings/haskell/${target}-register"
 				"${CMAKE_SOURCE_DIR}/src/plugins/haskell/Elektra/Haskell.hs"
 			)
-			add_custom_target (${target} DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/dist/build/libHS${target}.a")
+			add_custom_target (${target} DEPENDS ${PLUGIN_HASKELL_NAME})
 
 			else (GHC_PRIM_LIB)
 				remove_plugin (${target} "GHC_PRIM_LIB not found")
@@ -183,11 +214,15 @@ macro (add_haskell_plugin target)
 		INCLUDE_DIRECTORIES
 			${GHC_INCLUDE_DIRS}
 		LINK_LIBRARIES
-			${GHC_LIB_DIRS}
+			${GHC_LIBS}
 		DEPENDS
 			${target} c2hs_haskell
 		ADD_TEST
 	)
+
+	if (ADDTESTING_PHASE)
+		set_property (TEST testmod_haskell PROPERTY ENVIRONMENT "LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/lib")
+	endif (ADDTESTING_PHASE)
 
 	mark_as_advanced (
 		GHC_EXECUTABLE

--- a/cmake/Modules/LibAddHaskellPlugin.cmake
+++ b/cmake/Modules/LibAddHaskellPlugin.cmake
@@ -52,7 +52,7 @@ macro (add_haskell_plugin target)
 			)
 
 			set (CABAL_OPTS "--prefix=${CMAKE_INSTALL_PREFIX}")
-			if (BUILD_SHARED)
+			if (BUILD_SHARED OR BUILD_FULL)
 				# shared variants of ghc libraries have the ghc version as a suffix
 				set (GHC_DYNAMIC_SUFFIX "-ghc${GHC_VERSION}")
 				if (APPLE)
@@ -61,9 +61,10 @@ macro (add_haskell_plugin target)
 					set (GHC_DYNAMIC_ENDING ".so")
 				endif (APPLE)
 				set (CABAL_OPTS "${CABAL_OPTS};--enable-shared")
-			else (BUILD_SHARED)
+			elseif (BUILD_STATIC)
 				set (GHC_DYNAMIC_ENDING ".a")
-			endif (BUILD_SHARED)
+				set (CABAL_OPTS "${CABAL_OPTS};--disable-shared")
+			endif ()
 
 			# since we want to continue to use our cmake add_plugin macro
 			# we compile via the c compiler instead of ghc
@@ -177,13 +178,13 @@ macro (add_haskell_plugin target)
 				"${CMAKE_SOURCE_DIR}/src/plugins/haskell/Elektra/Haskell.hs"
 			)
 			add_custom_target (${target} DEPENDS ${PLUGIN_HASKELL_NAME})
-			if (BUILD_SHARED)
-				add_custom_command(TARGET ${target} POST_BUILD
+			if (BUILD_SHARED OR BUILD_FULL)
+				add_custom_command(TARGET ${target} POST_BUILD 
 			    	COMMAND ${CMAKE_COMMAND} -E copy
 			    		"${PLUGIN_HASKELL_NAME}"
 	    				"${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/"
 				)
-			endif (BUILD_SHARED)
+			endif (BUILD_SHARED OR BUILD_FULL)
 
 			else (GHC_PRIM_LIB)
 				remove_plugin (${target} "GHC_PRIM_LIB not found")

--- a/cmake/Modules/LibAddHaskellPlugin.cmake
+++ b/cmake/Modules/LibAddHaskellPlugin.cmake
@@ -128,10 +128,11 @@ macro (add_haskell_plugin target)
 				OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/dist/build/libHS${target}.a
 				# this way it will generate predictable output filenames
 				# and compile the haskell part of this plugin with cabal
-				COMMAND ${CABAL_EXECUTABLE} --ipid=${target} configure
+				COMMAND ${CABAL_EXECUTABLE} --ipid=${target} --enable-shared configure
 				COMMAND ${CABAL_EXECUTABLE} build
 				WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
 				DEPENDS "${CMAKE_BINARY_DIR}/src/bindings/haskell/${target}-register"
+				"${CMAKE_SOURCE_DIR}/src/plugins/haskell/Elektra/Haskell.hs"
 			)
 			add_custom_target (${target} DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/dist/build/libHS${target}.a")
 

--- a/src/bindings/haskell/CMakeLists.txt
+++ b/src/bindings/haskell/CMakeLists.txt
@@ -5,6 +5,7 @@ find_program (C2HS_EXECUTABLE c2hs)
 if (CABAL_EXECUTABLE) # set by find_program
 if (C2HS_EXECUTABLE)
 if (GHC_EXECUTABLE)
+if (NOT BUILD_STATIC)
 
 	set (CABAL_INCLUDE_DIRS "\"${CMAKE_SOURCE_DIR}/src/include\", \"${CMAKE_BINARY_DIR}/src/include\"")
 
@@ -128,14 +129,17 @@ if (GHC_EXECUTABLE)
 			set_property (TEST testhaskell_realworld_optimized PROPERTY ENVIRONMENT "LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/lib")
 		endif (ENABLE_KDB_TESTING)
 	endif (BUILD_TESTING)
+else (NOT BUILD_STATIC)
+	remove_binding (haskell "BUILD_STATIC is currently not compatible with the haskell bindings")
+endif (NOT BUILD_STATIC)
 else (GHC_EXECUTABLE)
-	remove_binding (c2hs_haskell "GHC not found")
+	remove_binding (haskell "GHC not found")
 endif (GHC_EXECUTABLE)
 else (C2HS_EXECUTABLE)
-	remove_binding (c2hs_haskell "c2hs not found")
+	remove_binding (haskell "c2hs not found")
 endif (C2HS_EXECUTABLE)
 else (CABAL_EXECUTABLE)
-	remove_binding (c2hs_haskell "cabal not found")
+	remove_binding (haskell "cabal not found")
 endif (CABAL_EXECUTABLE)
 
 mark_as_advanced (

--- a/src/bindings/haskell/CMakeLists.txt
+++ b/src/bindings/haskell/CMakeLists.txt
@@ -8,6 +8,32 @@ if (GHC_EXECUTABLE)
 
 	set (CABAL_INCLUDE_DIRS "\"${CMAKE_SOURCE_DIR}/src/include\", \"${CMAKE_BINARY_DIR}/src/include\"")
 
+	execute_process (
+		COMMAND ${GHC_EXECUTABLE} --numeric-version
+		OUTPUT_VARIABLE GHC_VERSION OUTPUT_STRIP_TRAILING_WHITESPACE
+	)
+
+	set (BINDING_HASKELL_NAME "${CMAKE_CURRENT_BINARY_DIR}/dist/build/libHSlibelektra-haskell-${KDB_VERSION}")
+	set (CABAL_OPTS "--prefix=${CMAKE_INSTALL_PREFIX}")
+	if (BUILD_SHARED OR BUILD_FULL)
+		set (BINDING_HASKELL_NAME "${BINDING_HASKELL_NAME}-ghc${GHC_VERSION}.so")
+		set (CABAL_OPTS "${CABAL_OPTS};--enable-shared")
+		if (BUILD_SHARED)
+			set (ELEKTRA_DEPENDENCY "elektra;elektra-kdb;")
+		elseif (BUILD_FULL)
+			set (ELEKTRA_DEPENDENCY "elektra-full;")
+		endif ()
+	elseif (BUILD_STATIC)
+		set (BINDING_HASKELL_NAME "${BINDING_HASKELL_NAME}.a")
+		set (ELEKTRA_DEPENDENCY "elektra-static;")
+	endif ()
+
+	if (BUILD_TESTING)
+		set (CABAL_OPTS "${CABAL_OPTS};--enable-tests")
+	endif (BUILD_TESTING)
+
+	string (REPLACE ";" " " CABAL_ELEKTRA_DEPENDENCY "${ELEKTRA_DEPENDENCY}")
+	
 	# configure include paths
 	configure_file (
 		"${CMAKE_CURRENT_SOURCE_DIR}/libelektra-haskell.cabal.in"
@@ -16,12 +42,12 @@ if (GHC_EXECUTABLE)
 	)
 
 	add_custom_command (
-		OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/dist/build/libHSlibelektra-haskell-${KDB_VERSION}.a"
+		OUTPUT ${BINDING_HASKELL_NAME}
 		"${CMAKE_CURRENT_BINARY_DIR}/dist/build/testhaskell_basic/testhaskell_basic"
 		"${CMAKE_CURRENT_BINARY_DIR}/dist/build/testhaskell_basic_optimized/testhaskell_basic_optimized"
 		"${CMAKE_CURRENT_BINARY_DIR}/dist/build/testhaskell_realworld/testhaskell_realworld"
 		"${CMAKE_CURRENT_BINARY_DIR}/dist/build/testhaskell_realworld_optimized/testhaskell_realworld_optimized"
-		COMMAND ${CABAL_EXECUTABLE} --ipid=libelektra-haskell-${KDB_VERSION} --enable-tests --enable-shared configure
+		COMMAND ${CABAL_EXECUTABLE} --ipid=libelektra-haskell-${KDB_VERSION} ${CABAL_OPTS} configure
 		COMMAND ${CABAL_EXECUTABLE} build
 		WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
 		DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/libelektra-haskell.cabal"
@@ -31,9 +57,9 @@ if (GHC_EXECUTABLE)
 		"${CMAKE_CURRENT_SOURCE_DIR}/src/Elektra/KDB.chs"
 		"${CMAKE_CURRENT_SOURCE_DIR}/test/Elektra.hs"
 		"${CMAKE_CURRENT_SOURCE_DIR}/test/ElektraRealWorld.hs"
-		elektra
+		"${ELEKTRA_DEPENDENCY}"
 	)
-	add_custom_target (c2hs_haskell ALL DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/dist/build/libHSlibelektra-haskell-${KDB_VERSION}.a")
+	add_custom_target (c2hs_haskell ALL DEPENDS "${BINDING_HASKELL_NAME}")
 
 	# build and install it to the cabal db
 	install (CODE "execute_process (COMMAND ${CABAL_EXECUTABLE} install WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})")

--- a/src/bindings/haskell/CMakeLists.txt
+++ b/src/bindings/haskell/CMakeLists.txt
@@ -62,7 +62,7 @@ if (GHC_EXECUTABLE)
 	add_custom_target (c2hs_haskell ALL DEPENDS "${BINDING_HASKELL_NAME}")
 
 	# build and install it to the cabal db
-	install (CODE "execute_process (COMMAND ${CABAL_EXECUTABLE} install WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})")
+	install (CODE "execute_process (COMMAND ${CABAL_EXECUTABLE} install WORKING_DIRECTORY \"${CMAKE_CURRENT_BINARY_DIR}\")")
 
 	if (BUILD_TESTING)
 		# test it using the executables, so cmake takes care about the rpaths

--- a/src/bindings/haskell/CMakeLists.txt
+++ b/src/bindings/haskell/CMakeLists.txt
@@ -17,33 +17,59 @@ if (GHC_EXECUTABLE)
 
 	add_custom_command (
 		OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/dist/build/libHSlibelektra-haskell-${KDB_VERSION}.a"
-		COMMAND ${CABAL_EXECUTABLE} --ipid=libelektra-haskell-${KDB_VERSION} configure
+		"${CMAKE_CURRENT_BINARY_DIR}/dist/build/testhaskell_basic/testhaskell_basic"
+		"${CMAKE_CURRENT_BINARY_DIR}/dist/build/testhaskell_basic_optimized/testhaskell_basic_optimized"
+		"${CMAKE_CURRENT_BINARY_DIR}/dist/build/testhaskell_realworld/testhaskell_realworld"
+		"${CMAKE_CURRENT_BINARY_DIR}/dist/build/testhaskell_realworld_optimized/testhaskell_realworld_optimized"
+		COMMAND ${CABAL_EXECUTABLE} --ipid=libelektra-haskell-${KDB_VERSION} --enable-tests --enable-shared configure
 		COMMAND ${CABAL_EXECUTABLE} build
 		WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
 		DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/libelektra-haskell.cabal"
+		"${CMAKE_CURRENT_SOURCE_DIR}/src/Elektra/Key.chs"
+		"${CMAKE_CURRENT_SOURCE_DIR}/src/Elektra/KeySet.chs"
+		"${CMAKE_CURRENT_SOURCE_DIR}/src/Elektra/Plugin.chs"
+		"${CMAKE_CURRENT_SOURCE_DIR}/src/Elektra/KDB.chs"
+		"${CMAKE_CURRENT_SOURCE_DIR}/test/Elektra.hs"
+		"${CMAKE_CURRENT_SOURCE_DIR}/test/ElektraRealWorld.hs"
+		elektra
 	)
 	add_custom_target (c2hs_haskell ALL DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/dist/build/libHSlibelektra-haskell-${KDB_VERSION}.a")
 
 	# build and install it to the cabal db
-	install(CODE "execute_process (COMMAND ${CABAL_EXECUTABLE} install WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})")
+	install (CODE "execute_process (COMMAND ${CABAL_EXECUTABLE} install WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})")
 
 	if (BUILD_TESTING)
-		# also test it with cabal
+		# test it using the executables, so cmake takes care about the rpaths
 		add_test (
-			NAME testhaskell_cabal
-			COMMAND ${CABAL_EXECUTABLE} test libelektra-haskell-test libelektra-haskell-test-optimized
-			WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+			NAME testhaskell_basic
+			COMMAND "${CMAKE_CURRENT_BINARY_DIR}/dist/build/testhaskell_basic/testhaskell_basic"
 		)
-		set_property (TEST testhaskell_cabal PROPERTY LABELS bindings)
+		set_property (TEST testhaskell_basic PROPERTY LABELS bindings)
+		set_property (TEST testhaskell_basic PROPERTY ENVIRONMENT "LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/lib")
+
+		add_test (
+			NAME testhaskell_basic_optimized
+			COMMAND "${CMAKE_CURRENT_BINARY_DIR}/dist/build/testhaskell_basic_optimized/testhaskell_basic_optimized"
+		)
+		set_property (TEST testhaskell_basic_optimized PROPERTY LABELS bindings)
+		set_property (TEST testhaskell_basic_optimized PROPERTY ENVIRONMENT "LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/lib")
 
 		if (ENABLE_KDB_TESTING)
 			add_test (
-				NAME testhaskell_realworld_cabal
-				COMMAND ${CABAL_EXECUTABLE} test libelektra-haskell-test-realworld libelektra-haskell-test-realworld-optimized
-				WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+				NAME testhaskell_realworld
+				COMMAND "${CMAKE_CURRENT_BINARY_DIR}/dist/build/testhaskell_realworld/testhaskell_realworld"
 			)
-			set_property (TEST testhaskell_realworld_cabal PROPERTY LABELS bindings)
-			set_property (TEST testhaskell_realworld_cabal APPEND PROPERTY LABELS kdbtests)
+			set_property (TEST testhaskell_realworld PROPERTY LABELS bindings)
+			set_property (TEST testhaskell_realworld APPEND PROPERTY LABELS kdbtests)
+			set_property (TEST testhaskell_realworld PROPERTY ENVIRONMENT "LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/lib")
+
+			add_test (
+				NAME testhaskell_realworld_optimized
+				COMMAND "${CMAKE_CURRENT_BINARY_DIR}/dist/build/testhaskell_realworld_optimized/testhaskell_realworld_optimized"
+			)
+			set_property (TEST testhaskell_realworld_optimized PROPERTY LABELS bindings)
+			set_property (TEST testhaskell_realworld_optimized APPEND PROPERTY LABELS kdbtests)
+			set_property (TEST testhaskell_realworld_optimized PROPERTY ENVIRONMENT "LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/lib")
 		endif (ENABLE_KDB_TESTING)
 	endif (BUILD_TESTING)
 else (GHC_EXECUTABLE)

--- a/src/bindings/haskell/CMakeLists.txt
+++ b/src/bindings/haskell/CMakeLists.txt
@@ -31,9 +31,9 @@ if (GHC_EXECUTABLE)
 		endif ()
 	elseif (BUILD_STATIC)
 		set (BINDING_HASKELL_NAME "${BINDING_HASKELL_NAME}.a")
+		set (CABAL_OPTS "${CABAL_OPTS};--disable-shared")
 		set (ELEKTRA_DEPENDENCY "elektra-static;")
 	endif ()
-
 	string (REPLACE ";" " " CABAL_ELEKTRA_DEPENDENCY "${ELEKTRA_DEPENDENCY}")
 	
 	# configure include paths
@@ -57,13 +57,13 @@ if (GHC_EXECUTABLE)
 		"${CMAKE_CURRENT_SOURCE_DIR}/test/ElektraRealWorld.hs"
 	)
 	add_custom_target (c2hs_haskell ALL DEPENDS "${BINDING_HASKELL_NAME}")
-	if (BUILD_SHARED)
+	if (BUILD_SHARED OR BUILD_FULL)
 		add_custom_command(TARGET c2hs_haskell POST_BUILD
 	    	COMMAND ${CMAKE_COMMAND} -E copy
 	    		"${BINDING_HASKELL_NAME}"
 	    		"${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/"
 		)
-	endif (BUILD_SHARED)
+	endif (BUILD_SHARED OR BUILD_FULL)
 	# build and install it to the cabal db
 	install (CODE "execute_process (COMMAND ${CABAL_EXECUTABLE} install WORKING_DIRECTORY \"${CMAKE_CURRENT_BINARY_DIR}\")")
 

--- a/src/bindings/haskell/CMakeLists.txt
+++ b/src/bindings/haskell/CMakeLists.txt
@@ -16,7 +16,13 @@ if (GHC_EXECUTABLE)
 	set (BINDING_HASKELL_NAME "${CMAKE_CURRENT_BINARY_DIR}/dist/build/libHSlibelektra-haskell-${KDB_VERSION}")
 	set (CABAL_OPTS "--prefix=${CMAKE_INSTALL_PREFIX}")
 	if (BUILD_SHARED OR BUILD_FULL)
-		set (BINDING_HASKELL_NAME "${BINDING_HASKELL_NAME}-ghc${GHC_VERSION}.so")
+		set (GHC_DYNAMIC_SUFFIX "-ghc${GHC_VERSION}")
+		if (APPLE)
+			set (GHC_DYNAMIC_ENDING ".dylib")
+		else (APPLE)
+			set (GHC_DYNAMIC_ENDING ".so")
+		endif (APPLE)
+		set (BINDING_HASKELL_NAME "${BINDING_HASKELL_NAME}${GHC_DYNAMIC_SUFFIX}${GHC_DYNAMIC_ENDING}")
 		set (CABAL_OPTS "${CABAL_OPTS};--enable-shared")
 		if (BUILD_SHARED)
 			set (ELEKTRA_DEPENDENCY "elektra;elektra-kdb;")
@@ -27,10 +33,6 @@ if (GHC_EXECUTABLE)
 		set (BINDING_HASKELL_NAME "${BINDING_HASKELL_NAME}.a")
 		set (ELEKTRA_DEPENDENCY "elektra-static;")
 	endif ()
-
-	if (BUILD_TESTING)
-		set (CABAL_OPTS "${CABAL_OPTS};--enable-tests")
-	endif (BUILD_TESTING)
 
 	string (REPLACE ";" " " CABAL_ELEKTRA_DEPENDENCY "${ELEKTRA_DEPENDENCY}")
 	
@@ -43,10 +45,6 @@ if (GHC_EXECUTABLE)
 
 	add_custom_command (
 		OUTPUT ${BINDING_HASKELL_NAME}
-		"${CMAKE_CURRENT_BINARY_DIR}/dist/build/testhaskell_basic/testhaskell_basic"
-		"${CMAKE_CURRENT_BINARY_DIR}/dist/build/testhaskell_basic_optimized/testhaskell_basic_optimized"
-		"${CMAKE_CURRENT_BINARY_DIR}/dist/build/testhaskell_realworld/testhaskell_realworld"
-		"${CMAKE_CURRENT_BINARY_DIR}/dist/build/testhaskell_realworld_optimized/testhaskell_realworld_optimized"
 		COMMAND ${CABAL_EXECUTABLE} --ipid=libelektra-haskell-${KDB_VERSION} ${CABAL_OPTS} configure
 		COMMAND ${CABAL_EXECUTABLE} build
 		WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
@@ -57,14 +55,46 @@ if (GHC_EXECUTABLE)
 		"${CMAKE_CURRENT_SOURCE_DIR}/src/Elektra/KDB.chs"
 		"${CMAKE_CURRENT_SOURCE_DIR}/test/Elektra.hs"
 		"${CMAKE_CURRENT_SOURCE_DIR}/test/ElektraRealWorld.hs"
-		"${ELEKTRA_DEPENDENCY}"
 	)
 	add_custom_target (c2hs_haskell ALL DEPENDS "${BINDING_HASKELL_NAME}")
-
+	if (BUILD_SHARED)
+		add_custom_command(TARGET c2hs_haskell POST_BUILD
+	    	COMMAND ${CMAKE_COMMAND} -E copy
+	    		"${BINDING_HASKELL_NAME}"
+	    		"${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/"
+		)
+	endif (BUILD_SHARED)
 	# build and install it to the cabal db
 	install (CODE "execute_process (COMMAND ${CABAL_EXECUTABLE} install WORKING_DIRECTORY \"${CMAKE_CURRENT_BINARY_DIR}\")")
 
 	if (BUILD_TESTING)
+		# recompile with tests enabled, to get the dependency graph for the static versions correct
+		# the tests need the elektra library already built - while for the haskell plugins it doesn't matter
+		# as a static build depends on the plugins but not on the bindings, this is the way we can resolve the
+		# circular dependency by treating the tests separately
+		set (HASKELL_TESTS 
+			"${CMAKE_CURRENT_BINARY_DIR}/dist/build/testhaskell_basic/testhaskell_basic"
+			"${CMAKE_CURRENT_BINARY_DIR}/dist/build/testhaskell_basic_optimized/testhaskell_basic_optimized"
+			"${CMAKE_CURRENT_BINARY_DIR}/dist/build/testhaskell_realworld/testhaskell_realworld"
+			"${CMAKE_CURRENT_BINARY_DIR}/dist/build/testhaskell_realworld_optimized/testhaskell_realworld_optimized"
+		)
+		add_custom_command (
+			OUTPUT ${HASKELL_TESTS}
+			COMMAND ${CABAL_EXECUTABLE} --ipid=libelektra-haskell-${KDB_VERSION} ${CABAL_OPTS} --enable-tests configure
+			COMMAND ${CABAL_EXECUTABLE} build
+			WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+			DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/libelektra-haskell.cabal"
+			"${CMAKE_CURRENT_SOURCE_DIR}/src/Elektra/Key.chs"
+			"${CMAKE_CURRENT_SOURCE_DIR}/src/Elektra/KeySet.chs"
+			"${CMAKE_CURRENT_SOURCE_DIR}/src/Elektra/Plugin.chs"
+			"${CMAKE_CURRENT_SOURCE_DIR}/src/Elektra/KDB.chs"
+			"${CMAKE_CURRENT_SOURCE_DIR}/test/Elektra.hs"
+			"${CMAKE_CURRENT_SOURCE_DIR}/test/ElektraRealWorld.hs"
+			${ELEKTRA_DEPENDENCY}
+			c2hs_haskell
+		)
+		add_custom_target (c2hs_haskell_tests ALL DEPENDS ${HASKELL_TESTS})
+
 		# test it using the executables, so cmake takes care about the rpaths
 		add_test (
 			NAME testhaskell_basic

--- a/src/bindings/haskell/README.md
+++ b/src/bindings/haskell/README.md
@@ -20,3 +20,4 @@ To open the bindings in ghci to play around with them call
   	- keyGetFullName doesn't has a size argument either
   	- keyGetBaseName behaves like keyBaseName
   	- keyUnescapedName returns a String, the null separators are written with \0
+- BUILD_STATIC is currently not compatible with the haskell bindings

--- a/src/bindings/haskell/libelektra-haskell.cabal.in
+++ b/src/bindings/haskell/libelektra-haskell.cabal.in
@@ -24,6 +24,7 @@ library
   default-language:  Haskell2010
   other-extensions:  ForeignFunctionInterface
   build-tools:       c2hs
+  ghc-options:       -fPIC
 
 test-suite testhaskell_basic
   type:              exitcode-stdio-1.0
@@ -34,7 +35,7 @@ test-suite testhaskell_basic
                    , hspec
                    , QuickCheck
   extra-libraries:   @CABAL_ELEKTRA_DEPENDENCY@
-  ghc-options:       -threaded -rtsopts -with-rtsopts=-N -O0 -j
+  ghc-options:       -O0 -j
   default-language:  Haskell2010
 
 test-suite testhaskell_basic_optimized
@@ -46,7 +47,7 @@ test-suite testhaskell_basic_optimized
                    , hspec
                    , QuickCheck
   extra-libraries:   @CABAL_ELEKTRA_DEPENDENCY@
-  ghc-options:       -threaded -rtsopts -with-rtsopts=-N -O1 -j
+  ghc-options:       -O1 -j
   default-language:  Haskell2010
 
 test-suite testhaskell_realworld
@@ -58,7 +59,7 @@ test-suite testhaskell_realworld
                    , hspec
                    , QuickCheck
   extra-libraries:   @CABAL_ELEKTRA_DEPENDENCY@
-  ghc-options:       -threaded -rtsopts -with-rtsopts=-N -O0 -j
+  ghc-options:       -O0 -j
   default-language:  Haskell2010
 
 test-suite testhaskell_realworld_optimized
@@ -70,7 +71,7 @@ test-suite testhaskell_realworld_optimized
                    , hspec
                    , QuickCheck
   extra-libraries:   @CABAL_ELEKTRA_DEPENDENCY@
-  ghc-options:       -threaded -rtsopts -with-rtsopts=-N -O1 -j
+  ghc-options:       -O1 -j
   default-language:  Haskell2010
 
 source-repository head

--- a/src/bindings/haskell/libelektra-haskell.cabal.in
+++ b/src/bindings/haskell/libelektra-haskell.cabal.in
@@ -33,7 +33,7 @@ test-suite testhaskell_basic
                    , libelektra-haskell
                    , hspec
                    , QuickCheck
-  extra-libraries:   elektra
+  extra-libraries:   @CABAL_ELEKTRA_DEPENDENCY@
   ghc-options:       -threaded -rtsopts -with-rtsopts=-N -O0 -j
   default-language:  Haskell2010
 
@@ -45,7 +45,7 @@ test-suite testhaskell_basic_optimized
                    , libelektra-haskell
                    , hspec
                    , QuickCheck
-  extra-libraries:   elektra
+  extra-libraries:   @CABAL_ELEKTRA_DEPENDENCY@
   ghc-options:       -threaded -rtsopts -with-rtsopts=-N -O1 -j
   default-language:  Haskell2010
 
@@ -57,7 +57,7 @@ test-suite testhaskell_realworld
                    , libelektra-haskell
                    , hspec
                    , QuickCheck
-  extra-libraries:   elektra
+  extra-libraries:   @CABAL_ELEKTRA_DEPENDENCY@
   ghc-options:       -threaded -rtsopts -with-rtsopts=-N -O0 -j
   default-language:  Haskell2010
 
@@ -69,7 +69,7 @@ test-suite testhaskell_realworld_optimized
                    , libelektra-haskell
                    , hspec
                    , QuickCheck
-  extra-libraries:   elektra
+  extra-libraries:   @CABAL_ELEKTRA_DEPENDENCY@
   ghc-options:       -threaded -rtsopts -with-rtsopts=-N -O1 -j
   default-language:  Haskell2010
 

--- a/src/bindings/haskell/libelektra-haskell.cabal.in
+++ b/src/bindings/haskell/libelektra-haskell.cabal.in
@@ -20,11 +20,12 @@ library
   build-depends:     base >= 4.7 && < 5
   includes:          kdb.h, kdbplugin.h
   include-dirs:      @CABAL_INCLUDE_DIRS@
+  extra-lib-dirs:    "@CMAKE_BINARY_DIR@/lib"
   default-language:  Haskell2010
   other-extensions:  ForeignFunctionInterface
   build-tools:       c2hs
 
-test-suite libelektra-haskell-test
+test-suite testhaskell_basic
   type:              exitcode-stdio-1.0
   hs-source-dirs:    "@CMAKE_CURRENT_SOURCE_DIR@/test"
   main-is:           Elektra.hs
@@ -36,7 +37,7 @@ test-suite libelektra-haskell-test
   ghc-options:       -threaded -rtsopts -with-rtsopts=-N -O0 -j
   default-language:  Haskell2010
 
-test-suite libelektra-haskell-test-optimized
+test-suite testhaskell_basic_optimized
   type:              exitcode-stdio-1.0
   hs-source-dirs:    "@CMAKE_CURRENT_SOURCE_DIR@/test"
   main-is:           Elektra.hs
@@ -48,7 +49,7 @@ test-suite libelektra-haskell-test-optimized
   ghc-options:       -threaded -rtsopts -with-rtsopts=-N -O1 -j
   default-language:  Haskell2010
 
-test-suite libelektra-haskell-test-realworld
+test-suite testhaskell_realworld
   type:              exitcode-stdio-1.0
   hs-source-dirs:    "@CMAKE_CURRENT_SOURCE_DIR@/test"
   main-is:           ElektraRealWorld.hs
@@ -60,7 +61,7 @@ test-suite libelektra-haskell-test-realworld
   ghc-options:       -threaded -rtsopts -with-rtsopts=-N -O0 -j
   default-language:  Haskell2010
 
-test-suite libelektra-haskell-test-realworld-optimized
+test-suite testhaskell_realworld_optimized
   type:              exitcode-stdio-1.0
   hs-source-dirs:    "@CMAKE_CURRENT_SOURCE_DIR@/test"
   main-is:           ElektraRealWorld.hs

--- a/src/bindings/jna/CMakeLists.txt
+++ b/src/bindings/jna/CMakeLists.txt
@@ -73,3 +73,7 @@ if (MAVEN_EXECUTABLE) # set by find_program
 else (MAVEN_EXECUTABLE)
 	remove_binding (jna "Maven Executable not found, but required to build the jna bindings")
 endif (MAVEN_EXECUTABLE)
+
+mark_as_advanced (
+	MAVEN_EXECUTABLE
+)

--- a/src/plugins/haskell/CMakeLists.txt
+++ b/src/plugins/haskell/CMakeLists.txt
@@ -1,13 +1,3 @@
 include (LibAddHaskellPlugin)
 
-if (GHC_FFI_LIB)
-if (GHC_RTS_LIB)
-
 add_haskell_plugin (haskell)
-
-else (GHC_RTS_LIB)
-	remove_plugin (haskell "GHC_RTS_LIB not found")
-endif (GHC_RTS_LIB)
-else (GHC_FFI_LIB)
-	remove_plugin (haskell "GHC_FFI_LIB not found")
-endif (GHC_FFI_LIB)

--- a/src/plugins/haskell/haskell.cabal.in
+++ b/src/plugins/haskell/haskell.cabal.in
@@ -17,6 +17,7 @@ library
   build-depends:     base >= 4.7 && < 5, libelektra-haskell
   default-language:  Haskell2010
   other-extensions:  ForeignFunctionInterface
+  ghc-options:       -fPIC
 
 source-repository head
   type:     git

--- a/src/plugins/haskell/testmod_haskell.c
+++ b/src/plugins/haskell/testmod_haskell.c
@@ -18,9 +18,9 @@ static void test_basics (void)
 {
 	printf ("test basics\n");
 
-	Key * parentKey = keyNew ("user/tests/haskelltemplate", KEY_END);
+	Key * parentKey = keyNew ("user/tests/haskell", KEY_END);
 	KeySet * conf = ksNew (0, KS_END);
-	PLUGIN_OPEN ("haskelltemplate");
+	PLUGIN_OPEN ("haskell");
 
 	KeySet * ks = ksNew (0, KS_END);
 


### PR DESCRIPTION
# Purpose

(Hopefully) allows the haskell tests to work even if elektra has only been built but not installed yet. Also recognized changes on the haskell binding source files so ninja recompiles it correctly.

# Checklist

- [X] commit messages are fine (with references to issues)
- [X] I ran all tests and everything went fine
- [X] I added unit tests (restructured ;) )

@sanssecours lets see if this also works on travis now, seems fine locally but maybe i had some leftovers that make it work although it shouldn't (did clean the build directory though)
