### PR TITLE
Haskell pluginprocess

### DIFF
--- a/cmake/Modules/LibAddHaskellPlugin.cmake
+++ b/cmake/Modules/LibAddHaskellPlugin.cmake
@@ -243,6 +243,8 @@ macro (add_haskell_plugin target)
 			${GHC_INCLUDE_DIRS}
 		LINK_LIBRARIES
 			${GHC_LIBS}
+		LINK_ELEKTRA
+			elektra-pluginprocess
 		DEPENDS
 			${target} c2hs_haskell
 		ADD_TEST

--- a/cmake/Modules/LibAddHaskellPlugin.cmake
+++ b/cmake/Modules/LibAddHaskellPlugin.cmake
@@ -36,8 +36,10 @@ macro (add_haskell_plugin target)
 
 	if (DEPENDENCY_PHASE)
 		find_package (Haskell)
+		find_package (Pluginprocess)
 
-		 # set by find_program
+		# set by find_program
+		if (PLUGINPROCESS_FOUND) 
 		if (HASKELL_FOUND)
 		list (FIND BINDINGS "haskell" FINDEX)
 		if (FINDEX GREATER -1)
@@ -231,6 +233,9 @@ macro (add_haskell_plugin target)
 		else (HASKELL_FOUND)
 			remove_plugin (${target} ${HASKELL_NOTFOUND_INFO})
 		endif (HASKELL_FOUND)
+		else (PLUGINPROCESS_FOUND)
+			remove_plugin (${target} "${PLUGINPROCESS_NOTFOUND_INFO}, but required for haskell plugins")
+		endif (PLUGINPROCESS_FOUND)
 	endif (DEPENDENCY_PHASE)
 
 	# compile our c wrapper which takes care of invoking the haskell runtime

