### PR TITLE
crypto: fix OpenSSL related linker warning

### DIFF
--- a/src/plugins/crypto/openssl_operations.c
+++ b/src/plugins/crypto/openssl_operations.c
@@ -355,7 +355,7 @@ int elektraCryptoOpenSSLEncrypt (elektraCryptoHandle * handle, Key * k, Key * er
 		content += partitionLen;
 	}
 
-	EVP_EncryptFinal (handle->encrypt, cipherBuffer, &written);
+	EVP_EncryptFinal_ex (handle->encrypt, cipherBuffer, &written);
 	if (written > 0)
 	{
 		BIO_write (encrypted, cipherBuffer, written);
@@ -445,7 +445,7 @@ int elektraCryptoOpenSSLDecrypt (elektraCryptoHandle * handle, Key * k, Key * er
 		}
 	}
 
-	EVP_DecryptFinal (handle->decrypt, contentBuffer, &written);
+	EVP_DecryptFinal_ex (handle->decrypt, contentBuffer, &written);
 	if (written > 0)
 	{
 		BIO_write (decrypted, contentBuffer, written);


### PR DESCRIPTION
Fixes #1969 .

# Purpose

Fix OpenSSL-related linker warning.

# Checklist

Check relevant points but please do not remove entries.
For docu fixes, spell checking, and similar nothing
needs to be checked.

- [x] commit messages are fine ("module: short statement" syntax and refer to issues)
- [ ] I added unit tests
- [x] I ran all tests locally and everything went fine
- [ ] affected documentation is fixed
- [ ] I added code comments, logging, and assertions (see doc/CODING.md)
- [ ] meta data is updated (e.g. README.md of plugins)
- [ ] release notes are updated (doc/news/_preparation_next_release.md)

@markus2330 please review my pull request
