### PR TITLE
Sanitizer: Ignore Issues in Old Versions of `libstdc++`

### DIFF
--- a/cmake/ElektraCompiling.cmake
+++ b/cmake/ElektraCompiling.cmake
@@ -97,7 +97,7 @@ endif ()
 
 if (ENABLE_ASAN)
 	set (EXTRA_FLAGS "${EXTRA_FLAGS} -fsanitize=undefined -fsanitize=address -fno-omit-frame-pointer")
-	if (NOT APPLE AND CMAKE_COMPILER_IS_GNUCXX)
+	if (NOT (APPLE OR ("${CMAKE_C_COMPILER_ID}" STREQUAL "Clang" AND "${CMAKE_C_COMPILER_VERSION}" VERSION_GREATER "4.0")))
 		set (CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -lubsan")
 	endif ()
 	set (ASAN_LIBRARY "-lasan") #this is needed for GIR to put asan in front

--- a/doc/man/elektra-merge-strategy.7
+++ b/doc/man/elektra-merge-strategy.7
@@ -32,23 +32,23 @@ The three\-way merge works by comparing the \fBours\fR KeySet and the \fBtheirs\
 .SH "STRATEGIES"
 Currently the following strategies exist:
 .
-.TP
-preserve
-Automerge only those keys where just one side deviates from base (default)\.
+.IP "\(bu" 4
+preserve: Automerge only those keys where just one side deviates from base (default)\.
 .
-.TP
-ours
-Whenever a conflict exists, use our version\.
+.IP "\(bu" 4
+ours: Whenever a conflict exists, use our version\.
 .
-.TP
-theirs
-Whenever a conflict exists, use their version\.
+.IP "\(bu" 4
+theirs: Whenever a conflict exists, use their version\.
 .
-.TP
-cut
-Removes existing keys below the resultpath and replaces them with the merged keyset\.
+.IP "\(bu" 4
+cut: Removes existing keys below the resultpath and replaces them with the merged keyset\.
 .
-.TP
-import
-Preserves existing keys in the resultpath if they do not exist in the merged keyset\. If the key does exist in the merged keyset, it will be overwritten\. (avoid using it)
+.IP "\(bu" 4
+unchanged: (EXPERIMENTAL, only for kdb\-mount) Do not fail if the operation does not change anything\.
+.
+.IP "\(bu" 4
+import: (DEPRECATED, avoid using it) Preserves existing keys in the resultpath if they do not exist in the merged keyset\. If the key does exist in the merged keyset, it will be overwritten\.
+.
+.IP "" 0
 

--- a/doc/man/kdb-mount.1
+++ b/doc/man/kdb-mount.1
@@ -87,6 +87,9 @@ For cascading mountpoints (starting with \fB/\fR) a mountpoint for the namespace
 .IP "\(bu" 4
 \fB\-W\fR, \fB\-\-with\-recommends\fR: Also add recommended plugins and warn if they are not available\.
 .
+.IP "\(bu" 4
+\fB\-f\fR, \fB\-\-force\fR: Unmount before mounting: Does not fail on already existing mountpoints\.
+.
 .IP "" 0
 .
 .SH "KDB"

--- a/scripts/run_asan
+++ b/scripts/run_asan
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-ASAN_OPTIONS=symbolize=1 ASAN_SYMBOLIZER_PATH=$(shell which llvm-symbolizer) make run_all
+ASAN_OPTIONS=symbolize=1 ASAN_SYMBOLIZER_PATH=$(which llvm-symbolizer) make run_all

--- a/src/include/kdbprivate.h
+++ b/src/include/kdbprivate.h
@@ -519,7 +519,6 @@ int elektraUnescapeKeyNamePartBegin (const char * source, size_t size, char ** d
 char * elektraUnescapeKeyNamePart (const char * source, size_t size, char * dest);
 
 
-
 /*Internally used for array handling*/
 int elektraValidateKeyName (const char * name, size_t size);
 int elektraReadArrayNumber (const char * baseName, kdb_long_long_t * oldIndex);

--- a/src/libs/tools/src/plugin.cpp
+++ b/src/libs/tools/src/plugin.cpp
@@ -94,6 +94,13 @@ void Plugin::uninit ()
 }
 
 void Plugin::loadInfo ()
+#if defined(__clang__)
+	// We disable the undefined behavior sanitizer here, because otherwise the last line in this function produces the following error:
+	// `runtime error: call to function (unknown) through pointer to incorrect function type`.
+	// - See also: https://github.com/ElektraInitiative/libelektra/pull/1728
+	// - TODO: Fix the undefined behavior
+	__attribute__ ((no_sanitize ("undefined")))
+#endif
 {
 	Key infoKey ("system/elektra/modules", KEY_END);
 	infoKey.addBaseName (spec.getName ());
@@ -385,6 +392,10 @@ int Plugin::close (kdb::Key & errorKey)
 }
 
 int Plugin::get (kdb::KeySet & ks, kdb::Key & parentKey)
+#if defined(__clang__)
+	// See `Plugin::loadInfo`
+	__attribute__ ((no_sanitize ("undefined")))
+#endif
 {
 	if (!plugin->kdbGet)
 	{
@@ -395,6 +406,10 @@ int Plugin::get (kdb::KeySet & ks, kdb::Key & parentKey)
 }
 
 int Plugin::set (kdb::KeySet & ks, kdb::Key & parentKey)
+#if defined(__clang__)
+	// See `Plugin::loadInfo`
+	__attribute__ ((no_sanitize ("undefined")))
+#endif
 {
 	if (!plugin->kdbSet)
 	{

--- a/tests/sanitizer.blacklist
+++ b/tests/sanitizer.blacklist
@@ -5,3 +5,5 @@ src:*xerces/*.hpp
 # memory leaks reported by asan in botan, no issue according to valgrind
 src:*crypto/botan_operations.cpp
 src:*botan/*.h
+# Memory leaks in `libstdc++`
+src:*4.*/bits/stl_tree.h

--- a/tests/shell/shell_recorder/CMakeLists.txt
+++ b/tests/shell/shell_recorder/CMakeLists.txt
@@ -47,12 +47,7 @@ if (ENABLE_KDB_TESTING)
 		"script.esr"
 	)
 
-	# Only add the tests below if they work using the current configuration
-	list (FIND REMOVED_PLUGINS mini PLUGIN_INDEX)
-	if (${PLUGIN_INDEX} EQUAL -1)
-		list (APPEND SCRIPT_TESTS "selftest.esr")
-	endif (${PLUGIN_INDEX} EQUAL -1)
-
+	# Only add the tests below if it works using the current configuration
 	list (FIND REMOVED_PLUGINS ni PLUGIN_INDEX)
 	if (${PLUGIN_INDEX} EQUAL -1)
 		list (APPEND SCRIPT_TESTS "mathcheck.esr")
@@ -68,6 +63,18 @@ if (ENABLE_KDB_TESTING)
 
 		set_property(TEST testshell_${testname_we} PROPERTY LABELS memleak kdbtests)
 	endforeach (name ${SCRIPT_TESTS})
+
+	# The tests below might fail on Linux if ASAN is enabled
+	# The problem might be related to a call of a function via a pointer of incorrect type
+	# See also: https://github.com/ElektraInitiative/libelektra/pull/1728
+	set (ASAN_LINUX ENABLE_ASAN AND ${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+	if (NOT (${ASAN_LINUX} AND CMAKE_CXX_COMPILER_ID MATCHES "Clang" AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 4))
+		# Only add the test below if it works using the current configuration
+		list (FIND REMOVED_PLUGINS mini PLUGIN_INDEX)
+		if (${PLUGIN_INDEX} EQUAL -1)
+			list (APPEND SCRIPT_TESTS "selftest.esr")
+		endif (${PLUGIN_INDEX} EQUAL -1)
+	endif (NOT (${ASAN_LINUX} AND CMAKE_CXX_COMPILER_ID MATCHES "Clang" AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 4))
 
 	if (ENABLE_REPLAY_TESTS)
 		file (GLOB REPLAY_TESTS replay_tests/*.esr)

--- a/tests/shell/shell_recorder/CMakeLists.txt
+++ b/tests/shell/shell_recorder/CMakeLists.txt
@@ -47,7 +47,12 @@ if (ENABLE_KDB_TESTING)
 		"script.esr"
 	)
 
-	# Only add the test below if it works using the current configuration
+	# Only add the tests below if they work using the current configuration
+	list (FIND REMOVED_PLUGINS mini PLUGIN_INDEX)
+	if (${PLUGIN_INDEX} EQUAL -1)
+		list (APPEND SCRIPT_TESTS "selftest.esr")
+	endif (${PLUGIN_INDEX} EQUAL -1)
+
 	list (FIND REMOVED_PLUGINS ni PLUGIN_INDEX)
 	if (${PLUGIN_INDEX} EQUAL -1)
 		list (APPEND SCRIPT_TESTS "mathcheck.esr")
@@ -64,32 +69,20 @@ if (ENABLE_KDB_TESTING)
 		set_property(TEST testshell_${testname_we} PROPERTY LABELS memleak kdbtests)
 	endforeach (name ${SCRIPT_TESTS})
 
-	# The tests below might fail on Linux if ASAN is enabled because of problematic code in `stl_tree.h`
-	# The cause of this seems to be a bug in old versions of `libstdc++`:
-	# http://lists.llvm.org/pipermail/cfe-dev/2013-August/031194.html
-	set (ASAN_LINUX ENABLE_ASAN AND ${CMAKE_SYSTEM_NAME} MATCHES "Linux")
-	if (NOT (${ASAN_LINUX} AND CMAKE_CXX_COMPILER_ID MATCHES "Clang" AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 5))
-		# Only add the test below if it works using the current configuration
-		list (FIND REMOVED_PLUGINS mini PLUGIN_INDEX)
-		if (${PLUGIN_INDEX} EQUAL -1)
-			list (APPEND SCRIPT_TESTS "selftest.esr")
-		endif (${PLUGIN_INDEX} EQUAL -1)
-
-		if (ENABLE_REPLAY_TESTS)
-			file (GLOB REPLAY_TESTS replay_tests/*.esr)
-			foreach (file ${REPLAY_TESTS})
-				get_filename_component (directory ${file} DIRECTORY)
-				get_filename_component (name_without_extension ${file} NAME_WE)
-				add_test (
-					testshell_replay_${name_without_extension}
-					"${CMAKE_CURRENT_BINARY_DIR}/shell_recorder.sh"
-					"${file}"
-					"${directory}/${name_without_extension}.epf"
-					)
-				set_property(TEST testshell_replay_${name_without_extension} PROPERTY LABELS memleak kdbtests)
-			endforeach (file ${SCRIPT_TESTS})
-		endif (ENABLE_REPLAY_TESTS)
-	endif (NOT (${ASAN_LINUX} AND CMAKE_CXX_COMPILER_ID MATCHES "Clang" AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 5))
+	if (ENABLE_REPLAY_TESTS)
+		file (GLOB REPLAY_TESTS replay_tests/*.esr)
+		foreach (file ${REPLAY_TESTS})
+			get_filename_component (directory ${file} DIRECTORY)
+			get_filename_component (name_without_extension ${file} NAME_WE)
+			add_test (
+				testshell_replay_${name_without_extension}
+				"${CMAKE_CURRENT_BINARY_DIR}/shell_recorder.sh"
+				"${file}"
+				"${directory}/${name_without_extension}.epf"
+				)
+			set_property(TEST testshell_replay_${name_without_extension} PROPERTY LABELS memleak kdbtests)
+		endforeach (file ${SCRIPT_TESTS})
+	endif (ENABLE_REPLAY_TESTS)
 
 	add_subdirectory (tutorial_wrapper)
 endif (ENABLE_KDB_TESTING)

--- a/tests/shell/shell_recorder/selftest.esr
+++ b/tests/shell/shell_recorder/selftest.esr
@@ -14,7 +14,7 @@ STDOUT: Set string to "value"
 STDOUT-REGEX: .*value.
 < kdb set $Mountpoint/key value
 
-STDERR: The command kdb not-a-command is not known
+STDERR: The command kdb.* not-a-command is not known
 < kdb not-a-command 1>/dev/null
 
 STDERR: .+not-a-command.+

--- a/tests/shell/shell_recorder/tutorial_wrapper/CMakeLists.txt
+++ b/tests/shell/shell_recorder/tutorial_wrapper/CMakeLists.txt
@@ -26,6 +26,12 @@ if (${PLUGIN_INDEX_SPEC} EQUAL -1)
 	add_s_test (kdb-global-umount "${CMAKE_SOURCE_DIR}/doc/help/kdb-global-umount.md")
 endif (${PLUGIN_INDEX_SPEC} EQUAL -1)
 
+# Only add test below if Validation plugin is available
+list (FIND REMOVED_PLUGINS validation PLUGIN_INDEX_VALIDATION)
+if (${PLUGIN_INDEX_VALIDATION} EQUAL -1)
+	add_s_test (tutorial_validation "${CMAKE_SOURCE_DIR}/doc/tutorials/validation.md")
+endif (${PLUGIN_INDEX_VALIDATION} EQUAL -1)
+
 add_s_test (readme_msr "${CMAKE_SOURCE_DIR}/tests/shell/shell_recorder/tutorial_wrapper/README.md")
 add_s_test (issue_template "${CMAKE_SOURCE_DIR}/.github/ISSUE_TEMPLATE.md")
 add_s_test (tutorial_cascading "${CMAKE_SOURCE_DIR}/doc/tutorials/cascading.md")
@@ -33,44 +39,29 @@ add_s_test (kdb-complete "${CMAKE_SOURCE_DIR}/doc/help/kdb-complete.md")
 add_s_test (kdb-ls "${CMAKE_SOURCE_DIR}/doc/help/kdb-ls.md")
 
 add_plugin_shell_test (blockresolver)
+add_plugin_shell_test (base64)
 add_plugin_shell_test (boolean)
 add_plugin_shell_test (csvstorage)
 add_plugin_shell_test (cachefilter)
 add_plugin_shell_test (camel)
 add_plugin_shell_test (conditionals)
+add_plugin_shell_test (dini)
 add_plugin_shell_test (directoryvalue)
 add_plugin_shell_test (enum)
 add_plugin_shell_test (hosts)
+add_plugin_shell_test (ini)
 add_plugin_shell_test (ipaddr)
 add_plugin_shell_test (line)
 add_plugin_shell_test (mathcheck)
+add_plugin_shell_test (mini)
 add_plugin_shell_test (mozprefs)
 add_plugin_shell_test (multifile)
 add_plugin_shell_test (range)
+add_plugin_shell_test (tcl)
 add_plugin_shell_test (type)
 add_plugin_shell_test (xerces)
 add_plugin_shell_test (yajl)
-
-# Most of the tests below might fail on Linux if ASAN is enabled because of problematic code in `stl_tree.h`
-# The cause of this seems to be a bug in old versions of `libstdc++`:
-# http://lists.llvm.org/pipermail/cfe-dev/2013-August/031194.html
-#
-# The INI test fails because of a function call through a pointer of incorrect type
-set (ASAN_LINUX ENABLE_ASAN AND ${CMAKE_SYSTEM_NAME} MATCHES "Linux")
-if (NOT (${ASAN_LINUX} AND CMAKE_CXX_COMPILER_ID MATCHES "Clang" AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 5))
-	list (FIND REMOVED_PLUGINS validation PLUGIN_INDEX_VALIDATION)
-	if (${PLUGIN_INDEX_VALIDATION} EQUAL -1)
-		add_s_test (tutorial_validation "${CMAKE_SOURCE_DIR}/doc/tutorials/validation.md")
-	endif (${PLUGIN_INDEX_VALIDATION} EQUAL -1)
-
-	add_plugin_shell_test (base64)
-	add_plugin_shell_test (dini)
-	add_plugin_shell_test (mini)
-	add_plugin_shell_test (tcl)
-	add_plugin_shell_test (yamlcpp)
-
-	add_plugin_shell_test (ini)
-endif (NOT (${ASAN_LINUX} AND CMAKE_CXX_COMPILER_ID MATCHES "Clang" AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 5))
+add_plugin_shell_test (yamlcpp)
 
 # Only works with super user privileges, since it writes to `/etc/hosts`:
 # add_s_test (tutorial_mount "${CMAKE_SOURCE_DIR}/doc/tutorials/mount.md")

--- a/tests/shell/shell_recorder/tutorial_wrapper/CMakeLists.txt
+++ b/tests/shell/shell_recorder/tutorial_wrapper/CMakeLists.txt
@@ -26,12 +26,6 @@ if (${PLUGIN_INDEX_SPEC} EQUAL -1)
 	add_s_test (kdb-global-umount "${CMAKE_SOURCE_DIR}/doc/help/kdb-global-umount.md")
 endif (${PLUGIN_INDEX_SPEC} EQUAL -1)
 
-# Only add test below if Validation plugin is available
-list (FIND REMOVED_PLUGINS validation PLUGIN_INDEX_VALIDATION)
-if (${PLUGIN_INDEX_VALIDATION} EQUAL -1)
-	add_s_test (tutorial_validation "${CMAKE_SOURCE_DIR}/doc/tutorials/validation.md")
-endif (${PLUGIN_INDEX_VALIDATION} EQUAL -1)
-
 add_s_test (readme_msr "${CMAKE_SOURCE_DIR}/tests/shell/shell_recorder/tutorial_wrapper/README.md")
 add_s_test (issue_template "${CMAKE_SOURCE_DIR}/.github/ISSUE_TEMPLATE.md")
 add_s_test (tutorial_cascading "${CMAKE_SOURCE_DIR}/doc/tutorials/cascading.md")
@@ -39,7 +33,6 @@ add_s_test (kdb-complete "${CMAKE_SOURCE_DIR}/doc/help/kdb-complete.md")
 add_s_test (kdb-ls "${CMAKE_SOURCE_DIR}/doc/help/kdb-ls.md")
 
 add_plugin_shell_test (blockresolver)
-add_plugin_shell_test (base64)
 add_plugin_shell_test (boolean)
 add_plugin_shell_test (csvstorage)
 add_plugin_shell_test (cachefilter)
@@ -49,19 +42,33 @@ add_plugin_shell_test (dini)
 add_plugin_shell_test (directoryvalue)
 add_plugin_shell_test (enum)
 add_plugin_shell_test (hosts)
-add_plugin_shell_test (ini)
 add_plugin_shell_test (ipaddr)
 add_plugin_shell_test (line)
 add_plugin_shell_test (mathcheck)
-add_plugin_shell_test (mini)
 add_plugin_shell_test (mozprefs)
 add_plugin_shell_test (multifile)
 add_plugin_shell_test (range)
-add_plugin_shell_test (tcl)
 add_plugin_shell_test (type)
 add_plugin_shell_test (xerces)
 add_plugin_shell_test (yajl)
 add_plugin_shell_test (yamlcpp)
+
+# The tests below might fail on Linux if ASAN is enabled
+# The problem might be related to a call of a function via a pointer of incorrect type
+# See also: https://github.com/ElektraInitiative/libelektra/pull/1728
+set (ASAN_LINUX ENABLE_ASAN AND ${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+if (NOT (${ASAN_LINUX} AND CMAKE_CXX_COMPILER_ID MATCHES "Clang" AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 4))
+	# Only add test below if Validation plugin is available
+	list (FIND REMOVED_PLUGINS validation PLUGIN_INDEX_VALIDATION)
+	if (${PLUGIN_INDEX_VALIDATION} EQUAL -1)
+		add_s_test (tutorial_validation "${CMAKE_SOURCE_DIR}/doc/tutorials/validation.md")
+	endif (${PLUGIN_INDEX_VALIDATION} EQUAL -1)
+
+	add_plugin_shell_test (base64)
+	add_plugin_shell_test (ini)
+	add_plugin_shell_test (mini)
+	add_plugin_shell_test (tcl)
+endif (NOT (${ASAN_LINUX} AND CMAKE_CXX_COMPILER_ID MATCHES "Clang" AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 4))
 
 # Only works with super user privileges, since it writes to `/etc/hosts`:
 # add_s_test (tutorial_mount "${CMAKE_SOURCE_DIR}/doc/tutorials/mount.md")


### PR DESCRIPTION
# Purpose

This PR simplifies the build process by using a blacklist to ignore sanitizer problems in `libstdc++`. Before this update we would explicitly disable tests, that reported problems in `libstdc++`.

# Checklist

- [x] I checked the only commit message twice.
- [x] I ran all tests and everything went fine.
- [x] I added a code comment in the sanitizer blacklist.