### PR TITLE
Fix non c99 errors

### DIFF
--- a/cmake/ElektraCompiling.cmake
+++ b/cmake/ElektraCompiling.cmake
@@ -19,6 +19,10 @@ if (C_STD)
 	message (STATUS "use C_STD as given by user: ${C_STD}")
 else ()
 	set (C_STD "-std=gnu99")
+
+	# gnu99 does not restrict useage of _GNU_SOURCE provided functions
+	# MUSL needs it to be set explicitly to enable functionality
+	set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -D_GNU_SOURCE")
 endif ()
 
 if (CXX_STD)

--- a/doc/news/_preparation_next_release.md
+++ b/doc/news/_preparation_next_release.md
@@ -271,6 +271,7 @@ Thanks to Michael Zronek and Vanessa Kos.
 ### Jenkins
 
 - A build job checks if PRs modify the release notes. *(Markus Raab)*
+- Create a new build job that checks for `C99` compliancy *(Lukas Winkler)*
 - Several improvements to the build system have been implemented *(Lukas Winkler)*:
   - Better Docker image handling.
   - Abort of previously queued but unfinished runs on new commits.

--- a/scripts/jenkins/Jenkinsfile
+++ b/scripts/jenkins/Jenkinsfile
@@ -1049,7 +1049,7 @@ def cpuCount() {
  */
 def ctest(target = "Test") {
   sh """ctest -j ${env.CTEST_PARALLEL_LEVEL} --force-new-ctest-process \
-          --output-on-failure --no-compress-output -T ${target}"""
+        --output-on-failure --no-compress-output -T ${target}"""
 }
 
 /* Helper for ctest to run MemCheck without memleak tagged tests

--- a/scripts/jenkins/Jenkinsfile
+++ b/scripts/jenkins/Jenkinsfile
@@ -362,6 +362,17 @@ def generateMainBuildStages() {
     [TEST.ALL, TEST.MEM, TEST.NOKDB, TEST.INSTALL]
   )
 
+  tasks << buildAndTest(
+    "debian-stable-c99",
+    DOCKER_IMAGES.stretch,
+    CMAKE_FLAGS_BUILD_ALL +
+      CMAKE_FLAGS_COVERAGE + [
+      'C_STD': '-std=c99',
+      'COMMON_FLAGS': '-Werror'
+    ],
+    []
+  )
+
   // Check the ABI and API compatibility of Elektra
   tasks << buildIcheck()
 

--- a/src/libs/elektra/CMakeLists.txt
+++ b/src/libs/elektra/CMakeLists.txt
@@ -1,3 +1,11 @@
+include (CheckSymbolExists)
+
+check_symbol_exists (strcasecmp "strings.h" HAVE_STRCASECMP)
+check_symbol_exists (strncasecmp "strings.h" HAVE_STRNCASECMP)
+if (HAVE_STRCASECMP AND HAVE_STRNCASECMP)
+    add_definitions (-DUSE_STRINGS_H)
+endif ()
+
 # ~~~
 # For static inclusion of libraries we need a list
 # of symbols to make the static runtime linker work.

--- a/src/libs/elektra/internal.c
+++ b/src/libs/elektra/internal.c
@@ -38,6 +38,26 @@
 #include <ctype.h>
 #endif
 
+#ifdef USE_STRINGS_H
+#include <strings.h>
+#else
+// MUSL libc implementations
+int strcasecmp(const char *_l, const char *_r)
+{
+	const unsigned char *l=(void *)_l, *r=(void *)_r;
+	for (; *l && *r && (*l == *r || tolower(*l) == tolower(*r)); l++, r++);
+	return tolower(*l) - tolower(*r);
+}
+
+int strncasecmp(const char *_l, const char *_r, size_t n)
+{
+	const unsigned char *l=(void *)_l, *r=(void *)_r;
+	if (!n--) return 0;
+	for (; *l && *r && n && (*l == *r || tolower(*l) == tolower(*r)); l++, r++, n--);
+	return tolower(*l) - tolower(*r);
+}
+#endif
+
 #include "kdbinternal.h"
 #include <kdbassert.h>
 

--- a/src/plugins/base64/CMakeLists.txt
+++ b/src/plugins/base64/CMakeLists.txt
@@ -1,4 +1,10 @@
+include (CheckSymbolExists)
 include (LibAddPlugin)
+
+check_symbol_exists (strdup "string.h" HAVE_STRDUP)
+if (NOT HAVE_STRDUP)
+	remove_plugin(base64 "requires strdup")
+endif (NOT HAVE_STRDUP)
 
 add_plugin (base64
 	    SOURCES base64_functions.h

--- a/src/plugins/boolean/CMakeLists.txt
+++ b/src/plugins/boolean/CMakeLists.txt
@@ -1,3 +1,10 @@
+include (CheckSymbolExists)
 include (LibAddMacros)
+
+check_symbol_exists (strdup "string.h" HAVE_STRDUP)
+check_symbol_exists (strtok_r "string.h" HAVE_STRTOK_R)
+if (NOT (HAVE_STRDUP AND HAVE_STRTOK_R))
+	remove_plugin (boolean "requires strdup and strtok_r")
+endif ()
 
 add_plugin (boolean SOURCES boolean.h boolean.c ADD_TEST TEST_README)

--- a/src/plugins/camel/CMakeLists.txt
+++ b/src/plugins/camel/CMakeLists.txt
@@ -1,3 +1,9 @@
+include (CheckSymbolExists)
 include (LibAddMacros)
+
+check_symbol_exists (getline "stdio.h" HAVE_GETLINE)
+if (NOT HAVE_GETLINE)
+	remove_plugin (camel "requires getline")
+endif ()
 
 add_plugin (camel SOURCES camel.h camel.c LINK_ELEKTRA elektra-ease ADD_TEST INSTALL_TEST_DATA TEST_README)

--- a/src/plugins/conditionals/CMakeLists.txt
+++ b/src/plugins/conditionals/CMakeLists.txt
@@ -1,4 +1,10 @@
+include (CheckSymbolExists)
 include (LibAddMacros)
+
+check_symbol_exists (strdup "string.h" HAVE_STRDUP)
+if (NOT HAVE_STRDUP)
+	remove_plugin(conditionals "could not find strdup")
+endif (NOT HAVE_STRDUP)
 
 add_plugin (
 	conditionals SOURCES conditionals.h conditionals.c LINK_ELEKTRA elektra-meta ADD_TEST TEST_README TEST_REQUIRED_PLUGINS dump ini ni)

--- a/src/plugins/crypto/CMakeLists.txt
+++ b/src/plugins/crypto/CMakeLists.txt
@@ -1,4 +1,13 @@
+include (CheckSymbolExists)
 include (LibAddPlugin)
+
+check_symbol_exists (strsep "string.h" HAVE_STRSEP)
+if (NOT HAVE_STRSEP)
+	remove_plugin (fcrypt "requires strsep")
+	remove_plugin (crypto_openssl "requires strsep")
+	remove_plugin (crypto_gcrypt "requires strsep")
+	remove_plugin (crypto_botan "requires strsep")
+endif ()
 
 if (DEPENDENCY_PHASE)
 

--- a/src/plugins/directoryvalue/CMakeLists.txt
+++ b/src/plugins/directoryvalue/CMakeLists.txt
@@ -1,3 +1,9 @@
+include (CheckSymbolExists)
 include (LibAddMacros)
+
+check_symbol_exists (strdup "string.h" HAVE_STRDUP)
+if (NOT HAVE_STRDUP)
+	remove_plugin(directoryvalue "requires strdup")
+endif (NOT HAVE_STRDUP)
 
 add_plugin (directoryvalue SOURCES directoryvalue.h directoryvalue.c LINK_ELEKTRA elektra-ease ADD_TEST TEST_README)

--- a/src/plugins/glob/CMakeLists.txt
+++ b/src/plugins/glob/CMakeLists.txt
@@ -1,3 +1,9 @@
+include (CheckSymbolExists)
 include (LibAddMacros)
+
+check_symbol_exists (strdup "string.h" HAVE_STRDUP)
+if (NOT HAVE_STRDUP)
+	remove_plugin(glob "requires strdup")
+endif (NOT HAVE_STRDUP)
 
 add_plugin (glob SOURCES glob.h glob.c ADD_TEST)

--- a/src/plugins/ini/CMakeLists.txt
+++ b/src/plugins/ini/CMakeLists.txt
@@ -1,4 +1,13 @@
+include (CheckSymbolExists)
 include (LibAddMacros)
+
+check_symbol_exists (strdup "string.h" HAVE_STRDUP)
+check_symbol_exists (strtok_r "string.h" HAVE_STRTOK_R)
+check_symbol_exists (strcasecmp "strings.h" HAVE_STRCASECMP)
+
+if (NOT (HAVE_STRDUP AND HAVE_STRTOK_R AND HAVE_STRCASECMP))
+	remove_plugin(ini "requires strdup, strtok_r and strcasecmp")
+endif ()
 
 file (GLOB INIH_FILES ${CMAKE_CURRENT_SOURCE_DIR}/inih-r29/*)
 


### PR DESCRIPTION
# Purpose

* Add a c99 build to our build server
* Disable parts of elektra that can not find their non c99 deps

# Checklist

Check relevant points but please do not remove entries.
For docu fixes, spell checking, and similar nothing
needs to be checked.

- [ ] commit messages are fine ("module: short statement" syntax and refer to issues)
- [ ] I added unit tests
- [ ] I ran all tests locally and everything went fine
- [ ] affected documentation is fixed
- [ ] I added code comments, logging, and assertions (see doc/CODING.md)
- [ ] meta data is updated (e.g. README.md of plugins)
- [ ] release notes are updated (doc/news/_preparation_next_release.md)
