### PR TITLE
mINI: Require `ccode` Plugin Instead of `code`

### DIFF
--- a/doc/news/_preparation_next_release.md
+++ b/doc/news/_preparation_next_release.md
@@ -133,6 +133,8 @@ Many problems were resolved with the following fixes:
 - <<TODO>>
 - <<TODO>>
 - <<TODO>>
+- We fixed a memory leak in the [mINI plugin](https://libelektra.org/plugins/mini) by requiring the plugin
+  [`ccode`](https://libelektra.org/plugins/ccode) instead of the “provider” `code`.
 
 
 ## Outlook

--- a/src/plugins/mini/README.md
+++ b/src/plugins/mini/README.md
@@ -1,7 +1,7 @@
 - infos = Information about the mini plugin is in keys below
 - infos/author = René Schwaiger <sanssecours@me.com>
 - infos/licence = BSD
-- infos/needs = code
+- infos/needs = ccode
 - infos/provides = storage/ini
 - infos/recommends =
 - infos/placements = getstorage setstorage


### PR DESCRIPTION
# Purpose

After this update the test `testshell_markdown_mini` should also complete successfully if we

- build Elektra with enabled address sanitizer and
- enable the leak sanitizer (via `ASAN_OPTIONS=detect_leaks=1`)

.

# Checklist

- [x] I checked all commit messages.
- [x] This pull request contains an updated version of the release notes.
