### PR TITLE
docker-jenkins-buildnode

### DIFF
--- a/doc/docker/jenkinsnode/Dockerfile
+++ b/doc/docker/jenkinsnode/Dockerfile
@@ -1,27 +1,13 @@
 FROM debian:stretch
 
-ARG SWIGVERSION="3.0.11"
-
 # install dependencies
 RUN apt-get update && apt-get -y upgrade
 RUN apt-get -y install \
-  apt-utils \
-  curl \
   build-essential \
   clang \
-  autotools-dev \
-  automake \
   cmake \
-  pkg-config \
-  doxygen \
-  graphviz \
-  bison \
   ruby-dev \
   python-dev \
-  python3-dev \
-  libpython3-dev \
-  liblua5.3-dev \
-  tclcl-dev \
   libaugeas-dev \
   libyajl-dev \
   libgit2-dev \
@@ -31,14 +17,10 @@ RUN apt-get -y install \
   libpcre3-dev \
   libpcre++-dev \
   libglib2.0-dev \
-  swig \
-  libyaml-cpp-dev \
-  libuv1-dev \
   libxerces-c-dev \
-  checkinstall \
+  libyaml-cpp-dev \
+  swig \
   valgrind \
-  devscripts \
-  dh-exec \
   libmarkdown2-dev \
   discount \
   dh-lua \
@@ -48,7 +30,6 @@ RUN apt-get -y install \
   ruby-ronn \
   libgcrypt20-dev \
   libbotan1.10-dev \
-  swig3.0 \
   libsystemd-dev \
   openjdk-8-jdk-headless \
   ghc \
@@ -62,9 +43,10 @@ RUN apt-get -y install \
   git \
   libcurl4-gnutls-dev
 RUN cabal update && \
-  gem install ronn && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+# TODO use elektra for the configuration steps below
 
 # setup the ssh server
 RUN sed --in-place 's/^\(PermitRootLogin\|UsePAM\|UseDNS\)/#\1/' /etc/ssh/sshd_config && \
@@ -81,7 +63,7 @@ RUN echo "\n\n\n\n\nY" | adduser --quiet --disabled-password jenkins && \
   mkdir /home/jenkins/.m2/ && \
   chown -R jenkins:jenkins /home/jenkins/.m2/ && \
   mkdir /home/jenkins/libelektra && \
-  echo "[user]\nname = Jenkins Buildbot\nemail = <your-email>" >> /home/jenkins/.gitconfig
+  echo "[user]\nname = Jenkins Buildbot\nemail = bot@libelektra.org" >> /home/jenkins/.gitconfig
 
 # setup the run- utilities
 COPY run-make /usr/local/bin/run-make

--- a/doc/docker/jenkinsnode/Dockerfile
+++ b/doc/docker/jenkinsnode/Dockerfile
@@ -42,8 +42,7 @@ RUN apt-get -y install \
   maven \
   git \
   libcurl4-gnutls-dev
-RUN cabal update && \
-  apt-get clean && \
+RUN apt-get clean && \
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # TODO use elektra for the configuration steps below
@@ -64,6 +63,11 @@ RUN echo "\n\n\n\n\nY" | adduser --quiet --disabled-password jenkins && \
   chown -R jenkins:jenkins /home/jenkins/.m2/ && \
   mkdir /home/jenkins/libelektra && \
   echo "[user]\nname = Jenkins Buildbot\nemail = bot@libelektra.org" >> /home/jenkins/.gitconfig
+
+# setup cabal for the jenkins user, then go back to root
+USER jenkins
+RUN cabal update
+USER root
 
 # setup the run- utilities
 COPY run-make /usr/local/bin/run-make

