### PR TITLE
Fix homepage builds

### DIFF
--- a/doc/news/_preparation_next_release.md
+++ b/doc/news/_preparation_next_release.md
@@ -226,9 +226,8 @@ Many problems were resolved with the following fixes:
 - The [`list` plugin](http://libelektra.org/plugins/list) which is responsible
   for global mounting had a bug which prevented globally mounted plugins from
   being configurable. *(Thomas Wahringer)*
-- Fix an issue with excluded plugins for rest-backend builds with ASAN enabled *(Lukas Winkler)*
-  - Reenable `ni` plugin for ASAN builds
-  - Disable failing markdown parser test for `validation` since it leaks memory and thus fails
+- Disable Markdown Shell Recorder test `validation.md` for ASAN builds.
+  It leaks memory and thus fails the test during spec mount. *(Lukas Winkler)*
 
 ## Outlook
 

--- a/doc/news/_preparation_next_release.md
+++ b/doc/news/_preparation_next_release.md
@@ -226,6 +226,9 @@ Many problems were resolved with the following fixes:
 - The [`list` plugin](http://libelektra.org/plugins/list) which is responsible
   for global mounting had a bug which prevented globally mounted plugins from
   being configurable. *(Thomas Wahringer)*
+- Fix an issue with excluded plugins for rest-backend builds with ASAN enabled *(Lukas Winkler)*
+  - Reenable `ni` plugin for ASAN builds
+  - Disable failing markdown parser test for `validation` since it leaks memory and thus fails
 
 ## Outlook
 

--- a/doc/todo/TESTING
+++ b/doc/todo/TESTING
@@ -90,6 +90,9 @@ ASAN disables the following parts during cmake as they throw errors:
 Further kdb_check_internal skips tests that output sanitizer warnings during
 load as it would make the test fail.
 
+No tutorial validation is done for `validation.md` with ASAN because during the
+mount spec step an memory leak is detected which fails the test.
+
 ## bindings
 
 - swig_ruby excluded due to failing tests (see #1770)

--- a/scripts/docker/homepage/backend/Dockerfile
+++ b/scripts/docker/homepage/backend/Dockerfile
@@ -102,6 +102,7 @@ RUN apt-get update && apt-get install -y \
          libboost-thread1.62.0 \
          libssl1.1 \
          libicu57 \
+         libyajl2 \
          pwgen \
     && rm -rf /var/lib/apt/lists/*
 

--- a/src/plugins/ni/CMakeLists.txt
+++ b/src/plugins/ni/CMakeLists.txt
@@ -4,10 +4,6 @@ set (NI ${CMAKE_CURRENT_SOURCE_DIR}/nickel-1.1.0)
 
 file (GLOB NI_FILES ${NI}/src/*.c ${NI}/src/*.h)
 
-if (DEPENDENCY_PHASE AND ENABLE_ASAN)
-	remove_plugin (ni "ni reports runtime errors about unsigned integer overflows if you compile it using AddressSanitizer")
-endif (DEPENDENCY_PHASE AND ENABLE_ASAN)
-
 add_plugin (ni SOURCES ni.h ni.c ${NI_FILES} INCLUDE_DIRECTORIES ${NI}/include ${NI}/src/include LINK_ELEKTRA elektra-ease ADD_TEST)
 
 if (ADDTESTING_PHASE)

--- a/tests/shell/shell_recorder/tutorial_wrapper/CMakeLists.txt
+++ b/tests/shell/shell_recorder/tutorial_wrapper/CMakeLists.txt
@@ -17,8 +17,11 @@ else (CMAKE_COMPILER_IS_GNUCXX AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 4.9)
 	add_msr_test (kdb_find "${CMAKE_SOURCE_DIR}/doc/help/kdb-find.md")
 endif (CMAKE_COMPILER_IS_GNUCXX AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 4.9)
 
-add_msr_test (tutorial_validation "${CMAKE_SOURCE_DIR}/doc/tutorials/validation.md" REQUIRED_PLUGINS ni validation)
-
+if (ENABLE_ASAN)
+	message (STATUS "Excluding Markdown Shell Recorder test for `validation`, as it leaks memory and fails with ASAN enabled")
+else (ENABLE_ASAN)
+	add_msr_test (tutorial_validation "${CMAKE_SOURCE_DIR}/doc/tutorials/validation.md" REQUIRED_PLUGINS ni validation)
+endif (ENABLE_ASAN)
 # ~~~
 # Only works with super user privileges, since it writes to `/etc/hosts`:
 # add_msr_test (tutorial_mount "${CMAKE_SOURCE_DIR}/doc/tutorials/mount.md")


### PR DESCRIPTION
# Purpose

Fix issues with the rest-backend.
`ni` was disabled for ASAN builds but is needed for website setup.

We fix exclusions and disable the leaking test instead of the whole plugin.

Resolves #2026

# Checklist

- [x] commit messages are fine ("module: short statement" syntax and refer to issues)
- [x] release notes are updated (doc/news/_preparation_next_release.md)



