### PR TITLE
Haskell bindings check dependencies

### DIFF
--- a/cmake/Modules/FindHaskell.cmake
+++ b/cmake/Modules/FindHaskell.cmake
@@ -1,0 +1,89 @@
+# Find the haskell environment required for the haskell bindings and plugins.
+# Only searches for the GHC compiler and not other haskell compilers as it is
+# the most widespread and advanced haskell compiler.
+#
+#  CABAL_EXECUTABLE      - Path to the cabal executable
+#  C2HS_EXECUTABLE	     - Path to the c2hs executable
+#  GHC_EXECUTABLE        - Path to the ghc executable
+#  GHC-PKG_EXECUTABLE    - Path to the ghc-pkg executable
+#  GHC_HSPEC_FOUND       - True if the hspec library is available
+#  GHC_QUICKCHECK_FOUND  - True if the QuickCheck library is available
+#  HASKELL_FOUND         - True if the whole required haskell environment exists
+#    This variable is set to true if CABAL_EXECUTABLE, C2HS_EXECUTABLE, GHC_EXECUTABLE
+#    and GHC-PKG_EXECUTABLE are all available. If BUILD_TESTING is enabled, it also
+#    requires GHC_HSPEC_FOUND and GHC_QUICKCHECK_FOUND to be true.
+#  HASKELL_NOTFOUND_INFO - A string describing which haskell dependency is missing
+#
+
+find_program (GHC_EXECUTABLE ghc)
+find_program (CABAL_EXECUTABLE cabal)
+find_program (C2HS_EXECUTABLE c2hs)
+find_program (GHC-PKG_EXECUTABLE ghc-pkg)
+
+set (HASKELL_FOUND 0)
+if (CABAL_EXECUTABLE)
+if (C2HS_EXECUTABLE)
+if (GHC_EXECUTABLE)
+if (GHC-PKG_EXECUTABLE)
+	
+	# check for hspec and QuickCheck
+	# ghc-pkg return code is 0 on success, 1 otherwise
+	execute_process (
+		COMMAND ${GHC-PKG_EXECUTABLE} latest hspec
+		RESULT_VARIABLE GHC_HSPEC_FOUND
+		OUTPUT_QUIET ERROR_QUIET
+	)
+
+	execute_process (
+		COMMAND ${GHC-PKG_EXECUTABLE} latest QuickCheck
+		RESULT_VARIABLE GHC_QUICKCHECK_FOUND
+		OUTPUT_QUIET ERROR_QUIET
+	)
+
+	# normalize the result variables, 0 means success which corresponds to 1 in cmake booleans
+	if (GHC_HSPEC_FOUND EQUAL 0)
+		set (GHC_HSPEC_FOUND 1)
+	else (GHC_HSPEC_FOUND EQUAL 0)
+		set (GHC_HSPEC_FOUND 0)
+	endif (GHC_HSPEC_FOUND EQUAL 0)
+
+	if (GHC_QUICKCHECK_FOUND EQUAL 0)
+		set (GHC_QUICKCHECK_FOUND 1)
+	else (GHC_QUICKCHECK_FOUND EQUAL 0)
+		set (GHC_QUICKCHECK_FOUND 0)
+	endif (GHC_QUICKCHECK_FOUND EQUAL 0)
+
+	if (GHC_HSPEC_FOUND OR NOT BUILD_TESTING)
+	if (GHC_QUICKCHECK_FOUND OR NOT BUILD_TESTING)
+		# all set, have fun with haskell!
+		set (HASKELL_FOUND 1)
+	else (GHC_QUICKCHECK_FOUND OR NOT BUILD_TESTING)
+		set (HASKELL_NOTFOUND_INFO "QuickCheck library not found")
+	endif (GHC_QUICKCHECK_FOUND OR NOT BUILD_TESTING)
+	else (GHC_HSPEC_FOUND OR NOT BUILD_TESTING)
+		set (HASKELL_NOTFOUND_INFO "hspec library not found")
+	endif (GHC_HSPEC_FOUND OR NOT BUILD_TESTING)
+
+else (GHC-PKG_EXECUTABLE)
+	set (HASKELL_NOTFOUND_INFO "ghc-pkg not found")
+endif (GHC-PKG_EXECUTABLE)
+else (GHC_EXECUTABLE)
+	set (HASKELL_NOTFOUND_INFO "GHC not found")
+endif (GHC_EXECUTABLE)
+else (C2HS_EXECUTABLE)
+	set (HASKELL_NOTFOUND_INFO "c2hs not found")
+endif (C2HS_EXECUTABLE)
+else (CABAL_EXECUTABLE)
+	set (HASKELL_NOTFOUND_INFO "cabal not found")
+endif (CABAL_EXECUTABLE)
+
+set (HASKELL_NOTFOUND_INFO "${HASKELL_NOTFOUND_INFO}, please refer to the readme in src/bindings/haskell/README.md")
+
+mark_as_advanced (
+	GHC_EXECUTABLE
+	GHC-PKG_EXECUTABLE
+	C2HS_EXECUTABLE
+	CABAL_EXECUTABLE
+	GHC_HSPEC_FOUND
+	GHC_QUICKCHECK_FOUND
+)

