### PR TITLE
Markdown Shell Recorder: Support Indented Code Blocks

### DIFF
--- a/doc/news/_preparation_next_release.md
+++ b/doc/news/_preparation_next_release.md
@@ -146,7 +146,7 @@ Many problems were resolved with the following fixes:
   [`ccode`](https://libelektra.org/plugins/ccode) instead of the “provider” `code`.
 - The script [`check_bashisms.sh`](https://master.libelektra.org/tests/shell/check_bashisms.sh) should now work correctly again, if the
   system uses the GNU version `find`.
-- The Markdown Shell Recorder now partially supports indented code blocks.
+- The Markdown Shell Recorder now supports indented code blocks.
 - We fixed some problems in the [Markdown Shell Recorder](https://master.libelektra.org/tests/shell/shell_recorder/tutorial_wrapper) test
   of [`kdb ls`](https://master.libelektra.org/doc/help/kdb-ls.md).
 

--- a/tests/shell/shell_recorder/tutorial_wrapper/SyntaxCheck.md
+++ b/tests/shell/shell_recorder/tutorial_wrapper/SyntaxCheck.md
@@ -1,57 +1,59 @@
-# Test 1
+# Syntax Check
 
-```sh
-# Backup-and-Restore:/test
-# testcomment
-kdb set /test/a a
-kdb set /test/b b
-# RET:0
-# should yield 'a'
-kdb get /test/a
-#> a
-# STDERR:
-kdb get /test/c
-# Expected:
-# RET:11
-# STDERR:Did not find key '/test/c'
-kdb rm -r /test
-```
+- Test 1
 
-# Test 2
+  ```sh
+  # Backup-and-Restore:/test
+  # testcomment
+  kdb set /test/a a
+  kdb set /test/b b
+  # RET:0
+  # should yield 'a'
+  kdb get /test/a
+  #> a
+  # STDERR:
+  kdb get /test/c
+  # Expected:
+  # RET:11
+  # STDERR:Did not find key '/test/c'
+  kdb rm -r /test
+  ```
 
-```sh
-kdb set /test/x x
-kdb set /test/y y
-kdb get /test/x
-#> x
-kdb get /test/y
-#> y
-kdb export /test ini
-# STDOUT-REGEX: (\[\]⏎)?x = x⏎y = y
-kdb ls /test
-kdb rm -r /test
-```
+- Test 2
 
-# Test 3
+  ```sh
+  kdb set /test/x x
+  kdb set /test/y y
+  kdb get /test/x
+  #> x
+  kdb get /test/y
+  #> y
+  kdb export /test ini
+  # STDOUT-REGEX: (\[\]⏎)?x = x⏎y = y
+  kdb ls /test
+  kdb rm -r /test
+  ```
 
-```sh
-ls
+- Test 3
 
-echo test
+  ```sh
+  ls
 
-#> test
+  echo test
 
-printf 'test\nbla'
-#> test
+  #> test
 
-#> bla
-if [ -e `kdb file user` ]; then cat `kdb file user`; fi
-```
+  printf 'test\nbla'
+  #> test
 
-# Sudo
+  #> bla
+  if [ -e `kdb file user` ]; then cat `kdb file user`; fi
+  ```
 
-```sh
-sudo echo `sudo kdb file system`
-sudo ls
-echo `    sudo kdb file system`
-```
+- Sudo
+
+  ```sh
+  sudo echo `sudo kdb file system`
+  sudo ls
+  echo `    sudo kdb file system`
+  ```

--- a/tests/shell/shell_recorder/tutorial_wrapper/markdown_shell_recorder.sh
+++ b/tests/shell/shell_recorder/tutorial_wrapper/markdown_shell_recorder.sh
@@ -53,7 +53,7 @@ translate()
 		fi
 
 		if grep -Eq "^(\s*)#" <<< "$line"; then
-			directive=$(sed -n 's/\s*# \(.*\)/\1/p' <<< "$line")
+			directive=$(sed -E 's/[ ]*# (.*)/\1/' <<< "$line")
 			cmd=$(cut -d ':' -f1 <<< "$directive")
 			arg=$(cut -d ':' -f2- <<< "$directive" | sed 's/[[:space:]]*//')
 


### PR DESCRIPTION
# Purpose

After this update the Shell Recorder should support intended code blocks properly.

# Checklist

- [x] I checked the commit message.
- [x] I ran all tests locally and everything went fine.
- [x] This pull request contains an updated version of the release notes.
