### PR TITLE
pluginprocess

### DIFF
--- a/cmake/Modules/FindPluginprocess.cmake
+++ b/cmake/Modules/FindPluginprocess.cmake
@@ -1,0 +1,31 @@
+# Find the dependencies of libpluginprocess to determine if plugins
+# which depend on it can be included or not.
+#
+#  HAVE_MKFIFO					- True if mkfifo is available on the platform
+#  HAVE_FORK					- True if fork is available on the platform
+#  HAVE_PLUGINPROCESS			- True if the pluginprocess library can be built
+#  PLUGINPROCESS_NOTFOUND_INFO	- A string describing which pluginprocess dependency is missing
+#
+include(CheckFunctionExists)
+
+check_function_exists (mkfifo HAVE_MKFIFO)
+check_function_exists (fork HAVE_FORK)
+
+if (HAVE_MKFIFO)
+if (HAVE_FORK)
+	set (PLUGINPROCESS_FOUND 1)
+else (HAVE_FORK)
+	set (PLUGINPROCESS_NOTFOUND_INFO
+		"fork does not exist on the target platform, excluding pluginprocess library")
+endif(HAVE_FORK)
+else(HAVE_MKFIFO)
+	message (PLUGINPROCESS_NOTFOUND_INFO
+		"mkfifo does not exist on the target platform, excluding pluginprocess library")
+endif(HAVE_MKFIFO)
+
+mark_as_advanced (
+	HAVE_MKFIFO
+	HAVE_FORK
+	PLUGINPROCESS_FOUND
+	PLUGINPROCESS_NOTFOUND_INFO
+)

