### PR TITLE
Travis: Use Latest Version of GCC and Clang

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,11 +28,11 @@ matrix:
           sources:
             - ubuntu-toolchain-r-test
           packages:
-            - g++-7
+            - g++-8
       env:
         - ASAN=ON
-        - CC_COMPILER=gcc-7
-        - CXX_COMPILER=g++-7
+        - CC_COMPILER=gcc-8
+        - CXX_COMPILER=g++-8
 
     - os: linux
       compiler: clang
@@ -87,10 +87,10 @@ matrix:
           sources:
             - ubuntu-toolchain-r-test
           packages:
-            - g++-7
+            - g++-8
       env:
-        - CC_COMPILER=gcc-7
-        - CXX_COMPILER=g++-7
+        - CC_COMPILER=gcc-8
+        - CXX_COMPILER=g++-8
 
     - os: linux
       compiler: clang

--- a/.travis.yml
+++ b/.travis.yml
@@ -232,12 +232,8 @@ before_script:
 script:
   - ninja
   - |
-    if [[ "$ASAN" = "ON" && "$TRAVIS_OS_NAME" == "linux" && "$CC" == "clang" ]]; then
-      # preload required libraries (LD_PRELOAD is a space separated list)
-      UBSAN_LIBRARY=$(find /usr/ -name '*libclang_rt.ubsan_standalone_cxx-x86_64.so')
-      LD_PRELOAD="$UBSAN_LIBRARY" ASAN_OPTIONS=symbolize=1 ASAN_SYMBOLIZER_PATH=$(which llvm-symbolizer) ninja run_all
-    elif [[ "$ASAN" = "ON" ]]; then
-      ASAN_OPTIONS=symbolize=1 ASAN_SYMBOLIZER_PATH=$(which llvm-symbolizer) ninja run_all
+    if [[ "$ASAN" = "ON" ]]; then
+      ninja run_all
     else
       ninja install
       ninja run_all && kdb run_all

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,14 +18,17 @@ matrix:
     - os: osx
       osx_image: xcode9.3beta
       compiler: clang
-      env: [ ASAN=ON ]
+      env:
+        - ASAN=ON
 
     - os: linux
       compiler: gcc
       addons:
         apt:
-          sources: [ ubuntu-toolchain-r-test ]
-          packages: [ g++-7 ]
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-7
       env:
         - ASAN=ON
         - CC_COMPILER=gcc-7
@@ -35,13 +38,15 @@ matrix:
       compiler: clang
       addons:
         apt:
-          sources: [ llvm-toolchain-trusty-6.0, ubuntu-toolchain-r-test ]
-          packages: [ clang-6.0 ]
+          sources:
+            - llvm-toolchain-trusty-6.0
+            - ubuntu-toolchain-r-test
+          packages:
+            - clang-6.0
       env:
         - ASAN=ON
         - CC_COMPILER=clang-6.0
         - CXX_COMPILER=clang++-6.0
-
 
     # FULL: Build full version of Elektra (BUILD_FULL=ON)
 
@@ -49,8 +54,10 @@ matrix:
       compiler: gcc
       addons:
         apt:
-          sources: [ ubuntu-toolchain-r-test ]
-          packages: [ g++-8 ]
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-8
       env:
         - FULL=ON
         - CC_COMPILER=gcc-8
@@ -70,14 +77,17 @@ matrix:
     - os: osx
       osx_image: xcode9.3beta
       compiler: clang
-      env: [ HASKELL=ON ]
+      env:
+        - HASKELL=ON
 
     - os: linux
       compiler: gcc
       addons:
         apt:
-          sources: [ ubuntu-toolchain-r-test ]
-          packages: [ g++-7 ]
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-7
       env:
         - CC_COMPILER=gcc-7
         - CXX_COMPILER=g++-7
@@ -86,8 +96,11 @@ matrix:
       compiler: clang
       addons:
         apt:
-          sources: [ llvm-toolchain-trusty-6.0, ubuntu-toolchain-r-test ]
-          packages: [ clang-6.0 ]
+          sources:
+            - llvm-toolchain-trusty-6.0
+            - ubuntu-toolchain-r-test
+          packages:
+            - clang-6.0
       env:
         - CC_COMPILER=clang-6.0
         - CXX_COMPILER=clang++-6.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,17 +26,35 @@ matrix:
         apt:
           sources: [ ubuntu-toolchain-r-test ]
           packages: [ g++-7 ]
-      env: [ ASAN=ON ]
+      env:
+        - ASAN=ON
+        - CC_COMPILER=gcc-7
+        - CXX_COMPILER=g++-7
 
     - os: linux
       compiler: clang
