### PR TITLE
Debian: Add Attribution Info for DownloadProject

### DIFF
--- a/debian/copyright
+++ b/debian/copyright
@@ -443,35 +443,6 @@ License: BSD-3-clause-markdownconverter
  IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  POSSIBILITY OF SUCH DAMAGE.
 
-Files: tests/gtest-1.7.0/*
-Copyright: 2003, 2005-2009 Google Inc.
-License: BSD-3-clause-gtest
- Redistribution and use in source and binary forms, with or without
- modification, are permitted provided that the following conditions are
- met:
- .
-     * Redistributions of source code must retain the above copyright
- notice, this list of conditions and the following disclaimer.
-     * Redistributions in binary form must reproduce the above
- copyright notice, this list of conditions and the following disclaimer
- in the documentation and/or other materials provided with the
- distribution.
-     * Neither the name of Google Inc. nor the names of its
- contributors may be used to endorse or promote products derived from
- this software without specific prior written permission.
- .
- THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
- A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
- OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
- SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
- LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
- DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
- THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
 Files: debian/*
 Copyright: 2010-2011, 2014-2015, Pino Toscano <pino@debian.org>
 License: GPL-2+

--- a/debian/copyright
+++ b/debian/copyright
@@ -37,6 +37,10 @@ License: BSD-3-clause
  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+Files: cmake/Modules/DownloadProject*
+Copyright: 2015 Craig Scott
+License: MIT
+
 Files: cmake/Modules/FindAugeas.cmake
        cmake/Modules/FindDBus.cmake
        cmake/Modules/FindGObjectIntrospection.cmake


### PR DESCRIPTION
# Purpose

This pull request adds copyright info for [DownloadProject](https://github.com/Crascit/DownloadProject) to the file `debian/copyright`.

# Checklist

- [x] I checked all commit messages.