### PR TITLE
group, hosts, passwd, shadow parser

### DIFF
--- a/src/error/specification
+++ b/src/error/specification
@@ -1258,3 +1258,9 @@ severity:warning
 ingroup:plugin
 module:gpgme
 macro:GPGME_INVALID_RECIPIENT
+
+number:201
+description:Failed to parse record
+severity:warning
+ingroup:plugin
+module:storage

--- a/src/libs/elektra/kdb.c
+++ b/src/libs/elektra/kdb.c
@@ -502,7 +502,7 @@ static int elektraGetCheckUpdateNeeded (Split * split, Key * parentKey)
  * @retval -1 on error
  * @retval 0 on success
  */
-static int elektraGetDoUpdate (Split * split, Key * parentKey)
+static int elektraGetDoUpdate (Split * split, Key * parentKey, Key * initialParent)
 {
 	const int bypassedSplits = 1;
 	for (size_t i = 0; i < split->size - bypassedSplits; i++)
@@ -514,6 +514,7 @@ static int elektraGetDoUpdate (Split * split, Key * parentKey)
 		}
 		Backend * backend = split->handles[i];
 		ksRewind (split->keysets[i]);
+		keySetMeta (parentKey, "fullPath", keyName (initialParent));
 		keySetName (parentKey, keyName (split->parents[i]));
 		keySetString (parentKey, keyString (split->parents[i]));
 
