### PR TITLE
YAML CPP: Update CMake Code for yaml-cpp 0.6

### DIFF
--- a/cmake/Modules/Findyaml-cpp.cmake
+++ b/cmake/Modules/Findyaml-cpp.cmake
@@ -6,6 +6,7 @@
 #  YAML-CPP_FOUND		System has yaml-cpp
 #  YAML-CPP_INCLUDE_DIRS	The yaml-cpp include directories
 #  YAML-CPP_LIBRARIES		The libraries needed to use yaml-cpp
+#  YAML-CPP_VERSION		The version string of yaml-cpp
 #
 # This script is a modified version of the code available here:
 # 	https://cmake.org/Wiki/CMake:How_To_Find_Libraries#Writing_find_modules
@@ -22,11 +23,13 @@ find_library(YAML-CPP_LIBRARY
 	NAMES yaml-cpp
 	HINTS ${PC_YAML-CPP_LIBDIR} ${PC_YAML-CPP_LIBRARY_DIRS})
 
+set(YAML-CPP_VERSION ${PC_YAML-CPP_VERSION})
+
 include(FindPackageHandleStandardArgs)
 # Handle the QUIETLY and REQUIRED arguments and set YAML-CPP_FOUND to TRUE, if all listed variables are TRUE
-find_package_handle_standard_args(yaml-cpp DEFAULT_MSG YAML-CPP_LIBRARY YAML-CPP_INCLUDE_DIR)
+find_package_handle_standard_args(yaml-cpp REQUIRED_VARS YAML-CPP_LIBRARY YAML-CPP_INCLUDE_DIR VERSION_VAR YAML-CPP_VERSION)
 
-mark_as_advanced(YAML-CPP_INCLUDE_DIR YAML-CPP_LIBRARY)
+mark_as_advanced(YAML-CPP_INCLUDE_DIR YAML-CPP_LIBRARY YAML-CPP_VERSION)
 
 set(YAML-CPP_LIBRARIES ${YAML-CPP_LIBRARY})
 set(YAML-CPP_INCLUDE_DIRS ${YAML-CPP_INCLUDE_DIR})

--- a/cmake/Modules/Findyaml-cpp.cmake
+++ b/cmake/Modules/Findyaml-cpp.cmake
@@ -9,27 +9,27 @@
 #  YAML-CPP_VERSION		The version string of yaml-cpp
 #
 # This script is a modified version of the code available here:
-# 	https://cmake.org/Wiki/CMake:How_To_Find_Libraries#Writing_find_modules
+#	https://cmake.org/Wiki/CMake:How_To_Find_Libraries#Writing_find_modules
 
-find_package(PkgConfig)
-pkg_check_modules(PC_YAML-CPP QUIET yaml-cpp)
+find_package (PkgConfig)
+pkg_check_modules (PC_YAML-CPP QUIET yaml-cpp)
 
