### PR TITLE
build: port i386 job to new build system

### DIFF
--- a/doc/BUILDSERVER.md
+++ b/doc/BUILDSERVER.md
@@ -91,7 +91,6 @@ build:
 * jenkins build [gcc-configure-debian-musl](https://build.libelektra.org/job/elektra-gcc-configure-debian-musl/) please
 * jenkins build [gcc-configure-debian-shared](https://build.libelektra.org/job/elektra-gcc-configure-debian-shared/) please
 * jenkins build [gcc-configure-debian-withspace](https://build.libelektra.org/job/elektra-gcc-configure-debian-withspace/) please
-* jenkins build [gcc-i386](https://build.libelektra.org/job/elektra-gcc-i386/) please
 * jenkins build [git-buildpackage-jessie](https://build.libelektra.org/job/elektra-git-buildpackage-jessie/) please
 * jenkins build [git-buildpackage-wheezy](https://build.libelektra.org/job/elektra-git-buildpackage-wheezy/) please
 * jenkins build [icc](https://build.libelektra.org/job/elektra-icc/) please

--- a/doc/news/_preparation_next_release.md
+++ b/doc/news/_preparation_next_release.md
@@ -212,7 +212,6 @@ Thanks to Armin Wurzinger.
   - Better Docker image handling.
   - Abort of previously queued but unfinished runs on new commits.
   - Document how to locally replicate the Docker environment used for tests.
-  *(Lukas Winkler)*
 - The Jenkins build server now also compiles and tests Elektra with enabled address sanitizer. *(Lukas Winkler)*
 - Ported GCC ASAN build job to new build system *(René Schwaiger + Lukas Winkler)*
 - Docker artifacts are now cleaned up in our daily build job. *(Lukas Winkler)*
@@ -224,6 +223,7 @@ Thanks to Armin Wurzinger.
 - Port `elektra-ini-mergerequests` to new build system. *(Lukas Winkler)*
 - Port `elektra-gcc-configure-debian-nokdbtest` to new build system. *(Lukas Winkler)*
 - Port `elektra-gcc-configure-xdg`to new build system. *(Lukas Winkler)*
+- Port `elektra-gcc-i386` to new build system. *(Lukas Winkler)*
 - Docker Registry is cleaned up by our daily buildserver task. *(Lukas Winkler)*
 
 

--- a/scripts/docker/debian/stretch/Dockerfile.i386
+++ b/scripts/docker/debian/stretch/Dockerfile.i386
@@ -1,0 +1,53 @@
+FROM debian:stretch
+
+ENV LANG C.UTF-8
+ENV LANGUAGE C.UTF-8
+ENV LC_ALL C.UTF-8
+
+RUN dpkg --add-architecture i386 \
+    && apt-get update \
+    && apt-get -y install \
+        curl \
+        build-essential \
+        autotools-dev \
+        automake \
+        cmake \
+        pkg-config \
+        gcc-multilib \
+        g++-multilib \
+        file \
+    && rm -rf /var/lib/apt/lists/*
+
+# Google Test
+ENV GTEST_ROOT=/opt/gtest
+ARG GTEST_VER=4e4df226fc197c0dda6e37f5c8c3845ca1e73a49
+RUN mkdir -p ${GTEST_ROOT} \
+    && cd /tmp \
+    && curl -o gtest.tar.gz \
+      -L https://github.com/google/googletest/archive/${GTEST_VER}.tar.gz \
+    && tar -zxvf gtest.tar.gz --strip-components=1 -C ${GTEST_ROOT} \
+    && rm gtest.tar.gz
+
+# Handle Java
+RUN echo 'export JAVA_HOME=$(readlink -f /usr/bin/javac | sed "s:/bin/javac::")'>> /etc/bash.bashrc
+RUN echo '\
+/usr/lib/jvm/java-8-openjdk-amd64/jre/lib/amd64/\n\
+/usr/lib/jvm/java-8-openjdk-amd64/jre/lib/amd64/server/\n' > /etc/ld.so.conf.d/jdk.conf
+RUN ldconfig
+
+# Create User:Group
+# The id is important as jenkins docker agents use the same id that is running
+# on the slaves to execute containers
+ARG JENKINS_GROUPID
+RUN groupadd \
+    -g ${JENKINS_GROUPID} \
+    jenkins
+
+ARG JENKINS_USERID
+RUN useradd \
+    --create-home \
+    --uid ${JENKINS_USERID} \
+    --gid ${JENKINS_GROUPID} \
+    --shell "/bin/bash" \
+    jenkins
+USER ${JENKINS_USERID}

--- a/scripts/jenkins/Jenkinsfile
+++ b/scripts/jenkins/Jenkinsfile
@@ -72,6 +72,11 @@ CMAKE_FLAGS_INI = [
     'KDB_DEFAULT_STORAGE': 'ini'
 ]
 
+CMAKE_FLAGS_I386 = [
+    'CMAKE_C_FLAGS': '-m32',
+    'CMAKE_CXX_FLAGS': '-m32'
+]
+
 CMAKE_FLAGS_ASAN = ['ENABLE_ASAN': 'ON']
 CMAKE_FLAGS_DEBUG = ['ENABLE_DEBUG': 'ON']
 CMAKE_FLAGS_LOGGER = ['ENABLE_LOGGER': 'ON']
@@ -160,6 +165,11 @@ def dockerInit() {
             "debian-stretch-minimal", this.&idTesting,
             "./scripts/docker/debian/stretch",
             "./scripts/docker/debian/stretch/Dockerfile.minimal"
+        )
+        DOCKER_IMAGES.stretch_i386 = createDockerImageDesc(
+            "debian-stretch-i386", this.&idTesting,
+            "./scripts/docker/debian/stretch",
+            "./scripts/docker/debian/stretch/Dockerfile.i386"
         )
         DOCKER_IMAGES.stretch_doc = createDockerImageDesc(
             "debian-stretch-doc", this.&idTesting,
@@ -318,6 +328,14 @@ def generateFullBuildStages() {
         DOCKER_IMAGES.sid,
         CMAKE_FLAGS_BUILD_ALL,
         [TEST.ALL, TEST.MEM, TEST.INSTALL]
+    )
+    tasks << buildAndTest(
+        "debian-stable-full-i386",
+        DOCKER_IMAGES.stretch_i386,
+        CMAKE_FLAGS_I386 + [
+            'PLUGINS': 'NODEP'
+        ],
+        [TEST.ALL]
     )
     tasks << buildAndTest(
         "debian-unstable-full-clang",


### PR DESCRIPTION
# Purpose

port i386 job to new build system

# Checklist

- [ ] commit messages are fine ("module: short statement" syntax and refer to issues)
- [ ] affected documentation is fixed
- [ ] release notes are updated (doc/news/_preparation_next_release.md)
