### PR TITLE
haskell-bindings-fix-readme-links: correct relative and absolute links

### DIFF
--- a/src/bindings/haskell/README.md
+++ b/src/bindings/haskell/README.md
@@ -7,8 +7,8 @@ GHC, cabal and C2HS, which generates the actual bindings out of a metacode and
 will be called during the build automatically.
 
 There are some examples how the bindings can be used in
-[examples](src/bindings/haskell/examples). Furthermore there exists the possibility 
-to write [plugins](src/plugins/haskell/) using the haskell bindings.
+[examples](examples/). Furthermore there exists the possibility 
+to write [plugins](/src/plugins/haskell/) using the haskell bindings.
 
 To build and test it manually call `cabal test` in <build_folder>/src/bindings/haskell.
 Otherwise the bindings will be installed along with elektra if the bindings are included 


### PR DESCRIPTION
# Purpose

As you can see only a very minor thing, had the links used in the bindings readme wrong. Should be fine to merge, only changes docu and i tried it in my fork already it works now.

# Checklist

- [X] affected documentation is fixed

@markus2330 please merge. Can i push such simple changes directly to master in the future?
