### PR TITLE
Fix ctest and add parallel

### DIFF
--- a/cmake/Modules/LibAddPlugin.cmake
+++ b/cmake/Modules/LibAddPlugin.cmake
@@ -122,6 +122,8 @@ function (add_plugintest testname)
 				COMMAND "${CMAKE_BINARY_DIR}/bin/${testexename}" "${CMAKE_CURRENT_SOURCE_DIR}"
 				WORKING_DIRECTORY "${WORKING_DIRECTORY}"
 				)
+		set_property(TEST ${testexename} PROPERTY
+				ENVIRONMENT "LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/lib")
 		if (ARG_MEMLEAK)
 			set_property(TEST ${testexename} PROPERTY
 				LABELS memleak)

--- a/cmake/Modules/LibAddTest.cmake
+++ b/cmake/Modules/LibAddTest.cmake
@@ -55,14 +55,16 @@ macro (add_gtest source)
 			"${CMAKE_BINARY_DIR}/bin/${source}"
 			"${CMAKE_CURRENT_BINARY_DIR}/"
 			)
+	set_property(TEST ${source} PROPERTY ENVIRONMENT
+		"LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/lib"
+	)
 
 	if (ARG_MEMLEAK)
-		set_property(TEST ${source} PROPERTY
-			LABELS memleak)
+		set_property(TEST ${source} PROPERTY LABELS memleak)
 	endif (ARG_MEMLEAK)
 	if (ARG_KDBTESTS)
-		set_property(TEST ${name} PROPERTY
-			LABELS kdbtests)
+		set_property(TEST ${name} PROPERTY LABELS kdbtests)
+		set_property(TEST ${name} PROPERTY RUN_SERIAL TRUE)
 	endif (ARG_KDBTESTS)
 	endif(BUILD_TESTING)
 endmacro (add_gtest)
@@ -94,8 +96,12 @@ function (add_msr_test NAME FILE)
 		COMMAND "${CMAKE_BINARY_DIR}/tests/shell/shell_recorder/tutorial_wrapper/markdown_shell_recorder.sh" "${FILE}"
 		WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
 		)
-	set_tests_properties (${TEST_NAME} PROPERTIES ENVIRONMENT "${ARG_ENVIRONMENT}")
-	set_property(TEST ${TEST_NAME} PROPERTY LABELS memleak kdbtests)
+	set_property(TEST ${TEST_NAME} PROPERTY ENVIRONMENT
+		"LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/lib"
+		"${ARG_ENVIRONMENT}"
+	)
+	set_property(TEST ${TEST_NAME} PROPERTY LABELS memleak kdbtests )
+	set_property(TEST ${TEST_NAME} PROPERTY RUN_SERIAL TRUE)
 endfunction ()
 
 # Add a Markdown Shell Recorder test for a certain plugin

--- a/doc/TESTING.md
+++ b/doc/TESTING.md
@@ -29,8 +29,14 @@ can use:
 
     make run_nokdbtests
 
-Directly running `ctest` might cause problems:
-You need to set `LD_LIBRARY_PATH` as `run_all` and `run_nokdbtests` do.
+You can also directly run ctest to make use of parallel testing:
+
+    ctest -T Test --output-on-failure -j 6
+    ctest -T MemCheck -LE memleak --output-on-failure -j 6
+
+The alternative to `make run_nokdbtests`:
+
+    ctest -T Test --output-on-failure -LE kdbtests -j 6
 
 If the access is denied, several tests will fail.
 You have some options to avoid running them as root:
@@ -84,6 +90,10 @@ You have some options to avoid running them as root:
   command:
 
         set_property(TEST testname PROPERTY LABELS memleak)
+- If your test modifies resources needed by other tests you also need to set
+    `RUN_SERIAL`:
+
+        set_property(TEST testname PROPERTY RUN_SERIAL TRUE)
 
 
 ## Strategy

--- a/doc/news/_preparation_next_release.md
+++ b/doc/news/_preparation_next_release.md
@@ -135,6 +135,11 @@ These notes are of interest for people developing Elektra:
 - If any of the tests in `make run_memcheck` fail valgrind will now set an exit-code which will get picked up by make.
 - The haskell binding now explicitly requires GHC installed with a minimum version of 8.0.0 during cmake
 - We introduced git reference repositories to save io on our build system
