### PR TITLE
Test: Exclude Ruby Instead of Semlock Plugin

### DIFF
--- a/doc/news/_preparation_next_release.md
+++ b/doc/news/_preparation_next_release.md
@@ -60,7 +60,7 @@ The following section lists news about the [modules](https://www.libelektra.org/
    to explicitly change a plugin's implementation if it shall be executed in an own
    process. This plugin is not completely finished yet, as currently there is no way
    for it to mimic the proxied plugin's contract in Elektra. It can be used with simple
-   plugins like `dump` however, check the limitations in the readme for more details.  *(Armin Wurzinger)*
+   plugins like `dump` however, check the limitations in the readme for more details. *(Armin Wurzinger)*
 
 ### gpgme
 

--- a/tests/kdb/testkdb_allplugins.cpp
+++ b/tests/kdb/testkdb_allplugins.cpp
@@ -33,9 +33,9 @@ std::vector<std::string> getAllPlugins ()
 	ModulesPluginDatabase mpd;
 	std::vector<std::string> plugins = mpd.listAllPlugins ();
 
-	// The JNI and Semlock plugins cause segmentation faults
+	// The JNI and Ruby plugins cause segmentation faults
 	plugins.erase (std::remove (plugins.begin (), plugins.end (), "jni"), plugins.end ());
-	plugins.erase (std::remove (plugins.begin (), plugins.end (), "semlock"), plugins.end ());
+	plugins.erase (std::remove (plugins.begin (), plugins.end (), "ruby"), plugins.end ());
 
 #ifdef ENABLE_ASAN
 	// ASAN reports memory leaks for the Augeas plugin on macOS: https://travis-ci.org/sanssecours/elektra/jobs/418524229


### PR DESCRIPTION
# Without Problematic Plugins

- [First Try](https://build.libelektra.org/jenkins/blue/organizations/jenkins/libelektra/detail/PR-2221/1/pipeline): 😊
- [Second Try](https://build.libelektra.org/jenkins/blue/organizations/jenkins/libelektra/detail/PR-2221/2/pipeline): 😊
- [Third Try](https://build.libelektra.org/jenkins/blue/organizations/jenkins/libelektra/detail/PR-2221/2/pipeline): 😊

# With Ruby Plugin

- [First Try](https://build.libelektra.org/jenkins/blue/organizations/jenkins/libelektra/detail/PR-2221/4/pipeline): 😊
- [Second Try](https://build.libelektra.org/jenkins/blue/organizations/jenkins/libelektra/detail/PR-2221/5/pipeline): 😊
- [Third Try](https://build.libelektra.org/jenkins/blue/organizations/jenkins/libelektra/detail/PR-2221/6/pipeline): 😭

# Without Ruby Plugin

- [First Try](https://build.libelektra.org/jenkins/blue/organizations/jenkins/libelektra/detail/PR-2221/7/pipeline): 😊
- [Second Try](https://build.libelektra.org/jenkins/blue/organizations/jenkins/libelektra/detail/PR-2221/8/pipeline): 😊
- [Third Try](https://build.libelektra.org/jenkins/blue/organizations/jenkins/libelektra/detail/PR-2221/9/pipeline): 😊
- [Fourth Try](https://build.libelektra.org/jenkins/blue/organizations/jenkins/libelektra/detail/PR-2221/10/pipeline): 😊
- [Fifth Try](https://build.libelektra.org/jenkins/blue/organizations/jenkins/libelektra/detail/PR-2221/11/pipeline): 😊
- [Sixth Try](https://build.libelektra.org/jenkins/blue/organizations/jenkins/libelektra/detail/PR-2221/12/pipeline): 😊
- [Seventh Try](https://build.libelektra.org/jenkins/blue/organizations/jenkins/libelektra/detail/PR-2221/13/pipeline): 😊
- [Eight Try](https://build.libelektra.org/jenkins/blue/organizations/jenkins/libelektra/detail/PR-2221/15/pipeline): 😊