### PR TITLE
scripts: add complexity calculation script

### DIFF
--- a/scripts/complexity.rb
+++ b/scripts/complexity.rb
@@ -1,100 +1,125 @@
-# @author Anton Hößl <e1427045@student.tuwien.ac.at>
-# @brief This script approximates the complexity of a elektra configuration namespace
+#! interpreter line
+# @author Anton Hoessl <e1427045@student.tuwien.ac.at>
+# @brief This script approximates the complexity of Elektra configuration settings
 # @date 18.04.2018
-# @tags generator
+# @tags specification calculation
+#
+# This script calculates the complexity of Elektra configuration settings.
+# It does so by checking for the meta information 'type' and 'check/type'.
+# All types of the type-plugin and enums are supported.
+# If a given key doesn't have the required metadata its complexity is assumed 2 as either configured correct or not.
+#
+# The complexity is displayed in the form of 2^x.
+#
+# To run this script you have to install Elektra's Ruby bindings or add the
+# path, under which the compiled Elektra Ruby library can be found to your
+# 'RUBYLIB' environment variable.
+#
+#  $> RUBYLIB="<path to the kdb.so>" ruby complexity.rb NAMESPACE
+#
 
 require 'kdb'
 
+# complexity for data-types in number of bits
+TYPE_COMPLEXITY = Hash.new(1)
+TYPE_COMPLEXITY['short'] = 8
+TYPE_COMPLEXITY['unsigned_short'] = 8
+TYPE_COMPLEXITY['long'] = 32
+TYPE_COMPLEXITY['unsigned_long'] = 32
+TYPE_COMPLEXITY['long_long'] = 64
+TYPE_COMPLEXITY['unsigned_long_long'] = 64
+TYPE_COMPLEXITY['float'] = 32
+TYPE_COMPLEXITY['double'] = 64
+TYPE_COMPLEXITY['long_double'] = 128
+TYPE_COMPLEXITY['char'] = 8
+TYPE_COMPLEXITY['octet'] = 8
+TYPE_COMPLEXITY['boolean'] = 1
+TYPE_COMPLEXITY['any'] = 1
+TYPE_COMPLEXITY['empty'] = 1
+TYPE_COMPLEXITY['string'] = 1
+
+#
+# Helper methods
+#
+
 # function checks if the type of the key is known and returns the number of bits needed to represent all possible values
 # of that key, returns 1 if it is a unknown type. Doesn't consider range checks etc...
-def evaluate_type(t, tc, k)
-  if tc.key?(t) then return tc[t] end
-  value = k.get_meta("check/enum")
-  if t == "enum" && value != nil then
-    
-    if value.start_with?("#") then 
-      # case of meta array
-      # get number of enums, build log base 2 and round it to the nearest integer
-      return Math.log2(Integer(value[1..-1])).ceil 
-    else
-      # case of enums defined as a string
-      return Math.log2(value.count(",") + 1).ceil
-    end
-    
-  end
-  return 1
+#
+# @param [Object] type of the passed key
+# @param [Object] key which should be processed, needed in case it doesn't have a known type or is an enum
+# @return [Integer] number of bits needed to represent the complexity of the given key
+#
+def evaluate_type(type, key)
+  return TYPE_COMPLEXITY[type] if TYPE_COMPLEXITY.key?(type)
+
+  value = key.get_meta('check/enum')
+  return unless type == 'enum' && !value.nil?
+
+  # case of meta array
+  # get number of enums, build log base 2 and round it to the nearest integer
+  return Math.log2(Integer(value[1..-1])).ceil if value.start_with?('#')
+
+  # case of enums defined as a string
+  Math.log2(value.count(',') + 1).ceil
 end
 
-if ARGV.count != 1 then
+#
+# application
+#
+
+if ARGV.count != 1
   p 'Usage: complexity.rb NAMESPACE'
   exit 1
 end
 
 APP_NS = ARGV[0]
 
-puts "Welcome to the Ruby Complexity script, calculating complexits for namespace:\n"
+puts "Welcome to the Ruby Complexity script, calculating complexity for namespace:\n"
 print APP_NS + "\nThis might take a while."
 
 # create a Kdb handle
 begin
   db = Kdb.open
 rescue Kdb::KDBException
-  puts "could not open KDB database: %s" % $!
+  puts format('could not open KDB database: %<error>s', error: $ERROR_INFO)
   exit 1
 end
-print "."
-# to get our desired config settings we have to create a keyset first
+print '.'
+# to get our desired config settings we have to create a key-set first
 ks = Kdb::KeySet.new
 begin
   # get all config keys under our application settings path
-  ret = db.get ks, APP_NS
+  db.get ks, APP_NS
 rescue Kdb::KDBException
-  puts "could not get Keys under %s: %s" % [APP_NS, $!]
+  puts format('could not get Keys below %<app_name_space>s: %<error>s',
+              app_name_space: APP_NS, error: $ERROR_INFO)
 end
 print ". (#{ks.size} keys found) \n"
 
-numbers_of = Hash.new(0);
+numbers_of = Hash.new(0)
 
-type_complexity = Hash.new(1); # complexity for data-types in number of bits
-type_complexity["short"] = 8;
-type_complexity["unsigned_short"] = 8;
-type_complexity["long"] = 32;
-type_complexity["unsigned_long"] = 32;
-type_complexity["long_long"] = 64;
-type_complexity["unsigned_long_long"] = 64;
-type_complexity["float"] = 32;
-type_complexity["double"] = 64;
-type_complexity["long_double"] = 128;
-type_complexity["char"] = 8;
-type_complexity["octet"] = 8;
-type_complexity["boolean"] = 1;
-type_complexity["any"] = 1;
-type_complexity["empty"] = 1;
-type_complexity["string"] = 1;
-
-complexityPower = 0;
+complexity_power = 0
 
 # go through all keys and process them
