### PR TITLE
cmake: use dini as default

### DIFF
--- a/cmake/ElektraCache.cmake
+++ b/cmake/ElektraCache.cmake
@@ -216,7 +216,7 @@ set (KDB_DB_INIT "elektra.ecf" CACHE STRING
 		"This configuration file will be used for bootstrapping."
 		)
 
-set (KDB_DEFAULT_STORAGE "dump" CACHE STRING
+set (KDB_DEFAULT_STORAGE "dini" CACHE STRING
 	"This storage plugin will be used initially (as default and for bootstrapping).")
 
 if (KDB_DEFAULT_STORAGE STREQUAL "storage")

--- a/doc/news/_preparation_next_release.md
+++ b/doc/news/_preparation_next_release.md
@@ -35,6 +35,7 @@ You can also read the news [on our website](https://www.libelektra.org/news/0.8.
 ## Highlights
 
 - New Logo
+- INI as new default configuration file format
 - <<HIGHLIGHT2>>
 - <<HIGHLIGHT3>>
 
@@ -47,6 +48,14 @@ It has a new shape and cooler colors.
 <img src="https://cdn.rawgit.com/ElektraInitiative/libelektra/master/doc/images/circle.svg" alt="Elektra" width="150" />
 
 Thanks to <<TODO>>
+
+### INI as new Default Configuration File Format
+
+As promised in the [previous release notes](https://www.libelektra.org/news/0.8.21-release.html) we switched to INI as default format.
+The migration will be smoothly: The `dini` plugin makes sure that old dump files are still being read.
+Only when writing out configuration files, configuration files are converted to INI.
+
+TODO: write a bit about INI syntax+short guide
 
 
 ### <<HIGHLIGHT1>>
@@ -80,6 +89,7 @@ compiled against an older 0.8 version of Elektra will continue to work
 
 These notes are of interest for people maintaining packages of Elektra:
 
+- `dini` is no longer experimental.
 - <<TODO>>
 
 ## Notes for Elektra's Developers

--- a/scripts/configure-mingw-w64
+++ b/scripts/configure-mingw-w64
@@ -18,8 +18,9 @@ cmake	-DENABLE_TESTING=OFF \
 	-DBUILD_STATIC=ON \
 	-DBUILD_FULL=ON \
 	-DBUILD_SHARED=OFF \
-	-DPLUGINS="wresolver;dump;dini;ini;base64" \
+	-DPLUGINS="wresolver;dump" \
 	-DKDB_DEFAULT_RESOLVER=wresolver  \
+	-DKDB_DEFAULT_STORAGE=dump \
 	-DKDB_DB_SYSTEM=kdb -DKDB_DB_SPEC=spec \
 	-DBUILD_DOCUMENTATION=OFF \
 	-DCMAKE_PIC_FLAGS="" \

--- a/scripts/configure-mingw-w64
+++ b/scripts/configure-mingw-w64
@@ -18,7 +18,7 @@ cmake	-DENABLE_TESTING=OFF \
 	-DBUILD_STATIC=ON \
 	-DBUILD_FULL=ON \
 	-DBUILD_SHARED=OFF \
-	-DPLUGINS="wresolver;dump" \
+	-DPLUGINS="wresolver;dump;dini;ini;base64" \
 	-DKDB_DEFAULT_RESOLVER=wresolver  \
 	-DKDB_DB_SYSTEM=kdb -DKDB_DB_SPEC=spec \
 	-DBUILD_DOCUMENTATION=OFF \

--- a/scripts/configure-xdg
+++ b/scripts/configure-xdg
@@ -5,7 +5,7 @@ SCRIPTS_DIR=$(dirname "$0")
 
 XDG_RESOLVER="resolver_mf_xp_x"
 
-cd $BUILD
+cd "$BUILD"
 cmake	-DPLUGINS="$XDG_RESOLVER;dump;sync;ini;dini;base64;spec;error;list;timeofday;profile;mathcheck;tracer;hosts;network;glob" \
 	-DKDB_DEFAULT_RESOLVER="$XDG_RESOLVER" \
 	$*

--- a/scripts/configure-xdg
+++ b/scripts/configure-xdg
@@ -6,6 +6,6 @@ SCRIPTS_DIR=$(dirname "$0")
 XDG_RESOLVER="resolver_mf_xp_x"
 
 cd $BUILD
-cmake	-DPLUGINS="$XDG_RESOLVER;dump;sync;spec;error;list;timeofday;profile;mathcheck;tracer;hosts;network;glob" \
+cmake	-DPLUGINS="$XDG_RESOLVER;dump;sync;ini;dini;base64;spec;error;list;timeofday;profile;mathcheck;tracer;hosts;network;glob" \
 	-DKDB_DEFAULT_RESOLVER="$XDG_RESOLVER" \
 	$*

--- a/src/plugins/dini/README.md
+++ b/src/plugins/dini/README.md
@@ -5,7 +5,7 @@
 - infos/provides = storage/ini
 - infos/recommends =
 - infos/placements = getstorage setstorage
-- infos/status = recommended productive maintained conformant compatible shelltest tested nodep libc experimental concept
+- infos/status = recommended productive maintained conformant compatible shelltest tested nodep libc
 - infos/metadata =
 - infos/description = default INI plugin
 

--- a/src/plugins/ini/ini.c
+++ b/src/plugins/ini/ini.c
@@ -1284,7 +1284,6 @@ static int iniWriteKeySet (FILE * fh, Key * parentKey, KeySet * returned, IniPlu
 						sectionKey = keyNew (keyString (parentMeta), KEY_END);
 						if (!keyIsBelow (oldSectionKey, sectionKey))
 						{
-							removeSectionKey = 1;
 							if (keyIsBelow (parentKey, sectionKey))
 							{
 								char * name = getIniName (parentKey, sectionKey);
@@ -1315,6 +1314,15 @@ static int iniWriteKeySet (FILE * fh, Key * parentKey, KeySet * returned, IniPlu
 								else
 									fprintf (fh, "[]\n");
 							}
+
+							if (removeSectionKey)
+							{
+								// remove previous sectionKey
+								keyDel (oldSectionKey);
+							}
+
+							// mark allocated sectionKey to be freed later
+							removeSectionKey = 1;
 						}
 						else
 						{

--- a/src/plugins/ini/ini.c
+++ b/src/plugins/ini/ini.c
@@ -1263,9 +1263,12 @@ static int iniWriteKeySet (FILE * fh, Key * parentKey, KeySet * returned, IniPlu
 				}
 				else
 				{
-					if (removeSectionKey) keyDel (sectionKey);
+					if (removeSectionKey)
+					{
+						keyDel (sectionKey);
+						removeSectionKey = 0;
+					}
 					sectionKey = parentKey;
-					removeSectionKey = 0;
 					fprintf (fh, "[]\n");
 				}
 			}

--- a/src/plugins/ini/ini.c
+++ b/src/plugins/ini/ini.c
@@ -1263,7 +1263,9 @@ static int iniWriteKeySet (FILE * fh, Key * parentKey, KeySet * returned, IniPlu
 				}
 				else
 				{
+					if (removeSectionKey) keyDel (sectionKey);
 					sectionKey = parentKey;
+					removeSectionKey = 0;
 					fprintf (fh, "[]\n");
 				}
 			}
@@ -1315,6 +1317,7 @@ static int iniWriteKeySet (FILE * fh, Key * parentKey, KeySet * returned, IniPlu
 						{
 							keyDel (sectionKey);
 							sectionKey = oldSectionKey;
+							removeSectionKey = 0;
 						}
 					}
 				}


### PR DESCRIPTION
# Purpose

Change default storage plugin to dini

# Checklist

Please only check relevant points.
For docu fixes, spell checking and similar nothing
needs to be checked.

- [x] commit messages are fine (with references to issues)
- [ ] I added unit tests
- [ ] I ran all tests and everything went fine
- [ ] affected documentation is fixed
- [ ] I added code comments, logging, and assertions (see doc/CODING.md)
- [ ] meta data is updated (e.g. README.md of plugins)
- [ ] release notes are updated (doc/news/_preparation_next_release.md)
