### PR TITLE
Install: Add Information About New Homebrew Formula

### DIFF
--- a/doc/API.md
+++ b/doc/API.md
@@ -182,7 +182,7 @@ Read more about [key names](/doc/help/elektra-key-names.md)
 ## Backend Overview
 
 The core of Elektra does not store configuration itself to the
-harddisk. Instead this work is delegated to backends.
+hard disk. Instead this work is delegated to backends.
 
 If you want to develop a backend, you should already have some experience
 with Elektra from the user point of view. You should be familiar with

--- a/doc/INSTALL.md
+++ b/doc/INSTALL.md
@@ -3,16 +3,16 @@
 
 ## Linux
 
-For the following Linux Distributions 0.8 packages are available:
+For the following Linux distributions and package managers 0.8 packages are available:
 
  - [Arch Linux](https://aur.archlinux.org/packages/elektra/)
- - [Homebrew](http://formulae.brew.sh/formula/elektra)
  - [Openwrt](https://github.com/openwrt/packages/tree/master/libs/elektra)
  - [OpenSuse](https://software.opensuse.org/package/elektra)
  - [Debian](https://packages.debian.org/de/jessie/libelektra4)
  - [Ubuntu](https://launchpad.net/ubuntu/+source/elektra)
  - [Gentoo](http://packages.gentoo.org/package/app-admin/elektra)
  - [Linux Mint](https://community.linuxmint.com/software/view/elektra-bin)
+ - [LinuxBrew](https://github.com/Linuxbrew/homebrew-core/blob/master/Formula/elektra.rb)
 
 Available, but not up-to-date:
 

--- a/doc/INSTALL.md
+++ b/doc/INSTALL.md
@@ -54,10 +54,13 @@ To build Debian Packages from the source you might want to use:
 
 ## macOS
 
-A tap for [Homebrew](http://brew.sh) is available [here](http://github.com/ElektraInitiative/homebrew-elektra). To install Elektra using this tap just use the two shell commands listed below.
+You can install Elektra using [Homebrew](http://brew.sh) via the shell command:
 
-	brew tap ElektraInitiative/homebrew-elektra
-	brew install elektra
+```sh
+brew install elektra
+```
+
+. We also provide a tap containing a more elaborate formula [here](http://github.com/ElektraInitiative/homebrew-elektra).
 
 ## Generic
 

--- a/doc/dev/algorithm.md
+++ b/doc/dev/algorithm.md
@@ -331,7 +331,7 @@ process involves no file operations.
 
 ### Duplicated Key Sets
 
-If some backends need synchronisation, the algorithm continues by
+If some backends need synchronization, the algorithm continues by
 filtering out all backends in the `Split` object that do not have changes.
 At this point, the `Split` object has a list of backends with their
 respective key sets.

--- a/doc/docker/buildelektra.sh
+++ b/doc/docker/buildelektra.sh
@@ -15,7 +15,7 @@ Then builds and installs Elektra.
   -t=DIR         download Elektra into DIR (relative to current working directory).
                  If DIR already exists, use sources from DIR.
                  Default DIR is './libelektra-TAG'.
-  -j=JOBS        Number of sumulateneos jobs/recipes executed by make (like make -j JOBS).
+  -j=JOBS        Number of simultaneous jobs/recipes executed by make (like make -j JOBS).
   -c=VERSION     Use clang. Set the version to use (either 5.0 or 3.8 in this container).
   -D=PARAMS      Pass additional parameters to cmake. Usage: -D="-DBINDINGS=cpp;glib".
   -h             display this help and exit.

--- a/doc/help/elektra-bootstrapping.md
+++ b/doc/help/elektra-bootstrapping.md
@@ -36,7 +36,7 @@ the init backend will be mounted there.
 
 ## SUMMARY
 
-To summarise, this approach delivers a good out-of-the-box experience
+To summarize, this approach delivers a good out-of-the-box experience
 capable of storing configuration. For special use cases, applications
 and administrators can mount specific backends anywhere except at, and
 below, `system/elektra`.  On `kdbOpen()`, the system

--- a/doc/man/elektra-bootstrapping.7
+++ b/doc/man/elektra-bootstrapping.7
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "ELEKTRA\-BOOTSTRAPPING" "7" "October 2017" "" ""
+.TH "ELEKTRA\-BOOTSTRAPPING" "7" "January 2018" "" ""
 .
 .SH "NAME"
 \fBelektra\-bootstrapping\fR \- default backend
@@ -22,7 +22,7 @@ Thus for full and static build variants an exchange at run\-time is not possible
 The \fBinit backend\fR is guaranteed to stay mounted at \fBsystem/elektra\fR where the configuration for Elektra itself is stored\. After mounting all backends, Elektra checks if \fBsystem/elektra\fR still resides at the default backend\. If not, the init backend will be mounted there\.
 .
 .SH "SUMMARY"
-To summarise, this approach delivers a good out\-of\-the\-box experience capable of storing configuration\. For special use cases, applications and administrators can mount specific backends anywhere except at, and below, \fBsystem/elektra\fR\. On \fBkdbOpen()\fR, the system bootstraps itself starting with the init backend\.
+To summarize, this approach delivers a good out\-of\-the\-box experience capable of storing configuration\. For special use cases, applications and administrators can mount specific backends anywhere except at, and below, \fBsystem/elektra\fR\. On \fBkdbOpen()\fR, the system bootstraps itself starting with the init backend\.
 .
 .P
 The default backend consists of a default storage plugin and default resolver plugin\. The default resolver has no specific requirements, but the default storage plugin must be able to handle full Elektra semantics\. The backend is mounted to root (\fB/\fR), so any keys can be stored in it\. The implementation of the core guarantees that user and system keys always stay separated\.

--- a/doc/news/_preparation_next_release.md
+++ b/doc/news/_preparation_next_release.md
@@ -90,7 +90,9 @@ The interface for I/O bindings is currently experimental.
 
 We added even more functionality, which could not make it to the highlights:
 
-- <<TODO>>
+- Elektra is now part of the official [Homebrew repository](http://formulae.brew.sh/formula/elektra). We still provide a
+  [tap](http://github.com/ElektraInitiative/homebrew-elektra), if you want to install Elektra together with plugins or bindings that require
+  additional libraries.
 
 ## Documentation
 

--- a/doc/news/_preparation_next_release.md
+++ b/doc/news/_preparation_next_release.md
@@ -104,7 +104,7 @@ As always, the ABI and API of kdb.h is fully compatible, i.e. programs
 compiled against an older 0.8 version of Elektra will continue to work
 (ABI) and you will be able to recompile programs without errors (API).
 
-Futhermore:
+Furthermore:
 
 - Added public headerfiles `kdbio.h`, `kdbiotest.h`.
 - Added private headerfiles `kdbioprivate.h`.

--- a/scripts/sed
+++ b/scripts/sed
@@ -9,6 +9,7 @@ s/favour/favor/g
 s/generalises/generalizes/g
 s/organisation/organization/g
 s/realise/realize/g
+s/synchronisation/synchronization/g
 s/synchronised/synchronized/g
 
 # ==========

--- a/scripts/sed
+++ b/scripts/sed
@@ -9,6 +9,7 @@ s/favour/favor/g
 s/generalises/generalizes/g
 s/organisation/organization/g
 s/realise/realize/g
+s/summarise/summarize/g
 s/synchronisation/synchronization/g
 s/synchronised/synchronized/g
 

--- a/src/plugins/semlock/README.md
+++ b/src/plugins/semlock/README.md
@@ -12,7 +12,7 @@
 This global semlock plugin introduces a read lock while `GET` and a read/write lock
 while `SET`.
 
-A semaphore is used for the synchronisation and the implemented algorithm favors the writer,
+A semaphore is used for the synchronization and the implemented algorithm favors the writer,
 because updates should be propagated soon as possible.
 
 The algorithm is described [here](https://en.wikipedia.org/wiki/Readers%E2%80%93writers_problem#Second_readers-writers_problem).


### PR DESCRIPTION
# Purpose

This PR adds information about the new Homebrew formula for Elektra in [`homebrew-core`](https://github.com/Homebrew/homebrew-core/blob/master/Formula/elektra.rb).

# Checklist

- [x] I checked all commit messages.
- [x] This PR adds documentation to `doc/INSTALL.md`.
- [x] I also updated the release notes.