### PR TITLE
logging plugins: add option for logging on pregetstorage

### DIFF
--- a/doc/news/_preparation_next_release.md
+++ b/doc/news/_preparation_next_release.md
@@ -83,7 +83,7 @@ We added even more functionality, which could not make it to the highlights:
   option called "get" which can be enabled to log which configuration settings
   are loaded by applications.
   The new option can be used for logging application behavior when using
-  [notifications](https://www.libelektra.org/tutorials/notifications).
+  [notifications](https://www.libelektra.org/tutorials/notifications). *(Thomas Wahringer)*
 - <<TODO>>
 - <<TODO>>
 - <<TODO>>

--- a/doc/news/_preparation_next_release.md
+++ b/doc/news/_preparation_next_release.md
@@ -77,6 +77,13 @@ We added even more functionality, which could not make it to the highlights:
   added.
   It can be used to integrate the notification feature with applications based
   on [ev](http://libev.schmorp.de) main loops. *(Thomas Wahringer)*
+- The logging plugins ["syslog"](https://www.libelektra.org/plugins/syslog),
+  ["journald"](https://www.libelektra.org/plugins/journald) and
+  ["logchange"](https://www.libelektra.org/plugins/logchange) now have a new
+  option called "get" which can be enabled to log which configuration settings
+  are loaded by applications.
+  The new option can be used for logging application behavior when using
+  [notifications](https://www.libelektra.org/tutorials/notifications).
 - <<TODO>>
 - <<TODO>>
 - <<TODO>>
@@ -101,7 +108,6 @@ We added even more functionality, which could not make it to the highlights:
 - <<TODO>>
 - <<TODO>>
 - <<TODO>>
-
 
 ## Documentation
 

--- a/doc/tutorials/README.md
+++ b/doc/tutorials/README.md
@@ -25,6 +25,7 @@ provides.
 - [Python Bindings](python-kdb.md)
 - [Ruby Bindings](/src/bindings/swig/ruby/README.md)
 - [Code Generation](/src/tools/gen/README.md)
+- [Notifications](notifications.md)
 
 ## System Administrators
 
@@ -52,4 +53,3 @@ These tutorials provide additional information on how to
 install and set up specific plugins and tools.
 
 - [Snippet Sharing REST-Service](snippet-sharing-rest-service.md)
-

--- a/doc/tutorials/notifications.md
+++ b/doc/tutorials/notifications.md
@@ -248,3 +248,18 @@ Existing I/O bindings provide a good inspiration on how to implement a custom
 binding.
 Since a binding is generic and not application specific it is much appreciated
 if you contribute your I/O binding back to the Elektra project.
+
+## Logging
+
+In order to log and analyze application behavior the logging plugins
+["syslog"](https://www.libelektra.org/plugins/syslog),
+["journald"](https://www.libelektra.org/plugins/journald) or
+["logchange"](https://www.libelektra.org/plugins/logchange) can be used.
+In order to log not only `kdbSet()` but also `kdbGet()` the option "get=on"
+should be used when mounting these plugins.
+
+For example:
+
+```
+$ kdb global-mount syslog get=on
+```

--- a/doc/tutorials/notifications.md
+++ b/doc/tutorials/notifications.md
@@ -255,7 +255,7 @@ In order to log and analyze application behavior the logging plugins
 ["syslog"](https://www.libelektra.org/plugins/syslog),
 ["journald"](https://www.libelektra.org/plugins/journald) or
 ["logchange"](https://www.libelektra.org/plugins/logchange) can be used.
-In order to log not only `kdbSet()` but also `kdbGet()` the option "get=on"
+In order to log not only `kdbSet()` but also `kdbGet()` the option "get=1"
 should be used when mounting these plugins.
 
 For example:

--- a/doc/tutorials/notifications.md
+++ b/doc/tutorials/notifications.md
@@ -255,11 +255,11 @@ In order to log and analyze application behavior the logging plugins
 ["syslog"](https://www.libelektra.org/plugins/syslog),
 ["journald"](https://www.libelektra.org/plugins/journald) or
 ["logchange"](https://www.libelektra.org/plugins/logchange) can be used.
-In order to log not only `kdbSet()` but also `kdbGet()` the option "get=1"
+In order to log not only `kdbSet()` but also `kdbGet()` the option `log/get=1`
 should be used when mounting these plugins.
 
 For example:
 
 ```
-$ kdb global-mount syslog get=on
+$ kdb global-mount syslog log/get=1
 ```

--- a/src/plugins/journald/README.md
+++ b/src/plugins/journald/README.md
@@ -3,17 +3,20 @@
 - infos/licence = BSD
 - infos/provides = logging
 - infos/needs =
-- infos/placements = postcommit postrollback
+- infos/placements = pregetstorage postcommit postrollback
 - infos/status = maintained libc global nodoc
 - infos/description = logging of committed and rolled back keys via systemd-journal
 
 ## Introduction
 
-The plugin logs successful and failed write attempts via the systemd journal daemon (systemd-journal). 
+The plugin logs successful and failed write attempts via the systemd journal daemon (systemd-journal).
 See the [systemd-journal manpage](http://www.freedesktop.org/software/systemd/man/systemd-journald.service.html) for more information about systemd-journal.
 Errors are reported with priority 3 (error priority) and use the message ID `fb3928ea453048649c61d62619847ef6`.
-Successful writes are reported with priority 5 (notice priority) and use the message ID `fc65eab25c18463f97e4f9b61ea31eae`. 
+Successful writes are reported with priority 5 (notice priority) and use the message ID `fc65eab25c18463f97e4f9b61ea31eae`.
+
+Configure the plugin with `get=on` to enable logging before a configuration is
+loaded. For example, `kdb gmount journald get=on`.
 
 ## Dependencies
 
-- `libsystemd-journal-dev`
+- `libsystemd-dev` (also called `libsystemd-journal-dev`)

--- a/src/plugins/journald/README.md
+++ b/src/plugins/journald/README.md
@@ -14,8 +14,8 @@ See the [systemd-journal manpage](http://www.freedesktop.org/software/systemd/ma
 Errors are reported with priority 3 (error priority) and use the message ID `fb3928ea453048649c61d62619847ef6`.
 Successful writes are reported with priority 5 (notice priority) and use the message ID `fc65eab25c18463f97e4f9b61ea31eae`.
 
-Configure the plugin with `get=on` to enable logging before a configuration is
-loaded. For example, `kdb gmount journald get=on`.
+Configure the plugin with `get=1` to enable logging when configuration is
+loaded. For example, `kdb gmount journald get=1`.
 
 ## Dependencies
 

--- a/src/plugins/journald/README.md
+++ b/src/plugins/journald/README.md
@@ -14,8 +14,8 @@ See the [systemd-journal manpage](http://www.freedesktop.org/software/systemd/ma
 Errors are reported with priority 3 (error priority) and use the message ID `fb3928ea453048649c61d62619847ef6`.
 Successful writes are reported with priority 5 (notice priority) and use the message ID `fc65eab25c18463f97e4f9b61ea31eae`.
 
-Configure the plugin with `get=1` to enable logging when configuration is
-loaded. For example, `kdb gmount journald get=1`.
+Configure the plugin with `log/get=1` to enable logging when configuration is
+loaded. For example, `kdb gmount journald log/get=1`.
 
 ## Dependencies
 

--- a/src/plugins/journald/journald.c
+++ b/src/plugins/journald/journald.c
@@ -19,16 +19,31 @@
 
 int elektraJournaldGet (Plugin * handle ELEKTRA_UNUSED, KeySet * returned, Key * parentKey ELEKTRA_UNUSED)
 {
-	KeySet * n;
-	ksAppend (returned,
-		  n = ksNew (30, keyNew ("system/elektra/modules/journald", KEY_VALUE, "journald plugin waits for your orders", KEY_END),
-			     keyNew ("system/elektra/modules/journald/exports", KEY_END),
-			     keyNew ("system/elektra/modules/journald/exports/get", KEY_FUNC, elektraJournaldGet, KEY_END),
-			     keyNew ("system/elektra/modules/journald/exports/set", KEY_FUNC, elektraJournaldSet, KEY_END),
-			     keyNew ("system/elektra/modules/journald/exports/error", KEY_FUNC, elektraJournaldError, KEY_END),
+	if (!strcmp (keyName (parentKey), "system/elektra/modules/journald"))
+	{
+		KeySet * n;
+		ksAppend (
+			returned,
+			n = ksNew (30,
+				   keyNew ("system/elektra/modules/journald", KEY_VALUE, "journald plugin waits for your orders", KEY_END),
+				   keyNew ("system/elektra/modules/journald/exports", KEY_END),
+				   keyNew ("system/elektra/modules/journald/exports/get", KEY_FUNC, elektraJournaldGet, KEY_END),
+				   keyNew ("system/elektra/modules/journald/exports/set", KEY_FUNC, elektraJournaldSet, KEY_END),
+				   keyNew ("system/elektra/modules/journald/exports/error", KEY_FUNC, elektraJournaldError, KEY_END),
 #include "readme_journald.c"
-			     keyNew ("system/elektra/modules/journald/infos/version", KEY_VALUE, PLUGINVERSION, KEY_END), KS_END));
-	ksDel (n);
+				   keyNew ("system/elektra/modules/journald/infos/version", KEY_VALUE, PLUGINVERSION, KEY_END), KS_END));
+		ksDel (n);
+		return 1;
+	}
+
+	if (strncmp (keyString (ksLookupByName (elektraPluginGetConfig (handle), "/config/get", 0)), "on", 2) == 0)
+	{
+		sd_journal_send ("MESSAGE=loading configuration %s", keyName (parentKey), "MESSAGE_ID=fc65eab25c18463f97e4f9b61ea31eae",
+				 "PRIORITY=5", /* notice priority */
+				 "HOME=%s", getenv ("HOME"), "USER=%s", getenv ("USER"), "PAGE_SIZE=%li", sysconf (_SC_PAGESIZE),
+				 "N_CPUS=%li", sysconf (_SC_NPROCESSORS_ONLN), NULL);
+	}
+
 	return 1;
 }
 
@@ -60,4 +75,3 @@ Plugin * ELEKTRA_PLUGIN_EXPORT (journald)
 		ELEKTRA_PLUGIN_ERROR,	&elektraJournaldError,
 		ELEKTRA_PLUGIN_END);
 }
-

--- a/src/plugins/journald/journald.c
+++ b/src/plugins/journald/journald.c
@@ -36,7 +36,7 @@ int elektraJournaldGet (Plugin * handle ELEKTRA_UNUSED, KeySet * returned, Key *
 		return 1;
 	}
 
-	if (strncmp (keyString (ksLookupByName (elektraPluginGetConfig (handle), "/get", 0)), "1", 1) == 0)
+	if (strncmp (keyString (ksLookupByName (elektraPluginGetConfig (handle), "/log/get", 0)), "1", 1) == 0)
 	{
 		sd_journal_send ("MESSAGE=loading configuration %s", keyName (parentKey), "MESSAGE_ID=fc65eab25c18463f97e4f9b61ea31eae",
 				 "PRIORITY=5", /* notice priority */

--- a/src/plugins/journald/journald.c
+++ b/src/plugins/journald/journald.c
@@ -36,7 +36,7 @@ int elektraJournaldGet (Plugin * handle ELEKTRA_UNUSED, KeySet * returned, Key *
 		return 1;
 	}
 
-	if (strncmp (keyString (ksLookupByName (elektraPluginGetConfig (handle), "/config/get", 0)), "on", 2) == 0)
+	if (strncmp (keyString (ksLookupByName (elektraPluginGetConfig (handle), "/get", 0)), "1", 1) == 0)
 	{
 		sd_journal_send ("MESSAGE=loading configuration %s", keyName (parentKey), "MESSAGE_ID=fc65eab25c18463f97e4f9b61ea31eae",
 				 "PRIORITY=5", /* notice priority */

--- a/src/plugins/logchange/README.md
+++ b/src/plugins/logchange/README.md
@@ -19,5 +19,5 @@ To use it, add it during mounting:
 
     kdb mount logchange.dump user/logchange dump logchange
 
-Configure the plugin with `get=on` to enable printing before a configuration is
-loaded. For example, `kdb gmount logchange get=on`.
+Configure the plugin with `get=1` to enable printing when configuration is
+loaded. For example, `kdb gmount logchange get=1`.

--- a/src/plugins/logchange/README.md
+++ b/src/plugins/logchange/README.md
@@ -19,5 +19,5 @@ To use it, add it during mounting:
 
     kdb mount logchange.dump user/logchange dump logchange
 
-Configure the plugin with `get=1` to enable printing when configuration is
-loaded. For example, `kdb gmount logchange get=1`.
+Configure the plugin with `log/get=1` to enable printing when configuration is
+loaded. For example, `kdb gmount logchange log/get=1`.

--- a/src/plugins/logchange/README.md
+++ b/src/plugins/logchange/README.md
@@ -3,7 +3,7 @@
 - infos/licence = BSD
 - infos/needs =
 - infos/provides = tracing
-- infos/placements = postgetstorage postcommit
+- infos/placements = pregetstorage postgetstorage postcommit
 - infos/status = maintained nodep global nodoc
 - infos/description = demonstrates notification of key changes
 
@@ -19,3 +19,5 @@ To use it, add it during mounting:
 
     kdb mount logchange.dump user/logchange dump logchange
 
+Configure the plugin with `get=on` to enable printing before a configuration is
+loaded. For example, `kdb gmount logchange get=on`.

--- a/src/plugins/logchange/logchange.c
+++ b/src/plugins/logchange/logchange.c
@@ -50,7 +50,7 @@ int elektraLogchangeGet (Plugin * handle, KeySet * returned, Key * parentKey ELE
 	if (ks) ksDel (ks);
 	elektraPluginSetData (handle, ksDup (returned));
 
-	if (strncmp (keyString (ksLookupByName (elektraPluginGetConfig (handle), "/get", 0)), "1", 1) == 0)
+	if (strncmp (keyString (ksLookupByName (elektraPluginGetConfig (handle), "/log/get", 0)), "1", 1) == 0)
 	{
 		KeySet * logset = ksNew (1, keyDup (parentKey), KS_END);
 		logKeys (logset, "loading configuration");

--- a/src/plugins/logchange/logchange.c
+++ b/src/plugins/logchange/logchange.c
@@ -17,6 +17,16 @@
 
 #include "logchange.h"
 
+static void logKeys (KeySet * ks, const char * message)
+{
+	ksRewind (ks);
+	Key * k = 0;
+	while ((k = ksNext (ks)) != 0)
+	{
+		printf ("%s: %s\n", message, keyName (k));
+	}
+}
+
 int elektraLogchangeGet (Plugin * handle, KeySet * returned, Key * parentKey ELEKTRA_UNUSED)
 {
 	if (!strcmp (keyName (parentKey), "system/elektra/modules/logchange"))
@@ -40,17 +50,14 @@ int elektraLogchangeGet (Plugin * handle, KeySet * returned, Key * parentKey ELE
 	if (ks) ksDel (ks);
 	elektraPluginSetData (handle, ksDup (returned));
 
-	return 1; /* success */
-}
-
-static void logKeys (KeySet * ks, const char * message)
-{
-	ksRewind (ks);
-	Key * k = 0;
-	while ((k = ksNext (ks)) != 0)
+	if (strncmp (keyString (ksLookupByName (elektraPluginGetConfig (handle), "/config/get", 0)), "on", 2) == 0)
 	{
-		printf ("%s: %s\n", message, keyName (k));
+		KeySet * logset = ksNew (1, keyDup (parentKey), KS_END);
+		logKeys (logset, "loading configuration");
+		ksDel (logset);
 	}
+
+	return 1; /* success */
 }
 
 int elektraLogchangeSet (Plugin * handle, KeySet * returned, Key * parentKey ELEKTRA_UNUSED)
@@ -114,4 +121,3 @@ Plugin * ELEKTRA_PLUGIN_EXPORT (logchange)
 		ELEKTRA_PLUGIN_CLOSE,	&elektraLogchangeClose,
 		ELEKTRA_PLUGIN_END);
 }
-

--- a/src/plugins/logchange/logchange.c
+++ b/src/plugins/logchange/logchange.c
@@ -50,7 +50,7 @@ int elektraLogchangeGet (Plugin * handle, KeySet * returned, Key * parentKey ELE
 	if (ks) ksDel (ks);
 	elektraPluginSetData (handle, ksDup (returned));
 
-	if (strncmp (keyString (ksLookupByName (elektraPluginGetConfig (handle), "/config/get", 0)), "on", 2) == 0)
+	if (strncmp (keyString (ksLookupByName (elektraPluginGetConfig (handle), "/get", 0)), "1", 1) == 0)
 	{
 		KeySet * logset = ksNew (1, keyDup (parentKey), KS_END);
 		logKeys (logset, "loading configuration");

--- a/src/plugins/syslog/README.md
+++ b/src/plugins/syslog/README.md
@@ -3,7 +3,7 @@
 - infos/licence = BSD
 - infos/provides = logging
 - infos/needs =
-- infos/placements = postcommit postrollback
+- infos/placements = pregetstorage postcommit postrollback
 - infos/status = maintained tested nodep global nodoc
 - infos/description = Logs set and error calls to syslog.
 
@@ -12,3 +12,5 @@
 This plugin is a logging plugin which adds a log entry to syslog on
 commit and rollback of the configuration.
 
+Configure the plugin with `get=on` to enable logging before a configuration is
+loaded. For example, `kdb gmount syslog get=on`.

--- a/src/plugins/syslog/README.md
+++ b/src/plugins/syslog/README.md
@@ -12,5 +12,5 @@
 This plugin is a logging plugin which adds a log entry to syslog on
 commit and rollback of the configuration.
 
-Configure the plugin with `get=on` to enable logging before a configuration is
-loaded. For example, `kdb gmount syslog get=on`.
+Configure the plugin with `get=1` to enable logging when configuration is
+loaded. For example, `kdb gmount syslog get=1`.

--- a/src/plugins/syslog/README.md
+++ b/src/plugins/syslog/README.md
@@ -12,5 +12,5 @@
 This plugin is a logging plugin which adds a log entry to syslog on
 commit and rollback of the configuration.
 
-Configure the plugin with `get=1` to enable logging when configuration is
-loaded. For example, `kdb gmount syslog get=1`.
+Configure the plugin with `log/get=1` to enable logging when configuration is
+loaded. For example, `kdb gmount syslog log/get=1`.

--- a/src/plugins/syslog/log.h
+++ b/src/plugins/syslog/log.h
@@ -5,13 +5,11 @@
  *
  * @copyright BSD License (see LICENSE.md or https://www.libelektra.org)
  */
+#ifndef ELEKTRA_PLUGIN_SYSLOG_H
+#define ELEKTRA_PLUGIN_SYSLOG_H
 
 #include <kdbplugin.h>
 #include <syslog.h>
-
-
-#define BACKENDNAME "syslog"
-#define BACKENDVERSION "0.0.1"
 
 int elektraSyslogOpen (Plugin * handle, Key * parentKey);
 int elektraSyslogClose (Plugin * handle, Key * parentKey);
@@ -20,3 +18,5 @@ int elektraSyslogSet (Plugin * handle, KeySet * ks, Key * parentKey);
 int elektraSyslogError (Plugin * handle, KeySet * returned, Key * parentKey);
 
 Plugin * ELEKTRA_PLUGIN_EXPORT (syslog);
+
+#endif

--- a/src/plugins/syslog/syslog.c
+++ b/src/plugins/syslog/syslog.c
@@ -57,7 +57,7 @@ int elektraSyslogGet (Plugin * handle, KeySet * returned, Key * parentKey)
 		return 1;
 	}
 
-	if (strncmp (keyString (ksLookupByName (elektraPluginGetConfig (handle), "/get", 0)), "1", 1) == 0)
+	if (strncmp (keyString (ksLookupByName (elektraPluginGetConfig (handle), "/log/get", 0)), "1", 1) == 0)
 	{
 		syslog (LOG_NOTICE, "loading configuration %s", keyName (parentKey));
 	}

--- a/src/plugins/syslog/syslog.c
+++ b/src/plugins/syslog/syslog.c
@@ -57,7 +57,7 @@ int elektraSyslogGet (Plugin * handle, KeySet * returned, Key * parentKey)
 		return 1;
 	}
 
-	if (strncmp (keyString (ksLookupByName (elektraPluginGetConfig (handle), "/get", 0)), "on", 2) == 0)
+	if (strncmp (keyString (ksLookupByName (elektraPluginGetConfig (handle), "/get", 0)), "1", 1) == 0)
 	{
 		syslog (LOG_NOTICE, "loading configuration %s", keyName (parentKey));
 	}

--- a/src/plugins/syslog/syslog.c
+++ b/src/plugins/syslog/syslog.c
@@ -36,20 +36,32 @@ int elektraSyslogClose (Plugin * handle, Key * parentKey ELEKTRA_UNUSED)
 	return 0; /* success */
 }
 
-int elektraSyslogGet (Plugin * handle ELEKTRA_UNUSED, KeySet * returned, Key * parentKey ELEKTRA_UNUSED)
+int elektraSyslogGet (Plugin * handle, KeySet * returned, Key * parentKey)
 {
-	KeySet * n;
-	ksAppend (returned,
-		  n = ksNew (30, keyNew ("system/elektra/modules/syslog", KEY_VALUE, "syslog plugin waits for your orders", KEY_END),
-			     keyNew ("system/elektra/modules/syslog/exports", KEY_END),
-			     keyNew ("system/elektra/modules/syslog/exports/open", KEY_FUNC, elektraSyslogOpen, KEY_END),
-			     keyNew ("system/elektra/modules/syslog/exports/close", KEY_FUNC, elektraSyslogClose, KEY_END),
-			     keyNew ("system/elektra/modules/syslog/exports/get", KEY_FUNC, elektraSyslogGet, KEY_END),
-			     keyNew ("system/elektra/modules/syslog/exports/set", KEY_FUNC, elektraSyslogSet, KEY_END),
-			     keyNew ("system/elektra/modules/syslog/exports/error", KEY_FUNC, elektraSyslogError, KEY_END),
+	if (!strcmp (keyName (parentKey), "system/elektra/modules/syslog"))
+	{
+		KeySet * n;
+		ksAppend (returned,
+			  n = ksNew (30,
+				     keyNew ("system/elektra/modules/syslog", KEY_VALUE, "syslog plugin waits for your orders", KEY_END),
+				     keyNew ("system/elektra/modules/syslog/exports", KEY_END),
+				     keyNew ("system/elektra/modules/syslog/exports/open", KEY_FUNC, elektraSyslogOpen, KEY_END),
+				     keyNew ("system/elektra/modules/syslog/exports/close", KEY_FUNC, elektraSyslogClose, KEY_END),
+				     keyNew ("system/elektra/modules/syslog/exports/get", KEY_FUNC, elektraSyslogGet, KEY_END),
+				     keyNew ("system/elektra/modules/syslog/exports/set", KEY_FUNC, elektraSyslogSet, KEY_END),
+				     keyNew ("system/elektra/modules/syslog/exports/error", KEY_FUNC, elektraSyslogError, KEY_END),
 #include "readme_syslog.c"
-			     keyNew ("system/elektra/modules/syslog/infos/version", KEY_VALUE, PLUGINVERSION, KEY_END), KS_END));
-	ksDel (n);
+				     keyNew ("system/elektra/modules/syslog/infos/version", KEY_VALUE, PLUGINVERSION, KEY_END), KS_END));
+		ksDel (n);
+
+		return 1;
+	}
+
+	if (strncmp (keyString (ksLookupByName (elektraPluginGetConfig (handle), "/get", 0)), "on", 2) == 0)
+	{
+		syslog (LOG_NOTICE, "loading configuration %s", keyName (parentKey));
+	}
+
 	return 1;
 }
 
@@ -82,7 +94,7 @@ int elektraSyslogError (Plugin * handle ELEKTRA_UNUSED, KeySet * returned, Key *
 Plugin * ELEKTRA_PLUGIN_EXPORT (syslog)
 {
 	// clang-format off
-	return elektraPluginExport(BACKENDNAME,
+	return elektraPluginExport("syslog",
 		ELEKTRA_PLUGIN_OPEN,	&elektraSyslogOpen,
 		ELEKTRA_PLUGIN_CLOSE,	&elektraSyslogClose,
 		ELEKTRA_PLUGIN_GET,	&elektraSyslogGet,
@@ -90,4 +102,3 @@ Plugin * ELEKTRA_PLUGIN_EXPORT (syslog)
 		ELEKTRA_PLUGIN_ERROR,	&elektraSyslogError,
 		ELEKTRA_PLUGIN_END);
 }
-


### PR DESCRIPTION
# Purpose

This PR adds an option for logging on kdbGet() before configuration is loaded.

The plugins "syslog", "journald" and "logchange" were changed. 
Logging on kdbGet() is disabled by default and needs to by enabled using "get=on" when mounting.
If enabled, the parentKey passed to kdbGet() is logged.

# Checklist

- [x] commit messages are fine (with references to issues)
- [x] I ran all tests and everything went fine
- [x] affected documentation is fixed
- [x] release notes are updated (doc/news/_preparation_next_release.md)

@markus2330 please review my pull request
