### PR TITLE
Improve coverage generation

### DIFF
--- a/scripts/jenkins/Jenkinsfile
+++ b/scripts/jenkins/Jenkinsfile
@@ -511,13 +511,7 @@ def cmake(String directory, Map args_map) {
 def publishCoverage() {
     echo "Start publication of coverage data"
     def uniquePrefix = 'publishCoverage'
-    def branchDir = 'unknownBranch'
-    if(isMaster()) {
-        branchDir = 'master'
-    } else {
-        branchDir = "PR_${env.ghprbPullId}"
-    }
-    def uploadDir = "${uniquePrefix}/${branchDir}/${env.STAGE_NAME}"
+    def uploadDir = "${uniquePrefix}/${env.BRANCH_NAME}/${env.STAGE_NAME}"
 
     sh "mkdir -p ${uploadDir}"
     sh "mv build/coverage ${uploadDir}"

--- a/scripts/jenkins/Jenkinsfile
+++ b/scripts/jenkins/Jenkinsfile
@@ -410,7 +410,7 @@ kill `pidof dbus-daemon`
             */
             archive(artifacts)
             if(test_coverage) {
-                publishCoverage(test_name)
+                publishCoverage()
             }
             if(test_mem || test_nokdb || test_all) {
                 xunitUpload()
@@ -507,19 +507,29 @@ def cmake(String directory, Map args_map) {
 }
 
 /* Publishes coverage reports
- * @param test_name Name of the test for identification
  */
-def publishCoverage(String test_name) {
+def publishCoverage() {
     echo "Start publication of coverage data"
-    sh "mkdir -p ssh/coverage/ || true"
-    sh "mv build/coverage ssh/coverage/${test_name} || true"
+    def uniquePrefix = 'publishCoverage'
+    def branchDir = 'unknownBranch'
+    if(isMaster()) {
+        branchDir = 'master'
+    } else {
+        branchDir = "PR_${env.ghprbPullId}"
+    }
+    def uploadDir = "${uniquePrefix}/${branchDir}/${env.STAGE_NAME}"
+
+    sh "mkdir -p ${uploadDir}"
+    sh "mv build/coverage ${uploadDir}"
+
     sshPublisher(publishers: [
       sshPublisherDesc(
         configName: 'doc.libelektra.org',
         transfers: [
           sshTransfer(
-            sourceFiles: 'ssh/**',
-            removePrefix: 'ssh'
+            sourceFiles: '${uploadDir}/**',
+            removePrefix: uniquePrefix,
+            remoteDir: 'coverage'
           )
       ])
     ])

--- a/scripts/jenkins/Jenkinsfile
+++ b/scripts/jenkins/Jenkinsfile
@@ -232,15 +232,13 @@ def generate_full_build_stages() {
     tasks << build_and_test(
         "debian-oldstable-full",
         DOCKER_IMAGES.jessie,
-        CMAKE_FLAGS_BUILD_ALL +
-            CMAKE_FLAGS_COVERAGE,
+        CMAKE_FLAGS_BUILD_ALL,
         [TEST_ALL, TEST_MEM, TEST_INSTALL]
     )
     tasks << build_and_test(
         "debian-unstable-full",
         DOCKER_IMAGES.sid,
-        CMAKE_FLAGS_BUILD_ALL +
-            CMAKE_FLAGS_COVERAGE,
+        CMAKE_FLAGS_BUILD_ALL,
         [TEST_ALL, TEST_MEM, TEST_INSTALL]
     )
     /* TODO Reenable for next release
@@ -248,7 +246,6 @@ def generate_full_build_stages() {
         "debian-stable-full-clang",
         DOCKER_IMAGES.stretch,
         CMAKE_FLAGS_BUILD_ALL +
-            CMAKE_FLAGS_COVERAGE +
             CMAKE_FLAGS_CLANG,
         [TEST_ALL, TEST_MEM, TEST_INSTALL]
     )

--- a/scripts/jenkins/Jenkinsfile
+++ b/scripts/jenkins/Jenkinsfile
@@ -510,20 +510,17 @@ def cmake(String directory, Map args_map) {
  */
 def publishCoverage() {
     echo "Start publication of coverage data"
-    def uniquePrefix = 'publishCoverage'
-    def uploadDir = "${uniquePrefix}/${env.BRANCH_NAME}/${env.STAGE_NAME}"
+    def uploadDir = "coverage/${env.BRANCH_NAME}/${env.STAGE_NAME}"
 
     sh "mkdir -p ${uploadDir}"
-    sh "mv build/coverage ${uploadDir}"
+    sh "mv -v -T build/coverage ${uploadDir}"
 
     sshPublisher(publishers: [
       sshPublisherDesc(
         configName: 'doc.libelektra.org',
         transfers: [
           sshTransfer(
-            sourceFiles: '${uploadDir}/**',
-            removePrefix: uniquePrefix,
-            remoteDir: 'coverage'
+            sourceFiles: uploadDir + '/**',
           )
       ])
     ])

--- a/scripts/jenkins/Jenkinsfile.daily
+++ b/scripts/jenkins/Jenkinsfile.daily
@@ -18,6 +18,10 @@ stage("Maintain docker repositories") {
     parallel generate_docker_maintanence_stages()
 }
 
+stage("Cleanup Files") {
+    parallel generate_file_cleanup_stages()
+}
+
 // Generators
 def generate_repository_maintanence_stages() {
     // Get all nodes with label 'gitmirror' and the master
@@ -75,7 +79,49 @@ def cleanup_docker_images(target_node) {
     }]
 }
 
+def generate_file_cleanup_stages() {
+    def tasks = [:]
+    tasks << cleanup_coverage()
+    return tasks
+}
+
+def cleanup_coverage() {
+    def cleanup_command = """
+find /srv/libelektra/coverage/ \
+    -mindepth 1 \
+    -maxdepth 1 \
+    -type d \
+    -ctime +30 \
+    -print0 \
+    | xargs -r -0 rm -R
+"""
+    return [(taskname): {
+        stage(taskname) {
+            node {
+                sshExec(
+                    'doc.libelektra.org',
+                    cleanup_command
+                )
+            }
+        }
+    }]
+}
+
 // Helpers
+def sshExec(remoteConfig, command) {
+    sshPublisher(publishers: [
+        sshPublisherDesc(
+            configName: remoteConfig,
+            transfers: [
+                sshTransfer(
+                    execCommand: command
+                )
+            ],
+            verbose: true
+        )
+    ])
+}
+
 def dockerImages() {
     def s = /docker images --format "{{.Repository}}" | awk '!seen[$0]++'/
     def r = sh returnStdout: true, script: s


### PR DESCRIPTION
# Purpose

Currently coverage reports overwrite each other with each build. Further quite a lot of test time is spent on generating and transmitting coverage data.

This PR restricts coverage generation to debian stable builds (which should have the highest coverage) to improve build times.
Further it modifies the target path on the documentation server to include the PR name.

# Checklist

- [x] commit messages are fine ("module: short statement" syntax and refer to issues)

@markus2330 please review my pull request
