### PR TITLE
 Release: Improve Structure of Release Notes

### DIFF
--- a/doc/METADATA.ini
+++ b/doc/METADATA.ini
@@ -119,7 +119,7 @@ usedby/plugin= hosts
 type= string
 description= Determines the character(s) used to start this comment.
 
-	This meta-key is empty if its an empty line/comment.
+	This metakey is empty if its an empty line/comment.
 
 	The default on absence of this key is plugin-specific.
 	Some comment start character should be assumed then.

--- a/doc/help/kdb-change-resolver-symlink.md
+++ b/doc/help/kdb-change-resolver-symlink.md
@@ -1,21 +1,21 @@
-kdb-change-storage-symlink -- Changes the default storage symlink
+kdb-change-resolver-symlink -- Changes the default resolver symlink
 ===================================================================
 
 ## SYNOPSIS
 
-`kdb change-storage-symlink <storage>`
+`kdb change-resolver-symlink <resolver>`
 
-Where `storage` is the name of the new default storage plugin.
+Where `resolver` is the name of the new default resolver plugin.
 
 ## DESCRIPTION
 
-This command updates the symlink pointing to the default storage if `storage` is a valid storage plugin.
+This command updates the symlink pointing to the default resolver if `resolver` is a valid resolver plugin.
 
 ## EXAMPLES
 
-Set default storage plugin to ini:
-`kdb change-storage-symlink ini`
+Set default resolver plugin to resolver_fm_hpu_b:
+`kdb change-resolver-symlink resolver_fm_hpu_b`
 
 ## SEE ALSO
 
-- [kdb-change-resolver-symlink(7)](kdb-change-resolver-symlink.md)
+- [kdb-change-storage-symlink(7)](kdb-change-storage-symlink.md)

--- a/doc/help/kdb-change-storage-symlink.md
+++ b/doc/help/kdb-change-storage-symlink.md
@@ -1,21 +1,21 @@
-kdb-change-resolver-symlink -- Changes the default resolver symlink
+kdb-change-storage-symlink -- Changes the default storage symlink
 ===================================================================
 
 ## SYNOPSIS
 
-`kdb change-resolver-symlink <resolver>`
+`kdb change-storage-symlink <storage>`
 
-Where `resolver` is the name of the new default resolver plugin.
+Where `storage` is the name of the new default storage plugin.
 
 ## DESCRIPTION
 
-This command updates the symlink pointing to the default resolver if `resolver` is a valid resolver plugin.
+This command updates the symlink pointing to the default storage if `storage` is a valid storage plugin.
 
 ## EXAMPLES
 
-Set default resolver plugin to resolver_fm_hpu_b:
-`kdb change-resolver-symlink resolver_fm_hpu_b`
+Set default storage plugin to ini:
+`kdb change-storage-symlink ini`
 
 ## SEE ALSO
 
-- [kdb-change-storage-symlink(7)](kdb-change-storage-symlink.md)
+- [kdb-change-resolver-symlink(7)](kdb-change-resolver-symlink.md)

--- a/doc/man/man1/kdb-change-resolver-symlink.1
+++ b/doc/man/man1/kdb-change-resolver-symlink.1
@@ -1,27 +1,27 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "KDB\-CHANGE\-STORAGE\-SYMLINK" "" "December 2017" "" ""
+.TH "KDB\-CHANGE\-RESOLVER\-SYMLINK" "" "June 2018" "" ""
 .
 .SH "NAME"
-\fBkdb\-change\-storage\-symlink\fR \- Changes the default storage symlink
+\fBkdb\-change\-resolver\-symlink\fR \- Changes the default resolver symlink
 .
 .SH "SYNOPSIS"
-\fBkdb change\-storage\-symlink <storage>\fR
+\fBkdb change\-resolver\-symlink <resolver>\fR
 .
 .P
-Where \fBstorage\fR is the name of the new default storage plugin\.
+Where \fBresolver\fR is the name of the new default resolver plugin\.
 .
 .SH "DESCRIPTION"
-This command updates the symlink pointing to the default storage if \fBstorage\fR is a valid storage plugin\.
+This command updates the symlink pointing to the default resolver if \fBresolver\fR is a valid resolver plugin\.
 .
 .SH "EXAMPLES"
