### PR TITLE
specreader: ignore non-spec keys

### DIFF
--- a/src/libs/tools/src/specreader.cpp
+++ b/src/libs/tools/src/specreader.cpp
@@ -162,8 +162,17 @@ SpecBackendBuilder SpecMountpointReader::readMountpointSpecification (KeySet con
 
 void SpecReader::readSpecification (KeySet const & cks)
 {
-	KeySet ks (cks);
+	KeySet ks;
 	Key mp;
+
+	// only accept keys in 'spec' namespace
+	for (Key k : cks)
+	{
+		if (k.isSpec ())
+		{
+			ks.append (k);
+		}
+	}
 
 	ks.rewind (); // we need old fashioned loop, because it can handle ks.cut during iteration
 	for (Key k = ks.next (); k; k = ks.next ())


### PR DESCRIPTION
# Purpose

Fixes issue #1633
Don't know if this patch may be considered to be an ugly patch, also I didn't find a nicer way to filter spec keys. However, this filters out all non-spec keys (in that case all cascading) before we try to parse the specification and build the backend.

# Checklist

- [x] commit messages are fine (with references to issues)
- [x] I ran all tests and everything went fine
- [ ] I added unit tests
- [ ] affected documentation is fixed
- [x] I added code comments, logging, and assertions
- [ ] meta data is updated (e.g. README.md of plugins)

@markus2330 please review my pull request