-ks.each { |k|
+ks.each do |k|
   found_meta_type = false
   k.meta.each do |m|
-    if m.name === "check/type" || m.name === "type" then
-      numbers_of[m.value] += 1;
-      complexityPower += evaluate_type(m.value, type_complexity, k)
-      found_meta_type = true
-      break
-    end
+    next unless m.name == 'check/type' || m.name == 'type'
+    numbers_of[m.value] += 1
+    complexity_power += evaluate_type(m.value, k)
+    found_meta_type = true
+    break
   end
-  
-  if !found_meta_type then
-    numbers_of['any'] += 1;
-    complexityPower += evaluate_type('any', type_complexity, k)
+
+  unless found_meta_type
+    numbers_of['any'] += 1
+    complexity_power += evaluate_type('any', k)
   end
-}
+end
 
 puts "\n\n"
-numbers_of.each {|key, value| puts "#{key} occured #{value} times."}
+numbers_of.each { |key, value| puts "#{key} occurred #{value} times." }
 puts "\n\n"
-puts "Total complexity is approximately 2^#{complexityPower}"
+puts "Total complexity is approximately 2^#{complexity_power}"
 
-db.close()
+db.close

--- a/scripts/complexity.rb
+++ b/scripts/complexity.rb
@@ -1,0 +1,100 @@
+# @author Anton Hößl <e1427045@student.tuwien.ac.at>
+# @brief This script approximates the complexity of a elektra configuration namespace
+# @date 18.04.2018
+# @tags generator
+
+require 'kdb'
+
+# function checks if the type of the key is known and returns the number of bits needed to represent all possible values
+# of that key, returns 1 if it is a unknown type. Doesn't consider range checks etc...
+def evaluate_type(t, tc, k)
+  if tc.key?(t) then return tc[t] end
+  value = k.get_meta("check/enum")
+  if t == "enum" && value != nil then
+    
+    if value.start_with?("#") then 
+      # case of meta array
+      # get number of enums, build log base 2 and round it to the nearest integer
+      return Math.log2(Integer(value[1..-1])).ceil 
+    else
+      # case of enums defined as a string
+      return Math.log2(value.count(",") + 1).ceil
+    end
+    
+  end
+  return 1
+end
+
+if ARGV.count != 1 then
+  p 'Usage: complexity.rb NAMESPACE'
+  exit 1
+end
+
+APP_NS = ARGV[0]
+
+puts "Welcome to the Ruby Complexity script, calculating complexits for namespace:\n"
+print APP_NS + "\nThis might take a while."
+
+# create a Kdb handle
+begin
+  db = Kdb.open
+rescue Kdb::KDBException
+  puts "could not open KDB database: %s" % $!
+  exit 1
+end
+print "."
+# to get our desired config settings we have to create a keyset first
+ks = Kdb::KeySet.new
+begin
+  # get all config keys under our application settings path
+  ret = db.get ks, APP_NS
+rescue Kdb::KDBException
+  puts "could not get Keys under %s: %s" % [APP_NS, $!]
+end
+print ". (#{ks.size} keys found) \n"
+
+numbers_of = Hash.new(0);
+
+type_complexity = Hash.new(1); # complexity for data-types in number of bits
+type_complexity["short"] = 8;
+type_complexity["unsigned_short"] = 8;
+type_complexity["long"] = 32;
+type_complexity["unsigned_long"] = 32;
+type_complexity["long_long"] = 64;
+type_complexity["unsigned_long_long"] = 64;
+type_complexity["float"] = 32;
+type_complexity["double"] = 64;
+type_complexity["long_double"] = 128;
+type_complexity["char"] = 8;
+type_complexity["octet"] = 8;
+type_complexity["boolean"] = 1;
+type_complexity["any"] = 1;
+type_complexity["empty"] = 1;
+type_complexity["string"] = 1;
+
+complexityPower = 0;
+
+# go through all keys and process them
+ks.each { |k|
+  found_meta_type = false
+  k.meta.each do |m|
+    if m.name === "check/type" || m.name === "type" then
+      numbers_of[m.value] += 1;
+      complexityPower += evaluate_type(m.value, type_complexity, k)
+      found_meta_type = true
+      break
+    end
+  end
+  
+  if !found_meta_type then
+    numbers_of['any'] += 1;
+    complexityPower += evaluate_type('any', type_complexity, k)
+  end
+}
+
+puts "\n\n"
+numbers_of.each {|key, value| puts "#{key} occured #{value} times."}
+puts "\n\n"
+puts "Total complexity is approximately 2^#{complexityPower}"
+
+db.close()


### PR DESCRIPTION
# Purpose

This will add a simple ruby script which calculates the complexity of a lib elektra namespace based on the number and type of found configuration keys.
The ruby swig binding is required for this script to work.

# Checklist

Check relevant points but please do not remove entries.
For docu fixes, spell checking, and similar nothing
needs to be checked.

- [x] commit messages are fine ("module: short statement" syntax and refer to issues)
- [ ] I added unit tests
- [ ] I ran all tests locally and everything went fine
- [ ] affected documentation is fixed
- [ ] I added code comments, logging, and assertions (see doc/CODING.md)
- [ ] meta data is updated (e.g. README.md of plugins)
- [ ] release notes are updated (doc/news/_preparation_next_release.md)

@markus2330 please review my pull request