--- a/cmake/Modules/LibAddHaskellPlugin.cmake
+++ b/cmake/Modules/LibAddHaskellPlugin.cmake
@@ -25,14 +25,10 @@ macro (add_haskell_plugin target)
 	string (TOUPPER ${PLUGIN_NAME} PLUGIN_NAME_UPPERCASE)
 
 	if (DEPENDENCY_PHASE)
-		find_program (GHC_EXECUTABLE ghc)
-		find_program (GHC-PKG_EXECUTABLE ghc-pkg)
-		find_program (CABAL_EXECUTABLE cabal)
+		find_package (Haskell)
 
 		 # set by find_program
-		if (CABAL_EXECUTABLE)
-		if (GHC_EXECUTABLE)
-		if (GHC-PKG_EXECUTABLE)
+		if (HASKELL_FOUND)
 		list (FIND BINDINGS "haskell" FINDEX)
 		if (FINDEX GREATER -1)
 
@@ -202,16 +198,10 @@ macro (add_haskell_plugin target)
 		else (FINDEX GREATER -1)
 			remove_plugin (${target} "haskell bindings are not included in the cmake configuration")
 		endif (FINDEX GREATER -1)
-		else (GHC-PKG_EXECUTABLE)
-			remove_plugin (${target} "ghc-pkg not found")
-		endif (GHC-PKG_EXECUTABLE)
-		else (GHC_EXECUTABLE)
-			remove_plugin (${target} "GHC not found")
-		endif (GHC_EXECUTABLE)
-		else (CABAL_EXECUTABLE)
-			remove_plugin (${target} "cabal not found")
-		endif (CABAL_EXECUTABLE)
-	endif ()
+		else (HASKELL_FOUND)
+			remove_plugin (${target} ${HASKELL_NOTFOUND_INFO})
+		endif (HASKELL_FOUND)
+	endif (DEPENDENCY_PHASE)
 
 	# compile our c wrapper which takes care of invoking the haskell runtime
 	# the actual haskell plugin gets linked in dynamically as a library
@@ -227,15 +217,11 @@ macro (add_haskell_plugin target)
 			${target} c2hs_haskell
 		ADD_TEST
 	)
