### PR TITLE
 CFramework: Support Comparison of Empty Key Sets

### DIFF
--- a/doc/news/_preparation_next_release.md
+++ b/doc/news/_preparation_next_release.md
@@ -309,6 +309,7 @@ Thanks to Daniel Bugl.
     spawned did not get cleaned up afterwards. *(Lukas Winkler)*
 - We disabled the general plugin test (`testkdb_allplugins`) for the [`semlock` plugin](https://libelektra.org/plugins/mini), since the
   test reported [memory leaks](https://issues.libelektra.org/2113) on the latest version of Debian Unstable. *(René Schwaiger)*
+- The [CFramework](https://master.libelektra.org/tests/cframework) macro `compare_keyset` now supports the comparison of two empty key sets. *(René Schwaiger)*
 
 [#1887]: https://github.com/ElektraInitiative/libelektra/issues/1887
 [Markdown Shell Recorder]: https://master.libelektra.org/tests/shell/shell_recorder/tutorial_wrapper

--- a/tests/cframework/tests.h
+++ b/tests/cframework/tests.h
@@ -233,7 +233,8 @@ int init (int argc, char ** argv);
 		nbTest++;                                                                                                                  \
 		KeySet * mmks1 = (KeySet *) pks1;                                                                                          \
 		KeySet * mmks2 = (KeySet *) pks2;                                                                                          \
-		if (mmks1 != mmks2)                                                                                                        \
+		int bothEmpty = ksGetSize (mmks1) == 0 && ksGetSize (mmks1) == ksGetSize (mmks2);                                          \
+		if (mmks1 != mmks2 && !bothEmpty)                                                                                          \
 		{                                                                                                                          \
 			Key * cmmk1 = 0;                                                                                                   \
 			Key * cmmk2 = 0;                                                                                                   \


### PR DESCRIPTION
# Checklist

- [x] I ran all tests locally and everything went fine.