### PR TITLE
Reformat CMake: Ensure `cmake-format` Works

### DIFF
--- a/doc/news/_preparation_next_release.md
+++ b/doc/news/_preparation_next_release.md
@@ -68,7 +68,7 @@ We added even more functionality, which could not make it to the highlights:
 
 ## Other News
 
-- The `crypto` plugin now uses Elektra's `libinvoke` and the `base64` plugin in order to encode and decode Base64 strings. This improvement reduces code duplication between the two plugins.
+- The `crypto` plugin now uses Elektra's `libinvoke` and the `base64` plugin in order to encode and decode Base64 strings. This improvement reduces code duplication between the two plugins. *(Peter Nirschl)*
 - <<TODO>>
 - <<TODO>>
 - <<TODO>>
@@ -128,12 +128,12 @@ These notes are of interest for people developing Elektra:
 - <<TODO>>
 - <<TODO>>
 - The script [`check_formatting.sh`](https://master.libelektra.org/tests/shell/check_formatting.sh) now also checks the formatting of CMake
-  code if you installed [`sponge`](https://joeyh.name/code/moreutils) and [`cmake-format`][].
+  code if you installed [`sponge`](https://joeyh.name/code/moreutils) and [`cmake-format`][]. *(René Schwaiger)*
 - Our Travis build job now
   - builds all (applicable) bindings by default again, and
   - checks the formatting of CMake code via [`cmake-format`][]
 
-  .
+  . *(René Schwaiger)*
 
 [`cmake-format`]: https://github.com/cheshirekow/cmake_format
 
@@ -145,12 +145,12 @@ Many problems were resolved with the following fixes:
 - <<TODO>>
 - <<TODO>>
 - We fixed a memory leak in the [mINI plugin](https://libelektra.org/plugins/mini) by requiring the plugin
-  [`ccode`](https://libelektra.org/plugins/ccode) instead of the “provider” `code`.
+  [`ccode`](https://libelektra.org/plugins/ccode) instead of the “provider” `code`. *(René Schwaiger)*
 - The script [`check_bashisms.sh`](https://master.libelektra.org/tests/shell/check_bashisms.sh) should now work correctly again, if the
-  system uses the GNU version `find`.
-- The Markdown Shell Recorder now supports indented code blocks.
+  system uses the GNU version `find`. *(René Schwaiger)*
+- The Markdown Shell Recorder now supports indented code blocks. *(René Schwaiger)*
 - We fixed some problems in the [Markdown Shell Recorder](https://master.libelektra.org/tests/shell/shell_recorder/tutorial_wrapper) test
-  of [`kdb ls`](https://master.libelektra.org/doc/help/kdb-ls.md).
+  of [`kdb ls`](https://master.libelektra.org/doc/help/kdb-ls.md). *(René Schwaiger)*
 
 
 ## Outlook

--- a/doc/news/_preparation_next_release.md
+++ b/doc/news/_preparation_next_release.md
@@ -151,6 +151,7 @@ Many problems were resolved with the following fixes:
 - The Markdown Shell Recorder now supports indented code blocks. *(René Schwaiger)*
 - We fixed some problems in the [Markdown Shell Recorder](https://master.libelektra.org/tests/shell/shell_recorder/tutorial_wrapper) test
   of [`kdb ls`](https://master.libelektra.org/doc/help/kdb-ls.md). *(René Schwaiger)*
+- The script [`reformat-cmake`](https://master.libelektra.org/scripts/reformat-cmake) now checks if `cmake-format` works before it reformats CMake files. Thank you to Klemens Böswirth for the [detailed description of the problem](https://github.com/ElektraInitiative/libelektra/pull/1903#discussion_r189332987). *(René Schwaiger)*
 
 
 ## Outlook

--- a/scripts/reformat-cmake
+++ b/scripts/reformat-cmake
@@ -13,7 +13,7 @@ CMAKE_FORMAT=$(which cmake-format)
 cd "$SOURCE"
 
 if [ -z "${CMAKE_FORMAT}" ]; then
-	echo 'Please install `cmake-format`'
+	2>&1 printf 'Please install `cmake-format`'
 	exit 0
 fi
 
@@ -25,7 +25,7 @@ if [ $? != 0 ]; then
 fi
 
 if [ -z "$(which sponge)" ]; then
-	echo 'Please install `sponge`'
+	2>&1 printf 'Please install `sponge`\n'
 	exit 0
 fi
 

--- a/scripts/reformat-cmake
+++ b/scripts/reformat-cmake
@@ -10,8 +10,17 @@ SCRIPTS_DIR=$(dirname "$0")
 
 CMAKE_FORMAT=$(which cmake-format)
 
+cd "$SOURCE"
+
 if [ -z "${CMAKE_FORMAT}" ]; then
 	echo 'Please install `cmake-format`'
+	exit 0
+fi
+
+output=$(2>&1 "${CMAKE_FORMAT}" CMakeLists.txt)
+
+if [ $? != 0 ]; then
+	2>&1 printf 'It seems your local installation of `cmake-format` is broken:\n\n%s' "$output"
 	exit 0
 fi
 
@@ -20,7 +29,6 @@ if [ -z "$(which sponge)" ]; then
 	exit 0
 fi
 
-cd "$SOURCE"
 
 for file in $(find . \( -name 'CMakeLists.txt' -or -name '*.cmake' \) -and \
 		     \(                                                    \


### PR DESCRIPTION
# Purpose

This pull request should fix the problem described [here](https://github.com/ElektraInitiative/libelektra/pull/1903#discussion_r189332987).

# Checklist

- [x] I checked all commit messages.
- [x] I tested the changes to the script `reformat-cmake` manually.
- [x] This PR contains an updated version of the release notes.
