### PR TITLE
crypto: stop gpg-agents after unit test

### DIFF
--- a/src/plugins/crypto/gpg.c
+++ b/src/plugins/crypto/gpg.c
@@ -862,11 +862,6 @@ int CRYPTO_PLUGIN_FUNCTION (gpgCall) (KeySet * conf, Key * errorKey, Key * msgKe
 	// wait for the gpg process to finish
 	waitpid (pid, &status, 0);
 
-	if (status != 0)
-	{
-		fprintf (stderr, "gpg returned %d\n", status);
-	}
-
 	// evaluate return code of finished child process
 	int retval = -1;
 	switch (status)

--- a/src/plugins/crypto/gpg.c
+++ b/src/plugins/crypto/gpg.c
@@ -862,6 +862,11 @@ int CRYPTO_PLUGIN_FUNCTION (gpgCall) (KeySet * conf, Key * errorKey, Key * msgKe
 	// wait for the gpg process to finish
 	waitpid (pid, &status, 0);
 
+	if (status != 0)
+	{
+		fprintf (stderr, "gpg returned %d\n", status);
+	}
+
 	// evaluate return code of finished child process
 	int retval = -1;
 	switch (status)

--- a/src/plugins/crypto/test_internals.h
+++ b/src/plugins/crypto/test_internals.h
@@ -331,6 +331,9 @@ static void test_gpg (void)
 
 	succeed_if (CRYPTO_PLUGIN_FUNCTION (gpgCall) (conf, errorKey, msg, argv, argc) == 1, "failed to install the GPG test key");
 
+	fprintf (stderr, "errorKey = %s\n", keyString (errorKey));
+	fprintf (stderr, "msg = %s\n", keyString (msg));
+
 	keyDel (msg);
 	keyDel (errorKey);
 	ksDel (conf);

--- a/src/plugins/crypto/test_internals.h
+++ b/src/plugins/crypto/test_internals.h
@@ -331,9 +331,6 @@ static void test_gpg (void)
 
 	succeed_if (CRYPTO_PLUGIN_FUNCTION (gpgCall) (conf, errorKey, msg, argv, argc) == 1, "failed to install the GPG test key");
 
-	fprintf (stderr, "errorKey = %s\n", keyString (errorKey));
-	fprintf (stderr, "msg = %s\n", keyString (msg));
-
 	keyDel (msg);
 	keyDel (errorKey);
 	ksDel (conf);

--- a/src/plugins/crypto/test_internals.h
+++ b/src/plugins/crypto/test_internals.h
@@ -324,8 +324,8 @@ static void test_gpg (void)
 	Key * errorKey = keyNew (0);
 
 	// install the gpg key
-	char * argv[] = { "", "--trust-model", "always", "-a", "--import", NULL };
-	const size_t argc = 6;
+	char * argv[] = { "", "--trust-model", "always", "--batch", "--yes", "-a", "--import", NULL };
+	const size_t argc = 8;
 	Key * msg = keyNew (0);
 	keySetBinary (msg, test_key_asc, test_key_asc_len);
 

--- a/src/plugins/crypto/test_internals.h
+++ b/src/plugins/crypto/test_internals.h
@@ -324,8 +324,8 @@ static void test_gpg (void)
 	Key * errorKey = keyNew (0);
 
 	// install the gpg key
-	char * argv[] = { "", "-a", "--import", NULL };
-	const size_t argc = 4;
+	char * argv[] = { "", "--trust-model", "always", "-a", "--import", NULL };
+	const size_t argc = 6;
 	Key * msg = keyNew (0);
 	keySetBinary (msg, test_key_asc, test_key_asc_len);
 


### PR DESCRIPTION
# Purpose

This PR affects unit tests of `crypto` and `fcrypt`.

The general idea is to:

1. set `GNUPGHOME` to a temporary directory,
2. delete the temporary directory and all of its contents as last step of the unit tests, and
3. shut down `gpg-agent` when the unit tests are done.

Step 2 instructs `gpg-agent` to shut down. A big thank you to @ingwinlu for finding out how to properly shut down the `gpg-agent`.

Closes #1928 .

# Checklist

Check relevant points but please do not remove entries.
For docu fixes, spell checking, and similar nothing
needs to be checked.

- [x] commit messages are fine ("module: short statement" syntax and refer to issues)
- [x] I added unit tests
- [x] I ran all tests locally and everything went fine
- [ ] affected documentation is fixed
- [x] I added code comments, logging, and assertions (see doc/CODING.md)
- [ ] meta data is updated (e.g. README.md of plugins)
- [ ] release notes are updated (doc/news/_preparation_next_release.md)

# TODOs

- [x] improve code quality
- [ ] adapt `fcrypt` unit test