+- Set `LD_LIBRARY_PATH` in all tests removing the need to specify it during
+  ctest runs
+- Provide the `RUN_SERIAL` property to all tests that can not be run in
+  parallel
+- Speeding up your test runs via ctest -j is now possible
 
 [Markdown Shell Recorder]: https://master.libelektra.org/tests/shell/shell_recorder/tutorial_wrapper
 

--- a/scripts/run_all
+++ b/scripts/run_all
@@ -14,4 +14,4 @@ fi
 #
 # also use `run make_memcheck` to check for memory issues (tests are complementary)
 
-LD_LIBRARY_PATH=`pwd`/lib ctest --force-new-ctest-process --output-on-failure --build-config $1
+ctest --force-new-ctest-process --output-on-failure --build-config $1

--- a/scripts/run_memcheck
+++ b/scripts/run_memcheck
@@ -6,4 +6,4 @@ then
 	exit 1
 fi
 
-LD_LIBRARY_PATH=`pwd`/lib ctest -T memcheck --output-on-failure --build-config $1 -LE memleak
+ctest -T memcheck --output-on-failure --build-config $1 -LE memleak

--- a/scripts/run_nokdbtests
+++ b/scripts/run_nokdbtests
@@ -8,4 +8,4 @@ fi
 
 # run all tests not writing to disc
 
-LD_LIBRARY_PATH=`pwd`/lib ctest -LE kdbtests --force-new-ctest-process --output-on-failure --build-config $1
+ctest -LE kdbtests --force-new-ctest-process --output-on-failure --build-config $1

--- a/src/bindings/gi/lua/CMakeLists.txt
+++ b/src/bindings/gi/lua/CMakeLists.txt
@@ -23,6 +23,10 @@ macro (do_gi_lua_test source)
 			TEST ${name}
 			APPEND PROPERTY LABELS kdbtests
 		)
+		set_property (
+			TEST ${name}
+			PROPERTY RUN_SERIAL TRUE
+		)
 	endif ()
 endmacro (do_gi_lua_test)
 

--- a/src/bindings/gi/python/CMakeLists.txt
+++ b/src/bindings/gi/python/CMakeLists.txt
@@ -23,6 +23,10 @@ macro (do_gi_python_test source)
 			TEST ${name}
 			APPEND PROPERTY LABELS kdbtests
 		)
+		set_property (
+			TEST ${name}
+			PROPERTY RUN_SERIAL TRUE
+		)
 	endif ()
 endmacro (do_gi_python_test)
 

--- a/src/bindings/glib/tests/CMakeLists.txt
+++ b/src/bindings/glib/tests/CMakeLists.txt
@@ -21,6 +21,12 @@ macro (do_glib_test file)
 
 	set_property (
 		TEST ${name}
+		PROPERTY ENVIRONMENT
+		"LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/lib"
+	)
+
+	set_property (
+		TEST ${name}
 		PROPERTY LABELS memleak bindings
 	)
 
@@ -28,6 +34,10 @@ macro (do_glib_test file)
 		set_property (
 			TEST ${name}
 			APPEND PROPERTY LABELS kdbtests
+		)
+		set_property (
+			TEST ${name}
+			PROPERTY RUN_SERIAL TRUE
 		)
 	endif ()
 endmacro (do_glib_test)

--- a/src/bindings/haskell/CMakeLists.txt
+++ b/src/bindings/haskell/CMakeLists.txt
@@ -130,6 +130,8 @@ if (NOT BUILD_STATIC)
 			set_property (TEST testhaskell_realworld
 				APPEND PROPERTY LABELS kdbtests)
 			set_property (TEST testhaskell_realworld
+				PROPERTY RUN_SERIAL TRUE)
+			set_property (TEST testhaskell_realworld
 				APPEND PROPERTY LABELS memleak)
 			set_property (TEST testhaskell_realworld
 				PROPERTY ENVIRONMENT "LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/lib")
@@ -140,6 +142,8 @@ if (NOT BUILD_STATIC)
 				PROPERTY LABELS bindings)
 			set_property (TEST testhaskell_realworld_optimized
 				APPEND PROPERTY LABELS kdbtests)