-Set default storage plugin to ini: \fBkdb change\-storage\-symlink ini\fR
+Set default resolver plugin to resolver_fm_hpu_b: \fBkdb change\-resolver\-symlink resolver_fm_hpu_b\fR
 .
 .SH "SEE ALSO"
 .
 .IP "\(bu" 4
-kdb\-change\-resolver\-symlink(7) \fIkdb\-change\-resolver\-symlink\.md\fR
+kdb\-change\-storage\-symlink(7) \fIkdb\-change\-storage\-symlink\.md\fR
 .
 .IP "" 0
 

--- a/doc/man/man1/kdb-change-storage-symlink.1
+++ b/doc/man/man1/kdb-change-storage-symlink.1
@@ -1,27 +1,27 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "KDB\-CHANGE\-RESOLVER\-SYMLINK" "" "December 2017" "" ""
+.TH "KDB\-CHANGE\-STORAGE\-SYMLINK" "" "June 2018" "" ""
 .
 .SH "NAME"
-\fBkdb\-change\-resolver\-symlink\fR \- Changes the default resolver symlink
+\fBkdb\-change\-storage\-symlink\fR \- Changes the default storage symlink
 .
 .SH "SYNOPSIS"
-\fBkdb change\-resolver\-symlink <resolver>\fR
+\fBkdb change\-storage\-symlink <storage>\fR
 .
 .P
-Where \fBresolver\fR is the name of the new default resolver plugin\.
+Where \fBstorage\fR is the name of the new default storage plugin\.
 .
 .SH "DESCRIPTION"
-This command updates the symlink pointing to the default resolver if \fBresolver\fR is a valid resolver plugin\.
+This command updates the symlink pointing to the default storage if \fBstorage\fR is a valid storage plugin\.
 .
 .SH "EXAMPLES"
-Set default resolver plugin to resolver_fm_hpu_b: \fBkdb change\-resolver\-symlink resolver_fm_hpu_b\fR
+Set default storage plugin to ini: \fBkdb change\-storage\-symlink ini\fR
 .
 .SH "SEE ALSO"
 .
 .IP "\(bu" 4
-kdb\-change\-storage\-symlink(7) \fIkdb\-change\-storage\-symlink\.md\fR
+kdb\-change\-resolver\-symlink(7) \fIkdb\-change\-resolver\-symlink\.md\fR
 .
 .IP "" 0
 

--- a/doc/news/_preparation_next_release.md
+++ b/doc/news/_preparation_next_release.md
@@ -140,6 +140,9 @@ Thanks to Armin Wurzinger.
 
 - We improved the formatting of our [compilation guide](/doc/COMPILE.md). *(René Schwaiger)*
 - We fixed various minor spelling mistakes in the documentation. *(René Schwaiger)*