--- a/doc/docker/jenkinsnode/Dockerfile
+++ b/doc/docker/jenkinsnode/Dockerfile
@@ -1,0 +1,95 @@
+FROM debian:stretch
+
+ARG SWIGVERSION="3.0.11"
+
+# install dependencies
+RUN apt-get update && apt-get -y upgrade
+RUN apt-get -y install \
+  apt-utils \
+  curl \
+  build-essential \
+  clang \
+  autotools-dev \
+  automake \
+  cmake \
+  pkg-config \
+  doxygen \
+  graphviz \
+  bison \
+  ruby-dev \
+  python-dev \
+  python3-dev \
+  libpython3-dev \
+  liblua5.3-dev \
+  tclcl-dev \
+  libaugeas-dev \
+  libyajl-dev \
+  libgit2-dev \
+  libboost-all-dev \
+  libssl-dev \
+  libdbus-1-dev \
+  libpcre3-dev \
+  libpcre++-dev \
+  libglib2.0-dev \
+  swig \
+  libyaml-cpp-dev \
+  libuv1-dev \
+  libxerces-c-dev \
+  checkinstall \
+  valgrind \
+  devscripts \
+  dh-exec \
+  libmarkdown2-dev \
+  discount \
+  dh-lua \
+  python-all \
+  python3-all \
+  libgtest-dev \
+  ruby-ronn \
+  libgcrypt20-dev \
+  libbotan1.10-dev \
+  swig3.0 \
+  libsystemd-dev \
+  openjdk-8-jdk-headless \
+  ghc \
+  ghc-dynamic \
+  cabal-install \
+  alex \
+  happy \
+  c2hs \
+  openssh-server \
+  maven \
+  git \
+  libcurl4-gnutls-dev
+RUN cabal update && \
+  gem install ronn && \
+  apt-get clean && \
+  rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+# setup the ssh server
+RUN sed --in-place 's/^\(PermitRootLogin\|UsePAM\|UseDNS\)/#\1/' /etc/ssh/sshd_config && \
+  echo "" >> /etc/ssh/sshd_config && \
+  echo "# Custom changes from `date`" >> /etc/ssh/sshd_config && \
+  echo "PermitRootLogin no" >> /etc/ssh/sshd_config && \
+  echo "UsePAM no" >> /etc/ssh/sshd_config && \
+  echo "UseDNS no" >> /etc/ssh/sshd_config && \
+  echo "SSH daemon config updated"
+
+# setup jenkins prerequisites
+RUN echo "\n\n\n\n\nY" | adduser --quiet --disabled-password jenkins && \
+  echo "jenkins:<password>" | chpasswd && \
+  mkdir /home/jenkins/.m2/ && \
+  chown -R jenkins:jenkins /home/jenkins/.m2/ && \
+  mkdir /home/jenkins/libelektra && \
+  echo "[user]\nname = Jenkins Buildbot\nemail = <your-email>" >> /home/jenkins/.gitconfig
+
+# setup the run- utilities
+COPY run-make /usr/local/bin/run-make
+COPY run-make-env /usr/local/bin/run-make-env
+COPY run-nice /usr/local/bin/run-nice
+RUN chmod a+x /usr/local/bin/run-*
+
+# start the ssh server
+EXPOSE 22
+RUN service ssh start
+CMD ["/usr/sbin/sshd", "-D", "-e"]

