### PR TITLE
kdb: proposal for nokdb profile

### DIFF
--- a/doc/help/kdb.md
+++ b/doc/help/kdb.md
@@ -76,7 +76,7 @@ For example, to permanently change verbosity one can use:
 
 Profiles allow users to change many/all configuration options of a tool
 at once. It influences from where the KDB entries are read.
-For example if you use:  
+For example if you use:<br>
 	`kdb export -p admin system`
 
 It will read its format configuration from `/sw/elektra/kdb/#0/admin/format`.
@@ -88,13 +88,15 @@ be chosen automatically according to the current user or current working directo
 Sometimes it is useful to start with default options, for example it is not
 possible to invert the `-q` option.
 In such situations one can simply select a non-existing profile, then `-q`
-works as usual:  
+works as usual:<br>
 	`kdb mount -p nonexist -q /abc dir/abc`
 
 There are two special profiles:
 
-- `%` is a fallback profile. It does not need to be selected and will be used if a key cannot be found in the main profile.
-- `nokdb` disables reading from `KDB`. Then only command-line arguments are used.
+- `%`:
+  Is a fallback profile. It does not need to be selected and will be used if a key cannot be found in the main profile.
+- `nokdb`:
+  Disables reading from `KDB`. Then only command-line arguments are used.
 
 ## BOOKMARKS
 

--- a/doc/help/kdb.md
+++ b/doc/help/kdb.md
@@ -59,10 +59,13 @@ The `kdb` utility reads its own configuration from three sources
 within the KDB (key database):
 
 1. /sw/kdb/**profile**/ (for legacy configuration)
-2. /sw/elektra/kdb/#0/%/ (for empty profile)
-3. /sw/elektra/kdb/#0/**profile**/ (for current profile)
+2. /sw/elektra/kdb/#0/%/ (for empty profile, `%` in Elektra
+   is used to represent a emptiness)
+3. /sw/elektra/kdb/#0/**profile**/ (for current profile,
+   if no `-p` or `--profile` is given, `current` will be
+   used)
 
-The last source where a configuration value is found, wins.
+Here the last source where a configuration value is found, wins.
 
 For example, to permanently change verbosity one can use:
 
@@ -72,10 +75,22 @@ For example, to permanently change verbosity one can use:
 - `kdb set /sw/elektra/kdb/#0/current/quiet 1`:
   Be quiet for every tool.
 
+If `%` is passed to
+`-p` or `--profile`, the KDB will not be consulted for configuration and
+only the command-line arguments are used.
+
 ## PROFILES
 
-Profiles allow users to change many/all configuration options of a tool
+Profiles allow users to change many/all configuration settings of a tool
 at once. It influences from where the KDB entries are read.
+Without a `-p` or `--profile` argument following profiles are used
+(in the order of preference):
+
+- `current`:
+  Is the profile to be used only if no `-p` argument was used.
+- `%`:
+  Is the fallback profile. It will be used if keys cannot be found in the main profile.
+
 For example if you use:<br>
 	`kdb export -p admin system`
 
@@ -91,12 +106,18 @@ In such situations one can simply select a non-existing profile, then `-q`
 works as usual:<br>
 	`kdb mount -p nonexist -q /abc dir/abc`
 
-There are two special profiles:
+If `%` is used as profile name for `-p`, the `kdb` tools disables reading from `KDB`
+for their own configuration settings. Then, they only use command-line arguments.
 
-- `%`:
-  Is a fallback profile. It does not need to be selected and will be used if a key cannot be found in the main profile.
-- `nokdb`:
-  Disables reading from `KDB`. Then only command-line arguments are used.
+To explicitly state the default behavior, we use:<br>
+	`-p current`
+
+To state that we do not want to read any configuration settings for `kdb`
+from KDB, we use:<br>
+	`-p %`
+
+> Note that KDB will still be used to perform the actions you want to perform
+> with the `kdb` tool.
 
 ## BOOKMARKS
 

