### PR TITLE
Markdown Shell Recorder: Add Partial Support for Indented Code Blocks

### DIFF
--- a/doc/help/kdb-ls.md
+++ b/doc/help/kdb-ls.md
@@ -37,61 +37,61 @@ This command will list the name of all keys below a given path.
 ## EXAMPLES
 
 ```sh
-# Backup-and-Restore: /sw/elektra/examples
+# Backup-and-Restore: /tests/examples
 
 # We use `dump` as storage format here, since storage plugins such as INI
-# automatically add keys between levels (e.g. `/sw/elektra/examples/kdb-ls/test/foo`).
-kdb mount ls.ecf /sw/elektra/examples dump
+# automatically add keys between levels (e.g. `/tests/examples/kdb-ls/test/foo`).
+kdb mount ls.ecf /tests/examples dump
 
 # Create the keys we use for the examples
-kdb set /sw/elektra/examples/kdb-ls/test val1
-kdb set /sw/elektra/examples/kdb-ls/test/foo/bar val2
-kdb set /sw/elektra/examples/kdb-ls/test/fizz/buzz fizzbuzz
-kdb set /sw/elektra/examples/kdb-ls/tost val3
-kdb set /sw/elektra/examples/kdb-ls/tost/level lvl
+kdb set /tests/examples/kdb-ls/test val1
+kdb set /tests/examples/kdb-ls/test/foo/bar val2
+kdb set /tests/examples/kdb-ls/test/fizz/buzz fizzbuzz
+kdb set /tests/examples/kdb-ls/tost val3
+kdb set /tests/examples/kdb-ls/tost/level lvl
 
-# list all keys below /sw/elektra/examples/kdb-ls
-kdb ls /sw/elektra/examples/kdb-ls
-#> user/sw/elektra/examples/kdb-ls/test
-#> user/sw/elektra/examples/kdb-ls/test/fizz/buzz
-#> user/sw/elektra/examples/kdb-ls/test/foo/bar
-#> user/sw/elektra/examples/kdb-ls/tost
-#> user/sw/elektra/examples/kdb-ls/tost/level
+# list all keys below /tests/examples/kdb-ls
+kdb ls /tests/examples/kdb-ls
+#> user/tests/examples/kdb-ls/test
+#> user/tests/examples/kdb-ls/test/fizz/buzz
+#> user/tests/examples/kdb-ls/test/foo/bar
+#> user/tests/examples/kdb-ls/tost
+#> user/tests/examples/kdb-ls/tost/level
 
-# list the next level of keys below /sw/elektra/examples/kdb-ls
+# list the next level of keys below /tests/examples/kdb-ls
 # note that if the search key ends with a /, it lists the next level
-kdb ls /sw/elektra/examples/kdb-ls/ --max-depth=1
-#> user/sw/elektra/examples/kdb-ls/test
-#> user/sw/elektra/examples/kdb-ls/tost
+kdb ls /tests/examples/kdb-ls/ --max-depth=1
+#> user/tests/examples/kdb-ls/test
+#> user/tests/examples/kdb-ls/tost
 
-# list the current level of keys below /sw/elektra/examples/kdb-ls
+# list the current level of keys below /tests/examples/kdb-ls
 # note the difference to the previous example
-kdb ls /sw/elektra/examples/kdb-ls --max-depth=1
-# this yields no output as /sw/elektra/examples/kdb-ls is not a key
+kdb ls /tests/examples/kdb-ls --max-depth=1
+# this yields no output as /tests/examples/kdb-ls is not a key
 
-# list all keys below /sw/elektra/examples/kdb-ls with are minimum 1 level (inclusive) away from that key
+# list all keys below /tests/examples/kdb-ls with are minimum 1 level (inclusive) away from that key
 # and maximum 2 levels away (exclusive)
-kdb ls /sw/elektra/examples/kdb-ls --min-depth=1 --max-depth=2
-#> user/sw/elektra/examples/kdb-ls/test
-#> user/sw/elektra/examples/kdb-ls/tost
+kdb ls /tests/examples/kdb-ls --min-depth=1 --max-depth=2
+#> user/tests/examples/kdb-ls/test
+#> user/tests/examples/kdb-ls/tost
 
-# list all keys below /sw/elektra/examples/kdb-ls/test
-kdb ls /sw/elektra/examples/kdb-ls/test
-#> user/sw/elektra/examples/kdb-ls/test
-#> user/sw/elektra/examples/kdb-ls/test/fizz/buzz
-#> user/sw/elektra/examples/kdb-ls/test/foo/bar
+# list all keys below /tests/examples/kdb-ls/test
+kdb ls /tests/examples/kdb-ls/test
+#> user/tests/examples/kdb-ls/test
+#> user/tests/examples/kdb-ls/test/fizz/buzz
+#> user/tests/examples/kdb-ls/test/foo/bar
 
-# list all keys under /sw/elektra/examples/kdb-ls in verbose mode
-kdb ls /sw/elektra/examples/kdb-ls/ -v
+# list all keys under /tests/examples/kdb-ls in verbose mode
+kdb ls /tests/examples/kdb-ls/ -v
 #> size of all keys in mountpoint: 5
 #> size of requested keys: 5
-#> user/sw/elektra/examples/kdb-ls/test
-#> user/sw/elektra/examples/kdb-ls/test/fizz/buzz
-#> user/sw/elektra/examples/kdb-ls/test/foo/bar
-#> user/sw/elektra/examples/kdb-ls/tost
-#> user/sw/elektra/examples/kdb-ls/tost/level
+#> user/tests/examples/kdb-ls/test
+#> user/tests/examples/kdb-ls/test/fizz/buzz
+#> user/tests/examples/kdb-ls/test/foo/bar
+#> user/tests/examples/kdb-ls/tost
+#> user/tests/examples/kdb-ls/tost/level
 
-kdb umount /sw/elektra/examples
+kdb umount /tests/examples
 ```
 
 ## SEE ALSO

