### PR TITLE
Markdown Shell Recorder: Support Empty `#>` directive

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ matrix:
     # ASAN: Enable AddressSanitizer
 
     - os: osx
-      osx_image: xcode9.3beta
+      osx_image: xcode9.3
       compiler: clang
       env:
         - ASAN=ON
@@ -69,13 +69,13 @@ matrix:
       compiler: gcc
 
     - os: osx
-      osx_image: xcode9.3beta
+      osx_image: xcode9.3
       compiler: clang
 
     # HASKELL: Only build Haskell binding and plugin
 
     - os: osx
-      osx_image: xcode9.3beta
+      osx_image: xcode9.3
       compiler: clang
       env:
         - HASKELL=ON

--- a/doc/news/_preparation_next_release.md
+++ b/doc/news/_preparation_next_release.md
@@ -218,6 +218,7 @@ Many problems were resolved with the following fixes:
 - The script [`check_bashisms.sh`](https://master.libelektra.org/tests/shell/check_bashisms.sh) should now work correctly again, if the
   system uses the GNU version `find`. *(René Schwaiger)*
 - The Markdown Shell Recorder now supports indented code blocks. *(René Schwaiger)*
+- The Markdown Shell Recorder now also tests if a command prints nothing to `stdout` if you add the check `#>`. *(René Schwaiger)*
 - We fixed some problems in the [Markdown Shell Recorder](https://master.libelektra.org/tests/shell/shell_recorder/tutorial_wrapper) test
   of [`kdb ls`](https://master.libelektra.org/doc/help/kdb-ls.md). *(René Schwaiger)*
 - The script [`reformat-cmake`](https://master.libelektra.org/scripts/reformat-cmake) now checks if `cmake-format` works before it reformats CMake files. Thank you to Klemens Böswirth for the [detailed description of the problem](https://github.com/ElektraInitiative/libelektra/pull/1903#discussion_r189332987). *(René Schwaiger)*

--- a/doc/news/_preparation_next_release.md
+++ b/doc/news/_preparation_next_release.md
@@ -174,7 +174,7 @@ These notes are of interest for people developing Elektra:
 - `clang` tests have been ported to the new build system *(Lukas Winkler et al)*
 - `clang-5.0` is now used for clang tests by the build system *(Lukas Winkler)*
 - An additional build job on Ubuntu:xenial has been added *(Lukas Winkler)*
-- Several improvments to the build system have been implemented *(Lukas Winkler)*:
+- Several improvements to the build system have been implemented *(Lukas Winkler)*:
   - Better Docker image handling.
   - Abort of previously queued but unfinished runs on new commits.
   - Document how to locally replicate the Docker environment used for tests.

--- a/doc/news/_preparation_next_release.md
+++ b/doc/news/_preparation_next_release.md
@@ -121,8 +121,9 @@ We improved the documentation in the following ways:
 - <<TODO>>
 - We added new [Markdown Shell Recorder](https://master.libelektra.org/tests/shell/shell_recorder/tutorial_wrapper) tests for the
   - [`file`](https://www.libelektra.org/plugins/file),
-  - [`iconv`](https://www.libelektra.org/plugins/iconv) and
-  - [`uname`](https://www.libelektra.org/plugins/uname),
+  - [`iconv`](https://www.libelektra.org/plugins/iconv),
+  - [`ni`](https://www.libelektra.org/plugins/ni), and
+  - [`uname`](https://www.libelektra.org/plugins/uname)
   plugin. *(René Schwaiger)*
 - We improved the formatting of our [compilation guide](/doc/COMPILE.md). *(René Schwaiger)*
 

--- a/src/plugins/ni/CMakeLists.txt
+++ b/src/plugins/ni/CMakeLists.txt
@@ -4,7 +4,8 @@ set (NI ${CMAKE_CURRENT_SOURCE_DIR}/nickel-1.1.0)
 
 file (GLOB NI_FILES ${NI}/src/*.c ${NI}/src/*.h)
 
-add_plugin (ni SOURCES ni.h ni.c ${NI_FILES} INCLUDE_DIRECTORIES ${NI}/include ${NI}/src/include LINK_ELEKTRA elektra-ease ADD_TEST)
+add_plugin (
+	ni SOURCES ni.h ni.c ${NI_FILES} INCLUDE_DIRECTORIES ${NI}/include ${NI}/src/include LINK_ELEKTRA elektra-ease ADD_TEST TEST_README)
 
 if (ADDTESTING_PHASE)
 	file (GLOB NI_INI_FILES ${NI}/src/tests/*.ini)

--- a/src/plugins/ni/README.md
+++ b/src/plugins/ni/README.md
@@ -61,6 +61,38 @@ For in-detail explanation of the syntax
 (nested keys are not supported by the plugin)
 [see /src/plugins/ni/nickel-1.1.0/include/bohr/ni.h](/src/plugins/ni/nickel-1.1.0/include/bohr/ni.h)
 
+## Examples
+
+```sh
+# Mount the `ni` plugin at `spec/tests/ni`
+sudo kdb mount file.ini spec/tests/ni ni
+
+# Add some metadata
+kdb setmeta spec/tests/ni/key metakey metavalue
+kdb setmeta spec/tests/ni/key check/type char
+
+# Retrieve metadata
+kdb lsmeta spec/tests/ni/key
+#> check/type
+#> metakey
+kdb getmeta spec/tests/ni/key metakey
+#> metavalue
+
+# Add and retrieve key values
+kdb get spec/tests/ni/key
+#>
+kdb set spec/tests/ni/key value
+kdb set spec/tests/ni/key/to nothing
+kdb get spec/tests/ni/key
+#> value
+kdb get spec/tests/ni/key/to
+#> nothing
+
+# Undo modifications
+kdb rm -r spec/tests/ni
+sudo kdb umount spec/tests/ni
+```
+
 ## Limitations
 
 - Supports most KeySets, but `kdb test` currently reports some errors

--- a/src/plugins/ni/README.md
+++ b/src/plugins/ni/README.md
@@ -15,40 +15,50 @@ This plugin uses the nickel library in order to read/write
 used in the `spec`-namespace or when any metadata should be
 stored.
 
-For ini files for applications, e.g. smb.conf you should prefer the
+For other applications, e.g. modifying `smb.conf` you should prefer the
 [ini plugin](/src/plugins/ini).
 
 ## Usage
 
-To mount a ni plugin you can simply use:
+To mount the ni plugin you can simply use:
 
-    kdb mount file.ini spec/ni ni
+```bash
+kdb mount file.ini spec/ni ni
+```
 
-The strength and usage of this plugin is that it supports arbitrary meta
-data and is still human readable.
-E.g.
+The strength of this plugin is that it supports arbitrary meta
+data and the file format is still human readable.
+For example the following lines:
 
-    [key]
-    meta=foo
+```ini
+[key]
+meta=foo
+```
 
-creates the key with metadata key `meta` and metadata value `foo`:
+specify that `key` has a metadata key `meta` containing the metavalue `foo`:
 
-    $ kdb getmeta user/ni/key meta
-    foo
+```bash
+kdb getmeta user/ni/key meta
+#> foo
+```
 
-the metadata for the parent key has following syntax:
+For the metadata of the parent key use the following syntax:
 
-    []
-    meta=foo
+```ini
+[]
+meta=foo
+```
 
 Line continuation works by ending the line with `\\`.
 
-Exporting a KeySet to the nickel format:
+To export a `KeySet` in the nickel format use:
 
-    kdb export spec/ni ni > example.ni
+```bash
+kdb export spec/ni ni > example.ni
+```
 
 For in-detail explanation of the syntax
-(nested keys are not supported by the plugin, however)
+(nested keys are not supported by the plugin)
 [see /src/plugins/ni/nickel-1.1.0/include/bohr/ni.h](/src/plugins/ni/nickel-1.1.0/include/bohr/ni.h)
 
 ## Limitations
@@ -56,8 +66,8 @@ For in-detail explanation of the syntax
 - Supports most KeySets, but `kdb test` currently reports some errors
   (likely because of the UTF-8 handling happening within ni).
 - Keys have a random order when written out.
-- No comments are preserved, they are simply removed.
-- Parse errors simply result to ignoring (and removing) these parts.
+- Comments are not preserved, they are simply removed.
+- Parse errors simply result in ignoring (and removing) these parts.
 
 ## Nickel
 
@@ -72,10 +82,10 @@ are possible, but limited in a keyname of a fixed size.
 The API of nickel is very suited for elektra, it can use
 `FILE*` pointers (using that elektra could open and lock
 files), the node-hierarchy can be transformed to
-keysets, but it lacks of many features like comments
+keysets, but it lacks many features like comments
 and types.
 
-The format is more general then the kde-ini format, it can
+The format is more general than the kde-ini format, it can
 handle their configuration well, when the section names
 do not exceed the specified length. Nesting is only required
 in the first depth, any deeper is not understood by kde config

--- a/src/plugins/yamlcpp/write.cpp
+++ b/src/plugins/yamlcpp/write.cpp
@@ -64,11 +64,11 @@ std::pair<bool, unsigned long long> isArrayIndex (NameIterator const & nameItera
 	{
 		return std::make_pair (true, stoull (name.substr (name.find_first_not_of ("#\\_"))));
 	}
-	catch (invalid_argument)
+	catch (invalid_argument const &)
 	{
 		return std::make_pair (false, 0);
 	}
-	catch (out_of_range)
+	catch (out_of_range const &)
 	{
 		errno = errnoValue;
 		return std::make_pair (false, 0);

--- a/tests/shell/shell_recorder/shell_recorder.sh
+++ b/tests/shell/shell_recorder/shell_recorder.sh
@@ -114,10 +114,11 @@ execute()
 	STDOUT=$(cat ./stdout)
 
 	[ -n "$STDOUT" ] && printf '%s\n' "STDOUT: $STDOUT" >> "$OutFile"
-	if [ -n "$STDOUTCMP" ];
+	if [ -n "${STDOUTCMP+unset}" ];
 	then
 		executedTests=$(( executedTests + 1 ))
-		if ! printf '%s' "$STDOUT" | replace_newline_return | grep -Fqx --text "$STDOUTCMP";
+		if ! printf '%s' "$STDOUT" | replace_newline_return | grep -Fqx --text "$STDOUTCMP" || \
+		   test -z "$STDOUTCMP" -a -n "$STDOUT";
 		then
 			printerr '\nERROR - STDOUT:\n“%s”\ndoes not match\n“%s”\n\n' "$STDOUT" "$STDOUTCMP"
 			printf '=== FAILED stdout does not match expected pattern %s\n' "$STDOUTCMP" >> "$OutFile"
@@ -246,7 +247,7 @@ run_script()
 		RETCMP=
 		ERRORCMP=
 		WARNINGSCMP=
-		STDOUTCMP=
+		unset STDOUTCMP
 		STDOUTRECMP=
 		unset STDERRCMP
 		ARG=
@@ -281,7 +282,7 @@ OutFile=$(mktempfile_elektra)
 RETCMP=
 ERRORCMP=
 WARNINGSCMP=
-STDOUTCMP=
+unset STDOUTCMP
 STDOUTRECMP=
 
 BACKUP=0

--- a/tests/shell/shell_recorder/tutorial_wrapper/markdown_shell_recorder.sh
+++ b/tests/shell/shell_recorder/tutorial_wrapper/markdown_shell_recorder.sh
@@ -12,7 +12,7 @@ resetGlobals()
 	WARNINGS=
 	STDOUTRE=
 	unset STDERR
-	STDOUT=
+	unset STDOUT
 	MOUNTPOINT=
 }
 
@@ -23,7 +23,7 @@ writeBlock()
 	[ -n "$ERROR" ] && printf 'ERROR: %s\n' "$ERROR" >> "$TMPFILE"
 	[ -n "$WARNINGS" ] && printf 'WARNINGS: %s\n' "$WARNINGS" >> "$TMPFILE"
 	[ -n "${STDERR+unset}" ] && printf 'STDERR: %s\n' "$STDERR" >> "$TMPFILE"
-	if [ -n "$STDOUT" ]; then printf 'STDOUT: %s\n' "$STDOUT" >> "$TMPFILE"
+	if [ -n "${STDOUT+unset}" ]; then printf 'STDOUT: %s\n' "$STDOUT" >> "$TMPFILE"
 	elif [ -n "$STDOUTRE" ]; then printf 'STDOUT-REGEX: %s\n' "$STDOUTRE" >> "$TMPFILE"
 	fi
 	COMMAND=$(sed s/sudo\ //g <<< "$COMMAND")

--- a/tests/shell/shell_recorder/tutorial_wrapper/markdown_shell_recorder.sh
+++ b/tests/shell/shell_recorder/tutorial_wrapper/markdown_shell_recorder.sh
@@ -12,7 +12,7 @@ resetGlobals()
 	WARNINGS=
 	STDOUTRE=
 	unset STDERR
-	OUTBUF=
+	STDOUT=
 	MOUNTPOINT=
 }
 
@@ -23,7 +23,7 @@ writeBlock()
 	[ -n "$ERROR" ] && printf 'ERROR: %s\n' "$ERROR" >> "$TMPFILE"
 	[ -n "$WARNINGS" ] && printf 'WARNINGS: %s\n' "$WARNINGS" >> "$TMPFILE"
 	[ -n "${STDERR+unset}" ] && printf 'STDERR: %s\n' "$STDERR" >> "$TMPFILE"
-	if [ -n "$OUTBUF" ]; then printf 'STDOUT: %s\n' "$OUTBUF" >> "$TMPFILE"
+	if [ -n "$STDOUT" ]; then printf 'STDOUT: %s\n' "$STDOUT" >> "$TMPFILE"
 	elif [ -n "$STDOUTRE" ]; then printf 'STDOUT-REGEX: %s\n' "$STDOUTRE" >> "$TMPFILE"
 	fi
 	COMMAND=$(sed s/sudo\ //g <<< "$COMMAND")
@@ -57,7 +57,7 @@ translate()
 	do
 		if grep -Eq '^\s*#>' <<< "$line"; then
 			output=$(sed -E -e 's/([ ]*#>$)/\1 /' -e 's/[ ]*#> (.*)/\1/' <<< "$line")
-			[ -z "$OUTBUF" ] && OUTBUF="$output" || OUTBUF="${OUTBUF}⏎$output"
+			[ -z "$STDOUT" ] && STDOUT="$output" || STDOUT="${STDOUT}⏎$output"
 		fi
 
 		if grep -Eq "^(\s*)#" <<< "$line"; then

--- a/tests/shell/shell_recorder/tutorial_wrapper/markdown_shell_recorder.sh
+++ b/tests/shell/shell_recorder/tutorial_wrapper/markdown_shell_recorder.sh
@@ -10,7 +10,6 @@ resetGlobals()
 	RET=
 	ERROR=
 	WARNINGS=
-	STDOUT=
 	STDOUTRE=
 	unset STDERR
 	OUTBUF=


### PR DESCRIPTION
# Purpose

This pull request adds

- support for empty `#>` checks to the Markdown Shell Recorder and
- a basic MSR test for the `ni` plugin.

.

# Checklist

- [x] I checked all commit messages.
- [x] I ran all tests locally and everything went fine.
- [x] The PR contains an updated version of the release notes.