--- a/doc/help/kdb.md
+++ b/doc/help/kdb.md
@@ -76,7 +76,7 @@ For example, to permanently change verbosity one can use:
 
 Profiles allow users to change many/all configuration options of a tool
 at once. It influences from where the KDB entries are read.
-For example if you use:
+For example if you use:  
 	`kdb export -p admin system`
 
 It will read its format configuration from `/sw/elektra/kdb/#0/admin/format`.
@@ -88,8 +88,13 @@ be chosen automatically according to the current user or current working directo
 Sometimes it is useful to start with default options, for example it is not
 possible to invert the `-q` option.
 In such situations one can simply select a non-existing profile, then `-q`
-works as usual:
+works as usual:  
 	`kdb mount -p nonexist -q /abc dir/abc`
+
+There are two special profiles:
+
+- `%` is a fallback profile. It does not need to be selected and will be used if a key cannot be found in the main profile.
+- `nokdb` disables reading from `KDB`. Then only command-line arguments are used.
 
 ## BOOKMARKS
 

--- a/doc/man/kdb.1
+++ b/doc/man/kdb.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "KDB" "1" "October 2017" "" ""
+.TH "KDB" "1" "December 2017" "" ""
 .
 .SH "NAME"
 \fBkdb\fR \- key database access tools
@@ -86,7 +86,10 @@ Be verbose for every tool\.
 Be quiet for every tool\.
 .
 .SH "PROFILES"
-Profiles allow users to change many/all configuration options of a tool at once\. It influences from where the KDB entries are read\. For example if you use: \fBkdb export \-p admin system\fR
+Profiles allow users to change many/all configuration options of a tool at once\. It influences from where the KDB entries are read\. For example if you use:
+.
+.br
+\fBkdb export \-p admin system\fR
 .
 .P
 It will read its format configuration from \fB/sw/elektra/kdb/#0/admin/format\fR\.
@@ -95,7 +98,21 @@ It will read its format configuration from \fB/sw/elektra/kdb/#0/admin/format\fR
 If you want different configuration per user or directories, you should prefer to use the \fBuser\fR and \fBdir\fR namespaces\. Then the correct configuration will be chosen automatically according to the current user or current working directory\.
 .
 .P
-Sometimes it is useful to start with default options, for example it is not possible to invert the \fB\-q\fR option\. In such situations one can simply select a non\-existing profile, then \fB\-q\fR works as usual: \fBkdb mount \-p nonexist \-q /abc dir/abc\fR
+Sometimes it is useful to start with default options, for example it is not possible to invert the \fB\-q\fR option\. In such situations one can simply select a non\-existing profile, then \fB\-q\fR works as usual:
+.
+.br
+\fBkdb mount \-p nonexist \-q /abc dir/abc\fR
+.
+.P
+There are two special profiles:
+.
+.IP "\(bu" 4
+\fB%\fR is a fallback profile\. It does not need to be selected and will be used if a key cannot be found in the main profile\.
+.
+.IP "\(bu" 4
+\fBnokdb\fR disables reading from \fBKDB\fR\. Then only command\-line arguments are used\.
+.
+.IP "" 0
 .
 .SH "BOOKMARKS"
 Elektra recommends to use rather long paths \fI/doc/tutorials/application\-integration\.md\fR because it ensures flexibility in the future (e\.g\. to use profiles and have a compatible path for new major versions of configuration)\.

--- a/doc/man/kdb.1
+++ b/doc/man/kdb.1
@@ -106,13 +106,13 @@ Sometimes it is useful to start with default options, for example it is not poss
 .P
 There are two special profiles:
 .
-.IP "\(bu" 4
-\fB%\fR is a fallback profile\. It does not need to be selected and will be used if a key cannot be found in the main profile\.
+.TP
+\fB%\fR
+Is a fallback profile\. It does not need to be selected and will be used if a key cannot be found in the main profile\.
 .
-.IP "\(bu" 4
-\fBnokdb\fR disables reading from \fBKDB\fR\. Then only command\-line arguments are used\.
-.
-.IP "" 0
+.TP
+\fBnokdb\fR
+Disables reading from \fBKDB\fR\. Then only command\-line arguments are used\.
 .
 .SH "BOOKMARKS"
 Elektra recommends to use rather long paths \fI/doc/tutorials/application\-integration\.md\fR because it ensures flexibility in the future (e\.g\. to use profiles and have a compatible path for new major versions of configuration)\.