--- a/doc/help/kdb-ls.md
+++ b/doc/help/kdb-ls.md
@@ -39,6 +39,10 @@ This command will list the name of all keys below a given path.
 ```sh
 # Backup-and-Restore: /sw/elektra/examples
 
+# We use `dump` as storage format here, since storage plugins such as INI
+# automatically add keys between levels (e.g. `/sw/elektra/examples/kdb-ls/test/foo`).
+kdb mount ls.ecf /sw/elektra/examples dump
+
 # Create the keys we use for the examples
 kdb set /sw/elektra/examples/kdb-ls/test val1
 kdb set /sw/elektra/examples/kdb-ls/test/foo/bar val2
@@ -86,6 +90,8 @@ kdb ls /sw/elektra/examples/kdb-ls/ -v
 #> user/sw/elektra/examples/kdb-ls/test/foo/bar
 #> user/sw/elektra/examples/kdb-ls/tost
 #> user/sw/elektra/examples/kdb-ls/tost/level
+
+kdb umount /sw/elektra/examples
 ```
 
 ## SEE ALSO

--- a/doc/help/kdb-ls.md
+++ b/doc/help/kdb-ls.md
@@ -48,17 +48,17 @@ kdb set /sw/elektra/examples/kdb-ls/tost/level lvl
 
 # list all keys below /sw/elektra/examples/kdb-ls
 kdb ls /sw/elektra/examples/kdb-ls
-#>user/sw/elektra/examples/kdb-ls/test
-#>user/sw/elektra/examples/kdb-ls/test/fizz/buzz
-#>user/sw/elektra/examples/kdb-ls/test/foo/bar
-#>user/sw/elektra/examples/kdb-ls/tost
-#>user/sw/elektra/examples/kdb-ls/tost/level
+#> user/sw/elektra/examples/kdb-ls/test
+#> user/sw/elektra/examples/kdb-ls/test/fizz/buzz
+#> user/sw/elektra/examples/kdb-ls/test/foo/bar
+#> user/sw/elektra/examples/kdb-ls/tost
+#> user/sw/elektra/examples/kdb-ls/tost/level
 
 # list the next level of keys below /sw/elektra/examples/kdb-ls
 # note that if the search key ends with a /, it lists the next level
 kdb ls /sw/elektra/examples/kdb-ls/ --max-depth=1
