### PR TITLE
build-homepage: build frontend with --force

### DIFF
--- a/src/tools/rest-frontend/build.sh
+++ b/src/tools/rest-frontend/build.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-cd @CMAKE_INSTALL_PREFIX@/@install_directory@ && ./node_modules/grunt-cli/bin/grunt full
+cd @CMAKE_INSTALL_PREFIX@/@install_directory@ && ./node_modules/grunt-cli/bin/grunt full --force


### PR DESCRIPTION
The Backend throws an excpetion if 'database' endpoint is called without
a 'sortBy' field. Therefore the backend returns with HTTP 500 which
aborts the frontend build process.

For now, we simply force the frontend build to be not blocked by this
minor issue.

@markus2330 please review my pull request