--- a/doc/man/kdb.1
+++ b/doc/man/kdb.1
@@ -64,15 +64,15 @@ The \fBkdb\fR utility reads its own configuration from three sources within the 
 /sw/kdb/\fBprofile\fR/ (for legacy configuration)
 .
 .IP "2." 4
-/sw/elektra/kdb/#0/%/ (for empty profile)
+/sw/elektra/kdb/#0/%/ (for empty profile, \fB%\fR in Elektra is used to represent a emptiness)
 .
 .IP "3." 4
-/sw/elektra/kdb/#0/\fBprofile\fR/ (for current profile)
+/sw/elektra/kdb/#0/\fBprofile\fR/ (for current profile, if no \fB\-p\fR or \fB\-\-profile\fR is given, \fBcurrent\fR will be used)
 .
 .IP "" 0
 .
 .P
-The last source where a configuration value is found, wins\.
+Here the last source where a configuration value is found, wins\.
 .
 .P
 For example, to permanently change verbosity one can use:
@@ -85,8 +85,22 @@ Be verbose for every tool\.
 \fBkdb set /sw/elektra/kdb/#0/current/quiet 1\fR
 Be quiet for every tool\.
 .
+.P
+If \fB%\fR is passed to \fB\-p\fR or \fB\-\-profile\fR, the KDB will not be consulted for configuration and only the command\-line arguments are used\.
+.
 .SH "PROFILES"
-Profiles allow users to change many/all configuration options of a tool at once\. It influences from where the KDB entries are read\. For example if you use:
+Profiles allow users to change many/all configuration settings of a tool at once\. It influences from where the KDB entries are read\. Without a \fB\-p\fR or \fB\-\-profile\fR argument following profiles are used (in the order of preference):
+.
+.TP
+\fBcurrent\fR
+Is the profile to be used only if no \fB\-p\fR argument was used\.
+.
+.TP
+\fB%\fR
+Is the fallback profile\. It will be used if keys cannot be found in the main profile\.
+.
+.P
+For example if you use:
 .
 .br
 \fBkdb export \-p admin system\fR
@@ -104,15 +118,19 @@ Sometimes it is useful to start with default options, for example it is not poss
 \fBkdb mount \-p nonexist \-q /abc dir/abc\fR
 .
 .P
-There are two special profiles:
+If \fB%\fR is used as profile name for \fB\-p\fR, the \fBkdb\fR tools disables reading from \fBKDB\fR for their own configuration settings\. Then, they only use command\-line arguments\.
 .
-.TP
-\fB%\fR
-Is a fallback profile\. It does not need to be selected and will be used if a key cannot be found in the main profile\.
+.P
+To explicitly state the default behavior, we use:
 .
-.TP
-\fBnokdb\fR
-Disables reading from \fBKDB\fR\. Then only command\-line arguments are used\.
+.br
+\fB\-p current\fR
+.
+.P
+To state that we do not want to read any configuration settings for \fBkdb\fR from KDB, we use:
+.
+.br
+\fB\-p %\fR
 .
 .SH "BOOKMARKS"
 Elektra recommends to use rather long paths \fI/doc/tutorials/application\-integration\.md\fR because it ensures flexibility in the future (e\.g\. to use profiles and have a compatible path for new major versions of configuration)\.

--- a/src/tools/kdb/cmdline.cpp
+++ b/src/tools/kdb/cmdline.cpp
@@ -273,7 +273,7 @@ Cmdline::Cmdline (int argc, char ** argv, Command * command)
 	}
 
 
