### PR TITLE
 CFramework: Improve Detection of `ftw.h`

### DIFF
--- a/doc/news/_preparation_next_release.md
+++ b/doc/news/_preparation_next_release.md
@@ -461,6 +461,7 @@ Thanks to Daniel Bugl.
 - The build system now automatically detects Homebrew’s OpenSSL version on macOS. *(René Schwaiger)*
 - We improved the automatic detection of Libgcrypt and OpenSSL. *(René Schwaiger)*
 - Resolved an issue where cmake did not properly set test feature macros to detect and use libc functionality. *(Lukas Winkler)*
+- Improve the detection of `ftw.h`, if the current build use the compiler switch `-Werror`. *(René Schwaiger)*
 
 [Google Test]: https://github.com/google/googletest
 

--- a/tests/cframework/CMakeLists.txt
+++ b/tests/cframework/CMakeLists.txt
@@ -8,7 +8,18 @@ add_definitions (${REQUIRED_FEATURE_MACROS})
 
 cmake_push_check_state (RESET)
 set (CMAKE_REQUIRED_DEFINITIONS ${REQUIRED_FEATURE_MACROS})
+
+set (CMAKE_C_FLAGS_OLD ${CMAKE_C_FLAGS})
+# On some system the check for `ftw.h` will produce warnings. In that case the detection of `ftw.h` will fail, if we use the flag `-Werror`.
+# We make sure that this is not the case by temporarily disabling `-Werror`.
+string (REPLACE "-Werror"
+		""
+		CMAKE_C_FLAGS
+		${CMAKE_C_FLAGS})
+
 check_symbol_exists (nftw "ftw.h" HAVE_NFTW)
+
+set (CMAKE_C_FLAGS ${CMAKE_C_FLAGS_OLD})
 cmake_pop_check_state ()
 
 if (HAVE_NFTW)

--- a/tests/cframework/CMakeLists.txt
+++ b/tests/cframework/CMakeLists.txt
@@ -2,7 +2,7 @@ include (CheckSymbolExists)
 include (LibAddMacros)
 include (CMakePushCheckState)
 
-# We need GNU_SOURCE and _XOEPN_SOURCE for full functinality
+# We need GNU_SOURCE and XOPEN_SOURCE for full functionality
 set (REQUIRED_FEATURE_MACROS -D_GNU_SOURCE -D_XOPEN_SOURCE=500 -D_DARWIN_C_SOURCE)
 add_definitions (${REQUIRED_FEATURE_MACROS})
 


### PR DESCRIPTION
# Description

Before this PR the command `kdb_runall` in the Travis build job `🍏 GCC` prints the following text:

```
CYPTO        TESTS
==================


crypto_gcrypt Results: 65 Tests done — 0 errors.
/Users/travis/build/sanssecours/elektra/tests/cframework/tests.c:542: error in clean_temp_home: Could not delete TMPHOME manually
--- running testmod_crypto_openssl ---


CYPTO        TESTS
==================


crypto_openssl Results: 65 Tests done — 0 errors.
/Users/travis/build/sanssecours/elektra/tests/cframework/tests.c:542: error in clean_temp_home: Could not delete TMPHOME manually
```

. After the PR the error messages are gone:

```
CYPTO        TESTS
==================


crypto_gcrypt Results: 65 Tests done — 0 errors.
--- running testmod_crypto_openssl ---


CYPTO        TESTS
==================


crypto_openssl Results: 65 Tests done — 0 errors.
```
.