--- a/doc/docker/jenkinsnode/README.md
+++ b/doc/docker/jenkinsnode/README.md
@@ -1,0 +1,47 @@
+# Configuring Elektra as a Jenkins build node with Docker
+
+This Dockerfile builds a dockerimage based on debian:stretch including all 
+requirements to build Elektra and most of its bindings/plugins to act as a build
+node for Jenkins. It contains an ssh server and a java environment to allow 
+jenkins to connect to the container and execute commands on top of that.
+
+Before building the image, you may want to adjust the password for jenkins to 
+something more secure, so adjust the line `echo "jenkins:<password>" | chpasswd && \`
+in the Dockerfile. Next adjust the line 
+`echo "[user]\nname = Jenkins Buildbot\nemail = <your-email>" >> /home/jenkins/.gitconfig`
+and insert your git settings.
+
+Optionally you can modify the file `run_make` if you want to
+increase the number of jobs for the make command on the build container. You can
+also modify `run_ionice` to adjust the build process' priority.
+
+Now build the image with the following command:
+
+```sh
+$ docker build -t buildelektra-stretch .
+```
+
+After the build process has completed you can create and run a Docker container 
+that uses the image we just created. Additionally you need to forward the ssh
+port to some port you want to use on the container's host so jenkins can connect
+to it. We give this container a name to easily refer to it at runtime.
+
+```sh
+$ docker run -d -p 22222:22 --name build-v2 buildelektra-stretch
+```
+
+Now you should be able to connect to the container locally via the host machine:
+
+```sh
+$ ssh jenkins@localhost -p 22222
+```
+
+Afterwards you need to ensure that this ssh port is also accessible from the 
+outside, so that the jenkins master server can connect to the build node.
+As this greatly depends on the given network setup we can't give an exact
+explanation for it, but you may need to expose the local port to the outside or
+even use SSH tunneling or forwarding in case your build node doesn't have direct
+access to the jenkins master server.
+
+Once this works, you have to add the credentials for the container's jenkins 
+user to the main jenkins server and connect to it. All done!

--- a/doc/docker/jenkinsnode/README.md
+++ b/doc/docker/jenkinsnode/README.md
@@ -7,13 +7,13 @@ jenkins to connect to the container and execute commands on top of that.
 
 Before building the image, you may want to adjust the password for jenkins to 
 something more secure, so adjust the line `echo "jenkins:<password>" | chpasswd && \`
-in the Dockerfile. Next adjust the line 
-`echo "[user]\nname = Jenkins Buildbot\nemail = <your-email>" >> /home/jenkins/.gitconfig`
-and insert your git settings.
+in the Dockerfile.
 
 Optionally you can modify the file `run_make` if you want to
 increase the number of jobs for the make command on the build container. You can
-also modify `run_ionice` to adjust the build process' priority.
+also modify `run_ionice` to adjust the build process' priority, which is set to
+idle by default in order to keep the host system responsive. In case you want to
+disable that, change the line `ionice -c 3 nice $*` in `run_ionice` to simply `$*`.
 
 Now build the image with the following command:
 

--- a/doc/docker/jenkinsnode/run-make
+++ b/doc/docker/jenkinsnode/run-make
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+set -ex
+run-nice make -j 1 $* VERBOSE=1

--- a/doc/docker/jenkinsnode/run-make-env
+++ b/doc/docker/jenkinsnode/run-make-env
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+set -ex
+SCRIPT=$(readlink -f "$0")
+SCRIPTPATH=$(dirname "$SCRIPT")
+env -i PATH="$PATH" HOME="$HOME" $SCRIPTPATH/run-make $*

--- a/doc/docker/jenkinsnode/run-nice
+++ b/doc/docker/jenkinsnode/run-nice
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+set -ex
+ionice -c 3 nice $*

--- a/doc/news/_preparation_next_release.md
+++ b/doc/news/_preparation_next_release.md
@@ -121,7 +121,8 @@ We added even more functionality, which could not make it to the highlights:
 
 We improved the documentation in the following ways:
 
-- <<TODO>>
+- We've [documented how you can setup a build node for Jenkins using a docker container](https://github.com/ElektraInitiative/libelektra/tree/master/doc/docker/jenkinsnode/README.md)
+  We also provide an example Dockerfile based on Debian Stretch for that purpose.
 
 ## Compatibility
 


### PR DESCRIPTION
# Purpose

Add Dockerfile, Readme and scripts for a jenkins build node with docker

# Checklist

- [X] affected documentation is fixed
- [X] release notes are updated (doc/news/_preparation_next_release.md)

@markus2330 There you go. I document the ssh setup for the v2 in our build server issue, as that has nothing to do with the build container in general.