-#>user/sw/elektra/examples/kdb-ls/test
-#>user/sw/elektra/examples/kdb-ls/tost
+#> user/sw/elektra/examples/kdb-ls/test
+#> user/sw/elektra/examples/kdb-ls/tost
 
 # list the current level of keys below /sw/elektra/examples/kdb-ls
 # note the difference to the previous example
@@ -68,24 +68,23 @@ kdb ls /sw/elektra/examples/kdb-ls --max-depth=1
 # list all keys below /sw/elektra/examples/kdb-ls with are minimum 1 level away from that key
 # and maximum 2 levels away
 kdb ls /sw/elektra/examples/kdb-ls --min-depth=1 --max-depth=2
-#>user/sw/elektra/examples/kdb-ls/tost/level
+#> user/sw/elektra/examples/kdb-ls/tost/level
 
 # list all keys below /sw/elektra/examples/kdb-ls/test
 kdb ls /sw/elektra/examples/kdb-ls/test
-#>user/sw/elektra/examples/kdb-ls/test
-#>user/sw/elektra/examples/kdb-ls/test/fizz/buzz
-#>user/sw/elektra/examples/kdb-ls/test/foo/bar
+#> user/sw/elektra/examples/kdb-ls/test
+#> user/sw/elektra/examples/kdb-ls/test/fizz/buzz
+#> user/sw/elektra/examples/kdb-ls/test/foo/bar
 
 # list all keys under /sw/elektra/examples/kdb-ls in verbose mode
 kdb ls /sw/elektra/examples/kdb-ls/ -v
