### PR TITLE
Invoke error key

### DIFF
--- a/doc/news/_preparation_next_release.md
+++ b/doc/news/_preparation_next_release.md
@@ -107,6 +107,7 @@ We added even more functionality, which could not make it to the highlights:
   additional libraries.
 - The building and linking of the haskell bindings and haskell plugins has been
 [greatly improved](https://github.com/ElektraInitiative/libelektra/pull/1698).
+- The invoke library can now [report errors](https://github.com/ElektraInitiative/libelektra/pull/1801) upon opening/closing a plugin. 
 
 ## Documentation
 

--- a/src/include/kdbinvoke.h
+++ b/src/include/kdbinvoke.h
@@ -11,7 +11,7 @@ extern "C" {
 
 typedef struct _ElektraInvokeHandle ElektraInvokeHandle;
 
-ElektraInvokeHandle * elektraInvokeOpen (const char *, KeySet * config);
+ElektraInvokeHandle * elektraInvokeOpen (const char *, KeySet * config, Key * errorKey);
 ElektraInvokeHandle * elektraInvokeInitialize (const char *);
 
 const void * elektraInvokeGetFunction (ElektraInvokeHandle *, const char *);
@@ -24,7 +24,7 @@ KeySet * elektraInvokeGetExports (ElektraInvokeHandle *);
 
 int elektraInvoke2Args (ElektraInvokeHandle *, const char *, KeySet * ks, Key * k);
 
-void elektraInvokeClose (ElektraInvokeHandle *);
+void elektraInvokeClose (ElektraInvokeHandle *, Key * errorKey);
 
 
 #ifdef __cplusplus

--- a/src/include/kdbpluginprocess.h
+++ b/src/include/kdbpluginprocess.h
@@ -38,7 +38,7 @@ int elektraPluginProcessOpen (ElektraPluginProcess *, Key *);
 int elektraPluginProcessIsParent (const ElektraPluginProcess *);
 int elektraPluginProcessSend (const ElektraPluginProcess *, pluginprocess_t, KeySet *, Key *);
 
-int elektraPluginProcessClose (ElektraPluginProcess *);
+int elektraPluginProcessClose (ElektraPluginProcess *, Key *);
 
 #ifdef __cplusplus
 }

--- a/src/libs/invoke/invoke.c
+++ b/src/libs/invoke/invoke.c
@@ -40,13 +40,13 @@ struct _ElektraInvokeHandle
 /**
  * @deprecated Do not use.
  *
- * Use `elektraInvokeOpen (name, 0)` instead.
+ * Use `elektraInvokeOpen (name, 0, 0)` instead.
  *
  * @see elektraInvokeOpen()
  */
 ElektraInvokeHandle * elektraInvokeInitialize (const char * elektraPluginName)
 {
-	return elektraInvokeOpen (elektraPluginName, 0);
+	return elektraInvokeOpen (elektraPluginName, 0, 0);
 }
 
 /**

--- a/src/plugins/blockresolver/blockresolver.c
+++ b/src/plugins/blockresolver/blockresolver.c
@@ -43,7 +43,7 @@ typedef struct
 static int elektraResolveFilename (Key * parentKey, ElektraResolveTempfile tmpFile)
 {
 	int rc = 0;
-	ElektraInvokeHandle * handle = elektraInvokeOpen ("resolver", 0);
+	ElektraInvokeHandle * handle = elektraInvokeOpen ("resolver", 0, 0);
 	if (!handle)
 	{
 		rc = -1;
@@ -82,7 +82,7 @@ static int elektraResolveFilename (Key * parentKey, ElektraResolveTempfile tmpFi
 	}
 
 RESOLVE_FAILED:
-	elektraInvokeClose (handle);
+	elektraInvokeClose (handle, 0);
 	return rc;
 }
 

--- a/src/plugins/curlget/curlget.c
+++ b/src/plugins/curlget/curlget.c
@@ -82,7 +82,7 @@ typedef struct
 static int elektraResolveFilename (Key * parentKey, ElektraResolveTempfile tmpFile)
 {
 	int rc = 0;
-	void * handle = elektraInvokeOpen ("resolver", 0);
+	void * handle = elektraInvokeOpen ("resolver", 0, 0);
 	if (!handle)
 	{
 		rc = -1;
@@ -121,7 +121,7 @@ static int elektraResolveFilename (Key * parentKey, ElektraResolveTempfile tmpFi
 	}
 
 RESOLVE_FAILED:
-	elektraInvokeClose (handle);
+	elektraInvokeClose (handle, 0);
 	return rc;
 }
 

--- a/src/plugins/dini/dini.c
+++ b/src/plugins/dini/dini.c
@@ -18,9 +18,9 @@ int elektraDiniOpen (Plugin * handle, Key * errorKey ELEKTRA_UNUSED)
 
 	dini->dumpConfig = ksDup (elektraPluginGetConfig (handle));
 	dini->iniConfig = ksDup (elektraPluginGetConfig (handle));
-	dini->dump = elektraInvokeOpen ("dump", dini->dumpConfig);
-	dini->ini = elektraInvokeOpen ("ini", dini->iniConfig);
-	dini->bin = elektraInvokeOpen ("binary", dini->iniConfig);
+	dini->dump = elektraInvokeOpen ("dump", dini->dumpConfig, 0);
+	dini->ini = elektraInvokeOpen ("ini", dini->iniConfig, 0);
+	dini->bin = elektraInvokeOpen ("binary", dini->iniConfig, 0);
 
 	dini->dumpErrors = keyNew ("", KEY_END);
 
@@ -33,9 +33,9 @@ int elektraDiniClose (Plugin * handle, Key * errorKey ELEKTRA_UNUSED)
 {
 	Dini * dini = elektraPluginGetData (handle);
 
-	elektraInvokeClose (dini->bin);
-	elektraInvokeClose (dini->ini);
-	elektraInvokeClose (dini->dump);
+	elektraInvokeClose (dini->bin, 0);
+	elektraInvokeClose (dini->ini, 0);
+	elektraInvokeClose (dini->dump, 0);
 
 	keyDel (dini->dumpErrors);
 	ksDel (dini->dumpConfig);

--- a/src/plugins/gitresolver/gitresolver.c
+++ b/src/plugins/gitresolver/gitresolver.c
@@ -59,7 +59,7 @@ typedef struct
 static int elektraResolveFilename (Key * parentKey, ElektraResolveTempfile tmpFile)
 {
 	int rc = 0;
-	ElektraInvokeHandle * handle = elektraInvokeOpen ("resolver", 0);
+	ElektraInvokeHandle * handle = elektraInvokeOpen ("resolver", 0, 0);
 	if (!handle)
 	{
 		rc = -1;
@@ -98,7 +98,7 @@ static int elektraResolveFilename (Key * parentKey, ElektraResolveTempfile tmpFi
 	}
 
 RESOLVE_FAILED:
-	elektraInvokeClose (handle);
+	elektraInvokeClose (handle, 0);
 	return rc;
 }
 int elektraGitresolverCheckFile (const char * filename)

--- a/src/plugins/haskell/haskell.c.in
+++ b/src/plugins/haskell/haskell.c.in
@@ -63,7 +63,7 @@ int elektraHaskellClose (Plugin * handle, Key * errorKey)
 	if (elektraPluginProcessIsParent (pp))
 	{
 		int result = elektraPluginProcessSend (pp, ELEKTRA_PLUGINPROCESS_CLOSE, NULL, errorKey);
-		if (elektraPluginProcessClose (pp)) elektraPluginSetData (handle, NULL);
+		if (elektraPluginProcessClose (pp, errorKey)) elektraPluginSetData (handle, NULL);
 		return result;
 	}
 

--- a/src/plugins/multifile/multifile.c
+++ b/src/plugins/multifile/multifile.c
@@ -106,7 +106,7 @@ static inline Codes rvToRc (int rc)
 static int elektraResolveFilename (Key * parentKey, ElektraResolveTempfile tmpFile)
 {
 	int rc = 0;
-	ElektraInvokeHandle * handle = elektraInvokeOpen ("resolver", 0);
+	ElektraInvokeHandle * handle = elektraInvokeOpen ("resolver", 0, 0);
 	if (!handle)
 	{
 		rc = -1;
@@ -145,7 +145,7 @@ static int elektraResolveFilename (Key * parentKey, ElektraResolveTempfile tmpFi
 	}
 
 RESOLVE_FAILED:
-	elektraInvokeClose (handle);
+	elektraInvokeClose (handle, 0);
 	return rc;
 }
 


### PR DESCRIPTION
# Purpose

Adds the possibility for the invoke library to report errors when trying to open/close a plugin as discussed in #1795 .

# Checklist

- [X] commit messages are fine (with references to issues)
- [ ] I added unit tests
- [X] I ran all tests and everything went fine
- [X] affected documentation is fixed
- [X] I added code comments, logging, and assertions (see doc/CODING.md)
- [X] meta data is updated (e.g. README.md of plugins)
- [X] release notes are updated (doc/news/_preparation_next_release.md)

@markus2330 As C doesn't support overloaded functions, i've adjusted the original interface now as its not a part of the core elektra library as far as i've understood because i think the function names fit pretty well. I've also adapted those few plugins using it already, but for those i am passing simply 0 as the error key so invoke will take care about the error key creation itself, which basically is the old behavior to avoid possibly breaking anything in plugins i do not maintain. For my own plugins i've incorporated the new error key already (and even had to do a small pluginprocess library adjustment.
