### PR TITLE
Shell Recorder: Always Remove Protocol File

### DIFF
--- a/doc/news/_preparation_next_release.md
+++ b/doc/news/_preparation_next_release.md
@@ -207,8 +207,9 @@ These notes are of interest for people developing Elektra:
    ```
 
    . The MSR will then check if the command printed nothing to the standard error output.
-- The [Shell Recorder][] now also prints the content of the protocol file if a test was unsuccessful or you used the command switch `-p`.
+- The [Shell Recorder][] now prints the content of the protocol file if a test was unsuccessful or you used the command switch `-p`.
   thanks to René Schwaiger
+- The [Shell Recorder][] now always removes the protocol file.
 - All current versions of Clang-Format (6.0+) and the outdated Clang-Format 5 will now produce exactly the same output for the whole
   codebase.
   thanks to René Schwaiger

--- a/tests/shell/shell_recorder/README.md
+++ b/tests/shell/shell_recorder/README.md
@@ -53,7 +53,10 @@ RET: 1337
 
 ```
 kdb set user/examples/shellrecorder/key value
+
+ERROR - RET:
 Return value “0” does not match “1337”
+
 
 ERROR - STDOUT:
 “Create a new key user/examples/shellrecorder/key with string "value"”
@@ -61,20 +64,17 @@ does not match
 “NaNaNaNaNaNaNa”
 
 shell_recorder /Users/rene/Documents/test.esr RESULTS: 2 test(s) done 2 error(s).
-Protocol File: /var/folders/hx/flbncdhj4fs87095gzxvnj3h0000gn/T/elektraenv.XXXXXXXXX.gWyTCr2O
-```
 
-. We see that both checks failed. The protocol file at the end of the output contain the real output and  return value of the command:
-
-```
-…
+—— Protocol ————————————————————————————————————————————————————
+CMD: kdb set user/examples/shellrecorder/key value
 RET: 0
-…
+=== FAILED return value does not match expected pattern 1337
 STDOUT: Create a new key user/examples/shellrecorder/key with string "value"
-…
+=== FAILED stdout does not match expected pattern NaNaNaNaNaNaNa
+————————————————————————————————————————————————————————————————
 ```
 
-.
+. We see that both checks failed. The protocol at the end of the output contain the real output and return value of the command.
 
 ## Configuration
 

--- a/tests/shell/shell_recorder/shell_recorder.sh
+++ b/tests/shell/shell_recorder/shell_recorder.sh
@@ -238,11 +238,11 @@ trap cleanup EXIT INT QUIT TERM
 
 # Parse optional argument `-p`
 OPTIND=1
-keepProtocol='false'
+printProtocol='false'
 while getopts "p" opt; do
 	case "$opt" in
 	p)
-		keepProtocol='true'
+		printProtocol='true'
 		;;
 	esac
 done
@@ -272,7 +272,7 @@ executedTests=0
 if [ "$#" -lt '1' ] || [ "$#" -gt '2' ];
 then
 	printf 'Usage: %s [-p] input_script [protocol to compare]\n\n' "$0"
-	printf '       -p    keep protocol file\n' "$0"
+	printf '       -p    print protocol file\n' "$0"
 	rm "$OutFile"
 	exit 0
 fi
@@ -313,14 +313,12 @@ then
 	fi
 fi
 
-if [ "$EVAL" -eq 0 ] && [ $keepProtocol = 'false' ]; then
-	rm -f "$OutFile"
-else
-	printerr '\nProtocol File: %s\n\n' "$OutFile"
-	printerr '—— Content of Protocol File ————————————————————————————————————————————————————\n'
+if [ "$EVAL" -ne 0 ] || [ $printProtocol = 'true' ]; then
+	printerr '\n\n—— Protocol ————————————————————————————————————————————————————\n'
 	>&2 cat "$OutFile"
-	printerr '————————————————————————————————————————————————————————————————————————————————\n'
+	printerr '————————————————————————————————————————————————————————————————\n'
 fi
+rm -f "$OutFile"
 
 rm "${TMPFILE}"
 exit "$EVAL"


### PR DESCRIPTION
# Purpose

The Shell Recorder now always removes the protocol file after it ran a test. It will still print the content of the protocol file

- if a test failed, or
- we used the command line switch `-p`

.

# Checklist

- [x] I checked all commit messages.
- [x] I ran all tests locally and everything went fine.
- [x] This PR contains an updated version of the release notes.
