### PR TITLE
Build: Add Support for C++ Tests to LibAddPlugin

### DIFF
--- a/.cmake-format.yaml
+++ b/.cmake-format.yaml
@@ -43,6 +43,7 @@ additional_commands:
     flags:
       - MEMLEAK
       - INSTALL_TEST_DATA
+      - CPP
     kwargs:
       INCLUDE_SYSTEM_DIRECTORIES: 1
       COMPILE_DEFINITIONS: "*"

--- a/.cmake-format.yaml
+++ b/.cmake-format.yaml
@@ -25,6 +25,7 @@ additional_commands:
     flags:
       - CPP
       - ADD_TEST
+      - CPP_TEST
       - INSTALL_TEST_DATA
       - TEST_README
     kwargs:

--- a/cmake/Modules/LibAddPlugin.cmake
+++ b/cmake/Modules/LibAddPlugin.cmake
@@ -266,6 +266,11 @@ endfunction ()
 # ADD_TEST:
 #  Add a plugin test case written in C (alternatively you can use add_gtest)
 #
+# CPP_TEST:
+#  If you add this optional keyword, then the function will add
+#  a C++ test instead of a C test. This argument only makes sense if you also
+#  specified the keyword `ADD_TEST`.
+#
 # INSTALL_TEST_DATA:
 #  Install a directory with test data which has the same name as the plugin.
 #
@@ -296,7 +301,7 @@ function (add_plugin PLUGIN_SHORT_NAME)
 	     TEST_ENVIRONMENT
 	     TEST_REQUIRED_PLUGINS)
 	cmake_parse_arguments (ARG
-			       "CPP;ADD_TEST;TEST_README;INSTALL_TEST_DATA;ONLY_SHARED" # optional keywords
+			       "CPP;CPP_TEST;ADD_TEST;TEST_README;INSTALL_TEST_DATA;ONLY_SHARED" # optional keywords
 			       "INCLUDE_SYSTEM_DIRECTORIES" # one value keywords
 			       "${MULTI_VALUE_KEYWORDS}" # multi value keywords
 			       ${ARGN})
@@ -313,6 +318,7 @@ function (add_plugin PLUGIN_SHORT_NAME)
 	restore_variable (${PLUGIN_NAME} ARG_INCLUDE_SYSTEM_DIRECTORIES)
 	restore_variable (${PLUGIN_NAME} ARG_LINK_ELEKTRA)
 	restore_variable (${PLUGIN_NAME} ARG_ADD_TEST)
+	restore_variable (${PLUGIN_NAME} ARG_CPP_TEST)
 	restore_variable (${PLUGIN_NAME} ARG_TEST_README)
 	restore_variable (${PLUGIN_NAME} ARG_TEST_ENVIRONMENT)
 	restore_variable (${PLUGIN_NAME} ARG_TEST_REQUIRED_PLUGINS)
@@ -338,6 +344,11 @@ function (add_plugin PLUGIN_SHORT_NAME)
 				set (HAS_INSTALL_TEST_DATA "INSTALL_TEST_DATA")
 			endif (ARG_INSTALL_TEST_DATA)
 
+			set (CPP_TEST "")
+			if (ARG_CPP_TEST)
+				set (CPP_TEST "CPP")
+			endif (ARG_CPP_TEST)
+
 			add_plugintest ("${PLUGIN_SHORT_NAME}"
 					LINK_LIBRARIES "${ARG_LINK_LIBRARIES}"
 					LINK_PLUGIN "${PLUGIN_SHORT_NAME}"
@@ -345,7 +356,8 @@ function (add_plugin PLUGIN_SHORT_NAME)
 					INCLUDE_DIRECTORIES "${ARG_INCLUDE_DIRECTORIES}"
 					INCLUDE_SYSTEM_DIRECTORIES "${ARG_INCLUDE_SYSTEM_DIRECTORIES}"
 					LINK_ELEKTRA "${ARG_LINK_ELEKTRA}"
-						     "${HAS_INSTALL_TEST_DATA}")
+						     "${HAS_INSTALL_TEST_DATA}"
+						     ${CPP_TEST})
 		endif ()
 
 		if (ARG_TEST_README AND ENABLE_KDB_TESTING)