--- a/src/bindings/haskell/src/Elektra/Plugin.chs
+++ b/src/bindings/haskell/src/Elektra/Plugin.chs
@@ -11,7 +11,7 @@ module Elektra.Plugin (
   elektraPluginSetData, elektraPluginGetData,
   elektraPluginOpenWith, elektraPluginCloseWith, 
   elektraPluginGetWith, elektraPluginSetWith,
-  elektraPluginErrorWith, elektraPluginCheckConfigWith
+  elektraPluginErrorWith
 ) where
 
 {#import Elektra.Key#}
@@ -66,10 +66,6 @@ elektraPluginSetWith = elektraPlugin3
 
 elektraPluginErrorWith :: (Plugin -> KeySet -> Key -> IO PluginStatus) -> Ptr Plugin -> Ptr KeySet -> Ptr Key -> IO Int
 elektraPluginErrorWith = elektraPlugin3
-
-elektraPluginCheckConfigWith :: (Key -> KeySet -> IO PluginStatus) -> Ptr Key -> Ptr KeySet -> IO Int
-elektraPluginCheckConfigWith f k ks = liftM fromEnum $ join $ 
-  liftM2 f (liftM Key $ newForeignPtr_ k) (liftM KeySet $ newForeignPtr_ ks)
 
 -- shared parameter conversation
 

--- a/src/include/kdbpluginprocess.h
+++ b/src/include/kdbpluginprocess.h
@@ -17,16 +17,15 @@ extern "C" {
  * allow this library to possibly be extended to further commands in
  * the future
  */
-typedef enum
-{
-// clang-format off
+typedef enum {
+	// clang-format off
 ELEKTRA_PLUGINPROCESS_OPEN=1,		/*!< Call the plugin's open function */
 ELEKTRA_PLUGINPROCESS_CLOSE=1<<1,	/*!< Call the plugin's close function */
 ELEKTRA_PLUGINPROCESS_GET=1<<2,		/*!< Call the plugin's get function */
 ELEKTRA_PLUGINPROCESS_SET=1<<3,		/*!< Call the plugin's set function */
 ELEKTRA_PLUGINPROCESS_ERROR=1<<4,	/*!< Call the plugin's error function */
 ELEKTRA_PLUGINPROCESS_END=0			/*!< End of arguments */
-// clang-format on
+	// clang-format on
 } pluginprocess_t;
 
 typedef struct _ElektraPluginProcess ElektraPluginProcess;

--- a/src/include/kdbpluginprocess.h
+++ b/src/include/kdbpluginprocess.h
@@ -10,6 +10,25 @@ namespace ckdb
 extern "C" {
 #endif
 
+/**
+ * Switches to denote which plugin methods to call in the child process.
+ * Basically a duplicate of the enum in kdbplugin.h, but necessary to
+ * have our own version to bypass the duplicate export check and to
+ * allow this library to possibly be extended to further commands in
+ * the future
+ */
+typedef enum
+{
+// clang-format off
+ELEKTRA_PLUGINPROCESS_OPEN=1,		/*!< Call the plugin's open function */
+ELEKTRA_PLUGINPROCESS_CLOSE=1<<1,	/*!< Call the plugin's close function */
+ELEKTRA_PLUGINPROCESS_GET=1<<2,		/*!< Call the plugin's get function */
+ELEKTRA_PLUGINPROCESS_SET=1<<3,		/*!< Call the plugin's set function */
+ELEKTRA_PLUGINPROCESS_ERROR=1<<4,	/*!< Call the plugin's error function */
+ELEKTRA_PLUGINPROCESS_END=0			/*!< End of arguments */
+// clang-format on
+} pluginprocess_t;
+
 typedef struct _ElektraPluginProcess ElektraPluginProcess;
 
 ElektraPluginProcess * elektraPluginProcessInit (Key *);
@@ -18,7 +37,7 @@ void elektraPluginProcessStart (Plugin *, ElektraPluginProcess *);
 int elektraPluginProcessOpen (ElektraPluginProcess *, Key *);
 
 int elektraPluginProcessIsParent (const ElektraPluginProcess *);
-int elektraPluginProcessSend (const ElektraPluginProcess *, plugin_t, KeySet *, Key *);
+int elektraPluginProcessSend (const ElektraPluginProcess *, pluginprocess_t, KeySet *, Key *);
 
 int elektraPluginProcessClose (ElektraPluginProcess *);
 

--- a/src/libs/pluginprocess/pluginprocess.c
+++ b/src/libs/pluginprocess/pluginprocess.c
@@ -92,21 +92,21 @@ void elektraPluginProcessStart (Plugin * handle, ElektraPluginProcess * pp)
 			// Its hard to figure out the enum size in a portable way but for this comparison it should be ok
 			switch (command)
 			{
-			case ELEKTRA_PLUGIN_OPEN:
+			case ELEKTRA_PLUGINPROCESS_OPEN:
 				counter++;
 				result = handle->kdbOpen (handle, originalKey);
 				break;
-			case ELEKTRA_PLUGIN_CLOSE:
+			case ELEKTRA_PLUGINPROCESS_CLOSE:
 				counter--;
 				result = handle->kdbClose (handle, originalKey);
 				break;
-			case ELEKTRA_PLUGIN_GET:
+			case ELEKTRA_PLUGINPROCESS_GET:
 				result = handle->kdbGet (handle, keySet, originalKey);
 				break;
-			case ELEKTRA_PLUGIN_SET:
+			case ELEKTRA_PLUGINPROCESS_SET:
 				result = handle->kdbSet (handle, keySet, originalKey);
 				break;
-			case ELEKTRA_PLUGIN_ERROR:
+			case ELEKTRA_PLUGINPROCESS_ERROR:
 				result = handle->kdbError (handle, keySet, originalKey);
 				break;
 			default:
@@ -145,9 +145,9 @@ void elektraPluginProcessStart (Plugin * handle, ElektraPluginProcess * pp)
  *
  * This will wrap all the required information to execute the given
  * command in a keyset and send it over to the child process. Then
- * it waits for the child process's answer and copies the result 
+ * it waits for the child process's answer and copies the result
  * back into the original plugin keyset and plugin key.
- * 
+ *
  * Typically called like
  * @code
 int elektraPluginSet (Plugin * handle, KeySet * returned, Key * parentKey)
@@ -169,7 +169,7 @@ int elektraPluginSet (Plugin * handle, KeySet * returned, Key * parentKey)
  * @see elektraPluginProcessIsParent for checking if we are in the parent or child process
  * @ingroup processplugin
  **/
-int elektraPluginProcessSend (const ElektraPluginProcess * pp, plugin_t command, KeySet * originalKeySet, Key * key)
+int elektraPluginProcessSend (const ElektraPluginProcess * pp, pluginprocess_t command, KeySet * originalKeySet, Key * key)
 {
 	// Some plugin functions don't use keysets, but we need one for our
 	// simple communication protocol, so create a temporary one
@@ -288,7 +288,7 @@ static char * getPipename (Key * errorKey, char * suffix)
  * Also the resulting process information has to be stored for the plugin.
  * In order to allow users to handle custom plugin data this will not
  * automatically call elektraPluginSetData.
- * 
+ *
  * Typically called in a plugin's open function like (assuming no custom plugin data):
  * @code
 int elektraPluginOpen (Plugin * handle, Key * errorKey)
@@ -352,9 +352,9 @@ ElektraPluginProcess * elektraPluginProcessInit (Key * errorKey)
 
 /** Call a plugin's open function in a child process
  *
- * This will increase the internal counter how often open/close has been called, 
+ * This will increase the internal counter how often open/close has been called,
  * so the opened pipes and forks will not be closed too early.
- * 
+ *
  * @param pp the data structure containing the plugin's process information
  * @param errorKey a key where error messages will be set
  * @retval the return value of the plugin's open function
@@ -364,12 +364,12 @@ ElektraPluginProcess * elektraPluginProcessInit (Key * errorKey)
 int elektraPluginProcessOpen (ElektraPluginProcess * pp, Key * errorKey)
 {
 	pp->counter = pp->counter + 1;
-	return elektraPluginProcessSend (pp, ELEKTRA_PLUGIN_OPEN, NULL, errorKey);
+	return elektraPluginProcessSend (pp, ELEKTRA_PLUGINPROCESS_OPEN, NULL, errorKey);
 }
 
 /** Cleanup a plugin process
  *
- * This will decrease the internal counter how often open/close has been called, 
+ * This will decrease the internal counter how often open/close has been called,
  * closing opened pipes when the counter reaches 0. This will not delete the
  * plugin data associated with the handle as it may contain other data out of
  * the scope of this library, so this has to be done manually like
@@ -385,8 +385,8 @@ int elektraPluginClose (Plugin * handle, Key * errorKey)
 
 	// actual plugin functionality to be executed in a child process
 	return ELEKTRA_PLUGIN_STATUS_SUCCESS;
-}	
- * @endcode 
+}
+ * @endcode
  *
  * @param pp the data structure containing the plugin's process information
  * @retval 1 if the data structure got cleaned up

--- a/src/plugins/haskell/Elektra/Haskell.hs
+++ b/src/plugins/haskell/Elektra/Haskell.hs
@@ -32,13 +32,8 @@ elektraHaskellError :: Plugin -> KeySet -> Key -> IO PluginStatus
 elektraHaskellError p ks k = keySetMeta k "/plugins/haskell" "elektraHaskellError" >> return Success
 hs_elektraHaskellError = elektraPluginErrorWith elektraHaskellError
 
-elektraHaskellCheckConfig :: Key -> KeySet -> IO PluginStatus
-elektraHaskellCheckConfig k ks = keySetMeta k "/plugins/haskell" "elektraHaskellCheckConfig" >> return Success
-hs_elektraHaskellCheckConfig = elektraPluginCheckConfigWith elektraHaskellCheckConfig
-
 foreign export ccall hs_elektraHaskellOpen :: Ptr Plugin -> Ptr Key -> IO Int
 foreign export ccall hs_elektraHaskellClose :: Ptr Plugin -> Ptr Key -> IO Int
 foreign export ccall hs_elektraHaskellGet :: Ptr Plugin -> Ptr KeySet -> Ptr Key -> IO Int
 foreign export ccall hs_elektraHaskellSet :: Ptr Plugin -> Ptr KeySet -> Ptr Key -> IO Int
 foreign export ccall hs_elektraHaskellError :: Ptr Plugin -> Ptr KeySet -> Ptr Key -> IO Int
-foreign export ccall hs_elektraHaskellCheckConfig :: Ptr Key -> Ptr KeySet -> IO Int

--- a/src/plugins/haskell/haskell.c.in
+++ b/src/plugins/haskell/haskell.c.in
@@ -43,7 +43,7 @@ int elektraHaskellOpen (Plugin * handle, Key * errorKey)
 	ElektraPluginProcess * pp = elektraPluginGetData (handle);
 	if (pp == NULL)
 	{
-		if ((pp = elektraPluginProcessInit (handle, errorKey)) == NULL) return ELEKTRA_PLUGIN_STATUS_ERROR;
+		if ((pp = elektraPluginProcessInit (errorKey)) == NULL) return ELEKTRA_PLUGIN_STATUS_ERROR;
 		elektraPluginSetData (handle, pp);
 		if (!elektraPluginProcessIsParent (pp)) elektraPluginProcessStart (handle, pp);
 	}

--- a/src/plugins/haskell/haskell.c.in
+++ b/src/plugins/haskell/haskell.c.in
@@ -92,8 +92,8 @@ int elektraHaskellGet (Plugin * handle, KeySet * returned, Key * parentKey)
 			       keyNew ("system/elektra/modules/@PLUGIN_NAME@/exports/get", KEY_FUNC, elektraHaskellGet, KEY_END),
 			       keyNew ("system/elektra/modules/@PLUGIN_NAME@/exports/set", KEY_FUNC, elektraHaskellSet, KEY_END),
 			       keyNew ("system/elektra/modules/@PLUGIN_NAME@/exports/error", KEY_FUNC, elektraHaskellError, KEY_END),
- // clang-format off
- #include ELEKTRA_README (@PLUGIN_NAME@)
+// clang-format off
+#include ELEKTRA_README (@PLUGIN_NAME@)
 			       // clang-format on
 			       keyNew ("system/elektra/modules/@PLUGIN_NAME@/infos/version", KEY_VALUE, PLUGINVERSION, KEY_END), KS_END);
 		ksAppend (returned, contract);

--- a/src/plugins/haskell/haskell.c.in
+++ b/src/plugins/haskell/haskell.c.in
@@ -62,7 +62,7 @@ int elektraHaskellClose (Plugin * handle, Key * errorKey)
 	ElektraPluginProcess * pp = elektraPluginGetData (handle);
 	if (elektraPluginProcessIsParent (pp))
 	{
-		int result = elektraPluginProcessSend (pp, ELEKTRA_PLUGIN_CLOSE, NULL, errorKey);
+		int result = elektraPluginProcessSend (pp, ELEKTRA_PLUGINPROCESS_CLOSE, NULL, errorKey);
 		if (elektraPluginProcessClose (pp)) elektraPluginSetData (handle, NULL);
 		return result;
 	}
@@ -103,7 +103,7 @@ int elektraHaskellGet (Plugin * handle, KeySet * returned, Key * parentKey)
 	}
 
 	ElektraPluginProcess * pp = elektraPluginGetData (handle);
-	if (elektraPluginProcessIsParent (pp)) return elektraPluginProcessSend (pp, ELEKTRA_PLUGIN_GET, returned, parentKey);
+	if (elektraPluginProcessIsParent (pp)) return elektraPluginProcessSend (pp, ELEKTRA_PLUGINPROCESS_GET, returned, parentKey);
 
 	return hs_elektraHaskellGet (handle, returned, parentKey);
 }
@@ -111,7 +111,7 @@ int elektraHaskellGet (Plugin * handle, KeySet * returned, Key * parentKey)
 int elektraHaskellSet (Plugin * handle, KeySet * returned, Key * parentKey)
 {
 	ElektraPluginProcess * pp = elektraPluginGetData (handle);
-	if (elektraPluginProcessIsParent (pp)) return elektraPluginProcessSend (pp, ELEKTRA_PLUGIN_SET, returned, parentKey);
+	if (elektraPluginProcessIsParent (pp)) return elektraPluginProcessSend (pp, ELEKTRA_PLUGINPROCESS_SET, returned, parentKey);
 
 	return hs_elektraHaskellSet (handle, returned, parentKey);
 }
@@ -119,7 +119,7 @@ int elektraHaskellSet (Plugin * handle, KeySet * returned, Key * parentKey)
 int elektraHaskellError (Plugin * handle, KeySet * returned, Key * parentKey)
 {
 	ElektraPluginProcess * pp = elektraPluginGetData (handle);
-	if (elektraPluginProcessIsParent (pp)) return elektraPluginProcessSend (pp, ELEKTRA_PLUGIN_ERROR, returned, parentKey);
+	if (elektraPluginProcessIsParent (pp)) return elektraPluginProcessSend (pp, ELEKTRA_PLUGINPROCESS_ERROR, returned, parentKey);
 
 	return hs_elektraHaskellError (handle, returned, parentKey);
 }

--- a/src/plugins/haskell/haskell.c.in
+++ b/src/plugins/haskell/haskell.c.in
@@ -60,7 +60,8 @@ int elektraHaskellOpen (Plugin * handle, Key * errorKey)
 int elektraHaskellClose (Plugin * handle, Key * errorKey)
 {
 	ElektraPluginProcess * pp = elektraPluginGetData (handle);
-	if (elektraPluginProcessIsParent (pp)) {
+	if (elektraPluginProcessIsParent (pp))
+	{
 		int result = elektraPluginProcessSend (pp, ELEKTRA_PLUGIN_CLOSE, NULL, errorKey);
 		if (elektraPluginProcessClose (pp)) elektraPluginSetData (handle, NULL);
 		return result;
@@ -82,25 +83,25 @@ int elektraHaskellGet (Plugin * handle, KeySet * returned, Key * parentKey)
 {
 	if (!elektraStrCmp (keyName (parentKey), "system/elektra/modules/@PLUGIN_NAME@"))
 	{
-		KeySet * contract = ksNew (
-			30,
-			keyNew ("system/elektra/modules/@PLUGIN_NAME@", KEY_VALUE, "@PLUGIN_NAME@ plugin waits for your orders", KEY_END),
-			keyNew ("system/elektra/modules/@PLUGIN_NAME@/exports", KEY_END),
-			keyNew ("system/elektra/modules/@PLUGIN_NAME@/exports/open", KEY_FUNC, elektraHaskellOpen, KEY_END),
-			keyNew ("system/elektra/modules/@PLUGIN_NAME@/exports/close", KEY_FUNC, elektraHaskellClose, KEY_END),
-			keyNew ("system/elektra/modules/@PLUGIN_NAME@/exports/get", KEY_FUNC, elektraHaskellGet, KEY_END),
-			keyNew ("system/elektra/modules/@PLUGIN_NAME@/exports/set", KEY_FUNC, elektraHaskellSet, KEY_END),
-			keyNew ("system/elektra/modules/@PLUGIN_NAME@/exports/error", KEY_FUNC, elektraHaskellError, KEY_END),
-// clang-format off
-#include ELEKTRA_README (@PLUGIN_NAME@)
-			// clang-format on
-			keyNew ("system/elektra/modules/@PLUGIN_NAME@/infos/version", KEY_VALUE, PLUGINVERSION, KEY_END), KS_END);
+		KeySet * contract =
+			ksNew (30, keyNew ("system/elektra/modules/@PLUGIN_NAME@", KEY_VALUE, "@PLUGIN_NAME@ plugin waits for your orders",
+					   KEY_END),
+			       keyNew ("system/elektra/modules/@PLUGIN_NAME@/exports", KEY_END),
+			       keyNew ("system/elektra/modules/@PLUGIN_NAME@/exports/open", KEY_FUNC, elektraHaskellOpen, KEY_END),
+			       keyNew ("system/elektra/modules/@PLUGIN_NAME@/exports/close", KEY_FUNC, elektraHaskellClose, KEY_END),
+			       keyNew ("system/elektra/modules/@PLUGIN_NAME@/exports/get", KEY_FUNC, elektraHaskellGet, KEY_END),
+			       keyNew ("system/elektra/modules/@PLUGIN_NAME@/exports/set", KEY_FUNC, elektraHaskellSet, KEY_END),
+			       keyNew ("system/elektra/modules/@PLUGIN_NAME@/exports/error", KEY_FUNC, elektraHaskellError, KEY_END),
+ // clang-format off
+ #include ELEKTRA_README (@PLUGIN_NAME@)
+			       // clang-format on
+			       keyNew ("system/elektra/modules/@PLUGIN_NAME@/infos/version", KEY_VALUE, PLUGINVERSION, KEY_END), KS_END);
 		ksAppend (returned, contract);
 		ksDel (contract);
 
 		return ELEKTRA_PLUGIN_STATUS_SUCCESS;
 	}
-	
+
 	ElektraPluginProcess * pp = elektraPluginGetData (handle);
 	if (elektraPluginProcessIsParent (pp)) return elektraPluginProcessSend (pp, ELEKTRA_PLUGIN_GET, returned, parentKey);
 

--- a/src/plugins/haskell/haskell.c.in
+++ b/src/plugins/haskell/haskell.c.in
@@ -35,38 +35,46 @@
 #endif
 
 #include <kdbhelper.h>
-
-static int started = 0;
+#include <kdbpluginprocess.h>
+#include <stdio.h>
 
 int elektraHaskellOpen (Plugin * handle, Key * errorKey)
 {
-	static char *argv[] = { "@PLUGIN_NAME@", 0 }, **argvPtr = argv;
-	static int argc = 1;
-	// Startup the haskell runtime with some dummy args
-	if (!started)
+	ElektraPluginProcess * pp = elektraPluginGetData (handle);
+	if (pp == NULL)
 	{
-		hs_init (&argc, &argvPtr);
-		started++;
+		if ((pp = elektraPluginProcessInit (handle, errorKey)) == NULL) return ELEKTRA_PLUGIN_STATUS_ERROR;
+		elektraPluginSetData (handle, pp);
+		if (!elektraPluginProcessIsParent (pp)) elektraPluginProcessStart (handle, pp);
 	}
+	if (elektraPluginProcessIsParent (pp)) return elektraPluginProcessOpen (pp, errorKey);
+
+	char *argv[] = { "@PLUGIN_NAME@", 0 }, **argvPtr = argv;
+	int argc = 1;
+	// Startup the haskell runtime with some dummy args
+	// Subsequent init calls are ignored by the runtime
+	hs_init (&argc, &argvPtr);
 	return hs_elektraHaskellOpen (handle, errorKey);
 }
 
 int elektraHaskellClose (Plugin * handle, Key * errorKey)
 {
+	ElektraPluginProcess * pp = elektraPluginGetData (handle);
+	if (elektraPluginProcessIsParent (pp)) {
+		int result = elektraPluginProcessSend (pp, ELEKTRA_PLUGIN_CLOSE, NULL, errorKey);
+		if (elektraPluginProcessClose (pp)) elektraPluginSetData (handle, NULL);
+		return result;
+	}
+
 	int ret = hs_elektraHaskellClose (handle, errorKey);
 	// Shutdown the haskell runtime
 	// Due to an unfortunate bug within GHC's ffi implementation we cannot
-	// restart the runtime if it got closed once during elektra's runtime.
-	// This usecase can happen though especially with dynamic plugins.
-	// As a temporary workaround we leave it open for now and just call a cleanup function
-	// to minimize resource usage while its not needed, as we can't guarantee we
-	// will never load it again without restarting elektra as a whole
+	// restart the runtime if it got closed once during elektra's runtime
+	// in the same process.
+	// Therefore we use the plugin process library to launch the runtime
+	// in a separate process.
 	// https://downloads.haskell.org/~ghc/8.2.2/docs/html/users_guide/bugs.html#infelicities-ffi
-	// hs_exit ();
-	if (!--started)
-	{
-		rts_done ();
-	}
+	hs_exit ();
 	return ret;
 }
 
@@ -83,7 +91,6 @@ int elektraHaskellGet (Plugin * handle, KeySet * returned, Key * parentKey)
 			keyNew ("system/elektra/modules/@PLUGIN_NAME@/exports/get", KEY_FUNC, elektraHaskellGet, KEY_END),
 			keyNew ("system/elektra/modules/@PLUGIN_NAME@/exports/set", KEY_FUNC, elektraHaskellSet, KEY_END),
 			keyNew ("system/elektra/modules/@PLUGIN_NAME@/exports/error", KEY_FUNC, elektraHaskellError, KEY_END),
-			keyNew ("system/elektra/modules/@PLUGIN_NAME@/exports/checkconf", KEY_FUNC, elektraHaskellCheckConfig, KEY_END),
 // clang-format off
 #include ELEKTRA_README (@PLUGIN_NAME@)
 			// clang-format on
@@ -93,28 +100,27 @@ int elektraHaskellGet (Plugin * handle, KeySet * returned, Key * parentKey)
 
 		return ELEKTRA_PLUGIN_STATUS_SUCCESS;
 	}
+	
+	ElektraPluginProcess * pp = elektraPluginGetData (handle);
+	if (elektraPluginProcessIsParent (pp)) return elektraPluginProcessSend (pp, ELEKTRA_PLUGIN_GET, returned, parentKey);
+
 	return hs_elektraHaskellGet (handle, returned, parentKey);
 }
 
 int elektraHaskellSet (Plugin * handle, KeySet * returned, Key * parentKey)
 {
-	// set all keys
-	// this function is optional
+	ElektraPluginProcess * pp = elektraPluginGetData (handle);
+	if (elektraPluginProcessIsParent (pp)) return elektraPluginProcessSend (pp, ELEKTRA_PLUGIN_SET, returned, parentKey);
+
 	return hs_elektraHaskellSet (handle, returned, parentKey);
 }
 
 int elektraHaskellError (Plugin * handle, KeySet * returned, Key * parentKey)
 {
-	// handle errors (commit failed)
-	// this function is optional
-	return hs_elektraHaskellError (handle, returned, parentKey);
-}
+	ElektraPluginProcess * pp = elektraPluginGetData (handle);
+	if (elektraPluginProcessIsParent (pp)) return elektraPluginProcessSend (pp, ELEKTRA_PLUGIN_ERROR, returned, parentKey);
 
-int elektraHaskellCheckConfig (Key * errorKey, KeySet * conf)
-{
-	// validate plugin configuration
-	// this function is optional
-	return hs_elektraHaskellCheckConfig (errorKey, conf);
+	return hs_elektraHaskellError (handle, returned, parentKey);
 }
 
 // clang-format off

--- a/src/plugins/haskell/haskell.h.in
+++ b/src/plugins/haskell/haskell.h.in
@@ -17,7 +17,6 @@ int elektraHaskellClose (Plugin * handle, Key * errorKey);
 int elektraHaskellGet (Plugin * handle, KeySet * ks, Key * parentKey);
 int elektraHaskellSet (Plugin * handle, KeySet * ks, Key * parentKey);
 int elektraHaskellError (Plugin * handle, KeySet * ks, Key * parentKey);
-int elektraHaskellCheckConfig (Key * errorKey, KeySet * conf);
 
 // clang-format off
 Plugin * ELEKTRA_PLUGIN_EXPORT (@PLUGIN_NAME@);


### PR DESCRIPTION
# Purpose

Executes Haskell Plugins in a separate process with libprocessplugin. As haskell plugins do not really work otherwise its directly integrated and not proxied via process, so it can be mounted directly also.

# Checklist

- [X] commit messages are fine (with references to issues)
- [ ] I added unit tests (they were already there and still work)
- [X] I ran all tests and everything went fine
- [X] affected documentation is fixed
- [X] I added code comments, logging, and assertions (see doc/CODING.md)
- [X] meta data is updated (e.g. README.md of plugins)
- [X] release notes are updated (doc/news/_preparation_next_release.md)

@markus2330 and the last big prerequisite for the typechecker prototype.. on macs ;) i'll fix the setup.hs issue in a separate pr.