### PR TITLE
Shell Recorder: Use Full or Static Version of `kdb`

### DIFF
--- a/doc/tutorials/validation.md
+++ b/doc/tutorials/validation.md
@@ -46,7 +46,7 @@ The most direct way to validate keys is
 sudo kdb mount validation.dump user/tutorial/together dump validation
 kdb vset user/tutorial/together/test 123 "[1-9][0-9]*" "Not a number"
 kdb set user/tutorial/together/test abc
-# STDERR: The command kdb set failed while accessing the key database .*
+# STDERR: The command kdb.* set failed while accessing the key database .*
 # ERROR:  42
 # RET:5
 ```

--- a/src/plugins/directoryvalue/README.md
+++ b/src/plugins/directoryvalue/README.md
@@ -5,7 +5,7 @@
 - infos/provides =
 - infos/recommends =
 - infos/placements = postgetstorage presetstorage
-- infos/status = maintained nodep preview experimental unfinished concept  discouraged
+- infos/status = maintained nodep preview
 - infos/metadata =
 - infos/description = This plugin converts directory values to leaf values
 

--- a/tests/shell/shell_recorder/CMakeLists.txt
+++ b/tests/shell/shell_recorder/CMakeLists.txt
@@ -3,6 +3,7 @@ if (ENABLE_KDB_TESTING)
 	SET(USE_CMAKE_KDB_COMMAND "")
 	if (BUILD_SHARED)
 		set (KDB_COMMAND "${CMAKE_BINARY_DIR}/bin/kdb")
+		set (ENABLE_REPLAY_TESTS TRUE)
 	elseif (BUILD_FULL)
 		set (KDB_COMMAND "${CMAKE_BINARY_DIR}/bin/kdb-full")
 	elseif (BUILD_STATIC)
@@ -74,18 +75,20 @@ if (ENABLE_KDB_TESTING)
 			list (APPEND SCRIPT_TESTS "selftest.esr")
 		endif (${PLUGIN_INDEX} EQUAL -1)
 
-		file (GLOB REPLAY_TESTS replay_tests/*.esr)
-		foreach (file ${REPLAY_TESTS})
-			get_filename_component (directory ${file} DIRECTORY)
-			get_filename_component (name_without_extension ${file} NAME_WE)
-			add_test (
-				testshell_replay_${name_without_extension}
-				"${CMAKE_CURRENT_BINARY_DIR}/shell_recorder.sh"
-				"${file}"
-				"${directory}/${name_without_extension}.epf"
-				)
-			set_property(TEST testshell_replay_${name_without_extension} PROPERTY LABELS memleak kdbtests)
-		endforeach (file ${SCRIPT_TESTS})
+		if (ENABLE_REPLAY_TESTS)
+			file (GLOB REPLAY_TESTS replay_tests/*.esr)
+			foreach (file ${REPLAY_TESTS})
+				get_filename_component (directory ${file} DIRECTORY)
+				get_filename_component (name_without_extension ${file} NAME_WE)
+				add_test (
+					testshell_replay_${name_without_extension}
+					"${CMAKE_CURRENT_BINARY_DIR}/shell_recorder.sh"
+					"${file}"
+					"${directory}/${name_without_extension}.epf"
+					)
+				set_property(TEST testshell_replay_${name_without_extension} PROPERTY LABELS memleak kdbtests)
+			endforeach (file ${SCRIPT_TESTS})
+		endif (ENABLE_REPLAY_TESTS)
 	endif (NOT (${ASAN_LINUX} AND CMAKE_CXX_COMPILER_ID MATCHES "Clang" AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 5))
 
 	add_subdirectory (tutorial_wrapper)

--- a/tests/shell/shell_recorder/CMakeLists.txt
+++ b/tests/shell/shell_recorder/CMakeLists.txt
@@ -2,12 +2,12 @@ if (ENABLE_KDB_TESTING)
 	# set kdb command
 	SET(USE_CMAKE_KDB_COMMAND "")
 	if (BUILD_SHARED)
-		set (KDB_COMMAND "${CMAKE_BINARY_DIR}/bin/kdb")
+		set (KDB_COMMAND "kdb")
 		set (ENABLE_REPLAY_TESTS TRUE)
 	elseif (BUILD_FULL)
-		set (KDB_COMMAND "${CMAKE_BINARY_DIR}/bin/kdb-full")
+		set (KDB_COMMAND "kdb-full")
 	elseif (BUILD_STATIC)
-		set (KDB_COMMAND "${CMAKE_BINARY_DIR}/bin/kdb-static")
+		set (KDB_COMMAND "kdb-static")
 	else()
 		message(SEND_ERROR "no kdb tool found, please enable BUILD_FULL, BUILD_STATIC or BUILD_SHARED")
 	endif ()
@@ -22,7 +22,7 @@ if (ENABLE_KDB_TESTING)
 		set (INCLUDE_COMMON
 			"${INCLUDE_COMMON_FILE}\n
 			KDB=\"${KDB_COMMAND}\"\n\
-			export PATH=\"`dirname \\\"$KDB\\\"`:$PATH\""
+			export PATH=\"${CMAKE_BINARY_DIR}/bin\":$PATH"
 		)
 	else (LENGTH_KDB_COMMAND EQUAL 0)
 		set (INCLUDE_COMMON "${INCLUDE_COMMON_FILE}\nKDB=\"kdb\"")

