### PR TITLE
Tests: Check Availability of Cheetah

### DIFF
--- a/tests/shell/check_gen.sh
+++ b/tests/shell/check_gen.sh
@@ -30,6 +30,14 @@ else
 	exit
 fi
 
+if /usr/bin/env python2 -c 'from Cheetah.Template import Template' 2> /dev/null
+then
+	echo "Cheetah available"
+else
+	echo "Cheetah not available"
+	exit
+fi
+
 [ -z "${CC}" ] && CC=gcc
 [ -z "${CXX}" ] && CXX=g++
 if "${CC}" --version 2> /dev/null | grep -Eq '^gcc'


### PR DESCRIPTION
# Purpose

This fixes a problem where `check_gen` would fail if [Cheetah](http://cheetahtemplate.org) is not installed.

# Checklist

- [x] I checked the commit message.
- [x] I ran all tests and everything went fine.