### PR TITLE
kdb: fix cp and mv

### DIFF
--- a/doc/help/kdb-cp.md
+++ b/doc/help/kdb-cp.md
@@ -16,6 +16,13 @@ Where `source` is the path of the key(s) you want to copy and `dest` is the path
 Note that when using the `-r` flag, `source` as well as all of the keys below it will be copied.
 
 
+## LIMITATIONS
+
+Neither `source` nor `dest` can be a cascading key.
+(Start with `/`).
+Make sure to select a namespace.
+
+
 ## RETURN VALUES
 
 This command will return the following values as an exit status:
@@ -25,7 +32,8 @@ This command will return the following values as an exit status:
 - 1-10:
   standard exit codes, see [kdb(1)](kdb.md)
 - 11:
-  Would override a key (pass `-f` to force)
+  No key to copy found.
+
 
 ## OPTIONS
 
@@ -57,7 +65,7 @@ To copy a single key:<br>
 
 To copy keys below an existing key:<br>
 `kdb cp -r user/example user/example/key1`<br>
-Note that in this example, all keys in the example directory will be copied below `key1` EXCEPT `key1`.
+Note that in this example, all keys in the example directory will be copied below `key1` **except** `key1`.
 
 
 

--- a/doc/help/kdb-get.md
+++ b/doc/help/kdb-get.md
@@ -7,6 +7,7 @@ kdb-get(1) -- Get the value of a key stored in the key database
 
 Where `key name` is the name of the key.
 
+
 ## DESCRIPTION
 
 This command is used to retrieve the value of a key.
@@ -14,9 +15,25 @@ This command is used to retrieve the value of a key.
 If you enter a `key name` starting with a leading `/`, then a cascading lookup will be performed in order to attempt to locate the key.
 In this case, using the `-v` option allows the user to see the full key name of the key if it is found.
 
-Note: There is a current limitation where only keys that are mounted will be considered during a cascading lookup.
-A workaround that will lookup all keys is to pass the `-a` option.
-Additionally, a user can use the command `kdb ls <same key>` to see if an override or a fallback will be considered by the lookup.
+
+## LIMITATIONS
+
+Only keys within the mountpoint or below the `<key name>` will be considered during a cascading lookup.
+A workaround is to pass the `-a` option.
+Use the command `kdb get -v <key name>` to see if an override or a fallback was considered by the lookup.
+
+
+
+## RETURN VALUES
+
+This command will return the following values as an exit status:
+
+- 0:
+  No errors.
+- 1-10:
+  standard exit codes, see [kdb(1)](kdb.md)
+- 11:
+  No key found.
 
 
 ## OPTIONS

--- a/doc/help/kdb-mv.md
+++ b/doc/help/kdb-mv.md
@@ -11,7 +11,27 @@ Note that when using the `-r` flag, `source` as well as all of the keys below it
 ## DESCRIPTION
 
 This command moves key(s) in the Key database.
-You can move keys to another directory within the database or even below another key.
+You can move keys to another other paths within the database.
+
+
+## LIMITATIONS
+
+Neither `source` nor `dest` can be a cascading key.
+(Start with `/`).
+Make sure to select a namespace.
+
+
+## RETURN VALUES
+
+This command will return the following values as an exit status:
+
+- 0:
+  No errors.
+- 1-10:
+  standard exit codes, see [kdb(1)](kdb.md)
+- 11:
+  No key to move found.
+
 
 
 ## OPTIONS
@@ -31,10 +51,10 @@ You can move keys to another directory within the database or even below another
 
 ## EXAMPLES
 
-To move multiple keys:
+To move multiple keys:  
 `kdb mv -r user/example1 user/example2`
 
-To move a single key:
+To move a single key:  
 `kdb mv user/example/key1 user/example/key2`
 
 

--- a/doc/man/kdb-cp.1
+++ b/doc/man/kdb-cp.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "KDB\-CP" "1" "December 2017" "" ""
+.TH "KDB\-CP" "1" "April 2018" "" ""
 .
 .SH "NAME"
 \fBkdb\-cp\fR \- Copy keys within the key database
