### PR TITLE
fix-kdb-complete-heap-overflow

### DIFF
--- a/src/tools/kdb/complete.cpp
+++ b/src/tools/kdb/complete.cpp
@@ -354,7 +354,7 @@ bool CompleteCommand::filterCascading (string const & argument, pair<Key, pair<i
 {
 	// For a cascading key completion, ignore the preceding namespace
 	const string test = current.first.getFullName ();
-	int cascadationOffset = test.find ("/");
+	size_t cascadationOffset = test.find ("/");
 	if (cascadationOffset == string::npos)
 	{
 		cascadationOffset = 0;

--- a/src/tools/kdb/complete.cpp
+++ b/src/tools/kdb/complete.cpp
@@ -359,7 +359,7 @@ bool CompleteCommand::filterCascading (string const & argument, pair<Key, pair<i
 	{
 		cascadationOffset = 0;
 	}
-	return argument.size () <= test.size () - cascadationOffset && equal (argument.begin (), argument.end (), test.begin ());
+	return argument.size () <= test.size () - cascadationOffset && equal (argument.begin (), argument.end (), test.begin () + cascadationOffset);
 }
 
 bool CompleteCommand::filterName (string const & argument, pair<Key, pair<int, int>> const & current)

--- a/src/tools/kdb/complete.cpp
+++ b/src/tools/kdb/complete.cpp
@@ -359,7 +359,8 @@ bool CompleteCommand::filterCascading (string const & argument, pair<Key, pair<i
 	{
 		cascadationOffset = 0;
 	}
-	return argument.size () <= test.size () - cascadationOffset && equal (argument.begin (), argument.end (), test.begin () + cascadationOffset);
+	return argument.size () <= test.size () - cascadationOffset &&
+	       equal (argument.begin (), argument.end (), test.begin () + cascadationOffset);
 }
 
 bool CompleteCommand::filterName (string const & argument, pair<Key, pair<int, int>> const & current)

--- a/src/tools/kdb/complete.cpp
+++ b/src/tools/kdb/complete.cpp
@@ -359,7 +359,7 @@ bool CompleteCommand::filterCascading (string const & argument, pair<Key, pair<i
 	{
 		cascadationOffset = 0;
 	}
-	return argument.size () <= test.size () && equal (argument.begin (), argument.end (), test.begin () + cascadationOffset);
+	return argument.size () <= test.size () - cascadationOffset && equal (argument.begin (), argument.end (), test.begin ());
 }
 
 bool CompleteCommand::filterName (string const & argument, pair<Key, pair<int, int>> const & current)

--- a/src/tools/kdb/complete.cpp
+++ b/src/tools/kdb/complete.cpp
@@ -354,7 +354,11 @@ bool CompleteCommand::filterCascading (string const & argument, pair<Key, pair<i
 {
 	// For a cascading key completion, ignore the preceding namespace
 	const string test = current.first.getFullName ();
-	const int cascadationOffset = test.find ("/");
+	int cascadationOffset = test.find ("/");
+	if (cascadationOffset == string::npos)
+	{
+		cascadationOffset = 0;
+	}
 	return argument.size () <= test.size () && equal (argument.begin (), argument.end (), test.begin () + cascadationOffset);
 }
 


### PR DESCRIPTION
# Purpose

There is a potential issue reported by asan, find will return str:npos if it is not found, which corresponds to -1 unsigned so the highest number, which can cause an overflow in the equality check then as this offset is added to the pointer.

# Checklist

Please only check relevant points.
For docu fixes, spell checking and similar nothing
needs to be checked.

- [X] commit messages are fine (with references to issues)
- [X] I ran all tests and everything went fine

@sanssecours on my machine it looks better now