-find_path(YAML-CPP_INCLUDE_DIR
+find_path (YAML-CPP_INCLUDE_DIR
 	NAMES yaml-cpp/yaml.h
 	HINTS ${PC_YAML-CPP_INCLUDEDIR} ${PC_YAML-CPP_INCLUDE_DIRS}
 	PATH_SUFFIXES yaml-cpp)
 
-find_library(YAML-CPP_LIBRARY
+find_library (YAML-CPP_LIBRARY
 	NAMES yaml-cpp
 	HINTS ${PC_YAML-CPP_LIBDIR} ${PC_YAML-CPP_LIBRARY_DIRS})
 
-set(YAML-CPP_VERSION ${PC_YAML-CPP_VERSION})
+set (YAML-CPP_VERSION ${PC_YAML-CPP_VERSION})
 
-include(FindPackageHandleStandardArgs)
+include (FindPackageHandleStandardArgs)
 # Handle the QUIETLY and REQUIRED arguments and set YAML-CPP_FOUND to TRUE, if all listed variables are TRUE
-find_package_handle_standard_args(yaml-cpp REQUIRED_VARS YAML-CPP_LIBRARY YAML-CPP_INCLUDE_DIR VERSION_VAR YAML-CPP_VERSION)
+find_package_handle_standard_args (yaml-cpp REQUIRED_VARS YAML-CPP_LIBRARY YAML-CPP_INCLUDE_DIR VERSION_VAR YAML-CPP_VERSION)
 
-mark_as_advanced(YAML-CPP_INCLUDE_DIR YAML-CPP_LIBRARY YAML-CPP_VERSION)
+mark_as_advanced (YAML-CPP_INCLUDE_DIR YAML-CPP_LIBRARY YAML-CPP_VERSION)
 
-set(YAML-CPP_LIBRARIES ${YAML-CPP_LIBRARY})
-set(YAML-CPP_INCLUDE_DIRS ${YAML-CPP_INCLUDE_DIR})
+set (YAML-CPP_LIBRARIES ${YAML-CPP_LIBRARY})
+set (YAML-CPP_INCLUDE_DIRS ${YAML-CPP_INCLUDE_DIR})

--- a/doc/news/_preparation_next_release.md
+++ b/doc/news/_preparation_next_release.md
@@ -113,7 +113,9 @@ We added even more functionality, which could not make it to the highlights:
   additional libraries.
 - The building and linking of the haskell bindings and haskell plugins has been
 [greatly improved](https://github.com/ElektraInitiative/libelektra/pull/1698).
-- The invoke library can now [report errors](https://github.com/ElektraInitiative/libelektra/pull/1801) upon opening/closing a plugin. 
+- The invoke library can now [report errors](https://github.com/ElektraInitiative/libelektra/pull/1801) upon opening/closing a plugin.
+- The [YAML CPP plugin](https://www.libelektra.org/plugins/yamlcpp) does not require [Boost](http://www.boost.org) anymore, if you
+  installed [yaml-cpp 0.6](https://github.com/jbeder/yaml-cpp/releases/tag/yaml-cpp-0.6.0).
 
 ## Documentation
 

--- a/src/plugins/yamlcpp/CMakeLists.txt
+++ b/src/plugins/yamlcpp/CMakeLists.txt
@@ -1,20 +1,22 @@
 if (DEPENDENCY_PHASE)
-	find_package (Boost QUIET)
-	if (NOT Boost_FOUND)
-		remove_plugin (yamlcpp "boost was not found")
-	endif (NOT Boost_FOUND)
-
 	find_package (yaml-cpp QUIET 0.5)
 	if (NOT YAML-CPP_FOUND)
 		remove_plugin (yamlcpp "yaml-cpp (libyaml-cpp-dev >= 0.5) not found")
 	else (NOT YAML-CPP_FOUND)
-		# Disable warnings about shadow declarations in yaml-cpp source code
-		if (APPLE AND CMAKE_COMPILER_IS_GNUCXX)
-			string (REPLACE "-Wshadow" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
-		endif (APPLE AND CMAKE_COMPILER_IS_GNUCXX)
+		if (YAML-CPP_VERSION VERSION_LESS "0.6.0")
+			find_package (Boost QUIET)
+			if (NOT Boost_FOUND)
+				remove_plugin (yamlcpp "yaml-cpp ${YAML-CPP_VERSION} requires Boost")
+			endif (NOT Boost_FOUND)
+			# Disable warnings about shadow declarations in yaml-cpp source code
+			if (APPLE AND CMAKE_COMPILER_IS_GNUCXX)
+				string (REPLACE "-Wshadow" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
+			endif (APPLE AND CMAKE_COMPILER_IS_GNUCXX)
+		set (YAML_PLUGIN_INCLUDE_DIRS ${Boost_INCLUDE_DIR})
+		endif (YAML-CPP_VERSION VERSION_LESS "0.6.0")
 	endif (NOT YAML-CPP_FOUND)
 
-	set (YAML_PLUGIN_INCLUDE_DIRS ${YAML-CPP_INCLUDE_DIR} ${Boost_INCLUDE_DIR})
+	set (YAML_PLUGIN_INCLUDE_DIRS ${YAML_PLUGIN_INCLUDE_DIRS} ${YAML-CPP_INCLUDE_DIR})
 endif (DEPENDENCY_PHASE)
 
 add_plugin (yamlcpp


### PR DESCRIPTION
# Purpose

Do not require [Boost](http://www.boost.org) for the YAML CPP plugin anymore, if CMake locates yaml-cpp 0.6 or newer. 

# Checklist

- [x] I checked all commit messages.
- [x] I ran all tests and everything went fine
- [x] The release notes are up do date.