@@ -14,6 +14,9 @@ This command copies key(s) in the Key database\. You can copy keys to another di
 .
 .P
 Where \fBsource\fR is the path of the key(s) you want to copy and \fBdest\fR is the path where you would like to copy the key(s) to\. Note that when using the \fB\-r\fR flag, \fBsource\fR as well as all of the keys below it will be copied\.
+.
+.SH "LIMITATIONS"
+Neither \fBsource\fR nor \fBdest\fR can be a cascading key\. (Start with \fB/\fR)\. Make sure to select a namespace\.
 .
 .SH "RETURN VALUES"
 This command will return the following values as an exit status:
@@ -28,7 +31,7 @@ standard exit codes, see kdb(1) \fIkdb\.md\fR
 .
 .TP
 11
-Would override a key (pass \fB\-f\fR to force)
+No key to copy found\.
 .
 .SH "OPTIONS"
 .
@@ -79,4 +82,4 @@ To copy keys below an existing key:
 \fBkdb cp \-r user/example user/example/key1\fR
 .
 .br
-Note that in this example, all keys in the example directory will be copied below \fBkey1\fR EXCEPT \fBkey1\fR\.
+Note that in this example, all keys in the example directory will be copied below \fBkey1\fR \fBexcept\fR \fBkey1\fR\.

--- a/doc/man/kdb-get.1
+++ b/doc/man/kdb-get.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "KDB\-GET" "1" "October 2017" "" ""
+.TH "KDB\-GET" "1" "April 2018" "" ""
 .
 .SH "NAME"
 \fBkdb\-get\fR \- Get the value of a key stored in the key database
@@ -18,8 +18,23 @@ This command is used to retrieve the value of a key\.
 .P
 If you enter a \fBkey name\fR starting with a leading \fB/\fR, then a cascading lookup will be performed in order to attempt to locate the key\. In this case, using the \fB\-v\fR option allows the user to see the full key name of the key if it is found\.
 .
-.P
-Note: There is a current limitation where only keys that are mounted will be considered during a cascading lookup\. A workaround that will lookup all keys is to pass the \fB\-a\fR option\. Additionally, a user can use the command \fBkdb ls <same key>\fR to see if an override or a fallback will be considered by the lookup\.
+.SH "LIMITATIONS"
+Only keys within the mountpoint or below the \fB<key name>\fR will be considered during a cascading lookup\. A workaround is to pass the \fB\-a\fR option\. Use the command \fBkdb get \-v <key name>\fR to see if an override or a fallback was considered by the lookup\.
+.
+.SH "RETURN VALUES"
+This command will return the following values as an exit status:
+.
+.TP
+0
+No errors\.
+.
+.TP
+1\-10
+standard exit codes, see kdb(1) \fIkdb\.md\fR
+.
+.TP
+11
+No key found\.
 .
 .SH "OPTIONS"
 .

--- a/doc/man/kdb-mv.1
+++ b/doc/man/kdb-mv.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "KDB\-MV" "1" "October 2017" "" ""
+.TH "KDB\-MV" "1" "April 2018" "" ""
 .
 .SH "NAME"
 \fBkdb\-mv\fR \- Move keys within the key database
@@ -13,7 +13,25 @@
 Where \fBsource\fR is the path of the key(s) you want to copy and \fBdest\fR is the path where you would like to move the key(s) to\. Note that when using the \fB\-r\fR flag, \fBsource\fR as well as all of the keys below it will be moved\.
 .
 .SH "DESCRIPTION"
-This command moves key(s) in the Key database\. You can move keys to another directory within the database or even below another key\.
+This command moves key(s) in the Key database\. You can move keys to another other paths within the database\.
+.
+.SH "LIMITATIONS"
+Neither \fBsource\fR nor \fBdest\fR can be a cascading key\. (Start with \fB/\fR)\. Make sure to select a namespace\.
+.
+.SH "RETURN VALUES"
+This command will return the following values as an exit status:
+.
+.TP
+0
+No errors\.
+.
+.TP
+1\-10
+standard exit codes, see kdb(1) \fIkdb\.md\fR
+.
+.TP
+11
+No key to move found\.
 .
 .SH "OPTIONS"
 .
