### PR TITLE
fix-xerces-installed-tests

### DIFF
--- a/src/plugins/xerces/testmod_xerces.c
+++ b/src/plugins/xerces/testmod_xerces.c
@@ -36,6 +36,8 @@ static void test_basics (void)
 	succeed_if (plugin->kdbSet (plugin, ks, parentKey) == 0, "call to kdbSet was not successful");
 	succeed_if (plugin->kdbGet (plugin, ks, invalidKey) == 0, "call to kdbSet was successful though the parentKey is invalid");
 
+	succeed_if (plugin->kdbClose (plugin, parentKey) == 1, "call to kdbClose was not successful");
+
 	keyDel (invalidKey);
 	keyDel (parentKey);
 	ksDel (ks);
@@ -165,7 +167,7 @@ static void test_simple_write (void)
 	printf ("test simple write\n");
 	fflush (stdout);
 
-	Key * parentKey = keyNew ("/sw/elektra/tests/xerces", KEY_VALUE, srcdir_file ("xerces/escaping-gen.xml"), KEY_END);
+	Key * parentKey = keyNew ("/sw/elektra/tests/xerces", KEY_VALUE, elektraFilename (), KEY_END);
 	KeySet * conf = ksNew (0, KS_END);
 	PLUGIN_OPEN ("xerces");
 
@@ -185,17 +187,18 @@ static void test_simple_write (void)
 
 	KeySet * ks = ksNew (5, root, keyNew ("/sw/elektra/tests/xerces/userKey", KEY_VALUE, "withValue", KEY_END), keyWithMeta,
 			     specialKeys, moreSpecialKeys, KS_END);
+	succeed_if (plugin->kdbSet (plugin, ks, parentKey) >= 1, "call to kdbSet was not successful");
+	succeed_if (output_error (parentKey), "error in kdbSet");
+	succeed_if (output_warnings (parentKey), "warnings in kdbSet");
 
-	succeed_if (plugin->kdbSet (plugin, ks, parentKey) == 1, "call to kdbSet was not successful");
-
-	compare_files (srcdir_file ("xerces/escaping.xml"));
-	// Its also another good deserialization test
-	Key * resultParentKey = keyNew ("/sw/elektra/tests/xerces", KEY_VALUE, srcdir_file ("xerces/escaping.xml"), KEY_END);
+	succeed_if (compare_line_files (srcdir_file ("xerces/escaping.xml"), keyString (parentKey)), "files do not match as expected")
+		// Its also another good deserialization test
+		Key * resultParentKey = keyNew ("/sw/elektra/tests/xerces", KEY_VALUE, srcdir_file ("xerces/escaping.xml"), KEY_END);
 	KeySet * result = ksNew (2, KS_END);
 	succeed_if (plugin->kdbGet (plugin, result, resultParentKey) == 1, "call to kdbGet was not successful");
 	compare_keyset (ks, result);
 
-	elektraUnlink (srcdir_file ("xerces/escaping-gen.xml"));
+	elektraUnlink (keyString (parentKey));
 
 	keyDel (parentKey);
 	ksDel (ks);
@@ -220,10 +223,12 @@ static void test_maven_pom (void)
 	succeed_if (plugin->kdbGet (plugin, ks, parentKey) == 1, "call to kdbGet was not successful");
 
 	// Its also another good deserialization test
-	Key * serializationParentKey = keyNew ("/sw/elektra/tests/xerces", KEY_VALUE, srcdir_file ("xerces/pom-gen.xml"), KEY_END);
-	succeed_if (plugin->kdbSet (plugin, ks, serializationParentKey) == 1, "call to kdbSet was not successful");
+	Key * serializationParentKey = keyNew ("/sw/elektra/tests/xerces", KEY_VALUE, elektraFilename (), KEY_END);
+	succeed_if (plugin->kdbSet (plugin, ks, serializationParentKey) >= 1, "call to kdbSet was not successful");
+	succeed_if (output_error (serializationParentKey), "error in kdbSet");
+	succeed_if (output_warnings (serializationParentKey), "warnings in kdbSet");
 