-      env: [ ASAN=ON ]
+      addons:
+        apt:
+          sources: [ llvm-toolchain-trusty-6.0, ubuntu-toolchain-r-test ]
+          packages: [ clang-6.0 ]
+      env:
+        - ASAN=ON
+        - CC_COMPILER=clang-6.0
+        - CXX_COMPILER=clang++-6.0
+
 
     # FULL: Build full version of Elektra (BUILD_FULL=ON)
 
     - os: linux
       compiler: gcc
-      env: [ FULL=ON ]
+      addons:
+        apt:
+          sources: [ ubuntu-toolchain-r-test ]
+          packages: [ g++-8 ]
+      env:
+        - FULL=ON
+        - CC_COMPILER=gcc-8
+        - CXX_COMPILER=g++-8
 
     - os: osx
       # Translating the `syslog` plugin with GCC on macOS 10.13 does not work, since GCC is unable to compile `sys/syslog.h`.
@@ -56,16 +74,23 @@ matrix:
 
     - os: linux
       compiler: gcc
-      apt:
-        sources: [ llvm-toolchain-trusty-6.0, ubuntu-toolchain-r-test]
-        packages: [ clang-format-6.0 ]
+      addons:
+        apt:
+          sources: [ ubuntu-toolchain-r-test ]
+          packages: [ g++-7 ]
+      env:
+        - CC_COMPILER=gcc-7
+        - CXX_COMPILER=g++-7
 
     - os: linux
       compiler: clang
       addons:
         apt:
-          sources: [ llvm-toolchain-trusty-5.0 ]
-          packages: [ clang-format-5.0 ]
+          sources: [ llvm-toolchain-trusty-6.0, ubuntu-toolchain-r-test ]
+          packages: [ clang-6.0 ]
+      env:
+        - CC_COMPILER=clang-6.0
+        - CXX_COMPILER=clang++-6.0
 
 before_install:
   - |
@@ -128,7 +153,8 @@ before_install:
     fi
   - |
     if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
-      [[ $ASAN == ON && $CC == gcc ]] && export CC=gcc-7 CXX=g++-7
+      [[ -n "$CC_COMPILER" ]] && export CC="$CC_COMPILER"
+      [[ -n "$CXX_COMPILER" ]] && export CXX="$CXX_COMPILER"
       sudo apt-get -qq update
       sudo apt-get install ninja-build
       sudo apt-get install devscripts # contains `checkbashisms`

--- a/doc/news/_preparation_next_release.md
+++ b/doc/news/_preparation_next_release.md
@@ -135,6 +135,7 @@ These notes are of interest for people maintaining packages of Elektra:
 - <<TODO>>
 - <<TODO>>
 - The Jenkins build server now also compiles and tests Elektra with enabled address sanitizer. *(Lukas Winkler)*
+- Travis now uses the latest version of GCC and Clang to translate Elektra on Linux. *(René Schwaiger)*
 
 
 ## Website
@@ -167,6 +168,7 @@ These notes are of interest for people developing Elektra:
   . *(René Schwaiger)*
 - (Markdown) Shell Recorder tests now save test data below `/tests` (see issue [#1887][]). *(René Schwaiger)*
 - The Markdown Shell Recorder checks `kdb set` commands to ensure we only add tests that store data below `/tests`. *(René Schwaiger)*
+- We disabled the test `testlib_notification` on ASAN enabled builds, since Clang reports that the test leaks memory. *(René Schwaiger)*
 
 [`cmake-format`]: https://github.com/cheshirekow/cmake_format
 [#1887]: https://github.com/ElektraInitiative/libelektra/issues/1887

--- a/src/libs/notification/tests/CMakeLists.txt
+++ b/src/libs/notification/tests/CMakeLists.txt
@@ -1,6 +1,7 @@
 include (LibAddMacros)
 
-if (BUILD_TESTING)
+# Clang with enabled ASAN reports that this test leaks memory: https://travis-ci.org/sanssecours/elektra/jobs/383014685#L2197
+if (BUILD_TESTING AND NOT ENABLE_ASAN)
 
 	add_headers (HDR_FILES)
 
@@ -25,4 +26,4 @@ if (BUILD_TESTING)
 
 	endforeach (file ${TESTS})
 
-endif (BUILD_TESTING)
+endif (BUILD_TESTING AND NOT ENABLE_ASAN)


### PR DESCRIPTION
# Purpose

Turns out we only installed recent versions of compilers on most of the Linux build jobs, but did not use them to compile Elektra 😳. This update should fix this problem. The PR also disables `testlib_notification` on ASAN enabled build jobs, since the test [seems to leak memory](https://travis-ci.org/sanssecours/elektra/jobs/383014685#L2197).

# Checklist

- [x] I checked all commit messages.
- [x] This PR adds a code comment about the disabled test `testlib_notification` to the relevant CMake code.
- [x] The pull request contains an updated version of the release notes.