-
-	if (ADDTESTING_PHASE)
-		set_property (TEST testmod_haskell PROPERTY ENVIRONMENT "LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/lib")
-	endif (ADDTESTING_PHASE)
+	if (ADDTESTING_PHASE AND BUILD_TESTING)
+		set_property (TEST testmod_${target} PROPERTY ENVIRONMENT "LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/lib")
+	endif (ADDTESTING_PHASE AND BUILD_TESTING)
 
 	mark_as_advanced (
-		GHC_EXECUTABLE
-		GHC-PKG_EXECUTABLE
-		CABAL_EXECUTABLE
 		GHC_FFI_LIB
 		GHC_RTS_LIB
 		GHC_BASE_LIB

--- a/src/bindings/haskell/CMakeLists.txt
+++ b/src/bindings/haskell/CMakeLists.txt
@@ -1,29 +1,7 @@
-find_program (GHC_EXECUTABLE ghc)
-find_program (CABAL_EXECUTABLE cabal)
-find_program (C2HS_EXECUTABLE c2hs)
-find_program (GHC-PKG_EXECUTABLE ghc-pkg)
+find_package (Haskell)
 
-if (CABAL_EXECUTABLE) # set by find_program
-if (C2HS_EXECUTABLE)
-if (GHC_EXECUTABLE)
-if (GHC-PKG_EXECUTABLE)
+if (HASKELL_FOUND) 
 if (NOT BUILD_STATIC)
-
-# check for hspec and QuickCheck
-# ghc-pkg return code is 0 on success, 1 otherwise
-execute_process (
-	COMMAND ${GHC-PKG_EXECUTABLE} latest hspec
-	RESULT_VARIABLE GHC_HSPEC_FOUND
-	OUTPUT_QUIET ERROR_QUIET
-)
-if (GHC_HSPEC_FOUND EQUAL 0)
-
-execute_process (
-	COMMAND ${GHC-PKG_EXECUTABLE} latest QuickCheck
-	RESULT_VARIABLE GHC_QUICKCHECK_FOUND
-	OUTPUT_QUIET ERROR_QUIET
-)
-if (GHC_QUICKCHECK_FOUND EQUAL 0)
 
 	set (CABAL_INCLUDE_DIRS "\"${CMAKE_SOURCE_DIR}/src/include\", \"${CMAKE_BINARY_DIR}/src/include\"")
 
@@ -147,33 +125,9 @@ if (GHC_QUICKCHECK_FOUND EQUAL 0)
 			set_property (TEST testhaskell_realworld_optimized PROPERTY ENVIRONMENT "LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/lib")
 		endif (ENABLE_KDB_TESTING)
 	endif (BUILD_TESTING)
-else (GHC_QUICKCHECK_FOUND EQUAL 0)
-	remove_binding (haskell "QuickCheck library not found")
-endif (GHC_QUICKCHECK_FOUND EQUAL 0)
-else (GHC_HSPEC_FOUND EQUAL 0)
-	remove_binding (haskell "hspec library not found")
-endif (GHC_HSPEC_FOUND EQUAL 0)
 else (NOT BUILD_STATIC)
 	remove_binding (haskell "BUILD_STATIC is currently not compatible with the haskell bindings")
 endif (NOT BUILD_STATIC)
-else (GHC-PKG_EXECUTABLE)
-	remove_binding (haskell "ghc-pkg not found")
-endif (GHC-PKG_EXECUTABLE)
-else (GHC_EXECUTABLE)
-	remove_binding (haskell "GHC not found")
-endif (GHC_EXECUTABLE)
-else (C2HS_EXECUTABLE)
-	remove_binding (haskell "c2hs not found")
-endif (C2HS_EXECUTABLE)
-else (CABAL_EXECUTABLE)
-	remove_binding (haskell "cabal not found")
-endif (CABAL_EXECUTABLE)
-
-mark_as_advanced (
-	GHC_EXECUTABLE
-	GHC-PKG_EXECUTABLE
-	C2HS_EXECUTABLE
-	CABAL_EXECUTABLE
-	GHC_HSPEC_FOUND
-	GHC_QUICKCHECK_FOUND
-)
+else (HASKELL_FOUND)
+	remove_binding (haskell ${HASKELL_NOTFOUND_INFO})
+endif (HASKELL_FOUND)

--- a/src/bindings/haskell/CMakeLists.txt
+++ b/src/bindings/haskell/CMakeLists.txt
@@ -1,11 +1,30 @@
 find_program (GHC_EXECUTABLE ghc)
 find_program (CABAL_EXECUTABLE cabal)
 find_program (C2HS_EXECUTABLE c2hs)
+find_program (GHC-PKG_EXECUTABLE ghc-pkg)
 
 if (CABAL_EXECUTABLE) # set by find_program
 if (C2HS_EXECUTABLE)
 if (GHC_EXECUTABLE)
+if (GHC-PKG_EXECUTABLE)
 if (NOT BUILD_STATIC)
+
+# check for hspec and QuickCheck
+# ghc-pkg return code is 0 on success, 1 otherwise
+execute_process (
+	COMMAND ${GHC-PKG_EXECUTABLE} latest hspec
+	RESULT_VARIABLE GHC_HSPEC_FOUND
+	OUTPUT_QUIET ERROR_QUIET
+)
+if (GHC_HSPEC_FOUND EQUAL 0)
+
+execute_process (
+	COMMAND ${GHC-PKG_EXECUTABLE} latest QuickCheck
+	RESULT_VARIABLE GHC_QUICKCHECK_FOUND
+	OUTPUT_QUIET ERROR_QUIET
+)
+if (GHC_QUICKCHECK_FOUND EQUAL 0)
+	message ("all fine, configuring")
 
 	set (CABAL_INCLUDE_DIRS "\"${CMAKE_SOURCE_DIR}/src/include\", \"${CMAKE_BINARY_DIR}/src/include\"")
 
@@ -129,9 +148,18 @@ if (NOT BUILD_STATIC)
 			set_property (TEST testhaskell_realworld_optimized PROPERTY ENVIRONMENT "LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/lib")
 		endif (ENABLE_KDB_TESTING)
 	endif (BUILD_TESTING)
+else (GHC_QUICKCHECK_FOUND EQUAL 0)
+	remove_binding (haskell "QuickCheck library not found")
+endif (GHC_QUICKCHECK_FOUND EQUAL 0)
+else (GHC_HSPEC_FOUND EQUAL 0)
+	remove_binding (haskell "hspec library not found")
+endif (GHC_HSPEC_FOUND EQUAL 0)
 else (NOT BUILD_STATIC)
 	remove_binding (haskell "BUILD_STATIC is currently not compatible with the haskell bindings")
 endif (NOT BUILD_STATIC)
+else (GHC-PKG_EXECUTABLE)
+	remove_binding (haskell "ghc-pkg not found")
+endif (GHC-PKG_EXECUTABLE)
 else (GHC_EXECUTABLE)
 	remove_binding (haskell "GHC not found")
 endif (GHC_EXECUTABLE)
@@ -144,6 +172,9 @@ endif (CABAL_EXECUTABLE)
 
 mark_as_advanced (
 	GHC_EXECUTABLE
+	GHC-PKG_EXECUTABLE
 	C2HS_EXECUTABLE
 	CABAL_EXECUTABLE
+	GHC_HSPEC_FOUND
+	GHC_QUICKCHECK_FOUND
 )

--- a/src/bindings/haskell/CMakeLists.txt
+++ b/src/bindings/haskell/CMakeLists.txt
@@ -24,7 +24,6 @@ execute_process (
 	OUTPUT_QUIET ERROR_QUIET
 )
 if (GHC_QUICKCHECK_FOUND EQUAL 0)
-	message ("all fine, configuring")
 
 	set (CABAL_INCLUDE_DIRS "\"${CMAKE_SOURCE_DIR}/src/include\", \"${CMAKE_BINARY_DIR}/src/include\"")
 

--- a/src/bindings/haskell/README.md
+++ b/src/bindings/haskell/README.md
@@ -10,11 +10,16 @@ There are some examples how the bindings can be used in
 [examples](src/bindings/haskell/examples). Furthermore there exists the possibility 
 to write [plugins](src/plugins/haskell/) using the haskell bindings.
 
-To build and test it manually call `cabal test`. Otherwise the bindings will be 
-installed along with elektra if the bindings are included in the build.
+To build and test it manually call `cabal test` in <build_folder>/src/bindings/haskell.
+Otherwise the bindings will be installed along with elektra if the bindings are included 
+in the build, so usually this shouldn't be necessary to do.
 
 To open the bindings in ghci to play around with them call
-`cabal repl --ghc-options="-lelektra"` in this folder. 
+`cabal repl` in the <build_folder>/src/bindings/haskell. 
+If the bindings have already been installed along with elektra, they should be 
+registered in the global cabal database already. Therefore you can easily use 
+them with `ghci`, by calling `:m Elektra.Key Elektra.KDB Elektra.KeySet Elektra.Plugin`
+inside ghci.
 
 ## Dependencies
 
@@ -22,15 +27,22 @@ To open the bindings in ghci to play around with them call
 - cabal > 1.24.0.2  (older versions may work but untested, 2.0.0.0 works as well)
 
 GHC and cabal can be either obtained using a package manager or downloaded directly
-from [the Haskell homepage](https://www.haskell.org/platform/).
+from [the Haskell homepage](https://www.haskell.org/platform/). 
 
 Before installing the remaining dependencies, make sure to update your cabal database
 which contains the current list of haskell packages by invoking `cabal update`, this
 is not done automatically.
 
-- c2hs `cabal install c2hs` > 0.28.2 (older versions untested)
 - hspec `cabal install hspec` (only if the tests are being built, v2.4.4 tested)
 - QuickCheck `cabal install QuickCheck` (only if the tests are being built, v2.10.1 tested)
+- c2hs > 0.28.2 (older versions may work but are untested)
+  c2hs is available in some package managers and should be installed from there in that case.
+  If c2hs is not available in the package manager (e.g. homebrew on macOS does not include it),
+  it can be installed via cabal by invoking `cabal install c2hs`.
+
+To configure the remaining dependencies with a single command, after having installed GHC
+and cabal, invoke `cabal update && cabal install hspec QuickCheck c2hs` if your package
+manager does not include c2hs, or `cabal update && cabal install hspec QuickCheck` otherwise.
 
 ## Limitations
 

--- a/src/bindings/haskell/README.md
+++ b/src/bindings/haskell/README.md
@@ -4,12 +4,33 @@ A full haskell binding using c2hs.
 ## Usage
 The bindings are built with cabal, Haskell's default build system. It needs the 
 GHC, cabal and C2HS, which generates the actual bindings out of a metacode and 
-will be called during the build automatically (Call `cabal install c2hs` to 
-install it globally).
+will be called during the build automatically.
 
-To build and test it call `cabal test`.
+There are some examples how the bindings can be used in
+[examples](src/bindings/haskell/examples). Furthermore there exists the possibility 
+to write [plugins](src/plugins/haskell/) using the haskell bindings.
+
+To build and test it manually call `cabal test`. Otherwise the bindings will be 
+installed along with elektra if the bindings are included in the build.
+
 To open the bindings in ghci to play around with them call
-`cabal repl --ghc-options="-lelektra"`. 
+`cabal repl --ghc-options="-lelektra"` in this folder. 
+
+## Dependencies
+
+- GHC (Glasgow Haskell Compiler) > 8.0.0 (older versions may work but are untested)
+- cabal > 1.24.0.2  (older versions may work but untested, 2.0.0.0 works as well)
+
+GHC and cabal can be either obtained using a package manager or downloaded directly
+from [the Haskell homepage](https://www.haskell.org/platform/).
+
+Before installing the remaining dependencies, make sure to update your cabal database
+which contains the current list of haskell packages by invoking `cabal update`, this
+is not done automatically.
+
+- c2hs `cabal install c2hs` > 0.28.2 (older versions untested)
+- hspec `cabal install hspec` (only if the tests are being built, v2.4.4 tested)
+- QuickCheck `cabal install QuickCheck` (only if the tests are being built, v2.10.1 tested)
 
 ## Limitations
 

--- a/src/bindings/haskell/libelektra-haskell.cabal.in
+++ b/src/bindings/haskell/libelektra-haskell.cabal.in
@@ -23,6 +23,7 @@ library
   extra-lib-dirs:    "@CMAKE_BINARY_DIR@/lib"
   default-language:  Haskell2010
   other-extensions:  ForeignFunctionInterface
+  extra-libraries:   @CABAL_ELEKTRA_DEPENDENCY@
   build-tools:       c2hs
   ghc-options:       -fPIC
 
@@ -34,7 +35,6 @@ test-suite testhaskell_basic
                    , libelektra-haskell
                    , hspec
                    , QuickCheck
-  extra-libraries:   @CABAL_ELEKTRA_DEPENDENCY@
   ghc-options:       -O0 -j
   default-language:  Haskell2010
 
@@ -46,7 +46,6 @@ test-suite testhaskell_basic_optimized
                    , libelektra-haskell
                    , hspec
                    , QuickCheck
-  extra-libraries:   @CABAL_ELEKTRA_DEPENDENCY@
   ghc-options:       -O1 -j
   default-language:  Haskell2010
 
@@ -58,7 +57,6 @@ test-suite testhaskell_realworld
                    , libelektra-haskell
                    , hspec
                    , QuickCheck
-  extra-libraries:   @CABAL_ELEKTRA_DEPENDENCY@
   ghc-options:       -O0 -j
   default-language:  Haskell2010
 
@@ -70,7 +68,6 @@ test-suite testhaskell_realworld_optimized
                    , libelektra-haskell
                    , hspec
                    , QuickCheck
-  extra-libraries:   @CABAL_ELEKTRA_DEPENDENCY@
   ghc-options:       -O1 -j
   default-language:  Haskell2010
 


### PR DESCRIPTION
# Purpose

Improves the dependency management of the haskell bindings mentioned in #1670 . The readme is also more precise about the dependencies now.

# Checklist

- [X] commit messages are fine (with references to issues)
- [X] I ran all tests and everything went fine
- [X] affected documentation is fixed
- [X] I added code comments, logging, and assertions
- [X] meta data is updated (e.g. README.md of plugins)

@markus2330 There is one little issue left. If one dependency is missing, and it excludes the bindings, then the haskell plugin will fail later on. This is because for what i've seen the plugins get configured first, so the bindings are still included and thus the haskell plugin is happy. But then it configures the bindings, notices some lib is missing and excludes the bindings. Thus then in the later phases the haskell plugin fails because it depends on a target added by the bindings, which obviously is missing now. 

We currently don't have a simple mechanism to handle such cases, do we? Anyway its probably not the biggest deal as the user will see that the bindings got excluded, it just would be nicer to hide the cmake error which follows then.