-#>size of all keys in mountpoint: 31
-#>size of requested keys: 5
-#>user/sw/elektra/examples/kdb-ls/test
-#>user/sw/elektra/examples/kdb-ls/test/fizz/buzz
-#>user/sw/elektra/examples/kdb-ls/test/foo/bar
-#>user/sw/elektra/examples/kdb-ls/tost
-#>user/sw/elektra/examples/kdb-ls/tost/level
-
+#> size of all keys in mountpoint: 31
+#> size of requested keys: 5
+#> user/sw/elektra/examples/kdb-ls/test
+#> user/sw/elektra/examples/kdb-ls/test/fizz/buzz
+#> user/sw/elektra/examples/kdb-ls/test/foo/bar
+#> user/sw/elektra/examples/kdb-ls/tost
+#> user/sw/elektra/examples/kdb-ls/tost/level
 ```
 
 ## SEE ALSO

--- a/doc/help/kdb-ls.md
+++ b/doc/help/kdb-ls.md
@@ -65,10 +65,11 @@ kdb ls /sw/elektra/examples/kdb-ls/ --max-depth=1
 kdb ls /sw/elektra/examples/kdb-ls --max-depth=1
 # this yields no output as /sw/elektra/examples/kdb-ls is not a key
 
-# list all keys below /sw/elektra/examples/kdb-ls with are minimum 1 level away from that key
-# and maximum 2 levels away
+# list all keys below /sw/elektra/examples/kdb-ls with are minimum 1 level (inclusive) away from that key
+# and maximum 2 levels away (exclusive)
 kdb ls /sw/elektra/examples/kdb-ls --min-depth=1 --max-depth=2
-#> user/sw/elektra/examples/kdb-ls/tost/level
+#> user/sw/elektra/examples/kdb-ls/test
+#> user/sw/elektra/examples/kdb-ls/tost
 
 # list all keys below /sw/elektra/examples/kdb-ls/test
 kdb ls /sw/elektra/examples/kdb-ls/test
@@ -78,7 +79,7 @@ kdb ls /sw/elektra/examples/kdb-ls/test
 
 # list all keys under /sw/elektra/examples/kdb-ls in verbose mode
 kdb ls /sw/elektra/examples/kdb-ls/ -v
-#> size of all keys in mountpoint: 31
+#> size of all keys in mountpoint: 5
 #> size of requested keys: 5
 #> user/sw/elektra/examples/kdb-ls/test
 #> user/sw/elektra/examples/kdb-ls/test/fizz/buzz

--- a/doc/man/man1/kdb-ls.1
+++ b/doc/man/man1/kdb-ls.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "KDB\-LS" "1" "April 2018" "" ""
+.TH "KDB\-LS" "1" "May 2018" "" ""
 .
 .SH "NAME"
 \fBkdb\-ls\fR \- List keys in the key database
@@ -68,43 +68,44 @@ kdb set /sw/elektra/examples/kdb\-ls/tost/level lvl
 
 # list all keys below /sw/elektra/examples/kdb\-ls
 kdb ls /sw/elektra/examples/kdb\-ls
-#>user/sw/elektra/examples/kdb\-ls/test
-#>user/sw/elektra/examples/kdb\-ls/test/fizz/buzz
-#>user/sw/elektra/examples/kdb\-ls/test/foo/bar
-#>user/sw/elektra/examples/kdb\-ls/tost
-#>user/sw/elektra/examples/kdb\-ls/tost/level
+#> user/sw/elektra/examples/kdb\-ls/test
+#> user/sw/elektra/examples/kdb\-ls/test/fizz/buzz
+#> user/sw/elektra/examples/kdb\-ls/test/foo/bar
+#> user/sw/elektra/examples/kdb\-ls/tost
+#> user/sw/elektra/examples/kdb\-ls/tost/level
 
 # list the next level of keys below /sw/elektra/examples/kdb\-ls
 # note that if the search key ends with a /, it lists the next level
 kdb ls /sw/elektra/examples/kdb\-ls/ \-\-max\-depth=1
-#>user/sw/elektra/examples/kdb\-ls/test
-#>user/sw/elektra/examples/kdb\-ls/tost
+#> user/sw/elektra/examples/kdb\-ls/test
+#> user/sw/elektra/examples/kdb\-ls/tost
 
 # list the current level of keys below /sw/elektra/examples/kdb\-ls
 # note the difference to the previous example
 kdb ls /sw/elektra/examples/kdb\-ls \-\-max\-depth=1
 # this yields no output as /sw/elektra/examples/kdb\-ls is not a key
 
-# list all keys below /sw/elektra/examples/kdb\-ls with are minimum 1 level away from that key
-# and maximum 2 levels away
+# list all keys below /sw/elektra/examples/kdb\-ls with are minimum 1 level (inclusive) away from that key
+# and maximum 2 levels away (exclusive)
 kdb ls /sw/elektra/examples/kdb\-ls \-\-min\-depth=1 \-\-max\-depth=2
-#>user/sw/elektra/examples/kdb\-ls/tost/level
+#> user/sw/elektra/examples/kdb\-ls/test
+#> user/sw/elektra/examples/kdb\-ls/tost
 
 # list all keys below /sw/elektra/examples/kdb\-ls/test
 kdb ls /sw/elektra/examples/kdb\-ls/test
-#>user/sw/elektra/examples/kdb\-ls/test
-#>user/sw/elektra/examples/kdb\-ls/test/fizz/buzz
-#>user/sw/elektra/examples/kdb\-ls/test/foo/bar
+#> user/sw/elektra/examples/kdb\-ls/test
+#> user/sw/elektra/examples/kdb\-ls/test/fizz/buzz
+#> user/sw/elektra/examples/kdb\-ls/test/foo/bar
 
 # list all keys under /sw/elektra/examples/kdb\-ls in verbose mode
 kdb ls /sw/elektra/examples/kdb\-ls/ \-v
-#>size of all keys in mountpoint: 31
-#>size of requested keys: 5
-#>user/sw/elektra/examples/kdb\-ls/test
-#>user/sw/elektra/examples/kdb\-ls/test/fizz/buzz
-#>user/sw/elektra/examples/kdb\-ls/test/foo/bar
-#>user/sw/elektra/examples/kdb\-ls/tost
-#>user/sw/elektra/examples/kdb\-ls/tost/level
+#> size of all keys in mountpoint: 5
+#> size of requested keys: 5
+#> user/sw/elektra/examples/kdb\-ls/test
+#> user/sw/elektra/examples/kdb\-ls/test/fizz/buzz
+#> user/sw/elektra/examples/kdb\-ls/test/foo/bar
+#> user/sw/elektra/examples/kdb\-ls/tost
+#> user/sw/elektra/examples/kdb\-ls/tost/level
 .
 .fi
 .

--- a/doc/man/man1/kdb-ls.1
+++ b/doc/man/man1/kdb-ls.1
@@ -57,61 +57,61 @@ Give debug information\.
 .
 .nf
 
-# Backup\-and\-Restore: /sw/elektra/examples
+# Backup\-and\-Restore: /tests/examples
 
 # We use `dump` as storage format here, since storage plugins such as INI
-# automatically add keys between levels (e\.g\. `/sw/elektra/examples/kdb\-ls/test/foo`)\.
-kdb mount ls\.ecf /sw/elektra/examples dump
+# automatically add keys between levels (e\.g\. `/tests/examples/kdb\-ls/test/foo`)\.
+kdb mount ls\.ecf /tests/examples dump
 
 # Create the keys we use for the examples
-kdb set /sw/elektra/examples/kdb\-ls/test val1
-kdb set /sw/elektra/examples/kdb\-ls/test/foo/bar val2
-kdb set /sw/elektra/examples/kdb\-ls/test/fizz/buzz fizzbuzz
-kdb set /sw/elektra/examples/kdb\-ls/tost val3
-kdb set /sw/elektra/examples/kdb\-ls/tost/level lvl
+kdb set /tests/examples/kdb\-ls/test val1
+kdb set /tests/examples/kdb\-ls/test/foo/bar val2
+kdb set /tests/examples/kdb\-ls/test/fizz/buzz fizzbuzz
+kdb set /tests/examples/kdb\-ls/tost val3
+kdb set /tests/examples/kdb\-ls/tost/level lvl
 
-# list all keys below /sw/elektra/examples/kdb\-ls
-kdb ls /sw/elektra/examples/kdb\-ls
-#> user/sw/elektra/examples/kdb\-ls/test
-#> user/sw/elektra/examples/kdb\-ls/test/fizz/buzz
-#> user/sw/elektra/examples/kdb\-ls/test/foo/bar
-#> user/sw/elektra/examples/kdb\-ls/tost
-#> user/sw/elektra/examples/kdb\-ls/tost/level
+# list all keys below /tests/examples/kdb\-ls
+kdb ls /tests/examples/kdb\-ls
+#> user/tests/examples/kdb\-ls/test
+#> user/tests/examples/kdb\-ls/test/fizz/buzz
+#> user/tests/examples/kdb\-ls/test/foo/bar
+#> user/tests/examples/kdb\-ls/tost
+#> user/tests/examples/kdb\-ls/tost/level
 
-# list the next level of keys below /sw/elektra/examples/kdb\-ls
+# list the next level of keys below /tests/examples/kdb\-ls
 # note that if the search key ends with a /, it lists the next level
-kdb ls /sw/elektra/examples/kdb\-ls/ \-\-max\-depth=1
-#> user/sw/elektra/examples/kdb\-ls/test
-#> user/sw/elektra/examples/kdb\-ls/tost
+kdb ls /tests/examples/kdb\-ls/ \-\-max\-depth=1
+#> user/tests/examples/kdb\-ls/test
+#> user/tests/examples/kdb\-ls/tost
 
-# list the current level of keys below /sw/elektra/examples/kdb\-ls
+# list the current level of keys below /tests/examples/kdb\-ls
 # note the difference to the previous example
-kdb ls /sw/elektra/examples/kdb\-ls \-\-max\-depth=1
-# this yields no output as /sw/elektra/examples/kdb\-ls is not a key
+kdb ls /tests/examples/kdb\-ls \-\-max\-depth=1
+# this yields no output as /tests/examples/kdb\-ls is not a key
 
-# list all keys below /sw/elektra/examples/kdb\-ls with are minimum 1 level (inclusive) away from that key
+# list all keys below /tests/examples/kdb\-ls with are minimum 1 level (inclusive) away from that key
 # and maximum 2 levels away (exclusive)
-kdb ls /sw/elektra/examples/kdb\-ls \-\-min\-depth=1 \-\-max\-depth=2
-#> user/sw/elektra/examples/kdb\-ls/test
-#> user/sw/elektra/examples/kdb\-ls/tost
+kdb ls /tests/examples/kdb\-ls \-\-min\-depth=1 \-\-max\-depth=2
+#> user/tests/examples/kdb\-ls/test
+#> user/tests/examples/kdb\-ls/tost
 
-# list all keys below /sw/elektra/examples/kdb\-ls/test
-kdb ls /sw/elektra/examples/kdb\-ls/test
-#> user/sw/elektra/examples/kdb\-ls/test
-#> user/sw/elektra/examples/kdb\-ls/test/fizz/buzz
-#> user/sw/elektra/examples/kdb\-ls/test/foo/bar
+# list all keys below /tests/examples/kdb\-ls/test
+kdb ls /tests/examples/kdb\-ls/test
+#> user/tests/examples/kdb\-ls/test
+#> user/tests/examples/kdb\-ls/test/fizz/buzz
+#> user/tests/examples/kdb\-ls/test/foo/bar
 
-# list all keys under /sw/elektra/examples/kdb\-ls in verbose mode
-kdb ls /sw/elektra/examples/kdb\-ls/ \-v
+# list all keys under /tests/examples/kdb\-ls in verbose mode
+kdb ls /tests/examples/kdb\-ls/ \-v
 #> size of all keys in mountpoint: 5
 #> size of requested keys: 5
-#> user/sw/elektra/examples/kdb\-ls/test
-#> user/sw/elektra/examples/kdb\-ls/test/fizz/buzz
-#> user/sw/elektra/examples/kdb\-ls/test/foo/bar
-#> user/sw/elektra/examples/kdb\-ls/tost
-#> user/sw/elektra/examples/kdb\-ls/tost/level
+#> user/tests/examples/kdb\-ls/test
+#> user/tests/examples/kdb\-ls/test/fizz/buzz
+#> user/tests/examples/kdb\-ls/test/foo/bar
+#> user/tests/examples/kdb\-ls/tost
+#> user/tests/examples/kdb\-ls/tost/level
 
-kdb umount /sw/elektra/examples
+kdb umount /tests/examples
 .
 .fi
 .

--- a/doc/man/man1/kdb-ls.1
+++ b/doc/man/man1/kdb-ls.1
@@ -59,6 +59,10 @@ Give debug information\.
 
 # Backup\-and\-Restore: /sw/elektra/examples
 
+# We use `dump` as storage format here, since storage plugins such as INI
+# automatically add keys between levels (e\.g\. `/sw/elektra/examples/kdb\-ls/test/foo`)\.
+kdb mount ls\.ecf /sw/elektra/examples dump
+
 # Create the keys we use for the examples
 kdb set /sw/elektra/examples/kdb\-ls/test val1
 kdb set /sw/elektra/examples/kdb\-ls/test/foo/bar val2
@@ -106,6 +110,8 @@ kdb ls /sw/elektra/examples/kdb\-ls/ \-v
 #> user/sw/elektra/examples/kdb\-ls/test/foo/bar
 #> user/sw/elektra/examples/kdb\-ls/tost
 #> user/sw/elektra/examples/kdb\-ls/tost/level
+
+kdb umount /sw/elektra/examples
 .
 .fi
 .

--- a/doc/news/_preparation_next_release.md
+++ b/doc/news/_preparation_next_release.md
@@ -146,6 +146,9 @@ Many problems were resolved with the following fixes:
   [`ccode`](https://libelektra.org/plugins/ccode) instead of the “provider” `code`.
 - The script [`check_bashisms.sh`](https://master.libelektra.org/tests/shell/check_bashisms.sh) should now work correctly again, if the
   system uses the GNU version `find`.
+- The Markdown Shell Recorder now partially supports indented code blocks.
+- We fixed some problems in the [Markdown Shell Recorder](https://master.libelektra.org/tests/shell/shell_recorder/tutorial_wrapper) test
+  of [`kdb ls`](https://master.libelektra.org/doc/help/kdb-ls.md).
 
 
 ## Outlook

--- a/tests/shell/shell_recorder/tutorial_wrapper/CMakeLists.txt
+++ b/tests/shell/shell_recorder/tutorial_wrapper/CMakeLists.txt
@@ -8,7 +8,7 @@ add_msr_test (readme_msr "${CMAKE_SOURCE_DIR}/tests/shell/shell_recorder/tutoria
 add_msr_test (issue_template "${CMAKE_SOURCE_DIR}/.github/ISSUE_TEMPLATE.md")
 add_msr_test (tutorial_cascading "${CMAKE_SOURCE_DIR}/doc/tutorials/cascading.md")
 add_msr_test (kdb-complete "${CMAKE_SOURCE_DIR}/doc/help/kdb-complete.md")
-add_msr_test (kdb-ls "${CMAKE_SOURCE_DIR}/doc/help/kdb-ls.md")
+add_msr_test (kdb-ls "${CMAKE_SOURCE_DIR}/doc/help/kdb-ls.md" REQUIRED_PLUGINS sync)
 
 add_msr_test (tutorial_validation "${CMAKE_SOURCE_DIR}/doc/tutorials/validation.md" REQUIRED_PLUGINS validation)
 

--- a/tests/shell/shell_recorder/tutorial_wrapper/markdown_shell_recorder.sh
+++ b/tests/shell/shell_recorder/tutorial_wrapper/markdown_shell_recorder.sh
@@ -48,7 +48,7 @@ translate()
 	while read -r line;
 	do
 		if grep -Eq '^\s*#>' <<< "$line"; then
-			output=$(sed 's/[ ]*#> \(.*\)/\1/' <<< "$line")
+			output=$(sed -E -e 's/([ ]*#>$)/\1 /' -e 's/[ ]*#> (.*)/\1/' <<< "$line")
 			[ -z "$OUTBUF" ] && OUTBUF="$output" || OUTBUF="${OUTBUF}⏎$output"
 		fi
 

--- a/tests/shell/shell_recorder/tutorial_wrapper/markdown_shell_recorder.sh
+++ b/tests/shell/shell_recorder/tutorial_wrapper/markdown_shell_recorder.sh
@@ -48,7 +48,7 @@ translate()
 	while read -r line;
 	do
 		if grep -Eq '^\s*#>' <<< "$line"; then
-			output=$(sed -n 's/\s*#> \(.*\)/\1/p' <<< "$line")
+			output=$(sed 's/[ ]*#> \(.*\)/\1/' <<< "$line")
 			[ -z "$OUTBUF" ] && OUTBUF="$output" || OUTBUF="${OUTBUF}⏎$output"
 		fi
 


### PR DESCRIPTION
# Purpose

This pull request should fix the problems of the Markdown Shell Recorder test of the Hexnumber plugin (see PR #1903).

# Checklist

- [x] I checked all commit messages.
- [x] I ran all tests locally and everything went fine.
- [x] This PR contains an updated version of the release notes.