@@ -42,7 +60,13 @@ Work in a recursive mode\.
 Explain what is happening\.
 .
 .SH "EXAMPLES"
-To move multiple keys: \fBkdb mv \-r user/example1 user/example2\fR
+To move multiple keys:
+.
+.br
+\fBkdb mv \-r user/example1 user/example2\fR
 .
 .P
-To move a single key: \fBkdb mv user/example/key1 user/example/key2\fR
+To move a single key:
+.
+.br
+\fBkdb mv user/example/key1 user/example/key2\fR

--- a/doc/news/_preparation_next_release.md
+++ b/doc/news/_preparation_next_release.md
@@ -92,6 +92,14 @@ compiled against an older 0.8 version of Elektra will continue to work
 We added:
 
 - the private headerfiles `kdbnotificationinternal.h`, `kdbioplugin.h`.
+- `kdb get`, `kdb mv` and `kdb cp` use error code `11` if keys are not found
+
+We removed:
+
+- not used error code `12` from `kdb mv` removed from docu
+- cascading keys as arguments to `kdb cp` and `kdb mv` now fail instead
+  of doing something unexpected, thanks to @sanssecours for reporting
+  (see #1483)
 
 ## Notes for Maintainer
 

--- a/src/tools/kdb/cmdline.cpp
+++ b/src/tools/kdb/cmdline.cpp
@@ -521,7 +521,7 @@ kdb::KeySet Cmdline::getPluginsConfig (string basepath) const
  *
  * @return a newly created key from the name found in cl.arguments[pos]
  */
-kdb::Key Cmdline::createKey (int pos) const
+kdb::Key Cmdline::createKey (int pos, bool allowCascading) const
 {
 	std::string name = arguments[pos];
 	// std::cerr << "Using " << name << std::endl;
@@ -550,6 +550,12 @@ kdb::Key Cmdline::createKey (int pos) const
 					"can be used (see 'man elektra-namespaces').\n" +
 					"Please also ensure that the path is separated by a '/'.\n" +
 					"An example for a valid absolute key is user/a/key, and for a valid cascading key /a/key.");
+	}
+
+	if (!allowCascading && root.isCascading ())
+	{
+		throw invalid_argument ("The key '" + root.getName () +
+					"'is a cascading keyname, which is not supported. Please choose a namespace.");
 	}
 
 	return root;

--- a/src/tools/kdb/cmdline.hpp
+++ b/src/tools/kdb/cmdline.hpp
@@ -91,7 +91,7 @@ public:
 	map bookmarks;
 	std::string profile;
 
-	kdb::Key createKey (int pos) const;
+	kdb::Key createKey (int pos, bool allowCascading = true) const;
 	kdb::Key resolveBookmark (std::string name) const;
 
 	kdb::KeySet getPluginsConfig (std::string basepath = "user/") const;

--- a/src/tools/kdb/cp.cpp
+++ b/src/tools/kdb/cp.cpp
@@ -47,17 +47,10 @@ int CpCommand::execute (Cmdline const & cl)
 	}
 
 	KeySet conf;
-	Key sourceKey = cl.createKey (0);
-	if (!sourceKey.isValid ())
-	{
-		throw invalid_argument ("Source given is not a valid keyname");
-	}
+	Key sourceKey = cl.createKey (0, false);
 
-	Key destKey = cl.createKey (1);
-	if (!destKey.isValid ())
-	{
-		throw invalid_argument ("Destination given is not a valid keyname");
-	}
+	Key destKey = cl.createKey (1, false);
+
 	string newDirName = destKey.getName ();
 
 	kdb.get (conf, sourceKey);