+- The man pages for [`kdb change-resolver-symlink`](https://www.libelektra.org/manpages/kdb-change-resolver-symlink) and
+   [`kdb change-storage-symlink`](https://www.libelektra.org/manpages/kdb-change-storage-symlink) referenced the wrong command.
+   *(Lukas Winkler, René Schwaiger)*
 
 ## Tests
 

--- a/doc/news/_preparation_next_release.md
+++ b/doc/news/_preparation_next_release.md
@@ -69,14 +69,39 @@ Thanks to Armin Wurzinger.
 ### <<HIGHLIGHT2>>
 
 
-## Other New Features
+## Plugins
 
-We added even more functionality, which could not make it to the highlights:
+### Crypto
 
-- A new I/O binding for [ev](https://www.libelektra.org/bindings/io_ev) has been
-  added.
-  It can be used to integrate the notification feature with applications based
-  on [ev](http://libev.schmorp.de) main loops. *(Thomas Wahringer)*
+- The `crypto` plugin now uses Elektra's `libinvoke` and the `base64` plugin in order to encode and decode Base64 strings. This improvement reduces code duplication between the two plugins. *(Peter Nirschl)*
+
+### HexNumber
+
+- The plugin [hexnumber](https://www.libelektra.org/plugins/hexnumber) has been added. It can be used
+  to convert hexadecimal values into decimal when read, and back to hexadecimal when written. *(Klemens Böswirth)*
+
+### List
+
+- The [`list` plugin](http://libelektra.org/plugins/list) now allows us to pass
+  common configuration for all plugins by using keys below the "config/" setting.
+  The updated plugin documentation contains more information and an example. *(Thomas Wahringer)*
+- The [`list` plugin](http://libelektra.org/plugins/list) which is responsible
+  for global mounting had a bug which prevented globally mounted plugins from
+  being configurable. *(Thomas Wahringer)*
+
+### mINI
+
+- We fixed a memory leak in the [mINI plugin](https://libelektra.org/plugins/mini) by requiring the plugin
+  [`ccode`](https://libelektra.org/plugins/ccode) instead of the “provider” `code`. *(René Schwaiger)*
+
+### Regex Dispatcher
+
+- The plugin [regexdispatcher](https://www.libelektra.org/plugins/regexdispatcher) has been added. It calculates regex representations for
+  commonly used specification keywords to be used with the [typechecker](https://www.libelektra.org/plugins/typechecker). Currently the
+  keywords `check/range`, `check/enum` and `check/validation` are supported. *(Armin Wurzinger)*
+
+### Misc
+
 - The logging plugins ["syslog"](https://www.libelektra.org/plugins/syslog),
   ["journald"](https://www.libelektra.org/plugins/journald) and
   ["logchange"](https://www.libelektra.org/plugins/logchange) now have a new
@@ -84,49 +109,111 @@ We added even more functionality, which could not make it to the highlights:
   are loaded by applications.
   The new option can be used for logging application behavior when using
   [notifications](https://www.libelektra.org/tutorials/notifications). *(Thomas Wahringer)*
-- The build system no longer installs haskell dependencies from hackage by itself, instead
-  this has to be done beforehand like it is the case with all other dependencies. The main
-  reason is that the build servers shouldn't compile the dependencies over and over again,
-  only if something changes. See the [readme](https://www.libelektra.org/bindings/haskell). *(Armin Wurzinger)*
+
+## Bindings
+
+- A new I/O binding for [ev](https://www.libelektra.org/bindings/io_ev) has been
+  added.
+  It can be used to integrate the notification feature with applications based
+  on [ev](http://libev.schmorp.de) main loops. *(Thomas Wahringer)*
+
+## Tools
+
 - The new tool `kdb find` lists keys of the database matching a certain regular expression. *(Markus Raab)*
-- <<TODO>>
+- You can now build the [Qt-GUI](https://www.libelektra.org/tools/qt-gui) using Qt `5.11`. *(René Schwaiger)*
 
-## New Plugins
+## Scripts
 
-- The plugin [hexnumber](https://www.libelektra.org/plugins/hexnumber) has been added. It can be used
-  to convert hexadecimal values into decimal when read, and back to hexadecimal when written. *(Klemens Böswirth)*
-- The plugin [regexdispatcher](https://www.libelektra.org/plugins/regexdispatcher) has been added. It calculates regex representations for commonly used specification
-  keywords to be used with the [typechecker](https://www.libelektra.org/plugins/typechecker). Currently the
-  keywords `check/range`, `check/enum` and `check/validation` are supported. *(Armin Wurzinger)*
-- <<TODO>>
-
-
-## Other News
-
-- The `crypto` plugin now uses Elektra's `libinvoke` and the `base64` plugin in order to encode and decode Base64 strings. This improvement reduces code duplication between the two plugins. *(Peter Nirschl)*
+- The script [`check_formatting.sh`](https://master.libelektra.org/tests/shell/check_formatting.sh) now also checks the formatting of CMake
+  code if you installed [`sponge`](https://joeyh.name/code/moreutils) and [`cmake-format`][]. *(René Schwaiger)*
+- The script [`check_bashisms.sh`](https://master.libelektra.org/tests/shell/check_bashisms.sh) should now work correctly again, if the
+  system uses the GNU version `find`. *(René Schwaiger)*
+- The script [`reformat-cmake`](https://master.libelektra.org/scripts/reformat-cmake) now checks if `cmake-format` works before it reformats CMake files. Thank you to Klemens Böswirth for the [detailed description of the problem](https://github.com/ElektraInitiative/libelektra/pull/1903#discussion_r189332987). *(René Schwaiger)*
+- `scripts/run_icheck` now no longer leaves the base directory of the project
+  when checking if the ABI changed. *(Lukas Winkler)*
 - The completion for [fish](http://fishshell.com) now also suggest the `info/` meta attributes of the
   [file plugin](https://www.libelektra.org/plugins/file). *(René Schwaiger)*
-- The [`list` plugin](http://libelektra.org/plugins/list) now allows us to pass
-  common configuration for all plugins by using keys below the "config/" setting.
-  The updated plugin documentation contains more information and an example. *(Thomas Wahringer)*
-- <<TODO>>
-- <<TODO>>
-- <<TODO>>
+
+[`cmake-format`]: https://github.com/cheshirekow/cmake_format
 
 ## Documentation
 
-We improved the documentation in the following ways:
+- We improved the formatting of our [compilation guide](/doc/COMPILE.md). *(René Schwaiger)*
+- We fixed various minor spelling mistakes in the documentation. *(René Schwaiger)*
 
-- <<TODO>>
-- <<TODO>>
-- <<TODO>>
+## Tests
+
 - We added new [Markdown Shell Recorder](https://master.libelektra.org/tests/shell/shell_recorder/tutorial_wrapper) tests for the
   - [`file`](https://www.libelektra.org/plugins/file),
   - [`iconv`](https://www.libelektra.org/plugins/iconv),
   - [`ni`](https://www.libelektra.org/plugins/ni), and
   - [`uname`](https://www.libelektra.org/plugins/uname)
   plugin. *(René Schwaiger)*
-- We improved the formatting of our [compilation guide](/doc/COMPILE.md). *(René Schwaiger)*
+- (Markdown) Shell Recorder tests now save test data below `/tests` (see issue [#1887][]). *(René Schwaiger)*
+- The Markdown Shell Recorder checks `kdb set` commands to ensure we only add tests that store data below `/tests`. *(René Schwaiger)*
+- The Markdown Shell Recorder now supports indented code blocks. *(René Schwaiger)*
+- The Markdown Shell Recorder now also tests if a command prints nothing to `stdout` if you add the check `#>`. *(René Schwaiger)*
+- We fixed some problems in the [Markdown Shell Recorder](https://master.libelektra.org/tests/shell/shell_recorder/tutorial_wrapper) test
+  of [`kdb ls`](https://master.libelektra.org/doc/help/kdb-ls.md). *(René Schwaiger)*
+
+[#1887]: https://github.com/ElektraInitiative/libelektra/issues/1887
+
+## Build
+
+### CMake
+
+- The build system no longer installs haskell dependencies from hackage by itself, instead
+  this has to be done beforehand like it is the case with all other dependencies. The main
+  reason is that the build servers shouldn't compile the dependencies over and over again,
+  only if something changes. See the [readme](https://www.libelektra.org/bindings/haskell). *(Armin Wurzinger)*
+- We now import the current version of [Google Test][] as external project at configuration time using
+   [DownloadProject](https://github.com/Crascit/DownloadProject). If you want to use a local installation of
+   [Google Test][] instead, please set the value of `GTEST_ROOT` to the path of you local copy of the
+   [Google Test][] framework. *(René Schwaiger)*
+- The cmake variable `GTEST_ROOT` now respects the environment variable
+  `GTEST_ROOT` if it is set. *(Lukas Winkler)*
+- We disabled the test `testlib_notification` on ASAN enabled builds, since Clang reports that the test leaks memory. *(René Schwaiger)*
+- Disable Markdown Shell Recorder test `validation.md` for ASAN builds.
+  It leaks memory and thus fails the test during spec mount. *(Lukas Winkler)*
+
+[Google Test]: https://github.com/google/googletest
+
+### Docker
+
+- `clang-5.0` is now used for clang tests by the build system *(Lukas Winkler)*
+- An additional build job on Ubuntu:xenial has been added *(Lukas Winkler)*
+- `withDockerEnv` Jenkinsfile helper now no longer provides stages automatically. *(Lukas Winkler)*
+- [Google Test][] is installed in Docker images used by the build system. *(Lukas Winkler)*
+
+## Infrastructure
+
+### Jenkins
+
+- A build job checks if PRs modify the release notes. *(Markus Raab)*
+- Several improvements to the build system have been implemented *(Lukas Winkler)*:
+  - Better Docker image handling.
+  - Abort of previously queued but unfinished runs on new commits.
+  - Document how to locally replicate the Docker environment used for tests.
+  *(Lukas Winkler)*
+- The Jenkins build server now also compiles and tests Elektra with enabled address sanitizer. *(Lukas Winkler)*
+- Ported GCC ASAN build job to new build system *(René Schwaiger + Lukas Winkler)*
+- Docker artifacts are now cleaned up in our daily build job. *(Lukas Winkler)*
+- `clang` tests have been ported to the new build system *(Lukas Winkler et al)*
+- `icheck` build server job has been ported to our new build system. *(Lukas Winkler)*
+- Port `elektra-gcc-configure-debian-optimizations` to new build system.
+- Port `elektra-gcc-configure-mingw-w64` to new build system. *(Lukas Winkler)*
+- Port `debian-multiconfig-gcc-stable` to new build system. *(Lukas Winkler)*
+- Port `elektra-ini-mergerequests` to new build system. *(Lukas Winkler)*
+- Port `elektra-gcc-configure-debian-nokdbtest` to new build system. *(Lukas Winkler)*
+- Docker Registry is cleaned up by our daily buildserver task. *(Lukas Winkler)*
+
+### Travis
+
+- Travis now uses the latest version of GCC and Clang to translate Elektra on Linux. *(René Schwaiger)*
+- Our Travis build job now
+  - builds all (applicable) bindings by default again, and
+  - checks the formatting of CMake code via [`cmake-format`][]
+  . *(René Schwaiger)*
 
 ## Compatibility
 
@@ -138,35 +225,6 @@ compiled against an older 0.8 version of Elektra will continue to work
 - <<TODO>>
 - <<TODO>>
 
-
-## Notes for Maintainer
-
-These notes are of interest for people maintaining packages of Elektra:
-
-- The cmake variable `GTEST_ROOT` now respects the environment variable
-  `GTEST_ROOT` if it is set. *(Lukas Winkler)*
-- <<TODO>>
-- <<TODO>>
-
-
-## Infrastructure
-
-- <<TODO>>
-- <<TODO>>
-- <<TODO>>
-
-### Jenkins
-
-- The Jenkins build server now also compiles and tests Elektra with enabled address sanitizer. *(Lukas Winkler)*
-
-### Travis
-
-- Travis now uses the latest version of GCC and Clang to translate Elektra on Linux. *(René Schwaiger)*
-- Our Travis build job now
-  - builds all (applicable) bindings by default again, and
-  - checks the formatting of CMake code via [`cmake-format`][]
-  . *(René Schwaiger)*
-
 ## Website
 
 The website is generated from the repository, so all information about
@@ -175,73 +233,6 @@ plugins, bindings and tools are always up to date. Furthermore, we changed:
 - <<TODO>>
 - <<TODO>>
 - <<TODO>>
-
-
-## Notes for Elektra's Developers
-
-These notes are of interest for people developing Elektra:
-
-- A build job checks if PRs modify the release notes. *(Markus Raab)*
-- `clang` tests have been ported to the new build system *(Lukas Winkler et al)*
-- `clang-5.0` is now used for clang tests by the build system *(Lukas Winkler)*
-- An additional build job on Ubuntu:xenial has been added *(Lukas Winkler)*
-- Several improvements to the build system have been implemented *(Lukas Winkler)*:
-  - Better Docker image handling.
-  - Abort of previously queued but unfinished runs on new commits.
-  - Document how to locally replicate the Docker environment used for tests.
-- <<TODO>>
-- <<TODO>>
-- Port `elektra-gcc-configure-debian-optimizations` to new build system.
-  *(Lukas Winkler)*
-- Ported GCC ASAN build job to new build system *(René Schwaiger + Lukas Winkler)*
-- `withDockerEnv` Jenkinsfile helper now no longer provides stages automatically. *(Lukas Winkler)*
-- Docker artifacts are now cleaned up in our daily build job. *(Lukas Winkler)*
-- `icheck` build server job has been ported to our new build system. *(Lukas Winkler)*
-- The script [`check_formatting.sh`](https://master.libelektra.org/tests/shell/check_formatting.sh) now also checks the formatting of CMake
-  code if you installed [`sponge`](https://joeyh.name/code/moreutils) and [`cmake-format`][]. *(René Schwaiger)*
-- (Markdown) Shell Recorder tests now save test data below `/tests` (see issue [#1887][]). *(René Schwaiger)*
-- The Markdown Shell Recorder checks `kdb set` commands to ensure we only add tests that store data below `/tests`. *(René Schwaiger)*
-- We disabled the test `testlib_notification` on ASAN enabled builds, since Clang reports that the test leaks memory. *(René Schwaiger)*
-- Docker Registry is cleaned up by our daily buildserver task. *(Lukas Winkler)*
-- We now import the current version of [Google Test][] as external project at configuration time using
-   [DownloadProject](https://github.com/Crascit/DownloadProject). If you want to use a local installation of
-   [Google Test][] instead, please set the value of `GTEST_ROOT` to the path of you local copy of the
-   [Google Test][] framework. *(René Schwaiger)*
-- [Google Test][] is installed in Docker images used by the build system. *(Lukas Winkler)*
-- Port `elektra-gcc-configure-mingw-w64` to new build system. *(Lukas Winkler)*
-- Port `debian-multiconfig-gcc-stable` to new build system. *(Lukas Winkler)*
-- Port `elektra-ini-mergerequests` to new build system. *(Lukas Winkler)*
-- Port `elektra-gcc-configure-debian-nokdbtest` to new build system. *(Lukas Winkler)*
-
-[`cmake-format`]: https://github.com/cheshirekow/cmake_format
-[#1887]: https://github.com/ElektraInitiative/libelektra/issues/1887
-[Google Test]: https://github.com/google/googletest
-
-## Fixes
-
-Many problems were resolved with the following fixes:
-
-- <<TODO>>
-- <<TODO>>
-- <<TODO>>
-- We fixed a memory leak in the [mINI plugin](https://libelektra.org/plugins/mini) by requiring the plugin
-  [`ccode`](https://libelektra.org/plugins/ccode) instead of the “provider” `code`. *(René Schwaiger)*
-- The script [`check_bashisms.sh`](https://master.libelektra.org/tests/shell/check_bashisms.sh) should now work correctly again, if the
-  system uses the GNU version `find`. *(René Schwaiger)*
-- The Markdown Shell Recorder now supports indented code blocks. *(René Schwaiger)*
-- The Markdown Shell Recorder now also tests if a command prints nothing to `stdout` if you add the check `#>`. *(René Schwaiger)*
-- We fixed some problems in the [Markdown Shell Recorder](https://master.libelektra.org/tests/shell/shell_recorder/tutorial_wrapper) test
-  of [`kdb ls`](https://master.libelektra.org/doc/help/kdb-ls.md). *(René Schwaiger)*
-- The script [`reformat-cmake`](https://master.libelektra.org/scripts/reformat-cmake) now checks if `cmake-format` works before it reformats CMake files. Thank you to Klemens Böswirth for the [detailed description of the problem](https://github.com/ElektraInitiative/libelektra/pull/1903#discussion_r189332987). *(René Schwaiger)*
-- `scripts/run_icheck` now no longer leaves the base directory of the project
-  when checking if the ABI changed. *(Lukas Winkler)*
-- You can now build the [Qt-GUI](https://www.libelektra.org/tools/qt-gui) using Qt `5.11`. *(René Schwaiger)*
-- We fixed various minor spelling mistakes in the documentation. *(René Schwaiger)*
-- The [`list` plugin](http://libelektra.org/plugins/list) which is responsible
-  for global mounting had a bug which prevented globally mounted plugins from
-  being configurable. *(Thomas Wahringer)*
-- Disable Markdown Shell Recorder test `validation.md` for ASAN builds.
-  It leaks memory and thus fails the test during spec mount. *(Lukas Winkler)*
 
 ## Outlook
 

--- a/doc/news/_preparation_next_release.md
+++ b/doc/news/_preparation_next_release.md
@@ -154,9 +154,18 @@ These notes are of interest for people maintaining packages of Elektra:
 - <<TODO>>
 - <<TODO>>
 - <<TODO>>
-- The Jenkins build server now also compiles and tests Elektra with enabled address sanitizer. *(Lukas Winkler)*
-- Travis now uses the latest version of GCC and Clang to translate Elektra on Linux. *(René Schwaiger)*
 
+### Jenkins
+
+- The Jenkins build server now also compiles and tests Elektra with enabled address sanitizer. *(Lukas Winkler)*
+
+### Travis
+
+- Travis now uses the latest version of GCC and Clang to translate Elektra on Linux. *(René Schwaiger)*
+- Our Travis build job now
+  - builds all (applicable) bindings by default again, and
+  - checks the formatting of CMake code via [`cmake-format`][]
+  . *(René Schwaiger)*
 
 ## Website
 
@@ -190,11 +199,6 @@ These notes are of interest for people developing Elektra:
 - `icheck` build server job has been ported to our new build system. *(Lukas Winkler)*
 - The script [`check_formatting.sh`](https://master.libelektra.org/tests/shell/check_formatting.sh) now also checks the formatting of CMake
   code if you installed [`sponge`](https://joeyh.name/code/moreutils) and [`cmake-format`][]. *(René Schwaiger)*
-- Our Travis build job now
-  - builds all (applicable) bindings by default again, and
-  - checks the formatting of CMake code via [`cmake-format`][]
-
-  . *(René Schwaiger)*
 - (Markdown) Shell Recorder tests now save test data below `/tests` (see issue [#1887][]). *(René Schwaiger)*
 - The Markdown Shell Recorder checks `kdb set` commands to ensure we only add tests that store data below `/tests`. *(René Schwaiger)*
 - We disabled the test `testlib_notification` on ASAN enabled builds, since Clang reports that the test leaks memory. *(René Schwaiger)*

--- a/doc/news/_preparation_next_release.md
+++ b/doc/news/_preparation_next_release.md
@@ -162,7 +162,7 @@ Thanks to Armin Wurzinger.
 
 ### CMake
 
-- The build system no longer installs haskell dependencies from hackage by itself, instead
+- The build system no longer installs Haskell dependencies from hackage by itself, instead
   this has to be done beforehand like it is the case with all other dependencies. The main
   reason is that the build servers shouldn't compile the dependencies over and over again,
   only if something changes. See the [readme](https://www.libelektra.org/bindings/haskell). *(Armin Wurzinger)*

--- a/doc/todo/NEWS.md
+++ b/doc/todo/NEWS.md
@@ -65,6 +65,16 @@ The following section lists news about the [modules](https://www.libelektra.org/
 
 The text below summarizes updates to the [C (and C++) based interface](https://www.libelektra.org/libraries/readme) of Elektra.
 
+### Compatibility
+
+As always, the ABI and API of kdb.h is fully compatible, i.e. programs
+compiled against an older 0.8 version of Elektra will continue to work
+(ABI) and you will be able to recompile programs without errors (API).
+
+- <<TODO>>
+- <<TODO>>
+- <<TODO>>
+
 ### <<Library1>>
 
 
@@ -139,16 +149,6 @@ you up to date with the multi-language support provided by Elektra.
 - <<TODO>>
 
 ### Travis
-
-- <<TODO>>
-- <<TODO>>
-- <<TODO>>
-
-## Compatibility
-
-As always, the ABI and API of kdb.h is fully compatible, i.e. programs
-compiled against an older 0.8 version of Elektra will continue to work
-(ABI) and you will be able to recompile programs without errors (API).
 
 - <<TODO>>
 - <<TODO>>

--- a/doc/todo/NEWS.md
+++ b/doc/todo/NEWS.md
@@ -48,23 +48,29 @@ You can also read the news [on our website](https://www.libelektra.org/news/0.8.
 ### <<HIGHLIGHT2>>
 
 
-## Other New Features
-
-We added even more functionality, which could not make it to the highlights:
+## Plugins
 
 - <<TODO>>
 - <<TODO>>
 - <<TODO>>
 
 
-## New Plugins
+
+## Bindings
 
 - <<TODO>>
 - <<TODO>>
 - <<TODO>>
 
 
-## Other News
+## Tools
+
+- <<TODO>>
+- <<TODO>>
+- <<TODO>>
+
+
+## Scripts
 
 - <<TODO>>
 - <<TODO>>
@@ -73,12 +79,45 @@ We added even more functionality, which could not make it to the highlights:
 
 ## Documentation
 
-We improved the documentation in the following ways:
+- <<TODO>>
+- <<TODO>>
+- <<TODO>>
+
+## Tests
 
 - <<TODO>>
 - <<TODO>>
 - <<TODO>>
 
+
+## Build
+
+### CMake
+
+- <<TODO>>
+- <<TODO>>
+- <<TODO>>
+
+### Docker
+
+- <<TODO>>
+- <<TODO>>
+- <<TODO>>
+
+
+## Infrastructure
+
+### Jenkins
+
+- <<TODO>>
+- <<TODO>>
+- <<TODO>>
+
+### Travis
+
+- <<TODO>>
+- <<TODO>>
+- <<TODO>>
 
 ## Compatibility
 
@@ -91,44 +130,10 @@ compiled against an older 0.8 version of Elektra will continue to work
 - <<TODO>>
 
 
-## Notes for Maintainer
-
-These notes are of interest for people maintaining packages of Elektra:
-
-- <<TODO>>
-- <<TODO>>
-- <<TODO>>
-
-
-## Infrastructure
-
-- <<TODO>>
-- <<TODO>>
-- <<TODO>>
-
-
 ## Website
 
 The website is generated from the repository, so all information about
 plugins, bindings and tools are always up to date. Furthermore, we changed:
-
-- <<TODO>>
-- <<TODO>>
-- <<TODO>>
-
-
-## Notes for Elektra's Developers
-
-These notes are of interest for people developing Elektra:
-
-- <<TODO>>
-- <<TODO>>
-- <<TODO>>
-
-
-## Fixes
-
-Many problems were resolved with the following fixes:
 
 - <<TODO>>
 - <<TODO>>

--- a/doc/todo/NEWS.md
+++ b/doc/todo/NEWS.md
@@ -50,17 +50,36 @@ You can also read the news [on our website](https://www.libelektra.org/news/0.8.
 
 ## Plugins
 
-- <<TODO>>
-- <<TODO>>
-- <<TODO>>
 
+### <<Plugin1>>
+
+
+### <<Plugin2>>
+
+
+### <<Plugin3>>
+
+
+## Libraries
+
+### <<Library1>>
+
+
+### <<Library2>>
+
+
+### <<Library3>>
 
 
 ## Bindings
 
-- <<TODO>>
-- <<TODO>>
-- <<TODO>>
+### <<Binding1>>
+
+
+### <<Binding2>>
+
+
+### <<Binding3>>
 
 
 ## Tools

--- a/doc/todo/NEWS.md
+++ b/doc/todo/NEWS.md
@@ -50,6 +50,7 @@ You can also read the news [on our website](https://www.libelektra.org/news/0.8.
 
 ## Plugins
 
+The following section lists news about the [modules](https://www.libelektra.org/plugins/readme) we updated in this release.
 
 ### <<Plugin1>>
 
@@ -62,6 +63,8 @@ You can also read the news [on our website](https://www.libelektra.org/news/0.8.
 
 ## Libraries
 
+The text below summarizes updates to the [C (and C++) based interface](https://www.libelektra.org/libraries/readme) of Elektra.
+
 ### <<Library1>>
 
 
@@ -72,6 +75,9 @@ You can also read the news [on our website](https://www.libelektra.org/news/0.8.
 
 
 ## Bindings
+
+Bindings allow you to utilize Elektra using [various programming languages](https://www.libelektra.org/bindings/readme). This section keeps
+you up to date with the multi-language support provided by Elektra.
 
 ### <<Binding1>>
 

--- a/scripts/fix-spelling
+++ b/scripts/fix-spelling
@@ -22,5 +22,5 @@ else
 	inplace=(-i '')
 fi
 
-$(sed "${inplace[@]}" -E -f "$script" `find . -type f -name '*.md' | egrep -v "^./(.git|tests/gtest-1.7.0|scripts/sed|scripts/fix-spelling|doc/images|doc/AUTHORS.md|doc/news)"`)
+$(sed "${inplace[@]}" -E -f "$script" `find . -type f -name '*.md' | egrep -v "^./(.git|scripts/sed|scripts/fix-spelling|doc/images|doc/AUTHORS.md|doc/news)"`)
 $(sed "${inplace[@]}" -E -f "$script" doc/*.ini)

--- a/src/plugins/typechecker/README.md
+++ b/src/plugins/typechecker/README.md
@@ -121,7 +121,7 @@ that two incompatible checks can be used for a single key.
 Create a sample configuration specification with three keys. As it is valid, there will be no error
 issued. We rely on the existence of [prelude.ini](/src/plugins/typechecker/typechecker/prelude.ini), which already
 contains the type definitions for `check/range`, `check/long` and `fallback/#` and mount it along.
-Please note not to mount prelude below the specification. We use kdb shell to delay the typechecking 
+Please note not to mount prelude below the specification. We use kdb shell to delay the type checking 
 until we have finished writing the whole specification.
 
 ```sh


### PR DESCRIPTION
# Purpose

We now use a structure, similar to the one of the repository, for the release notes. Instead of personal interest (maintainer, developer, user) we now use general technical topics (bindings, plugins, tools, …) as headings. This structure should it make much simpler to decide where to look for a certain new feature or bug fix.

# Checklist

- [x] I checked all commit messages.
- [x] This PR updates the release notes.