### PR TITLE
Check Bashisms: Fix Interoperability of Script

### DIFF
--- a/doc/news/_preparation_next_release.md
+++ b/doc/news/_preparation_next_release.md
@@ -143,6 +143,8 @@ Many problems were resolved with the following fixes:
 - <<TODO>>
 - We fixed a memory leak in the [mINI plugin](https://libelektra.org/plugins/mini) by requiring the plugin
   [`ccode`](https://libelektra.org/plugins/ccode) instead of the “provider” `code`.
+- The script [`check_bashisms.sh`](https://master.libelektra.org/tests/shell/check_bashisms.sh) should now work correctly again, if the
+  system uses the GNU version `find`.
 
 
 ## Outlook

--- a/scripts/docker/buildelektra.sh
+++ b/scripts/docker/buildelektra.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 
 set -o errexit
 set -o pipefail

--- a/scripts/reformat-cmake
+++ b/scripts/reformat-cmake
@@ -27,7 +27,6 @@ for file in $(find . \( -name 'CMakeLists.txt' -or -name '*.cmake' \) -and \
 			-not -regex '.*build/.*'                           \
 			-not -regex '.*gtest.*'                            \
 			-not -regex '.*cmake/Modules/FindHaskell.cmake$'   \
-			-not -regex '.*tests/shell/CMakeLists.txt$'        \
                      \));
 do
 	$CMAKE_FORMAT "$file" | unexpand | sponge "$file"

--- a/scripts/vagrant/buildelektra.sh
+++ b/scripts/vagrant/buildelektra.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 
 set -o errexit
 set -o pipefail

--- a/src/plugins/ini/crash_test/crash_test.md
+++ b/src/plugins/ini/crash_test/crash_test.md
@@ -4,7 +4,7 @@ The following Markdown Shell Recorder test checks that the INI plugin does not c
 not properly formatted.
 
 ```sh
-for file in $(find -E src/plugins/ini/crash_test -regex '.*crash[0-9]{3}.ini$' | sort); do                \
+for file in $(find src/plugins/ini/crash_test -regex '.*crash[0-9][0-9]*.ini$' | sort); do                \
 	cat "$file" | kdb import user/examples/ini ini 2>&1 | grep -q 'SIG' && echo "File $file caused a crash" \
 	kdb rm -rf user/examples/ini 2>&1 | grep -q 'SIG' && echo "File $file caused a crash"                   \
 	# Check if we successfully removed all keys                                                             \

--- a/tests/shell/CMakeLists.txt
+++ b/tests/shell/CMakeLists.txt
@@ -40,13 +40,12 @@ function (add_scripttest testname)
 
 	foreach (TARGET true false)
 		if (TARGET)
-			#cascading of if is && for poor people
 			if (INSTALL_TESTING)
-			if (NOT ${testname_we} STREQUAL "check_formatting")
-			if (NOT ${testname_we} STREQUAL "check_oclint")
-			if (NOT ${testname_we} STREQUAL "check_plugins")
-			if (NOT ${testname_we} STREQUAL "check_gen")
-			if (NOT ${testname_we} STREQUAL "check_external")
+
+			set (excluded_tests check_external check_formatting check_gen check_oclint check_plugins)
+
+			list (FIND excluded_tests "${testname_we}" index_exluded)
+			if (index_exluded EQUAL -1)
 			if (BUILD_FULL)
 				set (KDB_COMMAND "kdb-full")
 			else (BUILD_FULL)
@@ -70,11 +69,8 @@ function (add_scripttest testname)
 				WORLD_READ WORLD_EXECUTE
 				RENAME ${testname_we}
 				)
-			endif (NOT ${testname_we} STREQUAL "check_external")
-			endif (NOT ${testname_we} STREQUAL "check_gen")
-			endif (NOT ${testname_we} STREQUAL "check_plugins")
-			endif (NOT ${testname_we} STREQUAL "check_oclint")
-			endif (NOT ${testname_we} STREQUAL "check_formatting")
+			endif (index_exluded EQUAL -1)
+
 			endif(INSTALL_TESTING)
 		else (TARGET)
 			if (ENABLE_KDB_TESTING)

--- a/tests/shell/CMakeLists.txt
+++ b/tests/shell/CMakeLists.txt
@@ -32,7 +32,7 @@ function (add_scripttest testname)
 		if (TARGET)
 			if (INSTALL_TESTING)
 
-				set (excluded_tests check_external check_formatting check_gen check_oclint check_plugins)
+				set (excluded_tests check_bashisms check_external check_formatting check_gen check_oclint check_plugins)
 
 				list (FIND excluded_tests "${testname_we}" index_exluded)
 				if (index_exluded EQUAL -1)

--- a/tests/shell/CMakeLists.txt
+++ b/tests/shell/CMakeLists.txt
@@ -1,27 +1,15 @@
 include (LibAddMacros)
 
+set (IS_INSTALLED "YES")
+configure_file ("${CMAKE_CURRENT_SOURCE_DIR}/include_common.sh.in" "${CMAKE_CURRENT_BINARY_DIR}/include_common.sh" @ONLY)
 
-set(IS_INSTALLED "YES")
-configure_file (
-		"${CMAKE_CURRENT_SOURCE_DIR}/include_common.sh.in"
-		"${CMAKE_CURRENT_BINARY_DIR}/include_common.sh"
-		@ONLY
-	)
+file (READ "${CMAKE_CURRENT_BINARY_DIR}/include_common.sh" INCLUDE_COMMON_INSTALLED_FILE)
 
-file(READ "${CMAKE_CURRENT_BINARY_DIR}/include_common.sh"
-	INCLUDE_COMMON_INSTALLED_FILE)
+set (IS_INSTALLED "NO")
+configure_file ("${CMAKE_CURRENT_SOURCE_DIR}/include_common.sh.in" "${CMAKE_CURRENT_BINARY_DIR}/include_common.sh" @ONLY)
 
-
-set(IS_INSTALLED "NO")
-configure_file (
-		"${CMAKE_CURRENT_SOURCE_DIR}/include_common.sh.in"
-		"${CMAKE_CURRENT_BINARY_DIR}/include_common.sh"
-		@ONLY
-	)
-
-file(READ "${CMAKE_CURRENT_BINARY_DIR}/include_common.sh"
-	INCLUDE_COMMON_FILE)
-file(REMOVE "${CMAKE_CURRENT_BINARY_DIR}/include_common.sh")
+file (READ "${CMAKE_CURRENT_BINARY_DIR}/include_common.sh" INCLUDE_COMMON_FILE)
+file (REMOVE "${CMAKE_CURRENT_BINARY_DIR}/include_common.sh")
 
 # ~~~
 # Add a test for a script
@@ -44,89 +32,75 @@ function (add_scripttest testname)
 		if (TARGET)
 			if (INSTALL_TESTING)
 
-			set (excluded_tests check_external check_formatting check_gen check_oclint check_plugins)
+				set (excluded_tests check_external check_formatting check_gen check_oclint check_plugins)
 
-			list (FIND excluded_tests "${testname_we}" index_exluded)
-			if (index_exluded EQUAL -1)
-			if (BUILD_FULL)
-				set (KDB_COMMAND "kdb-full")
-			else (BUILD_FULL)
-				if (BUILD_STATIC)
-					set (KDB_COMMAND "kdb-static")
-				else (BUILD_STATIC)
-					set (KDB_COMMAND "kdb")
-				endif (BUILD_STATIC)
-			endif (BUILD_FULL)
-			set(RACE_COMMAND "$KDB race")
-			set(INCLUDE_COMMON "${INCLUDE_COMMON_INSTALLED_FILE}if [ -z \"$KDB\" ]; then KDB=${KDB_COMMAND}; fi")
-			configure_file(
-				"${filename}"
-				"${CMAKE_CURRENT_BINARY_DIR}/${testname}"
-				@ONLY
-				)
-			install (FILES "${CMAKE_CURRENT_BINARY_DIR}/${testname}"
-				DESTINATION ${TARGET_TOOL_EXEC_FOLDER}
-				PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE
-				GROUP_READ GROUP_EXECUTE
-				WORLD_READ WORLD_EXECUTE
-				RENAME ${testname_we}
-				)
-			endif (index_exluded EQUAL -1)
+				list (FIND excluded_tests "${testname_we}" index_exluded)
+				if (index_exluded EQUAL -1)
+					if (BUILD_FULL)
+						set (KDB_COMMAND "kdb-full")
+					else (BUILD_FULL)
+						if (BUILD_STATIC)
+							set (KDB_COMMAND "kdb-static")
+						else (BUILD_STATIC)
+							set (KDB_COMMAND "kdb")
+						endif (BUILD_STATIC)
+					endif (BUILD_FULL)
+					set (RACE_COMMAND "$KDB race")
+					set (INCLUDE_COMMON
+					     "${INCLUDE_COMMON_INSTALLED_FILE}if [ -z \"$KDB\" ]; then KDB=${KDB_COMMAND}; fi")
+					configure_file ("${filename}" "${CMAKE_CURRENT_BINARY_DIR}/${testname}" @ONLY)
+					install (FILES "${CMAKE_CURRENT_BINARY_DIR}/${testname}"
+						       DESTINATION
+						       ${TARGET_TOOL_EXEC_FOLDER}
+						       PERMISSIONS
+						       OWNER_READ
+						       OWNER_WRITE
+						       OWNER_EXECUTE
+						       GROUP_READ
+						       GROUP_EXECUTE
+						       WORLD_READ
+						       WORLD_EXECUTE
+						 RENAME ${testname_we})
+				endif (index_exluded EQUAL -1)
 
-			endif(INSTALL_TESTING)
+			endif (INSTALL_TESTING)
 		else (TARGET)
 			if (ENABLE_KDB_TESTING)
-			if (NOT ${testname_we} STREQUAL "run_all")
-			if (BUILD_FULL)
-				set (KDB_COMMAND "${CMAKE_BINARY_DIR}/bin/kdb-full")
-			elseif (BUILD_STATIC)
-				set (KDB_COMMAND "${CMAKE_BINARY_DIR}/bin/kdb-static")
-			elseif (BUILD_SHARED)
-				set (KDB_COMMAND "${CMAKE_BINARY_DIR}/bin/kdb")
-			else ()
-				message(SEND_ERROR "no kdb tool found, please enable BUILD_FULL, BUILD_STATIC or BUILD_SHARED")
-			endif (BUILD_FULL)
-			set(RACE_COMMAND "${CMAKE_BINARY_DIR}/bin/race")
-			set(INCLUDE_COMMON
-				"${INCLUDE_COMMON_FILE}KDB=\"${KDB_COMMAND}\""
-				)
-			set(testscriptname
-				"${CMAKE_CURRENT_BINARY_DIR}/testscr_${testname}")
-			configure_file(
-				"${filename}"
-				"${testscriptname}"
-				@ONLY
-				 )
-			add_test (
-				testscr_${testname_we}
-				"${testscriptname}"
-				)
-			#dash does memleak:
-			set_property(
-				TEST testscr_${testname_we}
-				PROPERTY LABELS memleak kdbtests)
-			set_property(
-				TEST testscr_${testname_we}
-				PROPERTY ENVIRONMENT "LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/lib")
-			set_property(
-				TEST testscr_${testname_we}
-				PROPERTY RUN_SERIAL TRUE)
-			endif (NOT ${testname_we} STREQUAL "run_all")
-			endif(ENABLE_KDB_TESTING)
+				if (NOT ${testname_we} STREQUAL "run_all")
+					if (BUILD_FULL)
+						set (KDB_COMMAND "${CMAKE_BINARY_DIR}/bin/kdb-full")
+					elseif (BUILD_STATIC)
+						set (KDB_COMMAND "${CMAKE_BINARY_DIR}/bin/kdb-static")
+					elseif (BUILD_SHARED)
+						set (KDB_COMMAND "${CMAKE_BINARY_DIR}/bin/kdb")
+					else ()
+						message (SEND_ERROR
+								 "no kdb tool found, please enable BUILD_FULL, BUILD_STATIC or BUILD_SHARED"
+							 )
+					endif (BUILD_FULL)
+					set (RACE_COMMAND "${CMAKE_BINARY_DIR}/bin/race")
+					set (INCLUDE_COMMON "${INCLUDE_COMMON_FILE}KDB=\"${KDB_COMMAND}\"")
+					set (testscriptname "${CMAKE_CURRENT_BINARY_DIR}/testscr_${testname}")
+					configure_file ("${filename}" "${testscriptname}" @ONLY)
+					add_test (testscr_${testname_we} "${testscriptname}") # dash does memleak:
+					set_property (TEST testscr_${testname_we} PROPERTY LABELS memleak kdbtests)
+					set_property (TEST testscr_${testname_we}
+						      PROPERTY ENVIRONMENT
+							       "LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/lib")
+					set_property (TEST testscr_${testname_we} PROPERTY RUN_SERIAL TRUE)
+				endif (NOT ${testname_we} STREQUAL "run_all")
+			endif (ENABLE_KDB_TESTING)
 		endif (TARGET)
-	endforeach()
+	endforeach ()
 
 endfunction (add_scripttest)
 
 if (INSTALL_TESTING)
-	install (
-		DIRECTORY "shell"
-		DESTINATION ${TARGET_TEST_DATA_FOLDER}
-	)
+	install (DIRECTORY "shell" DESTINATION ${TARGET_TEST_DATA_FOLDER})
 endif (INSTALL_TESTING)
 
 file (GLOB SCRIPT_TESTS *.sh)
 foreach (file ${SCRIPT_TESTS})
 	get_filename_component (name ${file} NAME)
-	add_scripttest(${name})
+	add_scripttest (${name})
 endforeach (file ${SCRIPT_TESTS})

--- a/tests/shell/CMakeLists.txt
+++ b/tests/shell/CMakeLists.txt
@@ -23,6 +23,7 @@ file(READ "${CMAKE_CURRENT_BINARY_DIR}/include_common.sh"
 	INCLUDE_COMMON_FILE)
 file(REMOVE "${CMAKE_CURRENT_BINARY_DIR}/include_common.sh")
 
+# ~~~
 # Add a test for a script
 #
 # The given testname is blah.sh
@@ -30,6 +31,7 @@ file(REMOVE "${CMAKE_CURRENT_BINARY_DIR}/include_common.sh")
 #   it will be installed on the system as blah.sh
 #   the test will be called testscr_blah
 #   and the script file for the test will be testscr_blah.sh
+# ~~~
 function (add_scripttest testname)
 	get_filename_component (testname_we ${testname} NAME_WE)
 

--- a/tests/shell/check_bashisms.sh
+++ b/tests/shell/check_bashisms.sh
@@ -13,8 +13,8 @@ find -version > /dev/null 2>&1 > /dev/null && FIND=find || FIND='find -E'
 # this way we also check subdirectories
 # The script `check-env-dep` uses process substitution which is **not** a standard `sh` feature!
 # See also: https://unix.stackexchange.com/questions/151925
-scripts=$($FIND scripts/ -type f -not -regex \
-	  '.+(/docker/.+|check-env-dep|Jenkinsfile(.daily)?|gitignore|kdb_zsh_completion|sed|Vagrantfile|\.(cmake|fish|in|md|txt))$' | \
+scripts=$($FIND scripts/ -type f -not -regex '.+/docker/.+' -not -regex \
+	'.+(check-env-dep|Jenkinsfile(.daily)?|gitignore|kdb_zsh_completion|run_dev_env|sed|Vagrantfile|\.(cmake|fish|in|md|txt))$' | \
 	  xargs)
 checkbashisms $scripts
 ret=$?

--- a/tests/shell/check_bashisms.sh
+++ b/tests/shell/check_bashisms.sh
@@ -13,7 +13,7 @@ find -version > /dev/null 2>&1 > /dev/null && FIND=find || FIND='find -E'
 # this way we also check subdirectories
 # The script `check-env-dep` uses process substitution which is **not** a standard `sh` feature!
 # See also: https://unix.stackexchange.com/questions/151925
-scripts=$($FIND scripts/ -type f -not -regex
+scripts=$($FIND scripts/ -type f -not -regex \
 	  '.+(/docker/.+|check-env-dep|Jenkinsfile(.daily)?|kdb_zsh_completion|sed|\.(cmake|fish|in|md|txt))$' | xargs)
 checkbashisms $scripts
 ret=$?

--- a/tests/shell/check_bashisms.sh
+++ b/tests/shell/check_bashisms.sh
@@ -8,10 +8,12 @@ command -v checkbashisms >/dev/null 2>&1 || { echo "checkbashisms command needed
 
 cd "@CMAKE_SOURCE_DIR@"
 
+find -version > /dev/null 2>&1 > /dev/null && FIND=find || FIND='find -E'
+
 # this way we also check subdirectories
 # The script `check-env-dep` uses process substitution which is **not** a standard `sh` feature!
 # See also: https://unix.stackexchange.com/questions/151925
-scripts=$(find -E scripts/ -type f -not -regex
+scripts=$($FIND scripts/ -type f -not -regex
 	  '.+(/docker/.+|check-env-dep|Jenkinsfile(.daily)?|kdb_zsh_completion|sed|\.(cmake|fish|in|md|txt))$' | xargs)
 checkbashisms $scripts
 ret=$?

--- a/tests/shell/check_bashisms.sh
+++ b/tests/shell/check_bashisms.sh
@@ -17,6 +17,7 @@ find -version > /dev/null 2>&1 > /dev/null && FIND='find scripts -regextype egre
 scripts=$($FIND -type f -not -regex \
 	  '.+(check-env-dep|gitignore|kdb_zsh_completion|run_dev_env|sed|(Docker|Jenkins|Vagrant)file.*|\.(cmake|fish|in|md|txt))$' | \
 	  xargs)
+exit_if_fail 'Unable to locate shell scripts via `find`'
 checkbashisms $scripts
 ret=$?
 # 2 means skipped file, e.g. README.md, that is fine

--- a/tests/shell/check_bashisms.sh
+++ b/tests/shell/check_bashisms.sh
@@ -8,12 +8,13 @@ command -v checkbashisms >/dev/null 2>&1 || { echo "checkbashisms command needed
 
 cd "@CMAKE_SOURCE_DIR@"
 
-find -version > /dev/null 2>&1 > /dev/null && FIND=find || FIND='find -E'
+# Use (non-emacs) extended regex for GNU find or BSD find
+find -version > /dev/null 2>&1 > /dev/null && FIND='find scripts -regextype egrep' || FIND='find -E scripts'
 
 # this way we also check subdirectories
 # The script `check-env-dep` uses process substitution which is **not** a standard `sh` feature!
 # See also: https://unix.stackexchange.com/questions/151925
-scripts=$($FIND scripts/ -type f -not -regex \
+scripts=$($FIND -type f -not -regex \
 	  '.+(check-env-dep|gitignore|kdb_zsh_completion|run_dev_env|sed|(Docker|Jenkins|Vagrant)file.*|\.(cmake|fish|in|md|txt))$' | \
 	  xargs)
 checkbashisms $scripts

--- a/tests/shell/check_bashisms.sh
+++ b/tests/shell/check_bashisms.sh
@@ -14,7 +14,7 @@ find -version > /dev/null 2>&1 > /dev/null && FIND=find || FIND='find -E'
 # The script `check-env-dep` uses process substitution which is **not** a standard `sh` feature!
 # See also: https://unix.stackexchange.com/questions/151925
 scripts=$($FIND scripts/ -type f -not -regex \
-	  '.+(/docker/.+|check-env-dep|Jenkinsfile(.daily)?|kdb_zsh_completion|sed|\.(cmake|fish|in|md|txt))$' | xargs)
+	  '.+(/docker/.+|check-env-dep|Jenkinsfile(.daily)?|kdb_zsh_completion|sed|Vagrantfile|\.(cmake|fish|in|md|txt))$' | xargs)
 checkbashisms $scripts
 ret=$?
 # 2 means skipped file, e.g. README.md, that is fine

--- a/tests/shell/check_bashisms.sh
+++ b/tests/shell/check_bashisms.sh
@@ -13,8 +13,8 @@ find -version > /dev/null 2>&1 > /dev/null && FIND=find || FIND='find -E'
 # this way we also check subdirectories
 # The script `check-env-dep` uses process substitution which is **not** a standard `sh` feature!
 # See also: https://unix.stackexchange.com/questions/151925
-scripts=$($FIND scripts/ -type f -not -regex '.+/docker/.+' -not -regex \
-	'.+(check-env-dep|Jenkinsfile(.daily)?|gitignore|kdb_zsh_completion|run_dev_env|sed|Vagrantfile|\.(cmake|fish|in|md|txt))$' | \
+scripts=$($FIND scripts/ -type f -not -regex \
+	  '.+(check-env-dep|gitignore|kdb_zsh_completion|run_dev_env|sed|(Docker|Jenkins|Vagrant)file.*|\.(cmake|fish|in|md|txt))$' | \
 	  xargs)
 checkbashisms $scripts
 ret=$?

--- a/tests/shell/check_bashisms.sh
+++ b/tests/shell/check_bashisms.sh
@@ -14,7 +14,8 @@ find -version > /dev/null 2>&1 > /dev/null && FIND=find || FIND='find -E'
 # The script `check-env-dep` uses process substitution which is **not** a standard `sh` feature!
 # See also: https://unix.stackexchange.com/questions/151925
 scripts=$($FIND scripts/ -type f -not -regex \
-	  '.+(/docker/.+|check-env-dep|Jenkinsfile(.daily)?|kdb_zsh_completion|sed|Vagrantfile|\.(cmake|fish|in|md|txt))$' | xargs)
+	  '.+(/docker/.+|check-env-dep|Jenkinsfile(.daily)?|gitignore|kdb_zsh_completion|sed|Vagrantfile|\.(cmake|fish|in|md|txt))$' | \
+	  xargs)
 checkbashisms $scripts
 ret=$?
 # 2 means skipped file, e.g. README.md, that is fine


### PR DESCRIPTION
# Purpose

After this pull request the script `check_bashisms.sh` should work both on macOS (BSD find) and Linux (GNU find).

# Checklist

- [x] I checked all commit messages. The issue reference in commit 70d6eeab should be correct.
- [x] I ran all tests locally and everything went fine.
- [x] The pull request contains an updated version of the release notes.