--- a/doc/news/_preparation_next_release.md
+++ b/doc/news/_preparation_next_release.md
@@ -317,6 +317,7 @@ Try it out now on: http://webui.libelektra.org:33334/
 - Fix compilation with `BUILD_TESTING=OFF` when `spec` or `list` plugins are not selected.
 - Set coverage prefix to `PROJECT_SOURCE_DIR`, resulting in easier readable
     coverage reports. *(Lukas Winkler)*
+- The functions `add_plugintest` and `add_plugin` now also support adding a C++ test instead of a C test. *(René Schwaiger)*
 
 [Google Test]: https://github.com/google/googletest
 

--- a/src/plugins/ccode/CMakeLists.txt
+++ b/src/plugins/ccode/CMakeLists.txt
@@ -1,12 +1,5 @@
-if (DEPENDENCY_PHASE)
-	include (LibAddTest)
-	add_gtest (testmod_ccode
-		   SOURCES ccode.cpp
-			   coder.cpp
-		   LINK_ELEKTRA elektra-kdb
-				elektra-plugin
-		   INCLUDE_DIRECTORIES "${CMAKE_CURRENT_BINARY_DIR}" # Required for `readme_ccode.c`
-				       "${CMAKE_SOURCE_DIR}/src/bindings/cpp/tests")
-endif (DEPENDENCY_PHASE)
+if (ADDTESTING_PHASE)
+	add_plugintest (ccode CPP LINK_ELEKTRA elektra-kdb elektra-plugin)
+endif (ADDTESTING_PHASE)
 
 add_plugin (ccode CPP SOURCES ccode.hpp ccode.cpp coder.hpp coder.cpp TEST_README TEST_REQUIRED_PLUGINS tcl base64)

--- a/src/plugins/ccode/CMakeLists.txt
+++ b/src/plugins/ccode/CMakeLists.txt
@@ -1,5 +1,1 @@
-if (ADDTESTING_PHASE)
-	add_plugintest (ccode CPP LINK_ELEKTRA elektra-kdb elektra-plugin)
-endif (ADDTESTING_PHASE)
-
-add_plugin (ccode CPP SOURCES ccode.hpp ccode.cpp coder.hpp coder.cpp TEST_README TEST_REQUIRED_PLUGINS tcl base64)
+add_plugin (ccode CPP ADD_TEST CPP_TEST SOURCES ccode.hpp ccode.cpp coder.hpp coder.cpp TEST_README TEST_REQUIRED_PLUGINS tcl base64)

--- a/src/plugins/type/CMakeLists.txt
+++ b/src/plugins/type/CMakeLists.txt
@@ -1,10 +1,5 @@
-if (DEPENDENCY_PHASE)
-	include (LibAddTest)
-	add_gtest (testmod_type
-		   MEMLEAK
-		   SOURCES types.cpp
-		   LINK_ELEKTRA elektra-kdb # for elektraPluginOpen elektraPluginClose
-		   INCLUDE_DIRECTORIES "${CMAKE_SOURCE_DIR}/src/bindings/cpp/tests")
-endif ()
+if (ADDTESTING_PHASE)
+	add_plugintest (type CPP MEMLEAK LINK_ELEKTRA elektra-kdb elektra-plugin)
+endif (ADDTESTING_PHASE)
 
 add_plugin (type CPP SOURCES type.hpp type.cpp types.hpp types.cpp type_checker.hpp TEST_README)

--- a/src/plugins/type/CMakeLists.txt
+++ b/src/plugins/type/CMakeLists.txt
@@ -1,5 +1,1 @@
-if (ADDTESTING_PHASE)
-	add_plugintest (type CPP MEMLEAK LINK_ELEKTRA elektra-kdb elektra-plugin)
-endif (ADDTESTING_PHASE)
-
-add_plugin (type CPP SOURCES type.hpp type.cpp types.hpp types.cpp type_checker.hpp TEST_README)
+add_plugin (type ADD_TEST CPP_TEST CPP SOURCES type.hpp type.cpp types.hpp types.cpp type_checker.hpp TEST_README)


### PR DESCRIPTION
# Purpose

This pull request adds C++ test support to the CMake functions 

- `add_plugintest` and
- `add_plugin`

.

# Checklist

- [x] I checked all commit messages.
- [x] I ran all tests locally and everything went fine.
- [x] The pull request contains updated documentation for the two functions mentioned above.
- [x] The release notes should be up to date.
