### PR TITLE
build: Implement debian-stable-multiconf

### DIFF
--- a/doc/news/_preparation_next_release.md
+++ b/doc/news/_preparation_next_release.md
@@ -199,7 +199,7 @@ These notes are of interest for people developing Elektra:
    [DownloadProject](https://github.com/Crascit/DownloadProject). If you want to use a local installation of
    [Google Test][] instead, please set the value of `GTEST_ROOT` to the path of you local copy of the
    [Google Test][] framework. *(René Schwaiger)*
-- [Google Test][] is installed in Docker images used by the build system.
+- [Google Test][] is installed in Docker images used by the build system. *(Lukas Winkler)*
 - Port `debian-multiconfig-gcc-stable` to new build system. *(Lukas Winkler)*
 
 [`cmake-format`]: https://github.com/cheshirekow/cmake_format

--- a/doc/news/_preparation_next_release.md
+++ b/doc/news/_preparation_next_release.md
@@ -200,6 +200,7 @@ These notes are of interest for people developing Elektra:
    [Google Test][] instead, please set the value of `GTEST_ROOT` to the path of you local copy of the
    [Google Test][] framework. *(René Schwaiger)*
 - [Google Test][] is installed in Docker images used by the build system.
+- Port `debian-multiconfig-gcc-stable` to new build system. *(Lukas Winkler)*
 
 [`cmake-format`]: https://github.com/cheshirekow/cmake_format
 [#1887]: https://github.com/ElektraInitiative/libelektra/issues/1887

--- a/scripts/jenkins/Jenkinsfile
+++ b/scripts/jenkins/Jenkinsfile
@@ -331,6 +331,25 @@ def generateFullBuildStages() {
         [:],
         [TEST.ALL]
     )
+    for(plugins in ['ALL', 'NODEP']) {
+        for(buildType in ['Debug', 'Release', 'RelWithDebInfo']) {
+            if (plugins == 'ALL' && buildType == 'RelWithDebInfo') {
+                // Skip as it tested via "debian-stable-full"
+                continue
+            }
+            def testName = "debian-stable-multiconf[plugins=${plugins},buildType=${buildType}]"
+            tasks << buildAndTest(
+                testName,
+                DOCKER_IMAGES.stretch,
+                [
+                    'PLUGINS': plugins,
+                    'CMAKE_BUILD_TYPE': buildType
+                ],
+                [TEST.ALL, TEST.MEM]
+            )
+        }
+    }
+
     return tasks
 }
 


### PR DESCRIPTION
# Purpose

Replace old `debian-multiconfig-gcc-stable` buildjob.

# Checklist

- [x] commit messages are fine ("module: short statement" syntax and refer to issues)
- [x] release notes are updated (doc/news/_preparation_next_release.md)
