### PR TITLE
KDB Find: Exclude Command on GCC 4.8 and Before

### DIFF
--- a/doc/news/_preparation_next_release.md
+++ b/doc/news/_preparation_next_release.md
@@ -193,6 +193,7 @@ Many problems were resolved with the following fixes:
   when checking if the ABI changed. *(Lukas Winkler)*
 - You can now build the [Qt-GUI](https://www.libelektra.org/tools/qt-gui) using Qt `5.11`. *(René Schwaiger)*
 - We fixed various minor spelling mistakes in the documentation. *(René Schwaiger)*
+- We exclude the command `kdb find`, if the we know that the current compiler ships with broken support for regular expressions. *(René Schwaiger)*
 
 
 ## Outlook

--- a/src/tools/kdb/CMakeLists.txt
+++ b/src/tools/kdb/CMakeLists.txt
@@ -7,6 +7,13 @@ add_toolheaders (HDR_FILES)
 include_directories (${CMAKE_CURRENT_SOURCE_DIR})
 
 file (GLOB SRC_FILES *.cpp)
+
+if (CMAKE_COMPILER_IS_GNUCXX AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 4.9)
+	set (REGEX_FIND "find.cpp$")
+	list_filter (SRC_FILES REGEX_FIND)
+	message (STATUS "Excluding kdb-find since GCC ${CMAKE_CXX_COMPILER_VERSION} does not support regular expressions properly")
+endif (CMAKE_COMPILER_IS_GNUCXX AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 4.9)
+
 set (SOURCES ${SRC_FILES} ${HDR_FILES})
 
 if (BUILD_SHARED OR BUILD_FULL)


### PR DESCRIPTION
# Purpose

Since GCC 4.7 and GCC 4.8 ship with [broken support for regular expressions](https://stackoverflow.com/questions/12530406/is-gcc-4-8-or-earlier-buggy-about-regular-expressions) 😭, we exclude the tool `kdb find` if we detect these compiler versions.

This pull request should fix the broken build jobs

- [`elektra-gcc-configure-debian-wheezy`](https://build.libelektra.org/jenkins/blue/organizations/jenkins/elektra-gcc-configure-debian-wheezy/detail/elektra-gcc-configure-debian-wheezy/1104/pipeline)  
- [`elektra-gcc47-all`](https://build.libelektra.org/jenkins/blue/organizations/jenkins/elektra-gcc47-all/detail/elektra-gcc47-all/1357/pipeline)

.

# Checklist

- [x] I checked all commit messages.
- [x] I ran all tests locally and everything went fine.
- [x] This pull request contains an updated version of the release notes.