@@ -590,6 +591,7 @@ static int elektraGetDoUpdateWithGlobalHooks (KDB * handle, Split * split, KeySe
 		Backend * backend = split->handles[i];
 		ksRewind (split->keysets[i]);
 		keySetName (parentKey, keyName (split->parents[i]));
+		keySetMeta (parentKey, "fullPath", keyName (initialParent));
 		keySetString (parentKey, keyString (split->parents[i]));
 		int start, end;
 		if (run == FIRST)
@@ -869,7 +871,7 @@ int kdbGet (KDB * handle, KeySet * ks, Key * parentKey)
 		/* Now do the real updating,
 		   but not for bypassed keys in split->size-1 */
 		clearError (parentKey);
-		if (elektraGetDoUpdate (split, parentKey) == -1)
+		if (elektraGetDoUpdate (split, parentKey, initialParent) == -1)
 		{
 			goto error;
 		}

--- a/src/plugins/chosts/CMakeLists.txt
+++ b/src/plugins/chosts/CMakeLists.txt
@@ -1,0 +1,7 @@
+include (LibAddMacros)
+
+add_plugin (chosts
+	    SOURCES chosts.h
+		    chosts.c
+	    ADD_TEST
+	    TEST_README)

--- a/src/plugins/chosts/README.md
+++ b/src/plugins/chosts/README.md
@@ -1,0 +1,54 @@
+- infos = Information about the chosts plugin is in keys below
+- infos/author = Author Name <elektra@libelektra.org>
+- infos/licence = BSD
+- infos/needs =
+- infos/provides = storage/hosts
+- infos/recommends =
+- infos/placements = getstorage setstorage
+- infos/status = recommended productive maintained reviewed conformant compatible coverage specific unittest shelltest tested nodep libc configurable final preview memleak experimental difficult unfinished old nodoc concept orphan obsolete discouraged -1000000
+- infos/metadata =
+- infos/description = one-line description of chosts
+
+## Introduction
+
+Copy this chosts if you want to start a new
+plugin written in C.
+
+## Usage
+
+You can use `scripts/copy-chosts`
+to automatically rename everything to your
+plugin name:
+
+	cd src/plugins
+	../../scripts/copy-chosts yourplugin
+
+Then update the README.md of your newly created plugin:
+
+- enter your full name+email in `infos/author`
+- make sure `status`, `placements`, and other clauses conform to
+  descriptions in `doc/CONTRACT.ini`
+- update the one-line description above
+- add your plugin in `src/plugins/README.md`
+- and rewrite the rest of this `README.md` to give a great
+  explanation of what your plugin does
+
+## Dependencies
+
+None.
+
+## Examples
+
+```sh
+# Backup-and-Restore: user/tests/chosts
+
+kdb set user/tests/chosts/key value
+#> Create a new key user/tests/chosts/key with string "value"
+
+kdb get /tests/chosts/key
+#> value
+```
+
+## Limitations
+
+None.

--- a/src/plugins/chosts/chosts.c
+++ b/src/plugins/chosts/chosts.c
@@ -5,6 +5,7 @@
  *
  * @copyright BSD License (see LICENSE.md or https://www.libelektra.org)
  *
+ * some of the code is inspired by / taken from musl
  */
 
 #include "chosts.h"

--- a/src/plugins/chosts/chosts.c
+++ b/src/plugins/chosts/chosts.c
@@ -1,0 +1,270 @@
+/**
+ * @file
+ *
+ * @brief Source for chosts plugin
+ *
+ * @copyright BSD License (see LICENSE.md or https://www.libelektra.org)
+ *
+ */
+
+#include "chosts.h"
+#include <ctype.h>
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <kdberrors.h>
+#include <kdbhelper.h>
+
+#include "inet_XX.c"
+
+#include "../cpasswd/getline.c"
+
+static int getAddressFamily (const char * address)
+{
+	struct in_addr addr;
+	if (__inet_aton (address, &addr)) return AF_INET;
+	unsigned char buf[sizeof (struct in6_addr)];
+	int s = __inet_pton (AF_INET6, address, buf);
+	if (s <= 0)
+	{
+		if (s == 0)
+			return 0;
+		else
+			return -1;
+	}
+	else
+		return AF_INET6;
+}
+
+static char * parseLine (char * line, char ** endPtr)
+{
+	char * ptr = line;
+	*endPtr = NULL;
+	while (*ptr && isspace (*ptr))
+		++ptr;
+	if ((!*ptr)) return NULL;
+	char * startPtr = ptr;
+	while (*ptr && !isspace (*ptr))
+		++ptr;
+	if (*ptr) *ptr++ = '\0';
+	*endPtr = ptr;
+	return startPtr;
+}
+
+static struct hostent * strToHent (char * line)
+{
+	struct hostent * hent = elektraCalloc (sizeof (struct hostent));
+	char * endPtr;
+	char * ptr = parseLine (line, &endPtr);
+	int af = getAddressFamily (ptr);
+	if (af <= 0) goto fail;
+	hent->h_addrtype = af;
+	hent->h_length = af == AF_INET6 ? 16 : 4;
+	hent->h_addr_list = elektraMalloc (2 * sizeof (char *));
+	hent->h_addr_list[0] = ptr;
+	hent->h_addr_list[1] = NULL;
+	// skip spaces
+	char * canon = parseLine (endPtr, &endPtr);
+	if (!canon) goto fail;
+	hent->h_name = canon;
+	size_t aliasCount = 0;
+	if (endPtr && (*endPtr + 1 != '\0'))
+	{
+		ptr = parseLine (endPtr, &endPtr);
+		while (ptr)
+		{
+			++aliasCount;
+			size_t newLen = ((aliasCount + 1) * (sizeof (char *)));
+			elektraRealloc ((void **) &hent->h_aliases, newLen);
+			hent->h_aliases[aliasCount - 1] = ptr;
+			hent->h_aliases[aliasCount] = NULL;
+			ptr = parseLine (endPtr, &endPtr);
+		}
+	}
+	return hent;
+fail:
+	if (hent->h_addr_list) elektraFree (hent->h_addr_list);
+	if (hent->h_aliases) elektraFree (hent->h_aliases);
+	elektraFree (hent);
+	return NULL;
+}
+
+static inline void appendAddressFamily (Key * key, struct hostent * hent)
+{
+	switch (hent->h_addrtype)
+	{
+	case AF_INET:
+		keyAddBaseName (key, "ipv4");
+		break;
+	case AF_INET6:
+		keyAddBaseName (key, "ipv6");
+		break;
+	default:
+		break;
+	}
+}
+
+static inline void addAliases (KeySet * ks, Key * append, struct hostent * hent)
+{
+	for (size_t i = 0; hent->h_aliases && hent->h_aliases[i]; ++i)
+	{
+		keyAddBaseName (append, hent->h_aliases[i]);
+		keySetString (append, hent->h_addr_list[0]);
+		ksAppendKey (ks, keyDup (append));
+		keySetBaseName (append, 0);
+	}
+}
+
+static KeySet * hentToKS (struct hostent * hent, KeySet * returned, Key * parentKey, SortBy index)
+{
+	Key * append = keyNew (keyName (parentKey), KEY_END);
+	KeySet * ks = NULL;
+	if (index == NAME)
+	{
+		keyAddBaseName (append, hent->h_name);
+		Key * existingHost = ksLookup (returned, append, KDB_O_NONE);
+		if (existingHost)
+		{
+			keyDel (append);
+			append = keyNew (keyName (existingHost), KEY_END);
+			appendAddressFamily (append, hent);
+			keySetString (append, hent->h_addr_list[0]);
+			if (!ksLookup (returned, append, KDB_O_NONE))
+			{
+				ksAppendKey (returned, keyDup (append));
+			}
+			addAliases (returned, append, hent);
+		}
+		else
+		{
+			ks = ksNew (0, KS_END);
+			keySetBinary (append, 0, 0);
+			ksAppendKey (ks, keyDup (append));
+			appendAddressFamily (append, hent);
+			keySetString (append, hent->h_addr_list[0]);
+			ksAppendKey (ks, keyDup (append));
+			addAliases (ks, append, hent);
+		}
+	}
+	else
+	{
+		appendAddressFamily (append, hent);
+		keyAddBaseName (append, hent->h_addr_list[0]);
+		Key * existingHost = ksLookup (returned, append, KDB_O_NONE);
+		if (existingHost)
+		{
+			keyDel (append);
+			append = keyNew (keyName (existingHost), KEY_END);
+			keySetString (append, hent->h_addr_list[0]);
+			addAliases (returned, append, hent);
+		}
+		else
+		{
+			ks = ksNew (0, KS_END);
+			keySetString (append, hent->h_name);
+			ksAppendKey (ks, keyDup (append));
+			addAliases (ks, append, hent);
+		}
+	}
+	keyDel (append);
+	return ks;
+}
+
+int elektraChostsGet (Plugin * handle ELEKTRA_UNUSED, KeySet * returned, Key * parentKey)
+{
+	if (!elektraStrCmp (keyName (parentKey), "system/elektra/modules/chosts"))
+	{
+		KeySet * contract =
+			ksNew (30, keyNew ("system/elektra/modules/chosts", KEY_VALUE, "chosts plugin waits for your orders", KEY_END),
+			       keyNew ("system/elektra/modules/chosts/exports", KEY_END),
+			       keyNew ("system/elektra/modules/chosts/exports/get", KEY_FUNC, elektraChostsGet, KEY_END),
+			       keyNew ("system/elektra/modules/chosts/exports/set", KEY_FUNC, elektraChostsSet, KEY_END),
+#include ELEKTRA_README (chosts)
+			       keyNew ("system/elektra/modules/chosts/infos/version", KEY_VALUE, PLUGINVERSION, KEY_END), KS_END);
+		ksAppend (returned, contract);
+		ksDel (contract);
+
+		return ELEKTRA_PLUGIN_STATUS_SUCCESS;
+	}
+
+	SortBy index = NAME;
+	const Key * fullPathMeta = keyGetMeta (parentKey, "fullPath");
+	if (fullPathMeta)
+	{
+		size_t cmpLen = strlen (keyName (parentKey)) + strlen ("/byAddress") + 1;
+		char * comparePath = elektraMalloc (cmpLen);
+		snprintf (comparePath, cmpLen - 1, "%s/byAddress", keyName (parentKey));
+		if (!strncmp (comparePath, keyString (fullPathMeta), strlen (comparePath)))
+		{
+			keyAddBaseName (parentKey, "byAddress");
+			index = ADDRESS;
+		}
+		elektraFree (comparePath);
+	}
+	FILE * f = fopen (keyString (parentKey), "r");
+	if (!f)
+	{
+		ELEKTRA_SET_ERRORF (110, parentKey, "Failed to open %s for reading\n", keyString (parentKey));
+		return -1;
+	}
+	char * line = NULL;
+	size_t len = 0;
+	ssize_t l = 0;
+	ssize_t lineno = -1;
+	struct hostent * hent;
+	while ((l = __getline (&line, &len, f)) != -1)
+	{
+		++lineno;
+		line[l - 1] = '\0';
+		// drop comments
+		char * ptr;
+		if ((ptr = strchr (line, '#')) != NULL)
+		{
+			*ptr = '\0';
+			l = ptr - line + 1;
+		}
+		ptr = line;
+		while (*ptr && isspace (*ptr))
+			++ptr;
+		if (ptr == line + l - 1) // line contains only a comment or spaces, skip line
+			continue;
+		hent = strToHent (line);
+		if (!hent)
+		{
+			ELEKTRA_ADD_WARNINGF (201, parentKey, "Failed to parese line %ld: '%s'... of hosts file, skipping to next record\n",
+					      lineno, line);
+			continue;
+		}
+		KeySet * ks = hentToKS (hent, returned, parentKey, index);
+		if (ks)
+		{
+			ksAppend (returned, ks);
+			ksDel (ks);
+		}
+		if (hent->h_addr_list) elektraFree (hent->h_addr_list);
+		if (hent->h_aliases) elektraFree (hent->h_aliases);
+		elektraFree (hent);
+	}
+	elektraFree (line);
+	fclose (f);
+	return ELEKTRA_PLUGIN_STATUS_SUCCESS;
+}
+
+int elektraChostsSet (Plugin * handle ELEKTRA_UNUSED, KeySet * returned ELEKTRA_UNUSED, Key * parentKey ELEKTRA_UNUSED)
+{
+	// set all keys
+	// this function is optional
+
+	return ELEKTRA_PLUGIN_STATUS_NO_UPDATE;
+}
+
+Plugin * ELEKTRA_PLUGIN_EXPORT (chosts)
+{
+	// clang-format off
+    return elektraPluginExport ("chosts",
+            ELEKTRA_PLUGIN_GET,	&elektraChostsGet,
+            ELEKTRA_PLUGIN_SET,	&elektraChostsSet,
+            ELEKTRA_PLUGIN_END);
+}

--- a/src/plugins/chosts/chosts.h
+++ b/src/plugins/chosts/chosts.h
@@ -1,0 +1,57 @@
+/**
+ * @file
+ *
+ * @brief Header for chosts plugin
+ *
+ * @copyright BSD License (see LICENSE.md or https://www.libelektra.org)
+ *
+ */
+
+#ifndef ELEKTRA_PLUGIN_CHOSTS_H
+#define ELEKTRA_PLUGIN_CHOSTS_H
+
+#include <kdbplugin.h>
+#include <stdint.h>
+
+#define PF_INET 2
+#define PF_INET6 10
+#define AF_INET PF_INET
+#define AF_INET6 PF_INET6
+
+struct hostent
+{
+	char * h_name;       /* Official name of host.  */
+	char ** h_aliases;   /* Alias list.  */
+	int h_addrtype;      /* Host address type.  */
+	int h_length;	/* Length of address.  */
+	char ** h_addr_list; /* List of addresses from name server.  */
+};
+
+typedef uint32_t in_addr_t;
+struct in_addr
+{
+	in_addr_t s_addr;
+};
+
+struct in6_addr
+{
+	union
+	{
+		uint8_t __s6_addr[16];
+		uint16_t __s6_addr16[8];
+		uint32_t __s6_addr32[4];
+	} __in6_union;
+};
+
+typedef enum
+{
+	NAME,
+	ADDRESS,
+} SortBy;
+
+int elektraChostsGet (Plugin * handle, KeySet * ks, Key * parentKey);
+int elektraChostsSet (Plugin * handle, KeySet * ks, Key * parentKey);
+
+Plugin * ELEKTRA_PLUGIN_EXPORT (chosts);
+
+#endif

--- a/src/plugins/chosts/inet_XX.c
+++ b/src/plugins/chosts/inet_XX.c
@@ -1,0 +1,115 @@
+// stolen from musl
+
+
+static int hexval (unsigned c)
+{
+	if (c - '0' < 10) return c - '0';
+	c |= 32;
+	if (c - 'a' < 6) return c - 'a' + 10;
+	return -1;
+}
+
+static int __inet_pton (int af, const char * restrict s, void * restrict a0)
+{
+	uint16_t ip[8];
+	unsigned char * a = a0;
+	int i, j, v, d, brk = -1, need_v4 = 0;
+
+	if (af == AF_INET)
+	{
+		for (i = 0; i < 4; i++)
+		{
+			for (v = j = 0; j < 3 && isdigit (s[j]); j++)
+				v = 10 * v + s[j] - '0';
+			if (j == 0 || (j > 1 && s[0] == '0') || v > 255) return 0;
+			a[i] = v;
+			if (s[j] == 0 && i == 3) return 1;
+			if (s[j] != '.') return 0;
+			s += j + 1;
+		}
+		return 0;
+	}
+	else if (af != AF_INET6)
+	{
+		errno = EAFNOSUPPORT;
+		return -1;
+	}
+
+	if (*s == ':' && *++s != ':') return 0;
+
+	for (i = 0;; i++)
+	{
+		if (s[0] == ':' && brk < 0)
+		{
+			brk = i;
+			ip[i & 7] = 0;
+			if (!*++s) break;
+			if (i == 7) return 0;
+			continue;
+		}
+		for (v = j = 0; j < 4 && (d = hexval (s[j])) >= 0; j++)
+			v = 16 * v + d;
+		if (j == 0) return 0;
+		ip[i & 7] = v;
+		if (!s[j] && (brk >= 0 || i == 7)) break;
+		if (i == 7) return 0;
+		if (s[j] != ':')
+		{
+			if (s[j] != '.' || (i < 6 && brk < 0)) return 0;
+			need_v4 = 1;
+			i++;
+			break;
+		}
+		s += j + 1;
+	}
+	if (brk >= 0)
+	{
+		memmove (ip + brk + 7 - i, ip + brk, 2 * (i + 1 - brk));
+		for (j = 0; j < 7 - i; j++)
+			ip[brk + j] = 0;
+	}
+	for (j = 0; j < 8; j++)
+	{
+		*a++ = ip[j] >> 8;
+		*a++ = ip[j];
+	}
+	if (need_v4 && __inet_pton (AF_INET, (void *) s, a - 4) <= 0) return 0;
+	return 1;
+}
+
+
+static int __inet_aton (const char * s0, struct in_addr * dest)
+{
+	const char * s = s0;
+	unsigned char * d = (void *) dest;
+	unsigned long a[4] = { 0 };
+	char * z;
+	int i;
+
+	for (i = 0; i < 4; i++)
+	{
+		a[i] = strtoul (s, &z, 0);
+		if (z == s || (*z && *z != '.') || !isdigit (*s)) return 0;
+		if (!*z) break;
+		s = z + 1;
+	}
+	if (i == 4) return 0;
+	switch (i)
+	{
+	case 0:
+		a[1] = a[0] & 0xffffff;
+		a[0] >>= 24;
+	case 1:
+		a[2] = a[1] & 0xffff;
+		a[1] >>= 16;
+	case 2:
+		a[3] = a[2] & 0xff;
+		a[2] >>= 8;
+	}
+	for (i = 0; i < 4; i++)
+	{
+		if (a[i] > 255) return 0;
+		d[i] = a[i];
+	}
+	return 1;
+}

--- a/src/plugins/chosts/testmod_chosts.c
+++ b/src/plugins/chosts/testmod_chosts.c
@@ -1,0 +1,28 @@
+/**
+ * @file
+ *
+ * @brief Tests for chosts plugin
+ *
+ * @copyright BSD License (see LICENSE.md or https://www.libelektra.org)
+ *
+ */
+
+#include <stdlib.h>
+#include <string.h>
+
+#include <kdbconfig.h>
+
+#include <tests_plugin.h>
+
+int main (int argc, char ** argv)
+{
+	printf ("CHOSTS     TESTS\n");
+	printf ("==================\n\n");
+
+	init (argc, argv);
+
+
+	print_result ("testmod_chosts");
+
+	return nbError;
+}

--- a/src/plugins/cpasswd/CMakeLists.txt
+++ b/src/plugins/cpasswd/CMakeLists.txt
@@ -1,0 +1,7 @@
+include (LibAddMacros)
+
+add_plugin (cpasswd
+	    SOURCES cpasswd.h
+		    cpasswd.c
+	    ADD_TEST
+	    TEST_README)

--- a/src/plugins/cpasswd/README.md
+++ b/src/plugins/cpasswd/README.md
@@ -1,0 +1,54 @@
+- infos = Information about the cpasswd plugin is in keys below
+- infos/author = Author Name <elektra@libelektra.org>
+- infos/licence = BSD
+- infos/needs =
+- infos/provides = storage/passwd
+- infos/recommends =
+- infos/placements = getstorage  setstorage
+- infos/status = recommended productive maintained reviewed conformant compatible coverage specific unittest shelltest tested nodep libc configurable final preview memleak experimental difficult unfinished old nodoc concept orphan obsolete discouraged -1000000
+- infos/metadata =
+- infos/description = one-line description of cpasswd
+
+## Introduction
+
+Copy this cpasswd if you want to start a new
+plugin written in C.
+
+## Usage
+
+You can use `scripts/copy-cpasswd`
+to automatically rename everything to your
+plugin name:
+
+	cd src/plugins
+	../../scripts/copy-cpasswd yourplugin
+
+Then update the README.md of your newly created plugin:
+
+- enter your full name+email in `infos/author`
+- make sure `status`, `placements`, and other clauses conform to
+  descriptions in `doc/CONTRACT.ini`
+- update the one-line description above
+- add your plugin in `src/plugins/README.md`
+- and rewrite the rest of this `README.md` to give a great
+  explanation of what your plugin does
+
+## Dependencies
+
+None.
+
+## Examples
+
+```sh
+# Backup-and-Restore: user/tests/cpasswd
+
+kdb set user/tests/cpasswd/key value
+#> Create a new key user/tests/cpasswd/key with string "value"
+
+kdb get /tests/cpasswd/key
+#> value
+```
+
+## Limitations
+
+None.

--- a/src/plugins/cpasswd/cpasswd.c
+++ b/src/plugins/cpasswd/cpasswd.c
@@ -1,0 +1,205 @@
+/**
+ * @file
+ *
+ * @brief Source for cpasswd plugin
+ *
+ * @copyright BSD License (see LICENSE.md or https://www.libelektra.org)
+ *
+ */
+
+#include "cpasswd.h"
+
+#include <kdberrors.h>
+#include <kdbhelper.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "getline.c"
+
+static struct passwd * strToPasswd (char * line)
+{
+	struct passwd * pwd = elektraMalloc (sizeof (struct passwd));
+	char * s = line;
+	pwd->pw_name = s++;
+	if (!(s = strchr (s, ':'))) goto fail;
+	*s++ = 0;
+	pwd->pw_passwd = s;
+	if (!(s = strchr (s, ':'))) goto fail;
+	*s++ = 0;
+	pwd->pw_uid = s;
+	if (!(s = strchr (s, ':'))) goto fail;
+	*s++ = 0;
+	pwd->pw_gid = s;
+	if (!(s = strchr (s, ':'))) goto fail;
+	*s++ = 0;
+	pwd->pw_gecos = s;
+	if (!(s = strchr (s, ':'))) goto fail;
+	*s++ = 0;
+	pwd->pw_dir = s;
+	if (!(s = strchr (s, ':'))) goto fail;
+	*s++ = 0;
+	pwd->pw_shell = s;
+	return pwd;
+fail:
+	elektraFree (pwd);
+	return NULL;
+}
+
+static KeySet * pwentToKS (struct passwd * pwd, Key * parentKey, SortBy index)
+{
+	const char * keys[PASSWD_FIELDS] = {
+		"uid", "gid", "name", "passwd", "gecos", "home", "shell",
+	};
+	void * fields[PASSWD_FIELDS] = {
+		pwd->pw_uid, pwd->pw_gid, pwd->pw_name, pwd->pw_passwd, pwd->pw_gecos, pwd->pw_dir, pwd->pw_shell,
+	};
+	KeySet * ks = ksNew (0, KS_END);
+	Key * append = keyNew (keyName (parentKey), KEY_END);
+	if (index == UID)
+		keyAddBaseName (append, pwd->pw_uid);
+	else
+		keyAddBaseName (append, pwd->pw_name);
+	keySetBinary (append, 0, 0);
+	ksAppendKey (ks, keyDup (append));
+	for (int i = 0; i < PASSWD_FIELDS; ++i)
+	{
+		keyAddBaseName (append, keys[i]);
+		keySetString (append, fields[i]);
+		ksAppendKey (ks, keyDup (append));
+		keySetString (append, 0);
+		keySetBaseName (append, 0);
+	}
+	keyDel (append);
+	return ks;
+}
+
+int elektraCpasswdGet (Plugin * handle ELEKTRA_UNUSED, KeySet * returned, Key * parentKey)
+{
+	if (!elektraStrCmp (keyName (parentKey), "system/elektra/modules/cpasswd"))
+	{
+		KeySet * contract =
+			ksNew (30, keyNew ("system/elektra/modules/cpasswd", KEY_VALUE, "cpasswd plugin waits for your orders", KEY_END),
+			       keyNew ("system/elektra/modules/cpasswd/exports", KEY_END),
+			       keyNew ("system/elektra/modules/cpasswd/exports/get", KEY_FUNC, elektraCpasswdGet, KEY_END),
+			       keyNew ("system/elektra/modules/cpasswd/exports/set", KEY_FUNC, elektraCpasswdSet, KEY_END),
+#include ELEKTRA_README (cpasswd)
+			       keyNew ("system/elektra/modules/cpasswd/infos/version", KEY_VALUE, PLUGINVERSION, KEY_END), KS_END);
+		ksAppend (returned, contract);
+		ksDel (contract);
+		return ELEKTRA_PLUGIN_STATUS_SUCCESS;
+	}
+
+	SortBy index = UID;
+	const Key * fullPathMeta = keyGetMeta (parentKey, "fullPath");
+	if (fullPathMeta)
+	{
+		size_t cmpLen = strlen (keyName (parentKey)) + strlen ("/byName") + 1;
+		char * comparePath = elektraMalloc (cmpLen);
+		snprintf (comparePath, cmpLen - 1, "%s/byName", keyName (parentKey));
+		if (!strncmp (comparePath, keyString (fullPathMeta), strlen (comparePath)))
+		{
+			keyAddBaseName (parentKey, "byName");
+			index = NAME;
+		}
+		elektraFree (comparePath);
+	}
+	FILE * f = fopen (keyString (parentKey), "r");
+	if (!f)
+	{
+		ELEKTRA_SET_ERRORF (110, parentKey, "Failed to open %s for reading\n", keyString (parentKey));
+		return -1;
+	}
+	char * line = NULL;
+	size_t len = 0;
+	ssize_t l = 0;
+	struct passwd * pwd;
+	size_t lineno = 0;
+	while ((l = __getline (&line, &len, f)) != -1)
+	{
+		line[l - 1] = '\0';
+		pwd = strToPasswd (line);
+		if (!pwd)
+		{
+			ELEKTRA_ADD_WARNINGF (201, parentKey, "Failed to parse line %ld: '%s'... of passwd file, skipping to next line\n",
+					      lineno, line);
+			++lineno;
+			continue;
+		}
+		++lineno;
+		KeySet * ks = pwentToKS (pwd, parentKey, index);
+		ksAppend (returned, ks);
+		ksDel (ks);
+		elektraFree (pwd);
+	}
+	elektraFree (line);
+	fclose (f);
+	return ELEKTRA_PLUGIN_STATUS_SUCCESS;
+}
+
+static int writeKS (FILE * f, const Key * key, KeySet * ks)
+{
+	const char * keys[PASSWD_FIELDS] = {
+		"uid", "gid", "name", "passwd", "gecos", "home", "shell",
+	};
+	struct passwd * pw = elektraMalloc (sizeof (struct passwd));
+	void * fields[PASSWD_FIELDS] = {
+		&pw->pw_uid, &pw->pw_gid, &pw->pw_name, &pw->pw_passwd, &pw->pw_gecos, &pw->pw_dir, &pw->pw_shell,
+	};
+	Key * searchKey = keyNew (keyName (key), KEY_END);
+	int rv = 1;
+	for (int i = 0; i < PASSWD_FIELDS; ++i)
+	{
+		keyAddBaseName (searchKey, keys[i]);
+		Key * lookup = ksLookup (ks, searchKey, KDB_O_NONE);
+		*(char **) (fields[i]) = (char *) (keyString (lookup));
+		keySetBaseName (searchKey, 0);
+	}
+	rv = fprintf (f, "%s:%s:%s:%s:%s:%s:%s\n", pw->pw_name, pw->pw_passwd, pw->pw_uid, pw->pw_gid, pw->pw_gecos, pw->pw_dir,
+		      pw->pw_shell);
+	if (rv < 0)
+		rv = -1;
+	else if (rv > 0)
+		rv = 1;
+	keyDel (searchKey);
+	elektraFree (pw);
+	return rv;
+}
+
+int elektraCpasswdSet (Plugin * handle ELEKTRA_UNUSED, KeySet * returned, Key * parentKey)
+{
+	const Key * fullPathMeta = keyGetMeta (parentKey, "fullPath");
+	if (fullPathMeta)
+	{
+		size_t cmpLen = strlen (keyName (parentKey)) + strlen ("/byName") + 1;
+		char * comparePath = elektraMalloc (cmpLen);
+		snprintf (comparePath, cmpLen - 1, "%s/byName", keyName (parentKey));
+		if (!strncmp (comparePath, keyString (fullPathMeta), strlen (comparePath))) keyAddBaseName (parentKey, "byName");
+		elektraFree (comparePath);
+	}
+	Key * cur;
+	ksRewind (returned);
+	FILE * f = fopen (keyString (parentKey), "w");
+	if (!f)
+	{
+		ELEKTRA_SET_ERRORF (75, parentKey, "Failed to open %s for writing\n", keyString (parentKey));
+		return -1;
+	}
+	int rv = 1;
+	while ((cur = ksNext (returned)) != NULL)
+	{
+		if (keyIsDirectBelow (parentKey, cur) != 1) continue;
+		rv = writeKS (f, cur, returned);
+		if (rv == -1) break;
+	}
+	fclose (f);
+	return rv;
+}
+
+Plugin * ELEKTRA_PLUGIN_EXPORT (cpasswd)
+{
+	// clang-format off
+    return elektraPluginExport ("cpasswd",
+            ELEKTRA_PLUGIN_GET,	&elektraCpasswdGet,
+            ELEKTRA_PLUGIN_SET,	&elektraCpasswdSet,
+            ELEKTRA_PLUGIN_END);
+}

--- a/src/plugins/cpasswd/cpasswd.c
+++ b/src/plugins/cpasswd/cpasswd.c
@@ -5,6 +5,7 @@
  *
  * @copyright BSD License (see LICENSE.md or https://www.libelektra.org)
  *
+ * some of the code is inspired by / taken from musl
  */
 
 #include "cpasswd.h"

--- a/src/plugins/cpasswd/cpasswd.h
+++ b/src/plugins/cpasswd/cpasswd.h
@@ -1,0 +1,40 @@
+/**
+ * @file
+ *
+ * @brief Header for cpasswd plugin
+ *
+ * @copyright BSD License (see LICENSE.md or https://www.libelektra.org)
+ *
+ */
+
+#ifndef ELEKTRA_PLUGIN_CPASSWD_H
+#define ELEKTRA_PLUGIN_CPASSWD_H
+
+#include <kdbplugin.h>
+
+#define PASSWD_FIELDS 7
+#define ID_MAX_CHARACTERS 11
+
+struct passwd
+{
+	char * pw_name;   /* Username.  */
+	char * pw_passwd; /* Password.  */
+	char * pw_uid;    /* User ID.  */
+	char * pw_gid;    /* Group ID.  */
+	char * pw_gecos;  /* Real name.  */
+	char * pw_dir;    /* Home directory.  */
+	char * pw_shell;  /* Shell program.  */
+};
+
+typedef enum
+{
+	NAME,
+	UID,
+} SortBy;
+
+int elektraCpasswdGet (Plugin * handle, KeySet * ks, Key * parentKey);
+int elektraCpasswdSet (Plugin * handle, KeySet * ks, Key * parentKey);
+
+Plugin * ELEKTRA_PLUGIN_EXPORT (cpasswd);
+
+#endif

--- a/src/plugins/cpasswd/getline.c
+++ b/src/plugins/cpasswd/getline.c
@@ -1,0 +1,45 @@
+// Freebsd getline.c
+
+
+static ssize_t ____getdelim (char ** buf, size_t * bufsiz, int delimiter, FILE * fp)
+{
+	char *ptr, *eptr;
+
+
+	if (*buf == NULL || *bufsiz == 0)
+	{
+		*bufsiz = BUFSIZ;
+		if ((*buf = elektraMalloc (*bufsiz)) == NULL) return -1;
+	}
+
+	for (ptr = *buf, eptr = *buf + *bufsiz;;)
+	{
+		int c = fgetc (fp);
+		if (c == -1)
+		{
+			if (feof (fp))
+				return ptr == *buf ? -1 : ptr - *buf;
+			else
+				return -1;
+		}
+		*ptr++ = c;
+		if (c == delimiter)
+		{
+			*ptr = '\0';
+			return ptr - *buf;
+		}
+		if (ptr + 2 >= eptr)
+		{
+			size_t nbufsiz = *bufsiz * 2;
+			ssize_t d = ptr - *buf;
+			if (elektraRealloc ((void **) buf, nbufsiz) < 0) return -1;
+			*bufsiz = nbufsiz;
+			eptr = *buf + nbufsiz;
+			ptr = *buf + d;
+		}
+	}
+}
+static ssize_t __getline (char ** buf, size_t * bufsiz, FILE * fp)
+{
+	return ____getdelim (buf, bufsiz, '\n', fp);
+}

--- a/src/plugins/cpasswd/testmod_cpasswd.c
+++ b/src/plugins/cpasswd/testmod_cpasswd.c
@@ -1,0 +1,27 @@
+/**
+ * @file
+ *
+ * @brief Tests for cpasswd plugin
+ *
+ * @copyright BSD License (see LICENSE.md or https://www.libelektra.org)
+ *
+ */
+
+#include <stdlib.h>
+#include <string.h>
+
+#include <kdbconfig.h>
+
+#include <tests_plugin.h>
+
+int main (int argc, char ** argv)
+{
+	printf ("CPASSWD     TESTS\n");
+	printf ("==================\n\n");
+
+	init (argc, argv);
+
+	print_result ("testmod_cpasswd");
+
+	return nbError;
+}

--- a/src/plugins/group/CMakeLists.txt
+++ b/src/plugins/group/CMakeLists.txt
@@ -1,0 +1,8 @@
+include (LibAddMacros)
+
+add_plugin (group
+	    SOURCES group.h
+		    group.c
+        LINK_ELEKTRA elektra-ease
+	    ADD_TEST
+	    TEST_README)

--- a/src/plugins/group/README.md
+++ b/src/plugins/group/README.md
@@ -1,0 +1,54 @@
+- infos = Information about the group plugin is in keys below
+- infos/author = Author Name <elektra@libelektra.org>
+- infos/licence = BSD
+- infos/needs =
+- infos/provides = storage/group
+- infos/recommends =
+- infos/placements = getstorage setstorage
+- infos/status = recommended productive maintained reviewed conformant compatible coverage specific unittest shelltest tested nodep libc configurable final preview memleak experimental difficult unfinished old nodoc concept orphan obsolete discouraged -1000000
+- infos/metadata =
+- infos/description = one-line description of group
+
+## Introduction
+
+Copy this group if you want to start a new
+plugin written in C.
+
+## Usage
+
+You can use `scripts/copy-group`
+to automatically rename everything to your
+plugin name:
+
+	cd src/plugins
+	../../scripts/copy-group yourplugin
+
+Then update the README.md of your newly created plugin:
+
+- enter your full name+email in `infos/author`
+- make sure `status`, `placements`, and other clauses conform to
+  descriptions in `doc/CONTRACT.ini`
+- update the one-line description above
+- add your plugin in `src/plugins/README.md`
+- and rewrite the rest of this `README.md` to give a great
+  explanation of what your plugin does
+
+## Dependencies
+
+None.
+
+## Examples
+
+```sh
+# Backup-and-Restore: user/tests/group
+
+kdb set user/tests/group/key value
+#> Create a new key user/tests/group/key with string "value"
+
+kdb get /tests/group/key
+#> value
+```
+
+## Limitations
+
+None.

--- a/src/plugins/group/group.c
+++ b/src/plugins/group/group.c
@@ -70,8 +70,8 @@ static KeySet * grpentToKS (struct group * grp, Key * parentKey, SortBy index)
 	}
 
 	Key * membersKey = keyNew (keyName (append), KEY_END);
-	keySetBaseName (membersKey, "members");
-	keySetBaseName (append, "members");
+	keyAddBaseName (membersKey, "members");
+	keyAddBaseName (append, "members");
 	keyAddBaseName (append, "#");
 	char * ptr = (char *) grp->gr_mem;
 	while (*ptr != '\0')

--- a/src/plugins/group/group.c
+++ b/src/plugins/group/group.c
@@ -5,6 +5,7 @@
  *
  * @copyright BSD License (see LICENSE.md or https://www.libelektra.org)
  *
+ * some of the code is inspired by / taken from musl
  */
 
 #include "group.h"

--- a/src/plugins/group/group.c
+++ b/src/plugins/group/group.c
@@ -1,0 +1,266 @@
+/**
+ * @file
+ *
+ * @brief Source for group plugin
+ *
+ * @copyright BSD License (see LICENSE.md or https://www.libelektra.org)
+ *
+ */
+
+#include "group.h"
+#include <kdbease.h>
+#include <kdberrors.h>
+#include <kdbhelper.h>
+#include <stddef.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/types.h>
+
+#include "../cpasswd/getline.c"
+
+static struct group * strToGroup (char * line)
+{
+	struct group * grp = elektraCalloc (sizeof (struct group));
+	char * s = line;
+	grp->gr_name = s++;
+	if (!(s = strchr (s, ':'))) goto cleanup;
+	*s++ = 0;
+	grp->gr_passwd = s;
+	if (!(s = strchr (s, ':'))) goto cleanup;
+	*s++ = 0;
+	grp->gr_gid = s;
+	if (!(s = strchr (s, ':'))) goto cleanup;
+	*s++ = 0;
+	grp->gr_mem = (char **) s;
+	return grp;
+cleanup:
+	elektraFree (grp);
+	return NULL;
+}
+
+static KeySet * grpentToKS (struct group * grp, Key * parentKey, SortBy index)
+{
+	KeySet * ks = ksNew (0, KS_END);
+	Key * append = keyNew (keyName (parentKey), KEY_END);
+	if (index == GID)
+		keyAddBaseName (append, grp->gr_gid);
+	else
+		keyAddBaseName (append, grp->gr_name);
+	keySetBinary (append, 0, 0);
+	ksAppendKey (ks, keyDup (append));
+
+	const char * keys[GROUP_FIELDS] = {
+		"name",
+		"gid",
+		"passwd",
+	};
+	void * fields[GROUP_FIELDS] = {
+		grp->gr_name,
+		grp->gr_gid,
+		grp->gr_passwd,
+	};
+	for (int i = 0; i < GROUP_FIELDS; ++i)
+	{
+		keyAddBaseName (append, keys[i]);
+		keySetString (append, fields[i]);
+		ksAppendKey (ks, keyDup (append));
+		keySetString (append, 0);
+		keySetBaseName (append, 0);
+	}
+
+	Key * membersKey = keyNew (keyName (append), KEY_END);
+	keySetBaseName (membersKey, "members");
+	keySetBaseName (append, "members");
+	keyAddBaseName (append, "#");
+	char * ptr = (char *) grp->gr_mem;
+	while (*ptr != '\0')
+	{
+		char * s = ptr;
+		while (*ptr)
+		{
+			++(ptr);
+			if (*ptr == ',') break;
+		}
+		if (*ptr == ',')
+		{
+			*ptr = '\0';
+			if (elektraArrayIncName (append) == -1) break;
+			Key * memKey = keyDup (append);
+			keySetString (memKey, s);
+			ksAppendKey (ks, memKey);
+			keySetString (membersKey, keyBaseName (append));
+			++(ptr);
+		}
+		else if (*ptr == '\0' && ptr > s)
+		{
+			if (elektraArrayIncName (append) == -1) break;
+			Key * memKey = keyDup (append);
+			keySetString (memKey, s);
+			ksAppendKey (ks, memKey);
+			keySetString (membersKey, keyBaseName (append));
+			break;
+		}
+		else
+			break;
+	}
+	ksAppendKey (ks, membersKey);
+	keyDel (append);
+	return ks;
+}
+
+int elektraGroupGet (Plugin * handle ELEKTRA_UNUSED, KeySet * returned, Key * parentKey)
+{
+	if (!elektraStrCmp (keyName (parentKey), "system/elektra/modules/group"))
+	{
+		KeySet * contract =
+			ksNew (30, keyNew ("system/elektra/modules/group", KEY_VALUE, "group plugin waits for your orders", KEY_END),
+			       keyNew ("system/elektra/modules/group/exports", KEY_END),
+			       keyNew ("system/elektra/modules/group/exports/get", KEY_FUNC, elektraGroupGet, KEY_END),
+			       keyNew ("system/elektra/modules/group/exports/set", KEY_FUNC, elektraGroupSet, KEY_END),
+#include ELEKTRA_README (group)
+			       keyNew ("system/elektra/modules/group/infos/version", KEY_VALUE, PLUGINVERSION, KEY_END), KS_END);
+		ksAppend (returned, contract);
+		ksDel (contract);
+		return ELEKTRA_PLUGIN_STATUS_SUCCESS;
+	}
+
+	SortBy index = GID;
+	const Key * fullPathMeta = keyGetMeta (parentKey, "fullPath");
+	if (fullPathMeta)
+	{
+		size_t cmpLen = strlen (keyName (parentKey)) + strlen ("/byName") + 1;
+		char * comparePath = elektraMalloc (cmpLen);
+		snprintf (comparePath, cmpLen - 1, "%s/byName", keyName (parentKey));
+		if (!strncmp (comparePath, keyString (fullPathMeta), strlen (comparePath)))
+		{
+			keyAddBaseName (parentKey, "byName");
+			index = NAME;
+		}
+		elektraFree (comparePath);
+	}
+
+	FILE * f = fopen (keyString (parentKey), "r");
+	if (!f)
+	{
+		ELEKTRA_SET_ERRORF (110, parentKey, "Failed to open %s for reading\n", keyString (parentKey));
+		return -1;
+	}
+	char * line = NULL;
+	size_t len = 0;
+	ssize_t l = 0;
+	struct group * grp;
+	size_t lineno = 0;
+	while ((l = __getline (&line, &len, f)) != -1)
+	{
+		line[l - 1] = '\0';
+		grp = strToGroup (line);
+		if (!grp)
+		{
+			ELEKTRA_ADD_WARNINGF (201, parentKey, "Failed to parse line %ld '%s'... of group file, skipping to next line\n",
+					      lineno, line);
+			++lineno;
+			continue;
+		}
+		++lineno;
+		KeySet * ks = grpentToKS (grp, parentKey, index);
+		ksAppend (returned, ks);
+		ksDel (ks);
+		elektraFree (grp);
+	}
+	elektraFree (line);
+	fclose (f);
+	return ELEKTRA_PLUGIN_STATUS_SUCCESS;
+}
+
+static int writeKS (FILE * f, const Key * key, KeySet * ks)
+{
+	Key * searchKey = keyNew (keyName (key), KEY_END);
+	struct group * grp = elektraMalloc (sizeof (struct group));
+	keyAddBaseName (searchKey, "gid");
+	Key * lookup = ksLookup (ks, searchKey, KDB_O_NONE);
+	grp->gr_gid = (char *) keyString (lookup);
+	keySetBaseName (searchKey, "name");
+	lookup = ksLookup (ks, searchKey, KDB_O_NONE);
+	grp->gr_name = (char *) keyString (lookup);
+	keySetBaseName (searchKey, "passwd");
+	lookup = ksLookup (ks, searchKey, KDB_O_NONE);
+	grp->gr_passwd = (char *) keyString (lookup);
+	keySetBaseName (searchKey, "members");
+	int rv = 0;
+	rv = fprintf (f, "%s:%s:%s:", grp->gr_name, grp->gr_passwd, grp->gr_gid);
+	if (rv < 0) goto cleanuponfail;
+	lookup = ksLookup (ks, searchKey, KDB_O_NONE);
+	if (keyString (lookup)[0] == '#')
+	{
+		KeySet * cutKS = ksCut (ks, lookup);
+		ksRewind (cutKS);
+		Key * cur;
+		char delim[2] = "";
+		while ((cur = ksNext (cutKS)) != NULL)
+		{
+			if (!keyCmp (lookup, cur)) continue;
+			rv = fprintf (f, "%s%s", delim, keyString (cur));
+			if (rv < 0)
+			{
+				ksAppend (ks, cutKS);
+				ksDel (cutKS);
+				goto cleanuponfail;
+			}
+			strncpy (delim, ",", 2);
+		}
+		ksAppend (ks, cutKS);
+		ksDel (cutKS);
+	}
+	fprintf (f, "\n");
+	keyDel (searchKey);
+	elektraFree (grp);
+	return 1;
+
+cleanuponfail:
+	keyDel (searchKey);
+	elektraFree (grp);
+	return -1;
+}
+
+int elektraGroupSet (Plugin * handle ELEKTRA_UNUSED, KeySet * returned, Key * parentKey)
+{
+
+	const Key * fullPathMeta = keyGetMeta (parentKey, "fullPath");
+	if (fullPathMeta)
+	{
+		size_t cmpLen = strlen (keyName (parentKey)) + strlen ("/byName") + 1;
+		char * comparePath = elektraMalloc (cmpLen);
+		snprintf (comparePath, cmpLen - 1, "%s/byName", keyName (parentKey));
+		if (!strncmp (comparePath, keyString (fullPathMeta), strlen (comparePath)))
+		{
+			keyAddBaseName (parentKey, "byName");
+		}
+		elektraFree (comparePath);
+	}
+	Key * cur;
+	ksRewind (returned);
+	FILE * f = fopen (keyString (parentKey), "w");
+	if (!f)
+	{
+		ELEKTRA_SET_ERRORF (75, parentKey, "Failed to open %s for writing\n", keyString (parentKey));
+		return -1;
+	}
+	int rv = 1;
+	while ((cur = ksNext (returned)) != NULL)
+	{
+		if (keyIsDirectBelow (parentKey, cur) != 1) continue;
+		rv = writeKS (f, cur, returned);
+		if (rv == -1) break;
+	}
+	fclose (f);
+	return rv;
+}
+
+Plugin * ELEKTRA_PLUGIN_EXPORT (group)
+{
+	// clang-format off
+    return elektraPluginExport ("group",
+            ELEKTRA_PLUGIN_GET,	&elektraGroupGet,
+            ELEKTRA_PLUGIN_SET,	&elektraGroupSet,
+            ELEKTRA_PLUGIN_END);
+}

--- a/src/plugins/group/group.h
+++ b/src/plugins/group/group.h
@@ -1,0 +1,38 @@
+/**
+ * @file
+ *
+ * @brief Header for group plugin
+ *
+ * @copyright BSD License (see LICENSE.md or https://www.libelektra.org)
+ *
+ */
+
+#ifndef ELEKTRA_PLUGIN_GROUP_H
+#define ELEKTRA_PLUGIN_GROUP_H
+
+#include <kdbplugin.h>
+
+#define ID_MAX_CHARACTERS 11
+#define GROUP_FIELDS 3
+
+struct group
+{
+	char * gr_name;   /* Group name.	*/
+	char * gr_passwd; /* Password.	*/
+	char * gr_gid;    /* Group ID.	*/
+	char ** gr_mem;   /* Member list.	*/
+};
+
+typedef enum
+{
+	NAME,
+	GID,
+} SortBy;
+
+
+int elektraGroupGet (Plugin * handle, KeySet * ks, Key * parentKey);
+int elektraGroupSet (Plugin * handle, KeySet * ks, Key * parentKey);
+
+Plugin * ELEKTRA_PLUGIN_EXPORT (group);
+
+#endif

--- a/src/plugins/group/testmod_group.c
+++ b/src/plugins/group/testmod_group.c
@@ -1,0 +1,28 @@
+/**
+ * @file
+ *
+ * @brief Tests for group plugin
+ *
+ * @copyright BSD License (see LICENSE.md or https://www.libelektra.org)
+ *
+ */
+
+#include <stdlib.h>
+#include <string.h>
+
+#include <kdbconfig.h>
+
+#include <tests_plugin.h>
+
+
+int main (int argc, char ** argv)
+{
+	printf ("GROUP     TESTS\n");
+	printf ("==================\n\n");
+
+	init (argc, argv);
+
+	print_result ("testmod_group");
+
+	return nbError;
+}

--- a/src/plugins/shadow/CMakeLists.txt
+++ b/src/plugins/shadow/CMakeLists.txt
@@ -1,0 +1,7 @@
+include (LibAddMacros)
+
+add_plugin (shadow
+	    SOURCES shadow.h
+		    shadow.c
+	    ADD_TEST
+	    TEST_README)

--- a/src/plugins/shadow/README.md
+++ b/src/plugins/shadow/README.md
@@ -1,0 +1,54 @@
+- infos = Information about the shadow plugin is in keys below
+- infos/author = Author Name <elektra@libelektra.org>
+- infos/licence = BSD
+- infos/needs =
+- infos/provides = storage/shadow
+- infos/recommends =
+- infos/placements = getstorage  setstorage
+- infos/status = recommended productive maintained reviewed conformant compatible coverage specific unittest shelltest tested nodep libc configurable final preview memleak experimental difficult unfinished old nodoc concept orphan obsolete discouraged -1000000
+- infos/metadata =
+- infos/description = one-line description of shadow
+
+## Introduction
+
+Copy this shadow if you want to start a new
+plugin written in C.
+
+## Usage
+
+You can use `scripts/copy-shadow`
+to automatically rename everything to your
+plugin name:
+
+	cd src/plugins
+	../../scripts/copy-shadow yourplugin
+
+Then update the README.md of your newly created plugin:
+
+- enter your full name+email in `infos/author`
+- make sure `status`, `placements`, and other clauses conform to
+  descriptions in `doc/CONTRACT.ini`
+- update the one-line description above
+- add your plugin in `src/plugins/README.md`
+- and rewrite the rest of this `README.md` to give a great
+  explanation of what your plugin does
+
+## Dependencies
+
+None.
+
+## Examples
+
+```sh
+# Backup-and-Restore: user/tests/shadow
+
+kdb set user/tests/shadow/key value
+#> Create a new key user/tests/shadow/key with string "value"
+
+kdb get /tests/shadow/key
+#> value
+```
+
+## Limitations
+
+None.

--- a/src/plugins/shadow/shadow.c
+++ b/src/plugins/shadow/shadow.c
@@ -1,0 +1,211 @@
+/**
+ * @file
+ *
+ * @brief Source for shadow plugin
+ *
+ * @copyright BSD License (see LICENSE.md or https://www.libelektra.org)
+ *
+ */
+
+#include "shadow.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <kdberrors.h>
+#include <kdbhelper.h>
+
+#include "../cpasswd/getline.c"
+
+static long xatol (char ** s)
+{
+	long x;
+	if (**s == ':' || **s == '\n') return -1;
+	for (x = 0; (unsigned) (**s - '0') < 10U; ++*s)
+		x = 10 * x + (**s - '0');
+	return x;
+}
+
+static struct spwd * strToShadow (char * line)
+{
+	struct spwd * sp = elektraMalloc (sizeof (struct spwd));
+	char * s = line;
+	sp->sp_namp = s;
+	if (!(s = strchr (s, ':'))) goto fail;
+	*s = 0;
+	sp->sp_pwdp = ++s;
+	if (!(s = strchr (s, ':'))) goto fail;
+	*s = 0;
+	s++;
+	sp->sp_lstchg = xatol (&s);
+	if (*s != ':') goto fail;
+	s++;
+	sp->sp_min = xatol (&s);
+	if (*s != ':') goto fail;
+	s++;
+	sp->sp_max = xatol (&s);
+	if (*s != ':') goto fail;
+	s++;
+	sp->sp_warn = xatol (&s);
+	if (*s != ':') goto fail;
+	s++;
+	sp->sp_inact = xatol (&s);
+	if (*s != ':') goto fail;
+	s++;
+	sp->sp_expire = xatol (&s);
+	if (*s != ':') goto fail;
+	s++;
+	sp->sp_flag = xatol (&s);
+	if (*s != '\n') goto fail;
+	return sp;
+fail:
+	elektraFree (sp);
+	return NULL;
+}
+
+static KeySet * spentToKS (struct spwd * sp, Key * parentKey)
+{
+	const char * keys[SHADOW_FIELDS] = { "login", "password", "ltschg", "min", "max", "warn", "inact", "expire", "flag" };
+	void * fields[SHADOW_FIELDS] = {
+		sp->sp_namp,  sp->sp_pwdp,   &sp->sp_lstchg, &sp->sp_min,  &sp->sp_max,
+		&sp->sp_warn, &sp->sp_inact, &sp->sp_expire, &sp->sp_flag,
+	};
+	KeySet * ks = ksNew (0, KS_END);
+	Key * append = keyNew (keyName (parentKey), KEY_END);
+	keyAddBaseName (append, sp->sp_namp);
+	ksAppendKey (ks, keyDup (append));
+	for (int i = 0; i < SHADOW_FIELDS; ++i)
+	{
+		keyAddBaseName (append, keys[i]);
+		if (i < 2)
+			keySetString (append, fields[i]);
+		else
+		{
+			char longBuf[11];
+			snprintf (longBuf, sizeof (longBuf), "%ld", *(long *) fields[i]);
+			keySetString (append, longBuf);
+		}
+		ksAppendKey (ks, keyDup (append));
+		keySetBaseName (append, 0);
+	}
+	keyDel (append);
+	return ks;
+}
+
+
+int elektraShadowGet (Plugin * handle ELEKTRA_UNUSED, KeySet * returned, Key * parentKey)
+{
+	if (!elektraStrCmp (keyName (parentKey), "system/elektra/modules/shadow"))
+	{
+		KeySet * contract =
+			ksNew (30, keyNew ("system/elektra/modules/shadow", KEY_VALUE, "shadow plugin waits for your orders", KEY_END),
+			       keyNew ("system/elektra/modules/shadow/exports", KEY_END),
+			       keyNew ("system/elektra/modules/shadow/exports/get", KEY_FUNC, elektraShadowGet, KEY_END),
+			       keyNew ("system/elektra/modules/shadow/exports/set", KEY_FUNC, elektraShadowSet, KEY_END),
+#include ELEKTRA_README (shadow)
+			       keyNew ("system/elektra/modules/shadow/infos/version", KEY_VALUE, PLUGINVERSION, KEY_END), KS_END);
+		ksAppend (returned, contract);
+		ksDel (contract);
+		return ELEKTRA_PLUGIN_STATUS_SUCCESS;
+	}
+
+	FILE * f = fopen (keyString (parentKey), "rbe");
+	if (!f)
+	{
+		ELEKTRA_SET_ERRORF (110, parentKey, "Failed to open configuration file %s\n", keyString (parentKey));
+		return -1;
+	}
+	char * line = NULL;
+	size_t len = 0;
+	ssize_t l = 0;
+	struct spwd * sp;
+	size_t lineno = 0;
+	while ((l = __getline (&line, &len, f)) != -1)
+	{
+		sp = strToShadow (line);
+		if (!sp)
+		{
+			ELEKTRA_ADD_WARNINGF (201, parentKey, "Failed to parse line '%s' of shadow file, skipping to next line\n", line);
+			++lineno;
+			continue;
+		}
+		++lineno;
+		KeySet * ks = spentToKS (sp, parentKey);
+		ksAppend (returned, ks);
+		ksRewind (returned);
+		ksDel (ks);
+		elektraFree (sp);
+	}
+	elektraFree (line);
+	fclose (f);
+	return ELEKTRA_PLUGIN_STATUS_SUCCESS;
+}
+
+
+static int writeKS (FILE * f, const Key * key, KeySet * ks)
+{
+	const char * keys[SHADOW_FIELDS] = { "login", "password", "ltschg", "min", "max", "warn", "inact", "expire", "flag" };
+	struct spwd * sp = elektraMalloc (sizeof (struct spwd));
+	void * fields[SHADOW_FIELDS] = {
+		&sp->sp_namp, &sp->sp_pwdp,  &sp->sp_lstchg, &sp->sp_min,  &sp->sp_max,
+		&sp->sp_warn, &sp->sp_inact, &sp->sp_expire, &sp->sp_flag,
+	};
+	Key * searchKey = keyNew (keyName (key), KEY_END);
+	int rv = 1;
+	for (int i = 0; i < SHADOW_FIELDS; ++i)
+	{
+		keyAddBaseName (searchKey, keys[i]);
+		Key * lookup = ksLookup (ks, searchKey, KDB_O_NONE);
+		if (i < 2)
+			*(char **) (fields[i]) = (char *) keyString (lookup);
+		else
+		{
+			if (!strcmp (keyString (lookup), "-1"))
+				*(long *) (fields[i]) = -1;
+			else
+				*(long *) (fields[i]) = atol (keyString (lookup));
+		}
+		keySetBaseName (searchKey, 0);
+	}
+	rv = fprintf (f, "%s:%s:%.*ld:%.*ld:%.*ld:%.*ld:%.*ld:%.*ld:%.*ld\n", STR (sp->sp_namp), STR (sp->sp_pwdp), NUM (sp->sp_lstchg),
+		      NUM (sp->sp_min), NUM (sp->sp_max), NUM (sp->sp_warn), NUM (sp->sp_inact), NUM (sp->sp_expire),
+		      NUM ((long) sp->sp_flag));
+	if (rv < 0)
+		rv = -1;
+	else if (rv > 0)
+		rv = 1;
+	keyDel (searchKey);
+	elektraFree (sp);
+	return rv;
+}
+
+
+int elektraShadowSet (Plugin * handle ELEKTRA_UNUSED, KeySet * returned, Key * parentKey)
+{
+	Key * cur;
+	ksRewind (returned);
+	FILE * f = fopen (keyString (parentKey), "w");
+	if (!f)
+	{
+		ELEKTRA_SET_ERRORF (75, parentKey, "Failed to open %s for writing\n", keyString (parentKey));
+		return -1;
+	}
+	int rv = 1;
+	while ((cur = ksNext (returned)) != NULL)
+	{
+		if (keyIsDirectBelow (parentKey, cur) != 1) continue;
+		rv = writeKS (f, cur, returned);
+		if (rv == -1) break;
+	}
+	fclose (f);
+	return rv;
+}
+
+Plugin * ELEKTRA_PLUGIN_EXPORT (shadow)
+{
+	// clang-format off
+    return elektraPluginExport ("shadow",
+            ELEKTRA_PLUGIN_GET,	&elektraShadowGet,
+            ELEKTRA_PLUGIN_SET, &elektraShadowSet,
+            ELEKTRA_PLUGIN_END);
+}

--- a/src/plugins/shadow/shadow.c
+++ b/src/plugins/shadow/shadow.c
@@ -5,7 +5,10 @@
  *
  * @copyright BSD License (see LICENSE.md or https://www.libelektra.org)
  *
+ * some of the code is inspired by / taken from musl
  */
+
+
 
 #include "shadow.h"
 #include <stdio.h>
@@ -25,7 +28,6 @@ static long xatol (char ** s)
 		x = 10 * x + (**s - '0');
 	return x;
 }
-
 static struct spwd * strToShadow (char * line)
 {
 	struct spwd * sp = elektraMalloc (sizeof (struct spwd));

--- a/src/plugins/shadow/shadow.h
+++ b/src/plugins/shadow/shadow.h
@@ -1,0 +1,44 @@
+/**
+ * @file
+ *
+ * @brief Header for cshadow plugin
+ *
+ * @copyright BSD License (see LICENSE.md or https://www.libelektra.org)
+ *
+ */
+
+#ifndef ELEKTRA_PLUGIN_SHADOW_H
+#define ELEKTRA_PLUGIN_SHADOW_H
+
+#include <kdbplugin.h>
+
+
+#define NUM(n) ((n) == -1 ? 0 : -1), ((n) == -1 ? 0 : (n))
+#define STR(s) ((s) ? (s) : "")
+
+#define SHADOW_FIELDS 9
+
+
+struct spwd
+{
+	char * sp_namp;		   /* Login name.  */
+	char * sp_pwdp;		   /* Encrypted password.  */
+	long int sp_lstchg;	/* Date of last change.  */
+	long int sp_min;	   /* Minimum number of days between changes.  */
+	long int sp_max;	   /* Maximum number of days between changes.  */
+	long int sp_warn;	  /* Number of days to warn user to change
+				       the password.  */
+	long int sp_inact;	 /* Number of days the account may be
+					    inactive.  */
+	long int sp_expire;	/* Number of days since 1970-01-01 until
+						 account expires.  */
+	unsigned long int sp_flag; /* Reserved.  */
+};
+
+
+int elektraShadowGet (Plugin * handle, KeySet * ks, Key * parentKey);
+int elektraShadowSet (Plugin * handle, KeySet * ks, Key * parentKey);
+
+Plugin * ELEKTRA_PLUGIN_EXPORT (shadow);
+
+#endif

--- a/src/plugins/shadow/testmod_shadow.c
+++ b/src/plugins/shadow/testmod_shadow.c
@@ -1,0 +1,28 @@
+/**
+ * @file
+ *
+ * @brief Tests for shadow plugin
+ *
+ * @copyright BSD License (see LICENSE.md or https://www.libelektra.org)
+ *
+ */
+
+#include <stdlib.h>
+#include <string.h>
+
+#include <kdbconfig.h>
+
+#include <tests_plugin.h>
+
+int main (int argc, char ** argv)
+{
+	printf ("SHADOW     TESTS\n");
+	printf ("==================\n\n");
+
+	init (argc, argv);
+
+
+	print_result ("testmod_shadow");
+
+	return nbError;
+}


### PR DESCRIPTION
parsers for group, hosts, passwd and shadow, most non-c99 code included in plugins
added full path to parent key as metadata to support calls like `ls system/passwd` and `ls system/passwd/byName` like most getent functions need. 

some of the code taken from musl, getline/delim taken from freebsd

## Basics

Do not describe the purpose here but:

- [ ] Short descriptions should be in the release notes (added as entry in
      doc/news/_preparation_next_release.md which contains `*(my name)*`)
      **Please always add something to the the release notes.**
- [ ] Longer descriptions should be in documentation or in design decisions.
- [ ] Describe details of how you changed the code in commit messages
      (first line should have `module: short statement` syntax)
- [ ] References to issues, e.g. `close #X`, should be in the commit messages.

## Checklist

Check relevant points but **please do not remove entries**.
For docu fixes, spell checking, and similar none of these points below
need to be checked.

- [ ] I added unit tests
- [ ] I ran all tests locally and everything went fine
- [ ] affected documentation is fixed
- [ ] I added code comments, logging, and assertions (see doc/CODING.md)
- [ ] meta data is updated (e.g. README.md of plugins)

## Review

Remove the line below and add the "work in progress" label if you do
not want the PR to be reviewed:

@markus2330 please review my pull request
