### PR TITLE
rest-backend: fix wrong usage of sizeof

### DIFF
--- a/src/tools/rest-backend/service_convert.cpp
+++ b/src/tools/rest-backend/service_convert.cpp
@@ -398,7 +398,7 @@ std::string ConvertEngine::extractFormatFromProviderList (const std::string & pr
 	{
 		if (boost::starts_with (provider, m_pluginProviderStorage + m_pluginProviderDelim))
 		{
-			format = provider.substr (sizeof (m_pluginProviderStorage));
+			format = provider.substr (m_pluginProviderStorage.length () + 1); // + delimiter length
 			break;
 		}
 	}


### PR DESCRIPTION
Instance var m_pluginProviderStorage is a `std::string`, therefore the method `length()` should be used for the string length

# Purpose

fixes issue #1636 

# Checklist

Please only check relevant points.
For docu fixes, spell checking and similar nothing
needs to be checked.

- [x] commit messages are fine (with references to issues)
- [x] I ran all tests and everything went fine
- [ ] I added unit tests
- [ ] affected documentation is fixed
- [x] I added code comments, logging, and assertions
- [x] meta data is updated (e.g. README.md of plugins)

@markus2330 please review my pull request