--- a/doc/news/_preparation_next_release.md
+++ b/doc/news/_preparation_next_release.md
@@ -37,7 +37,7 @@ You can also read the news [on our website](https://www.libelektra.org/news/0.8.
 - New Logo
 - INI as new default configuration file format
 - Bindings for Asynchronous I/O
-- <<HIGHLIGHT2>>
+- Plugin Processes
 - <<HIGHLIGHT3>>
 
 
@@ -80,8 +80,18 @@ This release includes an experimental I/O binding for [uv](http://libuv.org/).
 The interface for I/O bindings is currently experimental.
 
 
-### <<HIGHLIGHT2>>
+### Plugin Processes
 
+A new library called [pluginprocess](https://github.com/ElektraInitiative/libelektra/tree/master/src/libs/pluginprocess) 
+has been added. This library contains functions that aid in executing plugins in
+a separate process. This child process is forked from Elektra's main process 
+each time such plugin is used and gets closed again afterwards. It uses a simple
+communication protocol based on a KeySet that gets serialized through a pipe via
+the dump plugin to orchestrate the processes.
+
+Such a behavior this is useful for plugins which cause memory leaks to be 
+isolated in an own process. Furthermore this is useful for runtimes or libraries 
+that cannot be reinitialized in the same process after they have been used.
 
 ### <<HIGHLIGHT2>>
 

--- a/src/error/specification
+++ b/src/error/specification
@@ -1190,8 +1190,8 @@ module:pluginprocess
 macro:PLUGIN_PROCESS_INITIALIZATION
 
 number:191
-description:An issue happened while executing a pluginprocess command for a plugin
-severity:warning
+description:Failed to communicate with the child process
+severity:error
 ingroup:plugin
 module:pluginprocess
 macro:PLUGIN_PROCESS_COMMAND

--- a/src/error/specification
+++ b/src/error/specification
@@ -1181,3 +1181,17 @@ severity:error
 ingroup:plugin
 module:directoryvalue
 macro:DIRECTORY_VALUE_ARRAY
+
+number:190
+description:Failed to initialize the pluginprocess library for a plugin
+severity:error
+ingroup:plugin
+module:pluginprocess
+macro:PLUGIN_PROCESS_INITIALIZATION
+
+number:191
+description:An issue happened while executing a pluginprocess command for a plugin
+severity:warning
+ingroup:plugin
+module:pluginprocess
+macro:PLUGIN_PROCESS_COMMAND

--- a/src/include/CMakeLists.txt
+++ b/src/include/CMakeLists.txt
@@ -90,6 +90,7 @@ install (FILES
 	kdbmodule.h
 	kdbos.h
 	kdbplugin.h
+	kdbpluginprocess.h
 	kdbprivate.h
 	kdbproposal.h
 	kdbinvoke.h

--- a/src/include/kdbpluginprocess.h
+++ b/src/include/kdbpluginprocess.h
@@ -7,21 +7,20 @@
 #ifdef __cplusplus
 namespace ckdb
 {
-extern "C"
-{
+extern "C" {
 #endif
 
-	typedef struct _ElektraPluginProcess ElektraPluginProcess;
+typedef struct _ElektraPluginProcess ElektraPluginProcess;
 
-	ElektraPluginProcess * elektraPluginProcessInit (Plugin *, Key *);
-	void elektraPluginProcessStart (Plugin *, ElektraPluginProcess *);
+ElektraPluginProcess * elektraPluginProcessInit (Plugin *, Key *);
+void elektraPluginProcessStart (Plugin *, ElektraPluginProcess *);
 
-	int elektraPluginProcessOpen (ElektraPluginProcess *, Key *);
+int elektraPluginProcessOpen (ElektraPluginProcess *, Key *);
 
-	int elektraPluginProcessIsParent (const ElektraPluginProcess *);
-	int elektraPluginProcessSend (const ElektraPluginProcess *, plugin_t, KeySet *, Key *);
+int elektraPluginProcessIsParent (const ElektraPluginProcess *);
+int elektraPluginProcessSend (const ElektraPluginProcess *, plugin_t, KeySet *, Key *);
 
-	int elektraPluginProcessClose (ElektraPluginProcess *);
+int elektraPluginProcessClose (ElektraPluginProcess *);
 
 #ifdef __cplusplus
 }

--- a/src/include/kdbpluginprocess.h
+++ b/src/include/kdbpluginprocess.h
@@ -1,0 +1,32 @@
+#ifndef KDBPLUGINPROCESS_H
+#define KDBPLUGINPROCESS_H
+
+#include <kdb.h>
+#include <kdbplugin.h>
+
+#ifdef __cplusplus
+namespace ckdb
+{
+extern "C"
+{
+#endif
+
+	typedef struct _ElektraPluginProcess ElektraPluginProcess;
+
+	ElektraPluginProcess * elektraPluginProcessInit (Plugin *, Key *);
+	void elektraPluginProcessStart (Plugin *, ElektraPluginProcess *);
+
+	int elektraPluginProcessOpen (ElektraPluginProcess *, Key *);
+
+	int elektraPluginProcessIsParent (const ElektraPluginProcess *);
+	int elektraPluginProcessSend (const ElektraPluginProcess *, plugin_t, KeySet *, Key *);
+
+	int elektraPluginProcessClose (ElektraPluginProcess *);
+
+#ifdef __cplusplus
+}
+}
+#endif
+
+
+#endif

--- a/src/include/kdbpluginprocess.h
+++ b/src/include/kdbpluginprocess.h
@@ -12,7 +12,7 @@ extern "C" {
 
 typedef struct _ElektraPluginProcess ElektraPluginProcess;
 
-ElektraPluginProcess * elektraPluginProcessInit (Plugin *, Key *);
+ElektraPluginProcess * elektraPluginProcessInit (Key *);
 void elektraPluginProcessStart (Plugin *, ElektraPluginProcess *);
 
 int elektraPluginProcessOpen (ElektraPluginProcess *, Key *);

--- a/src/libs/CMakeLists.txt
+++ b/src/libs/CMakeLists.txt
@@ -12,6 +12,8 @@ add_subdirectory (meta)
 
 add_subdirectory (plugin)
 
+add_subdirectory (pluginprocess)
+
 add_subdirectory (utility)
 
 add_subdirectory (io)

--- a/src/libs/README.md
+++ b/src/libs/README.md
@@ -31,9 +31,14 @@ Applications and plugins can choose to not link against it if they want to stay 
     libelektra-pluginprocess.so
 
 **[libpluginprocess](pluginprocess/)** contains functions aiding in executing plugins in a separate
-process and communicating with those child processes. This is useful for plugins which cause memory
-leaks to be isolated in an own process. Furthermore this is useful for runtimes or libraries that
-cannot be reinitialized in the same process after they have been used.
+process and communicating with those child processes. This child process is forked from Elektra's 
+main process each time such plugin is used and gets closed again afterwards. It uses a simple
+communication protocol based on a KeySet that gets serialized through a pipe via the dump plugin to 
+orchestrate the processes.
+
+This is useful for plugins which cause memory leaks to be isolated in an own process. Furthermore 
+this is useful for runtimes or libraries that cannot be reinitialized in the same process after they 
+have been used.
 
 ### Libproposal
 

--- a/src/libs/README.md
+++ b/src/libs/README.md
@@ -26,6 +26,15 @@ Applications and plugins can choose to not link against it if they want to stay 
 
 **[libplugin](plugin/)** contains `elektraPlugin*` symbols and plugins should link against it.
 
+### Libpluginprocess
+
+    libelektra-pluginprocess.so
+
+**[libpluginprocess](pluginprocess/)** contains functions aiding in executing plugins in a separate
+process and communicating with those child processes. This is useful for plugins which cause memory
+leaks to be isolated in an own process. Furthermore this is useful for runtimes or libraries that
+cannot be reinitialized in the same process after they have been used.
+
 ### Libproposal
 
     libelektra-proposal.so

--- a/src/libs/pluginprocess/CMakeLists.txt
+++ b/src/libs/pluginprocess/CMakeLists.txt
@@ -1,9 +1,16 @@
+find_package (Pluginprocess)
+
 file (GLOB SOURCES *.c)
-add_lib (pluginprocess
-	SOURCES
-		${SOURCES}
-	LINK_ELEKTRA
-		elektra
-		elektra-invoke
-		elektra-plugin
-)
+
+if (PLUGINPROCESS_FOUND)
+	add_lib (pluginprocess
+		SOURCES
+			${SOURCES}
+		LINK_ELEKTRA
+			elektra
+			elektra-invoke
+			elektra-plugin
+	)
+else (PLUGINPROCESS_FOUND)
+	message ("${PLUGINPROCESS_NOTFOUND_INFO}, excluding pluginprocess library")
+endif(PLUGINPROCESS_FOUND)

--- a/src/libs/pluginprocess/CMakeLists.txt
+++ b/src/libs/pluginprocess/CMakeLists.txt
@@ -1,0 +1,9 @@
+file (GLOB SOURCES *.c)
+add_lib (pluginprocess
+	SOURCES
+		${SOURCES}
+	LINK_ELEKTRA
+		elektra
+		elektra-invoke
+		elektra-plugin
+)

--- a/src/libs/pluginprocess/pluginprocess.c
+++ b/src/libs/pluginprocess/pluginprocess.c
@@ -264,9 +264,9 @@ static char * getPipename (Key * errorKey, char * suffix)
 {
 	int pipenameSize;
 	char * pipename;
-	pipenameSize = snprintf (NULL, 0, "/tmp/libelektra-process-%s-XXXXXX", suffix);
+	pipenameSize = snprintf (NULL, 0, "/tmp/libelektra-pluginprocess-%s-XXXXXX", suffix);
 	pipename = elektraMalloc (pipenameSize + 1);
-	pipenameSize = snprintf (pipename, pipenameSize + 1, "/tmp/libelektra-process-%s-XXXXXX", suffix);
+	pipenameSize = snprintf (pipename, pipenameSize + 1, "/tmp/libelektra-pluginprocess-%s-XXXXXX", suffix);
 
 	int prevErrno = errno;
 	if (mktemp (pipename) == NULL || errno == ENOTDIR || errno == EINVAL)

--- a/src/libs/pluginprocess/pluginprocess.c
+++ b/src/libs/pluginprocess/pluginprocess.c
@@ -1,0 +1,379 @@
+/**
+ * @file
+ *
+ * @brief Source for the pluginprocess library
+ *
+ * Executes plugins in a separate process via fork and uses a simple
+ * communication protocol based on the dump plugin via named pipes.
+ *
+ * @copyright BSD License (see LICENSE.md or https://www.libelektra.org)
+ */
+
+#include "kdbpluginprocess.h"
+#include <kdbinvoke.h>
+// To access the plugin function pointers
+#include <kdberrors.h>
+#include <kdblogger.h>
+#include <kdbprivate.h>
+
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+struct _ElektraPluginProcess
+{
+	char * commandPipe;
+	char * resultPipe;
+	int pid;
+	int counter;
+	ElektraInvokeHandle * dump;
+};
+
+static void cleanupPluginData (ElektraPluginProcess * pp)
+{
+	elektraInvokeClose (pp->dump);
+	if (pp->pid) unlink (pp->commandPipe);
+	elektraFree (pp->commandPipe);
+	if (pp->pid) unlink (pp->resultPipe);
+	elektraFree (pp->resultPipe);
+	elektraFree (pp);
+}
+
+static char * intToStr (int i)
+{
+	int size;
+	char * str;
+	size = snprintf (NULL, 0, "%d", i);
+	str = elektraMalloc (size + 1);
+	size = snprintf (str, size + 1, "%d", i);
+	return str;
+}
+
+/** Start the child process' command loop
+ *
+ * This will make the child process wait for plugin commands
+ * and execute them, returning the result to the parent. This
+ * is typically called in a plugin's open function.
+ *
+ * @param handle the plugin's handle
+ * @param pp the data structure containing the plugin's process information
+ * @see elektraPluginProcessInit how to use this function in a plugin
+ * @ingroup processplugin
+ **/
+void elektraPluginProcessStart (Plugin * handle, ElektraPluginProcess * pp)
+{
+	Key * commandPipeKey = keyNew ("/pluginprocess/commandPipe", KEY_VALUE, pp->commandPipe, KEY_END);
+	Key * resultPipeKey = keyNew ("/pluginprocess/resultPipe", KEY_VALUE, pp->resultPipe, KEY_END);
+	KeySet * keySet = ksNew (0, KS_END);
+	int counter = 0;
+	plugin_t command = ELEKTRA_PLUGIN_END;
+
+	do
+	{
+		ELEKTRA_LOG_DEBUG ("C: Wait for a KeySet");
+		elektraInvoke2Args (pp->dump, "get", keySet, commandPipeKey);
+		ELEKTRA_LOG_DEBUG ("C: We received a KeySet with %zd keys in it", ksGetSize (keySet));
+		Key * commandKey = ksLookupByName (keySet, "/pluginprocess/command", KDB_O_POP);
+		char * endPtr;
+		// We'll always write some int value into it, so this should be fine
+		int prevErrno = errno;
+		errno = 0;
+		command = (int)strtol (keyString (commandKey), &endPtr, 10);
+
+		Key * originalNameKey = ksLookupByName (keySet, "/pluginprocess/original", KDB_O_POP);
+		Key * originalKey = ksLookupByName (keySet, keyString (originalNameKey), KDB_O_NONE);
+
+		int result = ELEKTRA_PLUGIN_STATUS_ERROR;
+		if (*endPtr == '\0' && errno != ERANGE)
+		{
+			ELEKTRA_LOG ("C: We want to execute the command with the value %d now", command);
+			switch (command)
+			{
+			case ELEKTRA_PLUGIN_OPEN:
+				counter++;
+				result = handle->kdbOpen (handle, originalKey);
+				break;
+			case ELEKTRA_PLUGIN_CLOSE:
+				counter--;
+				result = handle->kdbClose (handle, originalKey);
+				break;
+			case ELEKTRA_PLUGIN_GET:
+				result = handle->kdbGet (handle, keySet, originalKey);
+				break;
+			case ELEKTRA_PLUGIN_SET:
+				result = handle->kdbSet (handle, keySet, originalKey);
+				break;
+			case ELEKTRA_PLUGIN_ERROR:
+				result = handle->kdbError (handle, keySet, originalKey);
+				break;
+			default:
+				result = ELEKTRA_PLUGIN_STATUS_ERROR;
+			}
+			ELEKTRA_LOG_DEBUG ("C: Command executed with return value %d", result);
+		}
+		else
+		{
+			ELEKTRA_LOG_DEBUG ("C: Unrecognized command %s", keyString (commandKey));
+			ELEKTRA_ADD_WARNINGF (191, originalKey, "Received invalid command code or no KeySet: %s", keyString (commandKey));
+		}
+		errno = prevErrno;
+		char * resultStr = intToStr (result);
+		ksAppendKey (keySet, keyNew ("/pluginprocess/result", KEY_VALUE, resultStr, KEY_END));
+		elektraFree (resultStr);
+
+		ELEKTRA_LOG_DEBUG ("C: Writing the resulting KeySet back to the parent");
+		elektraInvoke2Args (pp->dump, "set", keySet, resultPipeKey);
+		keyDel (commandKey);
+		keyDel (originalNameKey);
+		ELEKTRA_LOG ("C: Command handled, startup counter is at %d", counter);
+	} while (counter);
+
+	// Final Cleanup
+	ELEKTRA_LOG_DEBUG ("C: All done, exiting the child process now");
+	keyDel (commandPipeKey);
+	keyDel (resultPipeKey);
+	ksDel (keySet);
+	cleanupPluginData (pp);
+	// All done, exit the child process
+	_Exit (EXIT_SUCCESS);
+}
+
+/** Call a plugin's function in a child process
+ *
+ * This will wrap all the required information to execute the given
+ * command in a keyset and send it over to the child process. Then
+ * it waits for the child process's answer and copies the result 
+ * back into the original plugin keyset and plugin key.
+ * 
+ * Typically called like
+ * @code
+int elektraPluginSet (Plugin * handle, KeySet * returned, Key * parentKey)
+{
+	ElektraPluginProcess * pp = elektraPluginGetData (handle);
+	if (elektraPluginProcessIsParent (pp)) return elektraPluginProcessSend (pp, ELEKTRA_PLUGIN_SET, returned, parentKey);
+
+	// actual plugin functionality to be executed in a child process
+	return ELEKTRA_PLUGIN_STATUS_SUCCESS;
+}
+ * @endcode
+ *
+ * @param pp the data structure containing the plugin's process information
+ * @param command the plugin command that should be executed, e.g. ELEKTRA_PLUGIN_GET
+ * @param originalKeySet the original key set that the parent process receives
+ * @param key the original key the parent process receives
+ * @retval ELEKTRA_PLUGIN_STATUS_ERROR if the child process communication failed
+ * @retval the called plugin's return value otherwise
+ * @see elektraPluginProcessIsParent for checking if we are in the parent or child process
+ * @ingroup processplugin
+ **/
+int elektraPluginProcessSend (const ElektraPluginProcess * pp, plugin_t command, KeySet * originalKeySet, Key * key)
+{
+	// Some plugin functions don't use keysets, but we need one for our
+	// simple communication protocol, so create a temporary one
+	KeySet * keySet = originalKeySet == NULL ? ksNew (3, KS_END) : ksDup (originalKeySet);
+	ksAppendKey (keySet, keyDup (key));
+	char * commandStr = intToStr (command);
+	ksAppendKey (keySet, keyNew ("/pluginprocess/command", KEY_VALUE, commandStr, KEY_END));
+	Key * originalKey = keyNew ("/pluginprocess/original", KEY_VALUE, keyName (key), KEY_END);
+	ksAppendKey (keySet, originalKey);
+
+	// Serialize, currently statically use dini our default format, this already writes everything out to the pipe
+	Key * commandPipeKey = keyNew ("/pluginprocess/commandPipe", KEY_VALUE, pp->commandPipe, KEY_END);
+	Key * resultPipeKey = keyNew ("/pluginprocess/resultPipe", KEY_VALUE, pp->resultPipe, KEY_END);
+	ELEKTRA_LOG ("P: We send %zd keys through the pipe now to issue command %d it", ksGetSize (keySet), command);
+	elektraInvoke2Args (pp->dump, "set", keySet, commandPipeKey);
+	ELEKTRA_LOG_DEBUG ("P: Waiting for the result now");
+	elektraInvoke2Args (pp->dump, "get", keySet, resultPipeKey);
+	ELEKTRA_LOG ("P: We received %zd keys in return", ksGetSize (keySet));
+
+	// Bring everything back in order by removing our process-related keys
+	Key * originalDeserializedKey = ksLookupByName (keySet, keyName (key), KDB_O_POP);
+	Key * resultKey = ksLookupByName (keySet, "/pluginprocess/result", KDB_O_POP);
+	char * endPtr;
+	int prevErrno = errno;
+	errno = 0;
+	int result = (int)strtol (keyString (resultKey), &endPtr, 10);
+	// Copy everything back into the actual keysets
+	keyCopy (key, originalDeserializedKey);
+	ksCopy (originalKeySet, keySet);
+
+	// Command finished, cleanup now
+	keyDel (commandPipeKey);
+	keyDel (resultPipeKey);
+	keyDel (originalDeserializedKey);
+	ksDel (keySet);
+
+	if (*endPtr != '\0' || errno == ERANGE)
+	{
+		ELEKTRA_ADD_WARNINGF (191, originalKey, "Received invalid return code or no KeySet: %s", keyString (resultKey));
+		keyDel (resultKey);
+		return ELEKTRA_PLUGIN_STATUS_ERROR;
+	}
+	keyDel (resultKey);
+	errno = prevErrno;
+
+	return result;
+}
+
+/** Check if a given plugin process is the parent or the child process
+ *
+ * @param pp the data structure containing the plugin's process information
+ * @retval 0 if it's the child process
+ * @retval the child process' pid otherwise
+ * @ingroup processplugin
+ **/
+int elektraPluginProcessIsParent (const ElektraPluginProcess * pp)
+{
+	return pp->pid;
+}
+
+static int elektraPluginProcessFork (Plugin * handle, Key * errorKey, ElektraPluginProcess * pp)
+{
+	// Prepare a named pipe so the dump plugin can serialize to it
+	// Create one pipe per plugin instance / handle
+	int mkfifoRet;
+	if ((mkfifoRet = mkfifo (pp->commandPipe, S_IRUSR | S_IWUSR)) == -1)
+	{
+		ELEKTRA_SET_ERRORF (190, errorKey, "Failed to initialize the command pipe, mkfifo () returned %d", mkfifoRet);
+		return -1;
+	}
+	if ((mkfifoRet = mkfifo (pp->resultPipe, S_IRUSR | S_IWUSR)) == -1)
+	{
+		ELEKTRA_SET_ERRORF (190, errorKey, "Failed to initialize the result pipe, mkfifo () returned %d", mkfifoRet);
+		return -1;
+	}
+
+	pid_t pid = fork ();
+	if (pid < 0)
+	{
+		ELEKTRA_SET_ERRORF (190, errorKey, "Failed to fork the plugin process, fork () returned %d", pid);
+		return -1;
+	}
+
+	pp->pid = pid;
+	ELEKTRA_LOG_DEBUG ("The pluginprocess handle is %p with the pid %d", (void *)handle, pid);
+	return 0;
+}
+
+static char * getPipename (Plugin * handle, char * suffix)
+{
+	int pipenameSize;
+	char * pipename;
+	pipenameSize = snprintf (NULL, 0, "/tmp/libelektra-process-%p-%s", (void *)handle, suffix);
+	pipename = elektraMalloc (pipenameSize + 1);
+	pipenameSize = snprintf (pipename, pipenameSize + 1, "/tmp/libelektra-process-%p-%s", (void *)handle, suffix);
+	return pipename;
+}
+
+/** Initialize a plugin to be executed in its own process
+ *
+ * This will prepare all the required resources and then fork the current
+ * process. After the initialization the child process will typically
+ * call the command loop while the parent starts to send commands to it.
+ * Also the resulting process information has to be stored for the plugin.
+ * In order to allow users to handle custom plugin data this will not
+ * automatically call elektraPluginSetData.
+ * 
+ * Typically called in a plugin's open function like (assuming no custom plugin data):
+ * @code
+int elektraPluginOpen (Plugin * handle, Key * errorKey)
+{
+	ElektraPluginProcess * pp = elektraPluginGetData (handle);
+	if (pp == NULL)
+	{
+		if ((pp = elektraPluginProcessInit (handle, errorKey)) == NULL) return ELEKTRA_PLUGIN_STATUS_ERROR;
+		elektraPluginSetData (handle, pp);
+		if (!elektraPluginProcessIsParent (pp)) elektraPluginProcessStart (handle, pp);
+	}
+	if (elektraPluginProcessIsParent (pp)) return elektraPluginProcessOpen (pp, errorKey);
+
+	// actual plugin functionality to be executed in a child process
+	return ELEKTRA_PLUGIN_STATUS_SUCCESS;
+}
+ * @endcode
+ *
+ * @param handle the plugin's handle
+ * @param errorKey a key where error messages will be set
+ * @retval NULL if the initialization failed
+ * @retval a pointer to the information
+ * @ingroup processplugin
+ **/
+ElektraPluginProcess * elektraPluginProcessInit (Plugin * handle, Key * errorKey)
+{
+	// First time initialization
+	ElektraPluginProcess * pp;
+	pp = elektraMalloc (sizeof (ElektraPluginProcess));
+	pp->commandPipe = getPipename (handle, "command");
+	pp->resultPipe = getPipename (handle, "result");
+	pp->dump = elektraInvokeOpen ("dump", 0);
+	pp->counter = 0;
+	if (pp->commandPipe && pp->resultPipe && pp->dump)
+	{
+		if (elektraPluginProcessFork (handle, errorKey, pp) < 0)
+		{
+			cleanupPluginData (pp);
+			return NULL;
+		}
+	}
+	else
+	{
+		cleanupPluginData (pp);
+		ELEKTRA_SET_ERROR (190, errorKey, "Failed to initialize the pipenames and the dump plugin");
+		return NULL;
+	}
+	return pp;
+}
+
+/** Call a plugin's open function in a child process
+ *
+ * This will increase the internal counter how often open/close has been called, 
+ * so the opened pipes and forks will not be closed too early.
+ * 
+ * @param pp the data structure containing the plugin's process information
+ * @param errorKey a key where error messages will be set
+ * @retval the return value of the plugin's open function
+ * @see elektraPluginProcessInit for an example how and where this function is typically used
+ * @ingroup processplugin
+ **/
+int elektraPluginProcessOpen (ElektraPluginProcess * pp, Key * errorKey)
+{
+	pp->counter = pp->counter + 1;
+	return elektraPluginProcessSend (pp, ELEKTRA_PLUGIN_OPEN, NULL, errorKey);
+}
+
+/** Cleanup a plugin process
+ *
+ * This will decrease the internal counter how often open/close has been called, 
+ * closing opened pipes when the counter reaches 0. This will not delete the
+ * plugin data associated with the handle as it may contain other data out of
+ * the scope of this library, so this has to be done manually like
+ * @code
+int elektraPluginClose (Plugin * handle, Key * errorKey)
+{
+	ElektraPluginProcess * pp = elektraPluginGetData (handle);
+	if (elektraPluginProcessIsParent (pp)) {
+		int result = elektraPluginProcessSend (pp, ELEKTRA_PLUGIN_CLOSE, NULL, errorKey);
+		if (elektraPluginProcessClose (pp)) elektraPluginSetData (handle, NULL);
+		return result;
+	}
+
+	// actual plugin functionality to be executed in a child process
+	return ELEKTRA_PLUGIN_STATUS_SUCCESS;
+}	
+ * @endcode 
+ *
+ * @param pp the data structure containing the plugin's process information
+ * @retval 1 if the data structure got cleaned up
+ * @retval 0 if the data structure is still used
+ * @ingroup processplugin
+ **/
+int elektraPluginProcessClose (ElektraPluginProcess * pp)
+{
+	pp->counter = pp->counter - 1;
+	if (!pp->counter) cleanupPluginData (pp);
+	return pp->counter <= 0;
+}

--- a/src/libs/pluginprocess/pluginprocess.c
+++ b/src/libs/pluginprocess/pluginprocess.c
@@ -231,7 +231,7 @@ int elektraPluginProcessIsParent (const ElektraPluginProcess * pp)
 	return pp->pid;
 }
 
-static int elektraPluginProcessFork (Plugin * handle, Key * errorKey, ElektraPluginProcess * pp)
+static int elektraPluginProcessFork (ElektraPluginProcess * pp, Key * errorKey)
 {
 	// Prepare a named pipe so the dump plugin can serialize to it
 	// Create one pipe per plugin instance / handle
@@ -255,7 +255,7 @@ static int elektraPluginProcessFork (Plugin * handle, Key * errorKey, ElektraPlu
 	}
 
 	pp->pid = pid;
-	ELEKTRA_LOG_DEBUG ("The pluginprocess handle is %p with the pid %d", (void *)handle, pid);
+	ELEKTRA_LOG_DEBUG ("The pluginprocess is set using the pipes %s and %s with the pid %d", pp->commandPipe, pp->resultPipe, pid);
 	return 0;
 }
 
@@ -313,7 +313,7 @@ ElektraPluginProcess * elektraPluginProcessInit (Plugin * handle, Key * errorKey
 	pp->counter = 0;
 	if (pp->commandPipe && pp->resultPipe && pp->dump)
 	{
-		if (elektraPluginProcessFork (handle, errorKey, pp) < 0)
+		if (elektraPluginProcessFork (pp, errorKey) < 0)
 		{
 			cleanupPluginData (pp);
 			return NULL;


### PR DESCRIPTION
# Purpose

This adds a library that allows plugins to be executed in a child process to workaround the global initialization issue described in #1768. 

It uses fork with a simple communication protocol based on elektra itself, invoking the dump plugin to let a plugin communicate with its child process via named pipes (as the dump plugin expects a file as the input argument to serialize from/to) using a few extra keys which indicate which plugin function to execute and what was the original key for plugin function calls.

# Checklist

- [X] commit messages are fine (with references to issues)
- [ ] I added unit tests
- [X] I ran all tests and everything went fine
- [x] affected documentation is fixed
- [X] I added code comments, logging, and assertions (see doc/CODING.md)
- [x] meta data is updated (e.g. README.md of plugins)
- [x] release notes are updated (doc/news/_preparation_next_release.md)

@markus2330 One more puzzle piece towards the typechecker. Actually, I have already used this library for it and indeed my reinitialization issues are now gone with it. I will make a separate PR which uses this for haskell plugins though to keep the PRs smaller (then you also see how its used exactly). You can preview it [here ](https://github.com/e1528532/libelektra/blob/haskell-pluginprocess/src/plugins/haskell/haskell.c.in).

Is some more in-depth documentation for this required? Basically i have added small examples to the functions and it's usage in the base haskell plugin should serve as a perfect example for it. We should maybe add a hint to the developer docu so other people encountering such reinitialization issues will be guided towards this library. As you suggested I've designed it for general usage, not only with haskell plugins.

Some branches that build on this (and the cabal sandboxing) thus i have no PRs for them yet:

[Using this library for haskell plugins](https://github.com/e1528532/libelektra/tree/haskell-pluginprocess)

and ultimately....
[Typechecker Prototype](https://github.com/e1528532/libelektra/tree/typechecker-prototype)
(though i still need to adjust one thing or two with it tomorrow before it can be finally tried out and it needs some README how to use it, currently i still have a path hardcoded)