### PR TITLE
kdb-set: add line about negative values to usage text

### DIFF
--- a/doc/help/kdb-set.md
+++ b/doc/help/kdb-set.md
@@ -18,7 +18,7 @@ To set a key to an empty value, `""` should be passed for the `value` argument.
 
 ## NEGATIVE VALUES
 
-To set a key to a negative value, `--` has to be used to stop option processing. (example below)
+To set a key to a negative value, `--` has to be used to stop option processing. (see example below)
 
 ## OPTIONS
 
@@ -57,20 +57,27 @@ To set a key to a negative value, `--` has to be used to stop option processing.
 ## EXAMPLES
 
 To set a Key to the value `Hello World!`:
+
 `kdb set user/example/key "Hello World!"`
 
 To create a new key with a null value:
+
 `kdb set user/example/key`
 
 To set a key to an empty value:
+
 `kdb set user/example/key ""`
 
 To set a key to a negative value:
+
 `kdb set -- /tests/neg -3`
 
 To create bookmarks:
+
 `kdb set user/sw/elektra/kdb/#0/current/bookmarks`
+
 followed by:
+
 `kdb set user/sw/elektra/kdb/#0/current/bookmarks/kdb user/sw/elektra/kdb/#0/current`
 
 

--- a/doc/help/kdb-set.md
+++ b/doc/help/kdb-set.md
@@ -16,6 +16,10 @@ This command allows the user to set the value of an individual key.
 
 To set a key to an empty value, `""` should be passed for the `value` argument.
 
+## NEGATIVE VALUES
+
+To set a key to a negative value, `--` has to be used to stop option processing. (example below)
+
 ## OPTIONS
 
 - `-H`, `--help`:
@@ -33,6 +37,8 @@ To set a key to an empty value, `""` should be passed for the `value` argument.
 - `-N`, `--namespace=NS`:
   Specify the namespace to use when writing cascading keys.
   See [below in KDB](#KDB).
+- `--`:
+  Do not process any following arguments starting with `-` as options.
 
 ## KDB
 
@@ -58,6 +64,9 @@ To create a new key with a null value:
 
 To set a key to an empty value:
 `kdb set user/example/key ""`
+
+To set a key to a negative value:
+`kdb set -- /tests/neg -3`
 
 To create bookmarks:
 `kdb set user/sw/elektra/kdb/#0/current/bookmarks`

--- a/doc/help/kdb.md
+++ b/doc/help/kdb.md
@@ -43,6 +43,8 @@ Every core-tool has the following options:
   Use a different kdb profile, see below.
 - `-C`, `--color <when>`:
   Print never/auto(default)/always colored output.
+- `--`:
+  Do not process any following arguments starting with `-` as options.
 
 ## COMMON OPTIONS
 

--- a/doc/news/_preparation_next_release.md
+++ b/doc/news/_preparation_next_release.md
@@ -158,6 +158,9 @@ Thanks to Armin Wurzinger.
 - The Markdown Shell Recorder now also tests if a command prints nothing to `stdout` if you add the check `#>`. *(René Schwaiger)*
 - We fixed some problems in the [Markdown Shell Recorder](https://master.libelektra.org/tests/shell/shell_recorder/tutorial_wrapper) test
   of [`kdb ls`](https://master.libelektra.org/doc/help/kdb-ls.md). *(René Schwaiger)*
+- The documentation for `kdb` and `kdb set` now mention the `--` option to stop option processing. This is useful for setting negative values among other things.
+
+## Compatibility
 
 [#1887]: https://github.com/ElektraInitiative/libelektra/issues/1887
 

--- a/doc/news/_preparation_next_release.md
+++ b/doc/news/_preparation_next_release.md
@@ -158,7 +158,7 @@ Thanks to Armin Wurzinger.
 - The Markdown Shell Recorder now also tests if a command prints nothing to `stdout` if you add the check `#>`. *(René Schwaiger)*
 - We fixed some problems in the [Markdown Shell Recorder](https://master.libelektra.org/tests/shell/shell_recorder/tutorial_wrapper) test
   of [`kdb ls`](https://master.libelektra.org/doc/help/kdb-ls.md). *(René Schwaiger)*
-- The documentation for `kdb` and `kdb set` now mention the `--` option to stop option processing. This is useful for setting negative values among other things.
+- The documentation for `kdb` and `kdb set` now mention the `--` option to stop option processing. This is useful for setting negative values among other things. *(Klemens Böswirth)*
 
 ## Compatibility
 

--- a/src/tools/kdb/set.hpp
+++ b/src/tools/kdb/set.hpp
@@ -39,7 +39,9 @@ public:
 	virtual std::string getLongHelpText () override
 	{
 		return "If no value is given, it will be set to a null-value\n"
-		       "To get an empty value you need to quote like \"\" (depending on shell)";
+		       "To get an empty value you need to quote like \"\" (depending on shell)\n"
+		       "To set a negative value you need to use '--' to stop option processing.\n"
+		       "(e.g. 'kdb set -- /tests/neg -3')\n";
 	}
 
 	virtual int execute (Cmdline const & cmdline) override;


### PR DESCRIPTION
# Purpose

Update the usage text of `kdb set` to indicate how to set negative values.

# Checklist
- [ ] commit messages are fine ("module: short statement" syntax and refer to issues)
- [ ] I added unit tests
- [ ] I ran all tests locally and everything went fine
- [ ] affected documentation is fixed
- [ ] I added code comments, logging, and assertions (see doc/CODING.md)
- [ ] meta data is updated (e.g. README.md of plugins)
- [ ] release notes are updated (doc/news/_preparation_next_release.md)

@markus2330 please review my pull request
