### PR TITLE
Tools: Disable Warning About Virtual Destructors

### DIFF
--- a/src/libs/tools/src/CMakeLists.txt
+++ b/src/libs/tools/src/CMakeLists.txt
@@ -6,6 +6,14 @@ add_toolheaders(HDR_FILES)
 
 file (GLOB_RECURSE SRC_FILES *.cpp)
 
+# TODO: Reenable the following warning after we add a virtual destructor to `PluginDatabase`, and its subclasses.
+# See also:
+# - https://github.com/ElektraInitiative/libelektra/pull/1841
+# - https://github.com/ElektraInitiative/libelektra/commit/15d67328
+if (CMAKE_C_COMPILER_ID MATCHES "Clang")
+	set_source_files_properties (backendbuilder.cpp PROPERTIES COMPILE_FLAGS -Wno-delete-non-virtual-dtor)
+endif (CMAKE_C_COMPILER_ID MATCHES "Clang")
+
 set (SOURCES ${SRC_FILES} ${HDR_FILES})
 
 set (__symbols_file ${CMAKE_CURRENT_SOURCE_DIR}/libelektratools-symbols.map)

--- a/src/libs/tools/tests/CMakeLists.txt
+++ b/src/libs/tools/tests/CMakeLists.txt
@@ -13,6 +13,20 @@ if (error_index GREATER -1)
 endif (error_index GREATER -1)
 
 file (GLOB TESTS testtool_*.cpp)
+
+# TODO: Reenable the following warning after we add a virtual destructor to `PluginDatabase`, and its subclasses.
+# See also:
+# - https://github.com/ElektraInitiative/libelektra/pull/1841
+# - https://github.com/ElektraInitiative/libelektra/commit/15d67328
+if (CMAKE_C_COMPILER_ID MATCHES "Clang")
+	set_source_files_properties (testtool_specreader.cpp
+				     testtool_backendbuilder.cpp
+				     testtool_backendparser.cpp
+				     PROPERTIES
+				     COMPILE_FLAGS
+				     -Wno-delete-non-virtual-dtor)
+endif (CMAKE_C_COMPILER_ID MATCHES "Clang")
+
 foreach (file ${TESTS})
 	get_filename_component (name ${file} NAME_WE)
 	if (NOT (name MATCHES testtool_mergingkdb AND (NOT ERROR_PLUGIN_AVAILABLE)))


### PR DESCRIPTION
# Purpose

This pull request disables a compiler warning (`Wdelete-non-virtual-dtor`) that broke the Travis macOS builds that use `clang` to translate Elektra.

# Checklist

- [x] I checked the commit message.
- [x] I ran all tests locally and everything went fine.