### PR TITLE
build: Add milestone steps to build pipeline

### DIFF
--- a/scripts/jenkins/Jenkinsfile
+++ b/scripts/jenkins/Jenkinsfile
@@ -132,17 +132,20 @@ lock('docker-images') {
 
 // quick builds to give fast initial feedback to programmers
 stage("Fast builds") {
+    milestone label: "Fast builds"
     parallel generate_fast_build_stages()
 }
 
 
 // tests to reach full coverage
 stage("Full builds") {
+    milestone label: "Full builds"
     parallel generate_full_build_stages()
 }
 
 // build debian packages + upload if on master
 stage("Build Debian Packages") {
+    milestone label: "Debian Packages"
     parallel generate_package_build_stages()
 }
 


### PR DESCRIPTION
# Purpose
Currently an older build finishing after a newer one could overwrite
the newer ones artifacts (for example the debian packages).
Adding milestone steps prevents that behaviour.

Docs:
By default, Pipeline builds can run concurrently.

The milestone step forces all builds to go through in order, so an
older build will never be allowed pass a milestone (it is aborted) if
a newer build already passed it.

In general this step grants:
* Builds pass milestones in order
  (taking the build number as sorter field).
* Older builds will not proceed (they are aborted) if a newer one
  already passed the milestone.
* When a build passes a milestone, any older build that passed the
  previous milestone but not this one is aborted.
* Once a build passes the milestone, it will never be aborted by a
  newer build that didn't pass the milestone yet.

# Checklist
- [X] commit messages are fine ("module: short statement" syntax and refer to issues)

@markus2330 please review my pull request
