### PR TITLE
"io-glib" binding: add supression rules for glib 2.42

### DIFF
--- a/tests/valgrind.suppression
+++ b/tests/valgrind.suppression
@@ -355,3 +355,14 @@
    ...
    fun:g_main_loop_run
 }
+{
+   glib context global state
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:*alloc
+   ...
+   fun:g_slice_alloc
+   fun:g_slist_prepend
+   fun:g_once_init_enter
+   fun:g_main_context_new
+}


### PR DESCRIPTION
# Purpose

For #1871: Add additional valgrind supression rules for leaking global state in glib 2.42 on Debian Jessie.

# Checklist

- [x] commit messages are fine (with references to issues)
- [x] I ran all tests and everything went fine

@markus2330 please review my pull request
