### PR TITLE
travis-ci: bump macOS/Xcode versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ matrix:
     # ASAN: Enable AddressSanitizer
 
     - os: osx
-      osx_image: xcode9.3
+      osx_image: xcode9.4
       compiler: clang
       env:
         - ASAN=ON
@@ -84,13 +84,13 @@ matrix:
       compiler: gcc
 
     - os: osx
-      osx_image: xcode9.3
+      osx_image: xcode9.4
       compiler: clang
 
     # HASKELL: Only build Haskell binding and plugin
 
     - os: osx
-      osx_image: xcode9.3
+      osx_image: xcode9.4
       compiler: clang
       env:
         - HASKELL=ON

--- a/doc/news/_preparation_next_release.md
+++ b/doc/news/_preparation_next_release.md
@@ -385,6 +385,7 @@ Try it out now on: http://webui.libelektra.org:33334/
   . *(René Schwaiger)*
 - Some cache issues on the Travis build job for cached haskell sandboxes have been resolved. *(Armin Wurzinger)*
 - Travis caches downloaded Homebrew packages to improve the reliability of macOS build jobs. *(René Schwaiger)*
+- Travis is now using Xcode 9.4.1 on macOS 10.13 for most macOS build jobs. *(Mihael Pranjić)*
 
 ## Compatibility
 


### PR DESCRIPTION
# Purpose

Bump macOS/Xcode versions on travis-ci.
I think there is no point to add this to release notes or anything else from the checklist.

# Checklist

Check relevant points but please do not remove entries.
For docu fixes, spell checking, and similar nothing
needs to be checked.

- [x] commit messages are fine ("module: short statement" syntax and refer to issues)
- [ ] I added unit tests
- [ ] I ran all tests locally and everything went fine
- [ ] affected documentation is fixed
- [ ] I added code comments, logging, and assertions (see doc/CODING.md)
- [ ] meta data is updated (e.g. README.md of plugins)
- [x] release notes are updated (doc/news/_preparation_next_release.md)

@markus2330 please review my pull request