--- a/tests/shell/shell_recorder/shell_recorder.sh
+++ b/tests/shell/shell_recorder/shell_recorder.sh
@@ -34,7 +34,7 @@ execute()
 	fi
 
 	[ -z "$Storage" ] && Storage="dump"
-	command=$(printf '%s' "$proto" | sed -e "s~kdb\ ~$KDB_BINARY ~g" \
+	command=$(printf '%s' "$proto" | sed -e "s~kdb\ ~$KDB ~g" \
 					     -e "s~\$Mountpoint~${Mountpoint}~g" \
 	                                     -e "s~\$File~${DBFile}~g"           \
 	                                     -e "s~\$Storage~${Storage}~g"       \
@@ -264,7 +264,6 @@ STDERRCMP=
 
 BACKUP=0
 TMPFILE=$(mktempfile_elektra)
-KDB_BINARY=$(basename "$KDB")
 
 # variables to count up errors and tests
 nbError=0

--- a/tests/shell/shell_recorder/shell_recorder.sh
+++ b/tests/shell/shell_recorder/shell_recorder.sh
@@ -34,7 +34,8 @@ execute()
 	fi
 
 	[ -z "$Storage" ] && Storage="dump"
-	command=$(printf '%s' "$proto" | sed -e "s~\$Mountpoint~${Mountpoint}~g" \
+	command=$(printf '%s' "$proto" | sed -e "s~kdb\ ~$KDB_BINARY ~g" \
+					     -e "s~\$Mountpoint~${Mountpoint}~g" \
 	                                     -e "s~\$File~${DBFile}~g"           \
 	                                     -e "s~\$Storage~${Storage}~g"       \
 	                                     -e "s~\$MountArgs~${MountArgs}~g")
@@ -263,6 +264,7 @@ STDERRCMP=
 
 BACKUP=0
 TMPFILE=$(mktempfile_elektra)
+KDB_BINARY=$(basename "$KDB")
 
 # variables to count up errors and tests
 nbError=0


### PR DESCRIPTION
# Purpose

The Shell Recorder now uses `kdb-full` or `kdb-static` if `kdb` is unavailable. This update should hopefully fix the problems of the build job [`elektra-multiconfig-gcc47-cmake-options`](https://build.libelektra.org/job/elektra-multiconfig-gcc47-cmake-options).

# Checklist

- [x] I checked all commit messages twice.
- [x] I ran all tests and everything went fine.