+			set_property (TEST testhaskell_realworld_optimized
+				PROPERTY RUN_SERIAL TRUE)
 			set_property (TEST testhaskell_realworld_optimized
 				APPEND PROPERTY LABELS memleak)
 			set_property (TEST testhaskell_realworld_optimized

--- a/src/bindings/io/doc/CMakeLists.txt
+++ b/src/bindings/io/doc/CMakeLists.txt
@@ -68,3 +68,9 @@ add_test (NAME ${testexename}
 	COMMAND "${CMAKE_BINARY_DIR}/bin/${testexename}" "${CMAKE_CURRENT_SOURCE_DIR}"
 	WORKING_DIRECTORY "${WORKING_DIRECTORY}"
 )
+set_property (
+	TEST ${testexename}
+	PROPERTY ENVIRONMENT
+	"LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/lib"
+)
+

--- a/src/bindings/io/glib/CMakeLists.txt
+++ b/src/bindings/io/glib/CMakeLists.txt
@@ -80,6 +80,11 @@ else ()
 		COMMAND "${CMAKE_BINARY_DIR}/bin/${testexename}" "${CMAKE_CURRENT_SOURCE_DIR}"
 		WORKING_DIRECTORY "${WORKING_DIRECTORY}"
 	)
+	set_property (
+		TEST ${testexename}
+		PROPERTY ENVIRONMENT
+		"LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/lib"
+	)
 
 	add_subdirectory (example)
 endif ()

--- a/src/bindings/io/uv/CMakeLists.txt
+++ b/src/bindings/io/uv/CMakeLists.txt
@@ -103,6 +103,11 @@ else ()
 		COMMAND "${CMAKE_BINARY_DIR}/bin/${TESTEXENAME}" "${CMAKE_CURRENT_SOURCE_DIR}"
 		WORKING_DIRECTORY "${WORKING_DIRECTORY}"
 	)
+	set_property (
+		TEST ${TESTEXENAME}
+		PROPERTY ENVIRONMENT
+		"LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/lib"
+)
 
 	add_subdirectory (example)
 endif ()

--- a/src/bindings/swig/lua/tests/CMakeLists.txt
+++ b/src/bindings/swig/lua/tests/CMakeLists.txt
@@ -24,6 +24,10 @@ macro (do_lua_test source)
 			TEST ${name}
 			APPEND PROPERTY LABELS kdbtests
 		)
+		set_property (
+			TEST ${name}
+            APPEND PROPERTY RUN_SERIAL TRUE
+		)
 	endif ()
 endmacro (do_lua_test)
 

--- a/src/bindings/swig/python/tests/CMakeLists.txt
+++ b/src/bindings/swig/python/tests/CMakeLists.txt
@@ -24,6 +24,10 @@ macro (do_python_test source)
 			TEST ${name}
 			APPEND PROPERTY LABELS kdbtests
 		)
+		set_property (
+			TEST ${name}
+			APPEND PROPERTY RUN_SERIAL TRUE
+		)
 	endif ()
 endmacro (do_python_test)
 

--- a/src/bindings/swig/python2/tests/CMakeLists.txt
+++ b/src/bindings/swig/python2/tests/CMakeLists.txt
@@ -24,6 +24,10 @@ macro (do_python_test source)
 			TEST ${name}
 			APPEND PROPERTY LABELS kdbtests
 		)
+		set_property (
+			TEST ${name}
+			PROPERTY RUN_SERIAL TRUE
+		)
 	endif ()
 endmacro (do_python_test)
 

--- a/src/bindings/swig/ruby/tests/CMakeLists.txt
+++ b/src/bindings/swig/ruby/tests/CMakeLists.txt
@@ -30,4 +30,9 @@ if (NOT (APPLE AND ENABLE_ASAN))
 		TEST "testruby_kdb"
 		APPEND PROPERTY LABELS kdbtests
 	)
+	set_property (
+		TEST "testruby_kdb"
+		PROPERTY RUN_SERIAL TRUE
+	)
+
 endif (NOT (APPLE AND ENABLE_ASAN))

--- a/src/libs/notification/tests/CMakeLists.txt
+++ b/src/libs/notification/tests/CMakeLists.txt
@@ -25,6 +25,11 @@ if (BUILD_TESTING)
 		add_test (NAME ${name}
 			COMMAND "${CMAKE_BINARY_DIR}/bin/${name}" "${CMAKE_CURRENT_SOURCE_DIR}"
 		)
