### PR TITLE
Markdown Shell Recorder: Print Path to Test File

### DIFF
--- a/doc/news/_preparation_next_release.md
+++ b/doc/news/_preparation_next_release.md
@@ -94,6 +94,7 @@ These notes are of interest for people developing Elektra:
 - All current versions of Clang-Format (6.0+) and the outdated Clang-Format 5 will now produce exactly the same output for the whole
   codebase.
 - We added an [Markdown Shell Recorder][] test for the [Constants](http://libelektra.org/plugins/constants) plugin.
+- The [Markdown Shell Recorder][] now prints the path of the test file.
 
 [Markdown Shell Recorder]: https://master.libelektra.org/tests/shell/shell_recorder/tutorial_wrapper
 

--- a/tests/shell/shell_recorder/tutorial_wrapper/markdown_shell_recorder.sh
+++ b/tests/shell/shell_recorder/tutorial_wrapper/markdown_shell_recorder.sh
@@ -102,6 +102,8 @@ translate()
 
 resetGlobals
 
+printf 'Input: %s\n' "$1"
+
 BLOCKS=$(sed -n '/```sh/,/```\n/p' "$1")
 BUF=
 SHELL_RECORDER_ERROR=0


### PR DESCRIPTION
# Purpose

After this PR the Markdown Shell Recorder prints the location of the current test file.

# Checklist

- [x] I checked all commit messages. The issue reference in commit e6c157e should be correct.
- [x] I ran all tests and everything went fine.
- [x] The PR also updates the release notes.