### PR TITLE
tests: Properly remove temporary test home dir

### DIFF
--- a/cmake/ElektraCompiling.cmake
+++ b/cmake/ElektraCompiling.cmake
@@ -117,6 +117,9 @@ if (CMAKE_CXX_COMPILER_ID STREQUAL "Intel")
 	set (CMAKE_INCLUDE_SYSTEM_FLAG_CXX "-isystem ")
 endif ()
 
+#
+# ASAN
+#
 if (ENABLE_ASAN)
 	set (EXTRA_FLAGS "${EXTRA_FLAGS} -fsanitize=undefined -fsanitize=address -fno-omit-frame-pointer")
 	set (ASAN_LIBRARY "-lasan") # this is needed for GIR to put asan in front

--- a/cmake/ElektraCompiling.cmake
+++ b/cmake/ElektraCompiling.cmake
@@ -90,6 +90,17 @@ if (CMAKE_COMPILER_IS_GNUCXX)
 	endif (WIN32)
 endif (CMAKE_COMPILER_IS_GNUCXX)
 
+#
+# Platform specific settings
+#
+if (APPLE)
+
+	# Workaround to not loose functions as soon as feature test macros are used
+	# https://boringssl.googlesource.com/boringssl/+/63a0797ff247f13870b649c3f6239d80be202752
+	# https://charm.cs.illinois.edu/redmine/issues/1743
+	add_definitions (-D_DARWIN_C_SOURCE)
+endif(APPLE)
+
 if (WIN32)
 	set (HAVE_WIN32 "1")
 	message (STATUS "Win32 detected")

--- a/cmake/ElektraCompiling.cmake
+++ b/cmake/ElektraCompiling.cmake
@@ -93,14 +93,6 @@ endif (CMAKE_COMPILER_IS_GNUCXX)
 #
 # Platform specific settings
 #
-if (APPLE)
-
-	# Workaround to not loose functions as soon as feature test macros are used
-	# https://boringssl.googlesource.com/boringssl/+/63a0797ff247f13870b649c3f6239d80be202752
-	# https://charm.cs.illinois.edu/redmine/issues/1743
-	add_definitions (-D_DARWIN_C_SOURCE)
-endif (APPLE)
-
 if (WIN32)
 	set (HAVE_WIN32 "1")
 	message (STATUS "Win32 detected")

--- a/cmake/ElektraCompiling.cmake
+++ b/cmake/ElektraCompiling.cmake
@@ -99,7 +99,7 @@ if (APPLE)
 	# https://boringssl.googlesource.com/boringssl/+/63a0797ff247f13870b649c3f6239d80be202752
 	# https://charm.cs.illinois.edu/redmine/issues/1743
 	add_definitions (-D_DARWIN_C_SOURCE)
-endif(APPLE)
+endif (APPLE)
 
 if (WIN32)
 	set (HAVE_WIN32 "1")

--- a/doc/news/_preparation_next_release.md
+++ b/doc/news/_preparation_next_release.md
@@ -218,6 +218,9 @@ Thanks to Michael Zronek and Vanessa Kos.
     *(Lukas Winkler)*
 - The OPMPHM has a new test case *(Kurt Micheli)*
 - Do not execute `fcrypt` and `crypto` unit tests if the `gpg` binary is not available. *(Peter Nirschl)*
+- Resolved an issue where tests did not cleanup properly after they ran.
+    This was especially noticable for `gpg` tests as the `gpg-agents` that were
+    spawned did not get cleaned up afterwards. *(Lukas Winkler)*
 
 ## Compatibility
 

--- a/tests/cframework/CMakeLists.txt
+++ b/tests/cframework/CMakeLists.txt
@@ -1,4 +1,20 @@
+include (CheckFunctionExists)
 include (LibAddMacros)
+
+check_function_exists (nftw HAVE_NFTW)
+check_function_exists (mkdtemp HAVE_MKDTEMP)
+check_function_exists (setenv HAVE_SETENV)
+
+if (HAVE_MKDTEMP AND HAVE_SETENV)
+	add_definitions (-D_POSIX_C_SOURCE=200809L)
+else (HAVE_MKDTEMP AND HAVE_SETENV)
+	message (WARNING "mkdtemp and setenv unavailable, disabling cframework")
+	return ()
+endif (HAVE_MKDTEMP AND HAVE_SETENV)
+
+if (HAVE_NFTW)
+	add_definitions (-D_XOPEN_SOURCE=500 -DHAVE_NFTW)
+endif (HAVE_NFTW)
 
 set (SOURCES tests.c)
 add_headers (SOURCES)

