### PR TITLE
Shell Recorder: Fix Syntax Error

### DIFF
--- a/tests/shell/shell_recorder/shell_recorder.sh
+++ b/tests/shell/shell_recorder/shell_recorder.sh
@@ -313,7 +313,7 @@ then
 	fi
 fi
 
-if [ "$EVAL" -eq 0 ] && [ $keepProtocol == 'false' ]; then
+if [ "$EVAL" -eq 0 ] && [ $keepProtocol = 'false' ]; then
 	rm -f "$OutFile"
 else
 	>&2 printf '\n📕\nProtocol File: %s\n' "$OutFile"


### PR DESCRIPTION
# Purpose

Fix a syntax error in the Shell Recorder script

# Checklist

- [x] I checked the commit message. 
- [x] I ran all tests and everything went fine.