+		set_property (
+			TEST ${name}
+			PROPERTY ENVIRONMENT
+			"LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/lib"
+		)
 
 	endforeach (file ${TESTS})
 

--- a/src/tools/web/CMakeLists.txt
+++ b/src/tools/web/CMakeLists.txt
@@ -62,10 +62,14 @@ else ()
 
     # test apis
     find_program (DREDD_EXECUTABLE "dredd")
-    if (NOT DREDD_EXECUTABLE)
-      # testing disabled
-    else ()
+    if (DREDD_EXECUTABLE)
+      # testing is possible
       add_test (NAME elektra-web COMMAND ./test.sh WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+      set_property (
+        TEST elektra-web
+        PROPERTY ENVIRONMENT
+        "LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/lib"
+      )
     endif ()
 
 endif ()

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -33,6 +33,11 @@ macro (do_test source)
 			"${CMAKE_BINARY_DIR}/bin/${source}"
 			"${CMAKE_CURRENT_BINARY_DIR}"
 			)
+	set_property (
+			TEST ${source}
+			PROPERTY ENVIRONMENT
+			"LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/lib"
+			)
 endmacro (do_test)
 
 if (NOT CMAKE_VERSION VERSION_LESS 3.2)

--- a/tests/shell/CMakeLists.txt
+++ b/tests/shell/CMakeLists.txt
@@ -104,7 +104,15 @@ function (add_scripttest testname)
 				"${testscriptname}"
 				)
 			#dash does memleak:
-			set_property(TEST testscr_${testname_we} PROPERTY LABELS memleak kdbtests)
+			set_property(
+				TEST testscr_${testname_we}
+				PROPERTY LABELS memleak kdbtests)
+			set_property(
+				TEST testscr_${testname_we}
+				PROPERTY ENVIRONMENT "LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/lib")
+			set_property(
+				TEST testscr_${testname_we}
+				PROPERTY RUN_SERIAL TRUE)
 			endif (NOT ${testname_we} STREQUAL "run_all")
 			endif(ENABLE_KDB_TESTING)
 		endif (TARGET)

--- a/tests/shell/shell_recorder/CMakeLists.txt
+++ b/tests/shell/shell_recorder/CMakeLists.txt
@@ -15,7 +15,15 @@ function (add_shell_recorder_test FILENAME)
 		"${CMAKE_CURRENT_BINARY_DIR}/shell_recorder.sh"
 		"${CMAKE_CURRENT_SOURCE_DIR}/${name}"
 		)
-	set_property(TEST testshell_${testname_we} PROPERTY LABELS memleak kdbtests)
+	set_property(
+		TEST testshell_${testname_we} PROPERTY
+		LABELS memleak kdbtests)
+	set_property(
+		TEST testshell_${testname_we} PROPERTY
+		ENVIRONMENT LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/lib)
+	set_property(
+		TEST testshell_${testname_we} PROPERTY
+		RUN_SERIAL TRUE)
 endfunction (add_shell_recorder_test FILENAME)
 
 if (ENABLE_KDB_TESTING)
@@ -92,7 +100,14 @@ if (ENABLE_KDB_TESTING)
 				"${file}"
 				"${directory}/${name_without_extension}.epf"
 				)
-			set_property(TEST testshell_replay_${name_without_extension} PROPERTY LABELS memleak kdbtests)
+			set_property(TEST testshell_replay_${name_without_extension} PROPERTY
+				LABELS memleak kdbtests)
+			set_property(
+				TEST testshell_replay_${name_without_extension} PROPERTY
+				ENVIRONMENT LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/lib)
+			set_property(
+				TEST testshell_replay_${name_without_extension} PROPERTY
+				RUN_SERIAL TRUE)
 		endforeach (file ${SCRIPT_TESTS})
 	endif (ENABLE_REPLAY_TESTS)
 


### PR DESCRIPTION
# Purpose

* Allow ctest to run parallel.
* Remove test scripts.

# Checklist

- [x] ~~remove targets pointing to old test scripts~~ Would loose cmake < 3.4 compatibility
- [x] old test scripts ~~are removed~~ only remove LD_LIBRARY_PATH
- [x] commit messages are fine ("module: short statement" syntax and refer to issues)
- [x] I ran all tests locally and everything went fine
- [x] affected documentation is fixed
- [x] release notes are updated (doc/news/_preparation_next_release.md)

ref #1900