-	Key * resultParentKey = keyNew ("/sw/elektra/tests/xerces", KEY_VALUE, srcdir_file ("xerces/pom-gen.xml"), KEY_END);
+	Key * resultParentKey = keyNew ("/sw/elektra/tests/xerces", KEY_VALUE, keyString (serializationParentKey), KEY_END);
 	KeySet * result = ksNew (64, KS_END);
 	succeed_if (plugin->kdbGet (plugin, result, resultParentKey) == 1, "call to kdbGet was not successful");
 
@@ -231,7 +236,7 @@ static void test_maven_pom (void)
 
 	compare_keyset (ks, result); // Should be the same
 
-	elektraUnlink (srcdir_file ("xerces/pom-gen.xml"));
+	elektraUnlink (keyString (serializationParentKey));
 
 	keyDel (parentKey);
 	ksDel (ks);
@@ -257,10 +262,12 @@ static void test_jenkins_config (void)
 	succeed_if (plugin->kdbGet (plugin, ks, parentKey) == 1, "call to kdbGet was not successful");
 
 	// Its also another good deserialization test
-	Key * serializationParentKey = keyNew ("/sw/elektra/tests/xerces", KEY_VALUE, srcdir_file ("xerces/jenkins-gen.xml"), KEY_END);
-	succeed_if (plugin->kdbSet (plugin, ks, serializationParentKey) == 1, "call to kdbSet was not successful");
+	Key * serializationParentKey = keyNew ("/sw/elektra/tests/xerces", KEY_VALUE, elektraFilename (), KEY_END);
+	succeed_if (plugin->kdbSet (plugin, ks, serializationParentKey) >= 1, "call to kdbSet was not successful");
+	succeed_if (output_error (serializationParentKey), "error in kdbSet");
+	succeed_if (output_warnings (serializationParentKey), "warnings in kdbSet");
 
-	Key * resultParentKey = keyNew ("/sw/elektra/tests/xerces", KEY_VALUE, srcdir_file ("xerces/jenkins-gen.xml"), KEY_END);
+	Key * resultParentKey = keyNew ("/sw/elektra/tests/xerces", KEY_VALUE, keyString (serializationParentKey), KEY_END);
 	KeySet * result = ksNew (64, KS_END);
 	succeed_if (plugin->kdbGet (plugin, result, resultParentKey) == 1, "call to kdbGet was not successful");
 
@@ -277,7 +284,7 @@ static void test_jenkins_config (void)
 
 	compare_keyset (ks, result); // Should be the same
 
-	elektraUnlink (srcdir_file ("xerces/jenkins-gen.xml"));
+	elektraUnlink (keyString (serializationParentKey));
 
 	keyDel (parentKey);
 	ksDel (ks);


### PR DESCRIPTION
# Purpose

Fixes #1666 and also fixes a memleak in the tests caused by a kdbOpen without a corresponding kdbClose.

# Checklist

Please only check relevant points.
For docu fixes, spell checking and similar nothing
needs to be checked.

- [X] commit messages are fine (with references to issues)
- [X] I ran all tests and everything went fine

@markus2330 
However there is still one little leak left, that again rather looks like some system issue to me and not caused by the xerces plugin, what do you think:

```
==8670==
==8670== HEAP SUMMARY:
==8670==     in use at exit: 32 bytes in 1 blocks
==8670==   total heap usage: 64,262 allocs, 64,261 frees, 7,765,932 bytes allocated
==8670==
==8670== 32 bytes in 1 blocks are still reachable in loss record 1 of 1
==8670==    at 0x4C31B25: calloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==8670==    by 0x70E082E: _dlerror_run (dlerror.c:141)
==8670==    by 0x70E0091: dlopen@@GLIBC_2.2.5 (dlopen.c:87)
==8670==    by 0x59D1AF8: elektraModulesLoad (dl.c:78)
==8670==    by 0x4E4B70A: elektraPluginOpen (plugin.c:270)
==8670==    by 0x10F82B: test_basics (testmod_xerces.c:26)
==8670==    by 0x10F82B: main (testmod_xerces.c:307)
==8670==
==8670== LEAK SUMMARY:
==8670==    definitely lost: 0 bytes in 0 blocks
==8670==    indirectly lost: 0 bytes in 0 blocks
==8670==      possibly lost: 0 bytes in 0 blocks
==8670==    still reachable: 32 bytes in 1 blocks
==8670==         suppressed: 0 bytes in 0 blocks
==8670==
==8670== For counts of detected and suppressed errors, rerun with: -v
==8670== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```
