### PR TITLE
Xerces: Remove Plugin on ASAN Enabled GCC Build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -142,6 +142,7 @@ before_install:
       sudo apt-get install libyaml-cpp-dev
       sudo apt-get install libuv-dev
       sudo apt-get install libdbus-1-dev
+      sudo apt-get install libxerces-c-dev
     fi
 
 #

--- a/doc/news/_preparation_next_release.md
+++ b/doc/news/_preparation_next_release.md
@@ -146,6 +146,9 @@ Many problems were resolved with the following fixes:
 - We resolved undefined behavior in polymorphic classes that contained virtual functions, by explicitly adding a virtual destructor.
 - small refactoring in `kdb-test`
 - Fix invalid handling of keynames in the [spec](http://libelektra.org/plugins/spec) plugin.
+- We now disable the [Xerces plugin](http://libelektra.org/plugins/xerces) if you use GCC with enabled ASAN to build Elektra. This update
+  makes sure that you do not build the plugin with compilation settings that are known to
+  [cause problems](https://github.com/ElektraInitiative/libelektra/issues/1895).
 
 ## Outlook
 

--- a/src/plugins/xerces/CMakeLists.txt
+++ b/src/plugins/xerces/CMakeLists.txt
@@ -5,6 +5,11 @@ if (DEPENDENCY_PHASE)
 		remove_plugin (xerces "XercesC library libxerces-c-dev not found")
 	elseif (XercesC_VERSION VERSION_LESS 3.0.0)
 		remove_plugin (xerces "XercesC library version 3.0.0 or higher required")
+	elseif (XercesC_VERSION VERSION_LESS 3.2)
+		if (ENABLE_ASAN AND CMAKE_COMPILER_IS_GNUCXX)
+			remove_plugin (xerces "XercesC ${XercesC_VERSION} reports runtime errors if you compile it with GCC "
+					      "using AddressSanitizer")
+		endif (ENABLE_ASAN AND CMAKE_COMPILER_IS_GNUCXX)
 	endif ()
 endif (DEPENDENCY_PHASE)
 


### PR DESCRIPTION
# Purpose

After this PR CMake disables the Xerces plugin on ASAN enabled GCC builds.

# Checklist

- [x] I checked all commit messages.
- [x] This pull request contains updated release notes.