### PR TITLE
Travis: Add ASAN Enabled GCC Build for Linux

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,14 @@ matrix:
       env: [ ASAN=ON ]
 
     - os: linux
+      compiler: gcc
+      addons:
+        apt:
+          sources: [ ubuntu-toolchain-r-test ]
+          packages: [ g++-7 ]
+      env: [ ASAN=ON ]
+
+    - os: linux
       compiler: clang
       env: [ ASAN=ON ]
 
@@ -114,6 +122,7 @@ before_install:
     fi
   - |
     if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
+      [[ $ASAN == ON && $CC == gcc ]] && export CC=gcc-7 CXX=g++-7
       sudo apt-get -qq update
       sudo apt-get install clang-format-3.8
       sudo apt-get install ninja-build

--- a/.travis.yml
+++ b/.travis.yml
@@ -172,7 +172,6 @@ before_script:
     ${CMAKE_OPT[@]}
     $TRAVIS_BUILD_DIR
   - export PATH=$PATH:"$INSTALL_DIR/bin"
-  - export LD_LIBRARY_PATH="$INSTALL_DIR/lib"
 
 script:
   - ninja

--- a/cmake/ElektraCompiling.cmake
+++ b/cmake/ElektraCompiling.cmake
@@ -108,6 +108,8 @@ if (ENABLE_ASAN)
 	endif ()
 
 	if (CMAKE_COMPILER_IS_GNUCXX AND NOT APPLE)
+		# Work around error “unrecognized option '--push-state'”
+		set (EXTRA_FLAGS "${EXTRA_FLAGS} -fuse-ld=gold")
 		set (CMAKE_SHARED_LINKER_FLAGS "-fsanitize=address ${CMAKE_SHARED_LINKER_FLAGS}")
 		# this is needed because of wrong pthread detection https://gcc.gnu.org/bugzilla/show_bug.cgi?id=69443
 		find_package(Threads)

--- a/cmake/ElektraCompiling.cmake
+++ b/cmake/ElektraCompiling.cmake
@@ -97,9 +97,6 @@ endif ()
 
 if (ENABLE_ASAN)
 	set (EXTRA_FLAGS "${EXTRA_FLAGS} -fsanitize=undefined -fsanitize=address -fno-omit-frame-pointer")
-	if (NOT (APPLE OR ("${CMAKE_C_COMPILER_ID}" STREQUAL "Clang" AND "${CMAKE_C_COMPILER_VERSION}" VERSION_GREATER "4.0")))
-		set (CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -lubsan")
-	endif ()
 	set (ASAN_LIBRARY "-lasan") #this is needed for GIR to put asan in front
 
 	if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
@@ -107,10 +104,9 @@ if (ENABLE_ASAN)
 		set (EXTRA_FLAGS "${EXTRA_FLAGS} -fsanitize-blacklist=\"${CMAKE_SOURCE_DIR}/tests/sanitizer.blacklist\"")
 	endif ()
 
-	if (CMAKE_COMPILER_IS_GNUCXX AND NOT APPLE)
+	if (CMAKE_COMPILER_IS_GNUCXX)
 		# Work around error “unrecognized option '--push-state'”
 		set (EXTRA_FLAGS "${EXTRA_FLAGS} -fuse-ld=gold")
-		set (CMAKE_SHARED_LINKER_FLAGS "-fsanitize=address ${CMAKE_SHARED_LINKER_FLAGS}")
 		# this is needed because of wrong pthread detection https://gcc.gnu.org/bugzilla/show_bug.cgi?id=69443
 		find_package(Threads)
 		set (THREAD_LIBS_AS_NEEDED "-Wl,--as-needed ${CMAKE_THREAD_LIBS_INIT}")

--- a/src/plugins/yamlcpp/CMakeLists.txt
+++ b/src/plugins/yamlcpp/CMakeLists.txt
@@ -4,6 +4,11 @@ if (DEPENDENCY_PHASE)
 		remove_plugin (yamlcpp "yaml-cpp (libyaml-cpp-dev >= 0.5) not found")
 	else (NOT YAML-CPP_FOUND)
 		if (YAML-CPP_VERSION VERSION_LESS "0.6.0")
+			if (ENABLE_ASAN AND CMAKE_COMPILER_IS_GNUCXX)
+				remove_plugin (yamlcpp "yaml-cpp ${YAML-CPP_VERSION} reports runtime errors if you compile it with GCC "
+						       "using AddressSanitizer")
+			endif (ENABLE_ASAN AND CMAKE_COMPILER_IS_GNUCXX)
+
 			find_package (Boost QUIET)
 			if (NOT Boost_FOUND)
 				remove_plugin (yamlcpp "yaml-cpp ${YAML-CPP_VERSION} requires Boost")


### PR DESCRIPTION
# Purpose

This PR

- adds a Linux build job for an ASAN enabled GCC build, and
- removes some unneeded CMake code for the ASAN build.

# Checklist

- [x] I checked all commit messages.
- [x] I ran all tests and everything went fine.
- [x] Since this pull request contains no noteworthy changes, I did not update the release notes.