### PR TITLE
Build: Fix Detection of Botan, Libgcrypt, LibGit2 and OpenSSL

### DIFF
--- a/doc/news/_preparation_next_release.md
+++ b/doc/news/_preparation_next_release.md
@@ -256,7 +256,14 @@ Many problems were resolved with the following fixes:
   thanks to René Schwaiger
 - type checker now also honors `type` next to `check/type`
 - Fix various compiler warnings
-- The detection of Botan, Libgcrypt and OpenSSL now also works properly, if we treat warnings as errors (compiler switch `-Werror`).
+- The detection of
+
+   - Botan,
+   - Libgcrypt,
+   - LibGit2 and
+   - OpenSSL
+
+   now also works properly, if we treat warnings as errors (compiler switch `-Werror`).
 
 ## Outlook
 

--- a/doc/news/_preparation_next_release.md
+++ b/doc/news/_preparation_next_release.md
@@ -256,6 +256,7 @@ Many problems were resolved with the following fixes:
   thanks to René Schwaiger
 - type checker now also honors `type` next to `check/type`
 - Fix various compiler warnings
+- The detection of Botan, Libgcrypt and OpenSSL now also works properly, if we treat warnings as errors (compiler switch `-Werror`).
 
 ## Outlook
 

--- a/src/plugins/crypto/compile_botan.cpp
+++ b/src/plugins/crypto/compile_botan.cpp
@@ -9,7 +9,7 @@
 
 #include <botan/init.h>
 
-int main (int argc, char ** argv)
+int main (void)
 {
 	Botan::LibraryInitializer::initialize ("");
 	return 0;

--- a/src/plugins/crypto/compile_gcrypt.c
+++ b/src/plugins/crypto/compile_gcrypt.c
@@ -9,8 +9,14 @@
 
 #include <gcrypt.h>
 
+gcry_cipher_hd_t nothing ()
+{
+	gcry_cipher_hd_t elektraCryptoHandle = NULL;
+	return elektraCryptoHandle;
+}
+
 int main (void)
 {
-	gcry_cipher_hd_t elektraCryptoHandle;
+	nothing ();
 	return 0;
 }

--- a/src/plugins/crypto/compile_openssl.c
+++ b/src/plugins/crypto/compile_openssl.c
@@ -9,8 +9,13 @@
 
 #include <openssl/evp.h>
 
+EVP_CIPHER_CTX * nothing (void)
+{
+	return NULL;
+}
+
 int main (void)
 {
-	EVP_CIPHER_CTX * opensslSpecificType;
+	nothing ();
 	return 0;
 }

--- a/src/plugins/gitresolver/gitresolver_test.c
+++ b/src/plugins/gitresolver/gitresolver_test.c
@@ -1,7 +1,8 @@
 #include <git2.h>
-void main (void)
+int main (void)
 {
 	git_libgit2_init ();
 	git_index_add_frombuffer (NULL, NULL, NULL, (size_t) NULL);
 	git_libgit2_shutdown ();
+	return 0;
 }


### PR DESCRIPTION
# Purpose

Before this update the build system did not detect 

   - Botan,
   - Libgcrypt,
   - LibGit2 and
   - OpenSSL

, if we treated warnings as errors (compiler switch `-Werror`).

# Checklist

- [x] I checked all commit messages.
- [x] I ran all tests locally and everything went fine.
- [x] This PR contains an updated version of the release notes.
