### PR TITLE
Travis: Always Consider Exit Status of `run_all`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -163,7 +163,6 @@ script:
       # Unfortunately the Haskell tests do not work currently:
       # https://github.com/ElektraInitiative/libelektra/issues/1631
       if [[ "$HASKELL" != "ON" ]]; then
-        ninja run_all
-        kdb run_all
+        ninja run_all && kdb run_all
       fi
     fi


### PR DESCRIPTION
# Purpose

This commit should fix the problem reported in issue #1764.

# Checklist

- [x] I checked the commit message. The issue reference in commit dfcd490 should be correct.