### PR TITLE
build: Port no-optimizations build job

### DIFF
--- a/doc/BUILDSERVER.md
+++ b/doc/BUILDSERVER.md
@@ -90,7 +90,6 @@ build:
 * jenkins build [gcc-configure-debian-intree](https://build.libelektra.org/job/elektra-gcc-configure-debian-intree/) please
 * jenkins build [gcc-configure-debian-musl](https://build.libelektra.org/job/elektra-gcc-configure-debian-musl/) please
 * jenkins build [gcc-configure-debian-shared](https://build.libelektra.org/job/elektra-gcc-configure-debian-shared/) please
-* jenkins build [gcc-configure-debian-optimizations](https://build.libelektra.org/job/elektra-gcc-configure-debian-optimizations/) please
 * jenkins build [gcc-configure-debian-withspace](https://build.libelektra.org/job/elektra-gcc-configure-debian-withspace/) please
 * jenkins build [gcc-configure-xdg](https://build.libelektra.org/job/elektra-gcc-configure-xdg/) please
 * jenkins build [gcc-i386](https://build.libelektra.org/job/elektra-gcc-i386/) please

--- a/doc/news/_preparation_next_release.md
+++ b/doc/news/_preparation_next_release.md
@@ -181,6 +181,8 @@ These notes are of interest for people developing Elektra:
   - Document how to locally replicate the Docker environment used for tests.
 - <<TODO>>
 - <<TODO>>
+- Port `elektra-gcc-configure-debian-optimizations` to new build system.
+  *(Lukas Winkler)*
 - Ported GCC ASAN build job to new build system *(René Schwaiger + Lukas Winkler)*
 - `withDockerEnv` Jenkinsfile helper now no longer provides stages automatically. *(Lukas Winkler)*
 - Docker artifacts are now cleaned up in our daily build job. *(Lukas Winkler)*

--- a/scripts/jenkins/Jenkinsfile
+++ b/scripts/jenkins/Jenkinsfile
@@ -75,6 +75,7 @@ CMAKE_FLAGS_INI = [
 CMAKE_FLAGS_ASAN = ['ENABLE_ASAN': 'ON']
 CMAKE_FLAGS_DEBUG = ['ENABLE_DEBUG': 'ON']
 CMAKE_FLAGS_LOGGER = ['ENABLE_LOGGER': 'ON']
+CMAKE_FLAGS_OPTIMIZATIONS_OFF = ['ENABLE_OPTIMIZATIONS': 'OFF']
 
 // Define TEST enum used in buildAndTest helper
 enum TEST {
@@ -358,6 +359,16 @@ def generateFullBuildStages() {
             'KDB_DEFAULT_RESOLVER': 'resolver_fm_b_b'
         ],
         [TEST.NOKDB]
+    )
+    tasks << buildAndTest(
+        "debian-stable-full-optimizations-off",
+        DOCKER_IMAGES.stretch,
+        CMAKE_FLAGS_BUILD_ALL +
+            CMAKE_FLAGS_OPTIMIZATIONS_OFF +
+            CMAKE_FLAGS_DEBUG +
+            CMAKE_FLAGS_LOGGER
+        ,
+        [TEST.ALL, TEST.MEM]
     )
     for(plugins in ['ALL', 'NODEP']) {
         for(buildType in ['Debug', 'Release', 'RelWithDebInfo']) {


### PR DESCRIPTION
# Purpose

Port https://build.libelektra.org/jenkins/job/elektra-gcc-configure-debian-optimizations/ to new build system.

# Checklist

- [x] commit messages are fine ("module: short statement" syntax and refer to issues)
- [ ] I added unit tests
- [x] I ran all tests locally and everything went fine
- [x] affected documentation is fixed
- [ ] I added code comments, logging, and assertions (see doc/CODING.md)
- [ ] meta data is updated (e.g. README.md of plugins)
- [x] release notes are updated (doc/news/_preparation_next_release.md)

