### PR TITLE
Ruby: Disable Plugin on GCC 4

### DIFF
--- a/src/plugins/ruby/CMakeLists.txt
+++ b/src/plugins/ruby/CMakeLists.txt
@@ -5,7 +5,12 @@ if (DEPENDENCY_PHASE)
 	find_package(Ruby)
 	find_swig()
 
-	if (RUBY_FOUND AND SWIG_FOUND)
+	# Disable on GCC 4 and earlier:
+	#	- https://build.libelektra.org/jenkins/job/elektra-gcc47-all
+	#	- https://build.libelektra.org/jenkins/job/elektra-gcc-configure-debian-wheezy
+	set(SUPPORTED_COMPILER NOT (CMAKE_CXX_COMPILER_ID MATCHES "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 5))
+
+	if (RUBY_FOUND AND SWIG_FOUND AND SUPPORTED_COMPILER)
 		include (LibAddMacros)
 
 		add_custom_command (OUTPUT runtime.h
@@ -20,6 +25,8 @@ if (DEPENDENCY_PHASE)
 		set_source_files_properties ("ruby.cpp" PROPERTIES COMPILE_FLAGS "${SWIG_COMPILE_FLAGS}")
 	elseif (NOT RUBY_FOUND)
 		remove_plugin (ruby "ruby not found")
+	elseif (NOT SUPPORTED_COMPILER)
+		remove_plugin (ruby "gcc version too old (gcc -dumpversion < 5.0)")
 	else ()
 		remove_plugin (ruby "swig not found")
 	endif ()


### PR DESCRIPTION
# Purpose

This pull request disables the Ruby plugin on GCC 4.x and earlier. At least GCC 4.7 is [unable to compile](https://build.libelektra.org/jenkins/job/elektra-gcc47-all/1127/console) the plugin:

```
src/plugins/ruby/ruby.cpp: In function 'VALUE get_exception_string(VALUE)':
src/plugins/ruby/ruby.cpp:98:42: error: expected ')' before 'PRIsVALUE'
src/plugins/ruby/ruby.cpp:99:17: warning: spurious trailing '%' in format [-Wformat]
src/plugins/ruby/ruby.cpp:99:17: warning: too many arguments for format [-Wformat-extra-args]
src/plugins/ruby/ruby.cpp:103:42: error: expected ')' before 'PRIsVALUE'
src/plugins/ruby/ruby.cpp:103:100: warning: spurious trailing '%' in format [-Wformat]
src/plugins/ruby/ruby.cpp:103:100: warning: too many arguments for format [-Wformat-extra-args]
src/plugins/ruby/ruby.cpp: In function 'VALUE rb_kdb_plugin_define(VALUE, VALUE)':
src/plugins/ruby/ruby.cpp:263:79: error: 'rb_funcall_with_block' was not declared in this scope
src/plugins/ruby/ruby.cpp: In function 'int init_ruby_environment(ckdb::Key*)':
src/plugins/ruby/ruby.cpp:312:18: error: 'ruby_setup' was not declared in this scope
```

.

# Checklist

- [x] I checked the commit message.
- [x] I ran all tests and everything went fine.