--- a/tests/cframework/CMakeLists.txt
+++ b/tests/cframework/CMakeLists.txt
@@ -1,22 +1,10 @@
-include (CheckFunctionExists)
+include (CheckSymbolExists)
 include (LibAddMacros)
 
-check_function_exists (nftw HAVE_NFTW)
-check_function_exists (mkdtemp HAVE_MKDTEMP)
-check_function_exists (setenv HAVE_SETENV)
-
-if (HAVE_MKDTEMP AND HAVE_SETENV)
-	add_definitions (-D_POSIX_C_SOURCE=200809L)
-else (HAVE_MKDTEMP AND HAVE_SETENV)
-
-	# XCode 9.2 on travis can not find the functions, but seems to work anyway.
-	# Hence we progress forward with just a warning and do not disable
-	# anything.
-	message (WARNING "mkdtemp and setenv could not be found")
-endif (HAVE_MKDTEMP AND HAVE_SETENV)
+check_symbol_exists (nftw "ftw.h" HAVE_NFTW)
 
 if (HAVE_NFTW)
-	add_definitions (-D_XOPEN_SOURCE=500 -DHAVE_NFTW)
+	add_definitions (-DUSE_NFTW)
 endif (HAVE_NFTW)
 
 set (SOURCES tests.c)

--- a/tests/cframework/CMakeLists.txt
+++ b/tests/cframework/CMakeLists.txt
@@ -8,8 +8,11 @@ check_function_exists (setenv HAVE_SETENV)
 if (HAVE_MKDTEMP AND HAVE_SETENV)
 	add_definitions (-D_POSIX_C_SOURCE=200809L)
 else (HAVE_MKDTEMP AND HAVE_SETENV)
-	message (WARNING "mkdtemp and setenv unavailable, disabling cframework")
-	return ()
+
+	# XCode 9.2 on travis can not find the functions, but seems to work anyway.
+	# Hence we progress forward with just a warning and do not disable
+	# anything.
+	message (WARNING "mkdtemp and setenv could not be found")
 endif (HAVE_MKDTEMP AND HAVE_SETENV)
 
 if (HAVE_NFTW)

--- a/tests/cframework/tests.c
+++ b/tests/cframework/tests.c
@@ -21,7 +21,7 @@
 #include <locale.h>
 #endif
 
-#ifdef HAVE_NFTW
+#ifdef USE_NFTW
 #include <ftw.h>
 #include <stdlib.h>
 #define NOPENFD 20
@@ -36,10 +36,6 @@ int nbTest;
 
 char file[KDB_MAX_PATH_LENGTH];
 char srcdir[KDB_MAX_PATH_LENGTH];
-
-#ifdef HAVE_CLEARENV
-int clearenv (void);
-#endif
 
 char * tmpfilename;
 char * tempHome;
@@ -486,7 +482,7 @@ int output_error (Key * errorKey)
 	return 0;
 }
 
-#ifdef HAVE_NFTW
+#ifdef USE_NFTW
 static int rm_all (const char * fpath, const struct stat * sb ELEKTRA_UNUSED, int tflag, struct FTW * ftwbuf ELEKTRA_UNUSED)
 {
 	if (tflag == FTW_F)
@@ -525,7 +521,7 @@ static void clean_temp_home (void)
 
 	if (tempHome)
 	{
-#ifdef HAVE_NFTW
+#ifdef USE_NFTW
 		int nftw_flags = FTW_DEPTH | FTW_PHYS;
 		succeed_if (nftw (tempHome, rm_all, NOPENFD, nftw_flags) == 0, "Could not delete TMPHOME via nftw");
 #else


### PR DESCRIPTION
# Purpose

* check if required functions are available
* set test feature macros explicitly if needed
* replace manual file deletion with nftw call if nftw is available.

This should resolve #2008 and some parts of #1973. But fcrypt still fails as soon as a `TMPDIR` is specified.

# Checklist

- [x] commit messages are fine ("module: short statement" syntax and refer to issues)
- [ ] I added unit tests
- [x] I ran all tests locally and everything went fine
- [ ] affected documentation is fixed
- [ ] I added code comments, logging, and assertions (see doc/CODING.md)
- [ ] meta data is updated (e.g. README.md of plugins)
- [x] release notes are updated (doc/news/_preparation_next_release.md)

@markus2330 please review my pull request
