### PR TITLE
Properly include headers for std::bind

### DIFF
--- a/src/libs/tools/src/backendparser.cpp
+++ b/src/libs/tools/src/backendparser.cpp
@@ -9,6 +9,8 @@
 
 #include <backendparser.hpp>
 
+#include <functional>
+
 #include <string>
 
 #include <keyset.hpp>


### PR DESCRIPTION
Signed-off-by: Nick Sarnie <commendsarnex@gmail.com>

# Purpose

bind lives in "functional"
http://www.cplusplus.com/reference/functional/bind/


@markus2330 please review my pull request
