### PR TITLE
Add regex tests + fix musl fstab issues

### DIFF
--- a/doc/news/_preparation_next_release.md
+++ b/doc/news/_preparation_next_release.md
@@ -108,6 +108,10 @@ Thanks to Michael Zronek and Vanessa Kos.
 
 - The `crypto` plugin now uses Elektra's `libinvoke` and the `base64` plugin in order to encode and decode Base64 strings. This improvement reduces code duplication between the two plugins. *(Peter Nirschl)*
 
+### fstab
+
+- The `fstab` plugin now passes tests on musl builds. *(Lukas Winkler)*
+
 ### HexNumber
 
 - The plugin [hexnumber](https://www.libelektra.org/plugins/hexnumber) has been added. It can be used

--- a/doc/news/_preparation_next_release.md
+++ b/doc/news/_preparation_next_release.md
@@ -198,6 +198,9 @@ Thanks to Michael Zronek and Vanessa Kos.
   of [`kdb ls`](https://master.libelektra.org/doc/help/kdb-ls.md). *(René Schwaiger)*
 - The documentation for `kdb` and `kdb set` now mention the `--` option to stop option processing. This is useful for setting negative values among other things. *(Klemens Böswirth)*
 - Plugins added with the flag `SHARED_ONLY` no longer get tested in the script `check_kdb_internal_check.sh` if executed with kdb-full or kdb-static. *(Armin Wurzinger)*
+- Add `compare_regex_to_line_files` which allows to compare a file made of
+    regex patterns to be compared with a text file line by line.
+    *(Lukas Winkler)*
 
 ## Compatibility
 

--- a/doc/news/_preparation_next_release.md
+++ b/doc/news/_preparation_next_release.md
@@ -164,6 +164,8 @@ Thanks to Michael Zronek and Vanessa Kos.
 
 - The script [`check_formatting.sh`](https://master.libelektra.org/tests/shell/check_formatting.sh) now also checks the formatting of CMake
   code if you installed [`sponge`](https://joeyh.name/code/moreutils) and [`cmake-format`][]. *(René Schwaiger)*
+- The script [`check_formatting.sh`](https://master.libelektra.org/tests/shell/check_formatting.sh) now no longer writes to stdout if clang-format5.0
+    can not be found. *(Lukas Winkler)*
 - The script [`check_bashisms.sh`](https://master.libelektra.org/tests/shell/check_bashisms.sh) should now work correctly again, if the
   system uses the GNU version `find`. *(René Schwaiger)*
 - The script [`reformat-cmake`](https://master.libelektra.org/scripts/reformat-cmake) now checks if `cmake-format` works before it reformats CMake files. Thank you to Klemens Böswirth for the [detailed description of the problem](https://github.com/ElektraInitiative/libelektra/pull/1903#discussion_r189332987). *(René Schwaiger)*

--- a/scripts/reformat-source
+++ b/scripts/reformat-source
@@ -8,7 +8,7 @@
 SCRIPTS_DIR=$(dirname "$0")
 . "${SCRIPTS_DIR}/include-common"
 
-CLANG_FORMAT=$(which clang-format-5.0)
+CLANG_FORMAT=$(which clang-format-5.0 2> /dev/null)
 
 if [ -z "${CLANG_FORMAT}" ]; then
 	CLANG_FORMAT=$(which clang-format)

--- a/src/plugins/fstab/fstab/fstab-write
+++ b/src/plugins/fstab/fstab/fstab-write
@@ -1,2 +1,2 @@
-/dev/sda6 / jfs defaults,errors=remount-ro 0 1
-/dev/sda10 none swap sw 0 0
+/dev/sda6\s+/\s+jfs\s+defaults,errors=remount-ro\s+0\s+1
+/dev/sda10\s+none\s+swap\s+sw\s+0\s+0

--- a/src/plugins/fstab/testmod_fstab.c
+++ b/src/plugins/fstab/testmod_fstab.c
@@ -84,7 +84,7 @@ void test_writefstab (const char * file)
 	succeed_if (output_error (parentKey), "error in kdbSet");
 	succeed_if (output_warnings (parentKey), "warnings in kdbSet");
 
-	succeed_if (compare_line_files (srcdir_file (file), keyString (parentKey)), "files do not match as expected");
+	succeed_if (compare_regex_to_line_files (srcdir_file (file), keyString (parentKey)), "files do not match as expected");
 
 	elektraUnlink (keyString (parentKey));
 	keyDel (parentKey);

--- a/tests/cframework/tests.h
+++ b/tests/cframework/tests.h
@@ -276,6 +276,7 @@ int init (int argc, char ** argv);
 
 int compare_files (const char * filename);
 int compare_line_files (const char * filename, const char * genfilename);
+int compare_regex_to_line_files (const char * filename, const char * genfilename);
 
 char * srcdir_file (const char * fileName);
 const char * elektraFilename (void);


### PR DESCRIPTION
# Purpose

* Provide a way to compare files made of regex patterns with regular files for tests and
* rewrite fstab tests to use this new functionality

Resolves #2081 

# Checklist

- [x] commit messages are fine ("module: short statement" syntax and refer to issues)
- [x] I added unit tests
- [x] I ran all tests locally and everything went fine
- [x] affected documentation is fixed
- [x] I added code comments, logging, and assertions (see doc/CODING.md)
- [x] meta data is updated (e.g. README.md of plugins)
- [x] release notes are updated (doc/news/_preparation_next_release.md)

@markus2330 please review my pull request
