### PR TITLE
tests: remove clearenv in tests

### DIFF
--- a/tests/cframework/tests.c
+++ b/tests/cframework/tests.c
@@ -27,9 +27,6 @@
 int nbError;
 int nbTest;
 
-uid_t nbUid;
-gid_t nbGid;
-
 char file[KDB_MAX_PATH_LENGTH];
 char srcdir[KDB_MAX_PATH_LENGTH];
 
@@ -50,18 +47,6 @@ int init (int argc, char ** argv)
 {
 	char * tmpvar;
 	int fd;
-
-	setlocale (LC_ALL, "");
-
-#ifdef HAVE_CLEARENV
-	clearenv ();
-#else
-	unsetenv ("HOME");
-	unsetenv ("USER");
-#endif
-
-	nbUid = getuid ();
-	nbGid = getgid ();
 
 	if (argc > 1)
 	{
@@ -115,12 +100,6 @@ Key * create_root_key (const char * backendName)
 {
 	Key * root = keyNew ("user/tests", KEY_END);
 	/*Make mountpoint beneath root, and do all tests here*/
-	/* Not needed anymore:
-	keySetDir(root);
-	keySetUID(root, nbUid);
-	keySetGID(root, nbGid);
-	keySetComment (root, "backend root key for tests");
-	*/
 	keyAddBaseName (root, backendName);
 	keySetString (root, backendName);
 	keySetString (root, backendName);


### PR DESCRIPTION
# Purpose

See #1906

# Checklist

Check relevant points but please do not remove entries.
For docu fixes, spell checking, and similar nothing
needs to be checked.

- [ ] commit messages are fine ("module: short statement" syntax and refer to issues)
- [ ] I added unit tests
- [ ] I ran all tests locally and everything went fine
- [ ] affected documentation is fixed
- [ ] I added code comments, logging, and assertions (see doc/CODING.md)
- [ ] meta data is updated (e.g. README.md of plugins)
- [ ] release notes are updated (doc/news/_preparation_next_release.md)

