### PR TITLE
Qt-GUI: Support Qt 5.11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -105,9 +105,7 @@ before_install:
       export PKG_CONFIG_PATH=/usr/local/opt/openssl/lib/pkgconfig
       brew install python@2; brew link --overwrite python@2
       brew install python || brew upgrade python
-      # Since Qt 5.10.1 GCC is unable to compile the Qt-GUI under macOS printing the following error message:
-      #   'init_priority' attribute is not supported on this platform
-      brew install qt@5.5
+      brew install qt
       brew install swig
       brew install yajl
       pip2 install cheetah # Required by kdb-gen

--- a/doc/news/_preparation_next_release.md
+++ b/doc/news/_preparation_next_release.md
@@ -177,6 +177,7 @@ Many problems were resolved with the following fixes:
 - The script [`reformat-cmake`](https://master.libelektra.org/scripts/reformat-cmake) now checks if `cmake-format` works before it reformats CMake files. Thank you to Klemens Böswirth for the [detailed description of the problem](https://github.com/ElektraInitiative/libelektra/pull/1903#discussion_r189332987). *(René Schwaiger)*
 - `scripts/run_icheck` now no longer leaves the base directory of the project
   when checking if the ABI changed. *(Lukas Winkler)*
+- You can now build the [Qt-GUI](https://www.libelektra.org/tools/qt-gui) using Qt `5.11`. *(René Schwaiger)*
 
 
 ## Outlook

--- a/doc/news/_preparation_next_release.md
+++ b/doc/news/_preparation_next_release.md
@@ -44,18 +44,18 @@ You can also read the news [on our website](https://www.libelektra.org/news/0.8.
 
 ### Type system preview
 
-Elektra supports specifying the semantics of keys via metakeys in the `spec` 
+Elektra supports specifying the semantics of keys via metakeys in the `spec`
 namespace. An example is the metakey `check/range` which can be used to specify
 that a key only holds numbers in a given range. Another metakey is `check/enum`
-which only allows specific keywords to be the content of a key. Up to now these 
+which only allows specific keywords to be the content of a key. Up to now these
 semantics are being checked at runtime. Therefore a type system was developed to
 be able to check configuration specifications statically. As an example, it
-would detect when one accidentially add both a range and an enum check if their 
+would detect when one accidentially add both a range and an enum check if their
 possible contents are not compatible with each other.
 
-The type system is available as a plugin that gets mounted along with a 
+The type system is available as a plugin that gets mounted along with a
 configuration specification into the spec namespace. Furthermore we include a
-set of type definitions for commonly used metakeys such as `check/range`, 
+set of type definitions for commonly used metakeys such as `check/range`,
 `check/long`, `fallback` or `override`.
 
 For more details see the
@@ -80,7 +80,7 @@ We added even more functionality, which could not make it to the highlights:
 
 ## New Plugins
 
-- The plugin [hexnumber](https://www.libelektra.org/plugins/hexnumber) has been added. It can be used 
+- The plugin [hexnumber](https://www.libelektra.org/plugins/hexnumber) has been added. It can be used
   to convert hexadecimal values into decimal when read, and back to hexadecimal when written.
 - <<TODO>>
 - <<TODO>>

--- a/src/tools/qt-gui/CMakeLists.txt
+++ b/src/tools/qt-gui/CMakeLists.txt
@@ -57,7 +57,7 @@ else ()
 	add_executable (qt-gui ${qt-gui_SRCS} ${qt-gui_HDRS} ${UIS} ${RSCS} ${TRS})
 	add_dependencies (qt-gui kdberrors_generated)
 
-	qt5_use_modules (qt-gui Quick Gui Core Qml Widgets)
+	target_link_libraries (qt-gui Qt5::Quick Qt5::Gui Qt5::Core Qt5::Qml Qt5::Widgets)
 
 	include_directories (${DISCOUNT_INCLUDES})
 	target_link_libraries (qt-gui ${DISCOUNT_LIBRARIES})


### PR DESCRIPTION
# Purpose

After this update building the Qt-GUI should also work if we use the [latest version of Qt](http://blog.qt.io/blog/2018/05/22/qt-5-11-released).

# Checklist

- [x] I checked all commit messages.
- [x] This PR contains an updated version of the release notes.
