### PR TITLE
haskell-bindings-fix-regression: add dependency as the binding librar…

### DIFF
--- a/src/bindings/haskell/CMakeLists.txt
+++ b/src/bindings/haskell/CMakeLists.txt
@@ -52,6 +52,7 @@ if (NOT BUILD_STATIC)
 		"${CMAKE_CURRENT_SOURCE_DIR}/src/Elektra/KDB.chs"
 		"${CMAKE_CURRENT_SOURCE_DIR}/test/Elektra.hs"
 		"${CMAKE_CURRENT_SOURCE_DIR}/test/ElektraRealWorld.hs"
+		${ELEKTRA_DEPENDENCY}
 	)
 	add_custom_target (c2hs_haskell ALL DEPENDS "${BINDING_HASKELL_NAME}")
 	if (BUILD_SHARED OR BUILD_FULL)


### PR DESCRIPTION
# Purpose

I fear i introduced a little regression by the latest change which makes the build non-deterministic, depending on the order in which cmake configures/compiles things. This should fix it again, initially i removed the dependency because of the static builds having a cyclic dependency then (elektra depending on haskell plugins, haskell plugins depending on haskell bindings, haskell bindings depending on elektra) but since static builds are not supported anyway for the haskell bindings it should be fine for the meanwhile.

# Checklist

- [X] I ran all tests and everything went fine (at least locally)

@sanssecours i hope this resolves the issue you reported in #1670. My own build is triggered here in case travis is slow again/still https://travis-ci.org/e1528532/libelektra/builds/295256480
