### PR TITLE
Docker: add clang

### DIFF
--- a/doc/docker/Dockerfile
+++ b/doc/docker/Dockerfile
@@ -1,10 +1,11 @@
-FROM ubuntu:xenial
+FROM ubuntu:artful
 
 ARG SWIGVERSION="3.0.11"
 
 RUN apt-get -qq update && apt-get -qq -y install \
 	curl \
 	build-essential \
+	clang-5.0 clang-3.8 \
 	autotools-dev \
 	automake \
 	cmake \
@@ -26,19 +27,10 @@ RUN apt-get -qq update && apt-get -qq -y install \
 	libdbus-1-dev \
 	libpcre3-dev \
 	libpcre++-dev \
+	libglib2.0-dev \
+	swig3.0 \
 	checkinstall \
 && gem install ronn \
 && rm -rf /var/lib/apt/lists/*
-
-# install Swig 3
-RUN cd /tmp \
-&& curl -fsS "https://codeload.github.com/swig/swig/tar.gz/rel-${SWIGVERSION}" \
-| tar xz \
-&& cd "swig-rel-${SWIGVERSION}" \
-&& ./autogen.sh \
-&& ./configure \
-&& make \
-&& make install \
-&& rm -rf "/tmp/swig-rel-${SWIGVERSION}"
 
 COPY buildelektra.sh /bin/buildelektra

--- a/doc/docker/Dockerfile
+++ b/doc/docker/Dockerfile
@@ -30,6 +30,7 @@ RUN apt-get -qq update && apt-get -qq -y install \
 	libglib2.0-dev \
 	swig3.0 \
 	checkinstall \
+	valgrind \
 && gem install ronn \
 && rm -rf /var/lib/apt/lists/*
 

--- a/doc/docker/README.md
+++ b/doc/docker/README.md
@@ -1,6 +1,6 @@
 # Trying out Elektra with Docker
 
-This Dockerfile builds a dockerimage based on ubuntu:xenial including all requirements to build Elektra.
+This Dockerfile builds a dockerimage based on ubuntu:artful including all requirements to build Elektra.
 
 If [Docker](https://www.docker.com/) is available on your machine change to the directory containing the file you are currently reading and build the image with
 ```sh

--- a/doc/docker/buildelektra.sh
+++ b/doc/docker/buildelektra.sh
@@ -6,7 +6,7 @@ set -o pipefail
 __FILE="$(basename "$0")"
 
 USAGE=$(cat <<EOF
-Usage: ${__FILE} [-h] [-b NAME] [-t DIR] TAG
+Usage: ${__FILE} [-h] [-b NAME] [-t DIR] [-j JOBS] TAG
 Downloads the Elektra commit specified by TAG.
 Then builds and installs Elektra.
   -b=NAME        do not install. build a .deb package with NAME instead.
@@ -15,11 +15,14 @@ Then builds and installs Elektra.
   -t=DIR         download Elektra into DIR (relative to current working directory).
                  If DIR already exists, use sources from DIR.
                  Default DIR is './libelektra-TAG'.
+  -j=JOBS        Number of sumulateneos jobs/recipes executed by make (like make -j JOBS).
+  -c=VERSION     Use clang. Set the version to use (either 5.0 or 3.8 in this container).
+  -D=PARAMS      Pass additional parameters to cmake. Usage: -D="-DBINDINGS=cpp;glib".
   -h             display this help and exit.
 EOF
 )
 
-while getopts "hb:s:t:" opt; do
+while getopts "hb:s:t:j:c:D:" opt; do
 	case $opt in
 		h)
 			echo "${USAGE}"
@@ -33,6 +36,15 @@ while getopts "hb:s:t:" opt; do
 			;;
 		t)
 			DIR="${OPTARG}"
+			;;
+    j)
+			JOBS="${OPTARG}"
+			;;
+    c)
+			CLANG_VERSION="${OPTARG}"
+			;;
+    D)
+			CMAKE_PARAMS="${OPTARG}"
 			;;
 		:)
 			printf "%s: missing argument for -%s\n" "${__FILE}" "${OPTARG}" >&2
@@ -63,12 +75,18 @@ if [ ! -d "${DIR}" ]; then
 	curl --fail --silent --show-error ${SOURCE} | tar xz --transform "s/libelektra-${TAG}/${DIR}/"
 fi
 
+# set compiler
+if [ ! -z "${CLANG_VERSION}" ]; then
+  export CC=clang-${CLANG_VERSION}
+  export CXX=clang++-${CLANG_VERSION}
+fi
+
 # build Elektra
 if [ ! -d "${DIR}/build" ]; then
 	mkdir "${DIR}/build"
 fi
 cd "${DIR}/build"
-cmake -DCMAKE_INSTALL_PREFIX=/usr .. && make -j
+cmake -DCMAKE_INSTALL_PREFIX=/usr ${CMAKE_PARAMS} .. && make -j ${JOBS}
 
 if [ -z "${NAME}" ]; then
 	# install elektra ..


### PR DESCRIPTION
# Purpose

Install and option to compile with `clang` in the Docker container.
Also extended the build script `buildelektra.sh` with new options:

- `j` for setting number of parallel make recipes/jobs
- `c` for setting the clang version to use
- `D` for setting cmake parameters

# Checklist

- [x] commit messages are fine (with references to issues)
- [x] I ran all tests and everything went fine
- [x] affected documentation is fixed

@markus2330 please review my pull request
