### PR TITLE
travis: fix for formatting issue on macOS

### DIFF
--- a/src/tools/kdb/test.cpp
+++ b/src/tools/kdb/test.cpp
@@ -437,7 +437,7 @@ bool checkArgument (std::vector<std::string> const & arguments, std::string test
 {
 	return arguments.size () == 1 || find (arguments.begin (), arguments.end (), testname) != arguments.end ();
 }
-}
+} // namespace
 
 void TestCommand::doTests (std::vector<std::string> const & arguments)
 {


### PR DESCRIPTION
# Purpose

Fix formatting inconsistency with clang-format on macOS (travis).
e.g. https://travis-ci.org/ElektraInitiative/libelektra/jobs/360580895

# Checklist

- [x] commit messages are fine (with references to issues)
- [x] I ran all tests and everything went fine

@markus2330 please review my pull request
