### PR TITLE
Detect nftw

### DIFF
--- a/doc/news/_preparation_next_release.md
+++ b/doc/news/_preparation_next_release.md
@@ -511,6 +511,7 @@ Thanks to Daniel Bugl.
 - Setup mailing for jenkins *(Lukas Winkler)*
   - send mail to build@libelektra.org when `master` fails *(Lukas Winkler)*
   - parse change list into mail *(Lukas Winkler)*
+  - do not send mails if pipeline run was aborted *(Lukas Winkler)*
 
 ### Travis
 

--- a/doc/news/_preparation_next_release.md
+++ b/doc/news/_preparation_next_release.md
@@ -460,6 +460,7 @@ Thanks to Daniel Bugl.
 - The function `add_plugintest` now also supports setting environment variables for C/C++ based tests. *(René Schwaiger)*
 - The build system now automatically detects Homebrew’s OpenSSL version on macOS. *(René Schwaiger)*
 - We improved the automatic detection of Libgcrypt and OpenSSL. *(René Schwaiger)*
+- Resolved an issue where cmake did not properly set test feature macros to detect and use libc functionality. *(Lukas Winkler)*
 
 [Google Test]: https://github.com/google/googletest
 

--- a/scripts/jenkins/Jenkinsfile
+++ b/scripts/jenkins/Jenkinsfile
@@ -1435,3 +1435,9 @@ def detectInterruption(Closure c) {
     }
   }
 }
+
+class UserInterruptedException extends Exception {
+    UserInterruptedException(String message) {
+        super(message)
+    }
+}

--- a/scripts/jenkins/Jenkinsfile
+++ b/scripts/jenkins/Jenkinsfile
@@ -163,8 +163,12 @@ def main() {
 }
 
 try {
-  main()
-} catch(e) {
+  detectInterruption {
+    main()
+  }
+} catch(UserInterruptedException uie) {
+  println "Caught ${uie}"
+} catch(Exception e) {
   if (isMaster()) {
     // If master is failing we want to know ASAP so send a mail.
     def changes = currentBuild.changeSets.collect() {
@@ -184,11 +188,6 @@ Changes: ${RUN_CHANGES_DISPLAY_URL}
 ${changes}
 
 Logs: ${currentBuild.rawBuild.getLog(20).join('\n')}
-
----
-Debug Information for mail step:
-currentResult: ${currentBuild.currentResult}
-Exception: ${e}
 """
     mail subject: "Build ${JOB_NAME} failed",
          body: message,
@@ -1405,5 +1404,34 @@ def getElektraWritableFiles() {
 def ensureDirsExist(listOfDirs) {
   listOfDirs.each {
     sh "mkdir -p $it || /bin/true"
+  }
+}
+
+
+/* Detect if pipeline was aborted
+ *
+ * Depending on which part of the pipeline was interrupted a different Exception
+ * is thrown. This wrapper makes sure a UserInterruptedException is thrown
+ * regardless of pipeline state.
+ *
+ * see: https://issues.jenkins-ci.org/browse/JENKINS-34376
+ */
+def detectInterruption(Closure c) {
+  try {
+    c()
+  } catch (org.jenkinsci.plugins.workflow.steps.FlowInterruptedException fie) {
+    // this ambiguous condition means a user probably aborted
+    if (fie.causes.size() == 0) {
+        throw new UserInterruptedException(fie)
+    } else {
+        throw fie
+    }
+  } catch (hudson.AbortException ae) {
+    // this ambiguous condition means during a shell step, user probably aborted
+    if (ae.getMessage().contains('script returned exit code 143')) {
+        throw new UserInterruptedException(ae)
+    } else {
+        throw ae
+    }
   }
 }

--- a/tests/cframework/CMakeLists.txt
+++ b/tests/cframework/CMakeLists.txt
@@ -1,7 +1,15 @@
 include (CheckSymbolExists)
 include (LibAddMacros)
+include (CMakePushCheckState)
 
+# We need GNU_SOURCE and _XOEPN_SOURCE for full functinality
+set (REQUIRED_FEATURE_MACROS -D_GNU_SOURCE -D_XOPEN_SOURCE=500 -D_DARWIN_C_SOURCE)
+add_definitions (${REQUIRED_FEATURE_MACROS})
+
+cmake_push_check_state (RESET)
+set (CMAKE_REQUIRED_DEFINITIONS ${REQUIRED_FEATURE_MACROS})
 check_symbol_exists (nftw "ftw.h" HAVE_NFTW)
+cmake_pop_check_state ()
 
 if (HAVE_NFTW)
 	add_definitions (-DUSE_NFTW)


### PR DESCRIPTION
Resolve an issue where NFTW was not detected by CMake.
Also adds the ability to ignore aborts when sending status mails.

Closes #2157.

## Basics

Do not describe the purpose here but:

- [ ] Short descriptions should be in the release notes (added as entry in
      doc/news/_preparation_next_release.md which contains `*(my name)*`)
      **Please always add something to the the release notes.**
- [ ] Longer descriptions should be in documentation or in design decisions.
- [ ] Describe details of how you changed the code in commit messages
      (first line should have `module: short statement` syntax)
- [ ] References to issues, e.g. `close #X`, should be in the commit messages.

## Checklist

Check relevant points but **please do not remove entries**.
For docu fixes, spell checking, and similar none of these points below
need to be checked.

- [ ] I added unit tests
- [ ] I ran all tests locally and everything went fine
- [ ] affected documentation is fixed
- [ ] I added code comments, logging, and assertions (see doc/CODING.md)
- [ ] meta data is updated (e.g. README.md of plugins)

## Review

Remove the line below and add the "work in progress" label if you do
not want the PR to be reviewed:

@markus2330 please review my pull request