-	if (profile != "nokdb")
+	if (profile != "%")
 	{
 		try
 		{

--- a/src/tools/kdb/cmdline.cpp
+++ b/src/tools/kdb/cmdline.cpp
@@ -273,70 +273,70 @@ Cmdline::Cmdline (int argc, char ** argv, Command * command)
 	}
 
 
-	try
-	{
-		using namespace kdb;
-		/*XXX: Step 4: use default from KDB, if available.*/
-		KDB kdb;
-		KeySet conf;
-
-		for (int i = 0; i <= 2; ++i)
+	if (profile != "nokdb") try
 		{
-			std::string dirname;
-			switch (i)
+			using namespace kdb;
+			/*XXX: Step 4: use default from KDB, if available.*/
+			KDB kdb;
+			KeySet conf;
+
+			for (int i = 0; i <= 2; ++i)
 			{
-			// prefer later dirnames (will override)
-			case 0:
-				dirname = "/sw/kdb/" + profile + "/";
-				break; // legacy
-			case 1:
-				dirname = "/sw/elektra/kdb/#0/%/";
-				break; // no profile
-			case 2:
-				dirname = "/sw/elektra/kdb/#0/" + profile + "/";
-				break; // current profile
+				std::string dirname;
+				switch (i)
+				{
+				// prefer later dirnames (will override)
+				case 0:
+					dirname = "/sw/kdb/" + profile + "/";
+					break; // legacy
+				case 1:
+					dirname = "/sw/elektra/kdb/#0/%/";
+					break; // no profile
+				case 2:
+					dirname = "/sw/elektra/kdb/#0/" + profile + "/";
+					break; // current profile
+				}
+
+				kdb.get (conf, dirname);
+
+				Key k = conf.lookup (dirname + "resolver");
+				if (k) resolver = k.get<string> ();
+
+				k = conf.lookup (dirname + "format");
+				if (k) format = k.get<string> ();
+
+				k = conf.lookup (dirname + "plugins");
+				if (k) plugins = k.get<string> ();
+
+				k = conf.lookup (dirname + "plugins/global");
+				if (k) globalPlugins = k.get<string> ();
+
+				k = conf.lookup (dirname + "namespace");
+				if (k) ns = k.get<string> ();
+
+				k = conf.lookup (dirname + "verbose");
+				if (k) verbose = k.get<bool> ();
+
+				k = conf.lookup (dirname + "quiet");
+				if (k) quiet = k.get<bool> ();
+
+				k = conf.lookup (dirname + "editor");
+				if (k) editor = k.get<string> ();
+
+				k = conf.lookup (dirname + "recommends");
+				if (k) withRecommends = k.get<bool> ();
+
+				map nks = conf.get<map> (dirname + "bookmarks");
+				bookmarks.insert (nks.begin (), nks.end ());
+
+				k = conf.lookup (dirname + "color");
+				if (k) color = k.get<std::string> ();
 			}
-
-			kdb.get (conf, dirname);
-
-			Key k = conf.lookup (dirname + "resolver");
-			if (k) resolver = k.get<string> ();
-
-			k = conf.lookup (dirname + "format");
-			if (k) format = k.get<string> ();
-
-			k = conf.lookup (dirname + "plugins");
-			if (k) plugins = k.get<string> ();
-
-			k = conf.lookup (dirname + "plugins/global");
-			if (k) globalPlugins = k.get<string> ();
-
-			k = conf.lookup (dirname + "namespace");
-			if (k) ns = k.get<string> ();
-
-			k = conf.lookup (dirname + "verbose");
-			if (k) verbose = k.get<bool> ();
-
-			k = conf.lookup (dirname + "quiet");
-			if (k) quiet = k.get<bool> ();
-
-			k = conf.lookup (dirname + "editor");
-			if (k) editor = k.get<string> ();
-
-			k = conf.lookup (dirname + "recommends");
-			if (k) withRecommends = k.get<bool> ();
-
-			map nks = conf.get<map> (dirname + "bookmarks");
-			bookmarks.insert (nks.begin (), nks.end ());
-
-			k = conf.lookup (dirname + "color");
-			if (k) color = k.get<std::string> ();
 		}
-	}
-	catch (kdb::KDBException const & ce)
-	{
-		std::cerr << "Sorry, I could not fetch my own configuration:\n" << ce.what () << std::endl;
-	}
+		catch (kdb::KDBException const & ce)
+		{
+			std::cerr << "Sorry, I could not fetch my own configuration:\n" << ce.what () << std::endl;
+		}
 
 	// reinit
 	index = 0;

--- a/src/tools/kdb/cmdline.cpp
+++ b/src/tools/kdb/cmdline.cpp
@@ -273,7 +273,9 @@ Cmdline::Cmdline (int argc, char ** argv, Command * command)
 	}
 
 
