### PR TITLE
YAML CPP: Use Bash to Convert Hex Value

### DIFF
--- a/src/plugins/yamlcpp/README.md
+++ b/src/plugins/yamlcpp/README.md
@@ -257,13 +257,9 @@ echo 'bin: !!binary aGk=' > `kdb file /examples/binary`
 kdb get /examples/binary/bin
 #> \x68\x69
 
-# We can use `ruby` to convert the hexadecimal value returned by `kdb get`
-# to its ASCII representation. If you use `bash` or `fish` as shell then
-#     printf `kdb get /examples/binary/bin` # Bash
-# or
-#     printf (kdb get /examples/binary/bin) # fish
-# should work too.
-ruby -e "print ARGV[0].split('\x')[1..-1].map { |byte| byte.to_i(16).chr }.join" `kdb get /examples/binary/bin`
+# We can use `bash` to convert the hexadecimal value returned by `kdb get`
+# to its ASCII representation.
+bash -c 'printf `kdb get /examples/binary/bin`'
 #> hi
 
 # Add a string value to the database


### PR DESCRIPTION
# Purpose

Currently the Markdown [Shell Recorder Test](https://master.libelektra.org/tests/shell/shell_recorder/tutorial_wrapper) of [YAML CPP](https://www.libelektra.org/plugins/yamlcpp) requires `ruby`. This update removes this requirement. 

# Checklist

- [x] I checked the commit message.
- [x] Since this PR only contains a minor fix, I did not modify the release notes.