### PR TITLE
Fix Path to Qt on Travis/Use Namespace `ckdb` in `kdberrors.h`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -100,7 +100,7 @@ before_install:
       brew install swig
       brew install yajl
       pip2 install cheetah # Required by kdb-gen
-      export Qt5_DIR=/usr/local/opt/qt5
+      export Qt5_DIR=/usr/local/opt/qt@5.5
     fi
   - |
     if [[ "$TRAVIS_OS_NAME" == "osx" && "$HASKELL" == "ON" ]] ; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -100,7 +100,6 @@ before_install:
       brew install swig
       brew install yajl
       pip2 install cheetah # Required by kdb-gen
-      export Qt5_DIR=/usr/local/opt/qt@5.5
     fi
   - |
     if [[ "$TRAVIS_OS_NAME" == "osx" && "$HASKELL" == "ON" ]] ; then

--- a/doc/news/_preparation_next_release.md
+++ b/doc/news/_preparation_next_release.md
@@ -247,6 +247,13 @@ These notes are of interest for people developing Elektra:
 - `BINDINGS` was greatly improved and the CMake functions were simplified.
    Bindings now also have a `README.md` with meta data.
    A big thanks to Thomas Wahringer.
+- Including `kdberrors.h` in a C++ files now also works, if you do not add the statement
+
+  ```cpp
+  using namespace ckdb;
+  ```
+
+  before you import `kdberrors.h`.
 
 ## Fixes
 

--- a/doc/news/_preparation_next_release.md
+++ b/doc/news/_preparation_next_release.md
@@ -254,6 +254,8 @@ These notes are of interest for people developing Elektra:
   ```
 
   before you import `kdberrors.h`.
+- The CMake code for Elektra’s [Qt-GUI](https://www.libelektra.org/tools/qt-gui) now detects the location of Qt 5 automatically if you
+  installed Qt via Homebrew.
 
 ## Fixes
 

--- a/scripts/sed
+++ b/scripts/sed
@@ -70,7 +70,8 @@ s/\<metalanguage/meta-language/g
 
 s/\<round ?trip/round-trip/g
 
-s/\<(compile|deployment|mount|run|startup) ?time/\1-time/g
+s/\<(compile|deployment|mount|startup) ?time/\1-time/g
+s/\<(run) time/\1-time/g
 
 s/\<time[- ]stamp/timestamp/g
 

--- a/src/error/exporterrors.cpp
+++ b/src/error/exporterrors.cpp
@@ -36,6 +36,10 @@ ostream & operator<< (ostream & os, parse_t & p)
 	   << "#include <kdbmacros.h>" << endl
 	   << "#include <string.h>" << endl
 	   << endl
+	   << "#ifdef __cplusplus" << endl
+	   << "	using namespace ckdb;" << endl
+	   << endl
+	   << "#endif" << endl
 	   << "#define ELEKTRA_SET_ERROR(number, key, text) ELEKTRA_SET_ERROR_HELPER\\" << endl
 	   << "	(number, key, text, __FILE__, __LINE__)" << endl
 	   << endl

--- a/src/libs/notification/tests/CMakeLists.txt
+++ b/src/libs/notification/tests/CMakeLists.txt
@@ -1,6 +1,8 @@
 include (LibAddMacros)
 
-if (BUILD_TESTING)
+set (ASAN_LINUX (ENABLE_ASAN AND CMAKE_SYSTEM_NAME MATCHES "Linux"))
+
+if (BUILD_TESTING AND NOT ${ASAN_LINUX})
 
 	add_headers (HDR_FILES)
 
@@ -28,4 +30,4 @@ if (BUILD_TESTING)
 
 	endforeach (file ${TESTS})
 
-endif (BUILD_TESTING)
+endif (BUILD_TESTING AND NOT ${ASAN_LINUX})

--- a/src/libs/notification/tests/testlib_notification.c
+++ b/src/libs/notification/tests/testlib_notification.c
@@ -1,7 +1,7 @@
 /**
  * @file
  *
- * @brief Tests for notification libraray.
+ * @brief Tests for notification library.
  *
  * @copyright BSD License (see LICENSE.md or https://www.libelektra.org)
  *

--- a/src/plugins/yamlcpp/README.md
+++ b/src/plugins/yamlcpp/README.md
@@ -398,5 +398,6 @@ sudo kdb umount user/examples/yamlcpp
 - Saving a **single scalar value** directly below the mountpoint does not work
 - Adding and removing keys does remove **comments** inside the configuration file
 - The plugin currently lacks proper **type support** for scalars.
+- If Elektra uses YAML CPP as **default storage** plugin, multiple tests of the test suite fail
 
 [yaml-cpp]: https://github.com/jbeder/yaml-cpp

--- a/src/tools/qt-gui/CMakeLists.txt
+++ b/src/tools/qt-gui/CMakeLists.txt
@@ -7,6 +7,11 @@ if (POLICY CMP0053)
 	cmake_policy(SET CMP0053 OLD)
 endif ()
 
+if (APPLE)
+	# Provide list of default paths for Homebrew version of Qt
+	list (APPEND CMAKE_PREFIX_PATH "/usr/local/opt/qt5" "/usr/local/opt/qt@5.5")
+endif (APPLE)
+
 set(QCOMPONENTS Core Quick Gui Qml Widgets Test)
 find_package(Qt5 COMPONENTS ${QCOMPONENTS})
 find_package(Qt5 OPTIONAL_COMPONENTS Svg QUIET)


### PR DESCRIPTION
# Purpose

This PR improves

  - the detection of Qt on macOS, and
  - the usability of `kdberrors.h` inside C++ code

.

# Checklist

- [x] I checked all commit messages.
- [x] The PR also contains updates for the release notes.