-	if (profile != "nokdb") try
+	if (profile != "nokdb")
+	{
+		try
 		{
 			using namespace kdb;
 			/*XXX: Step 4: use default from KDB, if available.*/
@@ -337,6 +339,7 @@ Cmdline::Cmdline (int argc, char ** argv, Command * command)
 		{
 			std::cerr << "Sorry, I could not fetch my own configuration:\n" << ce.what () << std::endl;
 		}
+	}
 
 	// reinit
 	index = 0;

--- a/src/tools/kdb/external.cpp
+++ b/src/tools/kdb/external.cpp
@@ -142,37 +142,40 @@ void runManPage (std::string command, std::string profile)
 	const char * man = "/usr/bin/man";
 	using namespace kdb;
 	Key k = nullptr;
-	try
+	if (profile != "nokdb")
 	{
-		KDB kdb;
-		KeySet conf;
-		std::string dirname;
-		for (int i = 0; i <= 2; ++i)
+		try
 		{
-			switch (i)
+			KDB kdb;
+			KeySet conf;
+			std::string dirname;
+			for (int i = 0; i <= 2; ++i)
 			{
-			case 0:
-				dirname = "/sw/elektra/kdb/#0/" + profile + "/";
-				break;
-			case 1:
-				dirname = "/sw/elektra/kdb/#0/%/";
-				break;
-			case 2:
-				dirname = "/sw/kdb/" + profile + "/";
-				break; // legacy
-			}
-			kdb.get (conf, dirname);
-			if (!k) // first one wins, because we do not reassign
-			{
-				k = conf.lookup (dirname + "man");
+				switch (i)
+				{
+				case 0:
+					dirname = "/sw/elektra/kdb/#0/" + profile + "/";
+					break;
+				case 1:
+					dirname = "/sw/elektra/kdb/#0/%/";
+					break;
+				case 2:
+					dirname = "/sw/kdb/" + profile + "/";
+					break; // legacy
+				}
+				kdb.get (conf, dirname);
+				if (!k) // first one wins, because we do not reassign
+				{
+					k = conf.lookup (dirname + "man");
+				}
 			}
 		}
-	}
-	catch (kdb::KDBException const & ce)
-	{
-		std::cerr << "There is a severe problem with your installation!\n"
-			  << "kdbOpen() failed with the info:" << std::endl
-			  << ce.what () << std::endl;
+		catch (kdb::KDBException const & ce)
+		{
+			std::cerr << "There is a severe problem with your installation!\n"
+				  << "kdbOpen() failed with the info:" << std::endl
+				  << ce.what () << std::endl;
+		}
 	}
 	if (k)
 	{


### PR DESCRIPTION
# Purpose

When KDB is severely broken (e.g. KDB.get does not work) currently the kdb tool always emits errors when trying to read its own configuration.

This is a proposal to add the profile "nokdb" which allows to not use KDB for the configuration of the kdb-tool. (Of course the main actions of `kdb` still use KDB.)

- This idea might be a misfeature (to give profiles a semantics), so I thought it would be good to discuss it first.
- The formatting is not really nice.

# Checklist

Please only check relevant points.
For docu fixes, spell checking and similar nothing
needs to be checked.

- [X] commit messages are fine (with references to issues)

TODO:

- [ ] I added unit tests
- [ ] I ran all tests and everything went fine
- [ ] affected documentation is fixed
- [ ] I added code comments, logging, and assertions (see doc/CODING.md)
- [ ] meta data is updated (e.g. README.md of plugins)
- [ ] release notes are updated (doc/news/_preparation_next_release.md)
