### PR TITLE
Fix archivation

### DIFF
--- a/doc/news/_preparation_next_release.md
+++ b/doc/news/_preparation_next_release.md
@@ -301,6 +301,8 @@ Thanks to Michael Zronek and Vanessa Kos.
   Instead we added a new test checking if `PLUGINS=NODEP` builds in an minimal
   Docker image. *(Lukas Winkler)*
 - Speed up coverage data upload. *(Lukas Winkler)*
+- Fix an issue where file archivation did not happen because of surpressed shell
+    expansion *(Lukas Winkler)*
 
 ### Travis
 

--- a/scripts/jenkins/Jenkinsfile
+++ b/scripts/jenkins/Jenkinsfile
@@ -742,7 +742,7 @@ def buildAndTest(testName, image, extraCmakeFlags = [:],
         def buildDir='build directory'
 
         if(tests) {
-          artifacts.add("${buildDir}/Testing/*/*.xml")
+          artifacts.add("\"${buildDir}\"/Testing/*/*.xml")
         }
 
         try {
@@ -919,9 +919,9 @@ def archive(paths) {
     def dest = "${prefix}${env.STAGE_NAME}/"
     sh "mkdir -p ${dest}"
     paths.each { path ->
-        sh "cp -v \"${path}\" ${dest} || true"
+        sh "cp -v ${path} ${dest} || true"
     }
-    archiveArtifacts artifacts: "${prefix}**", fingerprint: true, allowEmptyArchive: true
+    archiveArtifacts artifacts: "${prefix}**", fingerprint: true
   } else {
     echo "No Artifacts to archive"
   }


### PR DESCRIPTION
The space in buildDir can not be escaped during `cp` as it does not allow the shell to expand `*`.