### PR TITLE
invoke-error-key-fix

### DIFF
--- a/src/libs/invoke/invoke.c
+++ b/src/libs/invoke/invoke.c
@@ -85,17 +85,17 @@ ElektraInvokeHandle * elektraInvokeOpen (const char * elektraPluginName, KeySet 
 		config = ksDup (config);
 	}
 
-	if (!errorKey)
+	int errorKeyMissing = !errorKey;
+	if (errorKeyMissing)
 	{
 		errorKey = keyNew (0, KEY_END);
 	}
-	else
-	{
-		keyIncRef (errorKey);
-	}
 
 	Plugin * plugin = elektraPluginOpen (elektraPluginName, modules, config, errorKey);
-	keyDel (errorKey);
+	if (errorKeyMissing)
+	{
+		keyDel (errorKey);
+	}
 	if (!plugin)
 	{
 		elektraModulesClose (modules, NULL);
@@ -291,16 +291,16 @@ void elektraInvokeClose (ElektraInvokeHandle * handle, Key * errorKey)
 	{
 		return;
 	}
-	if (!errorKey)
+	int errorKeyMissing = !errorKey;
+	if (errorKeyMissing)
 	{
 		errorKey = keyNew (0, KEY_END);
 	}
-	else
-	{
-		keyIncRef (errorKey);
-	}
 	elektraPluginClose (handle->plugin, errorKey);
-	keyDel (errorKey);
+	if (errorKeyMissing)
+	{
+		keyDel (errorKey);
+	}
 	elektraModulesClose (handle->modules, NULL);
 	ksDel (handle->modules);
 	ksDel (handle->exports);


### PR DESCRIPTION
# Purpose

I noticed keyDel doesn't decrease the refcount but assumed that for the error key for invoke functions, so i corrected this to get the correct behavior.

# Checklist

- [X] commit messages are fine (with references to issues)
- [X] I ran all tests and everything went fine

@markus2330 a quick fix, looks like you were happy with my assumption that keyDel decreases the refcount too :D i'll just merge it once the build passes