@@ -65,12 +58,18 @@ int CpCommand::execute (Cmdline const & cl)
 	KeySet tmpConf = conf;
 	KeySet oldConf;
 
+	std::string sourceName = sourceKey.getName ();
 	oldConf.append (tmpConf.cut (sourceKey));
+
+	if (!oldConf.size ())
+	{
+		std::cerr << "No key to copy found below '" << sourceName << "'" << std::endl;
+		return 11;
+	}
 
 	KeySet newConf;
 
 	oldConf.rewind ();
-	std::string sourceName = sourceKey.getName ();
 	if (cl.verbose) cout << "common name: " << sourceName << endl;
 	if (cl.recursive)
 	{
@@ -86,6 +85,12 @@ int CpCommand::execute (Cmdline const & cl)
 	{
 		// just copy one key
 		Key k = oldConf.next ();
+		if (k != sourceKey)
+		{
+			cerr << "First key found " << k.getName () << " does not exactly match given key " << sourceKey.getName ()
+			     << ", aborting (use -r to move hierarchy)\n";
+			return 11;
+		}
 		Key rk = rename_key (k, sourceName, newDirName, cl.verbose);
 		copySingleKey (cl, rk, tmpConf, newConf);
 	}

--- a/src/tools/kdb/get.cpp
+++ b/src/tools/kdb/get.cpp
@@ -189,8 +189,8 @@ int GetCommand::execute (Cmdline const & cl)
 	}
 	else
 	{
-		cerr << "Did not find key";
-		ret = 1;
+		cerr << "Did not find key '" << root.getName () << "'";
+		ret = 11;
 	}
 
 	if (!cl.noNewline)

--- a/src/tools/kdb/mv.cpp
+++ b/src/tools/kdb/mv.cpp
@@ -32,9 +32,9 @@ int MvCommand::execute (Cmdline const & cl)
 	}
 
 	KeySet conf;
-	Key sourceKey = cl.createKey (0);
+	Key sourceKey = cl.createKey (0, false);
 
-	Key destKey = cl.createKey (1);
+	Key destKey = cl.createKey (1, false);
 	string newDirName = destKey.getName ();
 
 	Key root = tools::helper::commonKeyName (sourceKey, destKey);
@@ -44,18 +44,18 @@ int MvCommand::execute (Cmdline const & cl)
 	KeySet oldConf;
 
 	oldConf.append (tmpConf.cut (sourceKey));
+	std::string sourceName = sourceKey.getName ();
 
 	if (!oldConf.size ())
 	{
-		cerr << "No key to be moved found\n";
-		return 1;
+		std::cerr << "No key to copy found below '" << sourceName << "'" << std::endl;
+		return 11;
 	}
 
 	KeySet newConf;
 
 	Key k;
 	oldConf.rewind ();
-	std::string sourceName = sourceKey.getName ();
 
 	if (cl.recursive)
 	{
@@ -72,7 +72,7 @@ int MvCommand::execute (Cmdline const & cl)
 		{
 			cerr << "First key found " << k.getName () << " does not exactly match given key " << sourceKey.getName ()
 			     << ", aborting (use -r to move hierarchy)\n";
-			return 1;
+			return 11;
 		}
 		newConf.append (rename_key (k, sourceName, newDirName, cl.verbose));
 	}


### PR DESCRIPTION
- do not allow cascading keys
- do not allow wrong key to be copied
- check if there is something to copy, and fail otherwise
- error codes for "key not found" are now 11 (for get, mv, cp)
- improve error message

fix #1483

# Checklist

Check relevant points but please do not remove entries.
For docu fixes, spell checking, and similar nothing
needs to be checked.

- [ ] commit messages are fine ("module: short statement" syntax and refer to issues)
- [ ] I added unit tests
- [ ] I ran all tests locally and everything went fine
- [ ] affected documentation is fixed
- [ ] I added code comments, logging, and assertions (see doc/CODING.md)
- [ ] meta data is updated (e.g. README.md of plugins)
- [ ] release notes are updated (doc/news/_preparation_next_release.md)

