### PR TITLE
Tests: Shell: kdb_internal_check exclude semlock

### DIFF
--- a/tests/shell/check_kdb_internal_check.sh
+++ b/tests/shell/check_kdb_internal_check.sh
@@ -28,7 +28,7 @@ do
 		continue
 		;;
 	"semlock")
-		# exclude due to issue #1781
+		# exclude due to issue 1781
 		continue
 		;;
 	esac

--- a/tests/shell/check_kdb_internal_check.sh
+++ b/tests/shell/check_kdb_internal_check.sh
@@ -27,6 +27,10 @@ do
 		# output on open/close
 		continue
 		;;
+	"semlock")
+		# output on open/close
+		continue
+		;;
 	esac
 
 	> $FILE

--- a/tests/shell/check_kdb_internal_check.sh
+++ b/tests/shell/check_kdb_internal_check.sh
@@ -28,7 +28,7 @@ do
 		continue
 		;;
 	"semlock")
-		# output on open/close
+		# exclude due to issue #1781
 		continue
 		;;
 	esac


### PR DESCRIPTION
# Purpose

`check_kdb_internal_check.sh` checks all added plugins and does not care about excluded testcases,
therefore `semlock` could fail and should be removed till fixed properly.

# Checklist

- [x] commit messages are fine (with references to issues)
- [ ] I added unit tests
- [x] I ran all tests and everything went fine
- [ ] affected documentation is fixed
- [ ] I added code comments, logging, and assertions (see doc/CODING.md)
- [ ] meta data is updated (e.g. README.md of plugins)
- [ ] release notes are updated (doc/news/_preparation_next_release.md)