### PR TITLE
mmapstorage: lock mapped files

### DIFF
--- a/doc/news/_preparation_next_release.md
+++ b/doc/news/_preparation_next_release.md
@@ -47,20 +47,20 @@ You can also read the news [on our website](https://www.libelektra.org/news/0.8.
 
   | Plugin | Time |
   | --- | --- |
-  | `dump` | 63692 |
-  | `mmapstorage` | 4338 |
-  | `mmapstorage_crc` | 8813 |
+  | `dump` | 63794 |
+  | `mmapstorage` | 4325 |
+  | `mmapstorage_crc` | 9072 |
 
   Median read time in microseconds:
 
   | Plugin | Time |
   | --- | --- |
-  | `dump` | 74889 |
-  | `mmapstorage` | 1116 |
-  | `mmapstorage_crc` | 5250 |
+  | `dump` | 76419 |
+  | `mmapstorage` | 1115 |
+  | `mmapstorage_crc` | 5338 |
 
   In our benchmark, the `mmapstorage` plugin writes more than 14x faster,
-  and reads more than 67x faster than the `dump` storage plugin. *(Mihael Pranjić)*
+  and reads more than 68x faster than the `dump` storage plugin. *(Mihael Pranjić)*
 
 
 - Hybrid Search Algorithm for `ksLookup (...)`

--- a/src/plugins/mmapstorage/README.md
+++ b/src/plugins/mmapstorage/README.md
@@ -80,3 +80,8 @@ kdb rm -r user/tests/mmapstorage
 # Unmount mmapstorage
 sudo kdb umount user/tests/mmapstorage
 ```
+
+## Limitations
+
+Currently mapped files shall not be altered, otherwise the behaviour is undefined. Therefore we set an
+advisory lock with `flock()`, such that competing KDB instances can not overwrite mapped files.

--- a/src/plugins/mmapstorage/internal.h
+++ b/src/plugins/mmapstorage/internal.h
@@ -27,7 +27,7 @@
 /** Size to store a 64-bit (max.) address.
  * format: 0xADDR -> ADDR in hex, for 64bit addr: 2 bytes (0x) + 16 bytes (ADDR) + 1 byte (ending null)
  */
-#define SIZEOF_ADDR_STRING (19)
+#define SIZEOF_ADDR_STRING (3 + (sizeof (void *) * 2))
 
 /** Flag for mmap file format. Defines whether file was written with checksum on or off. */
 #define ELEKTRA_MMAP_CHECKSUM_ON (1)

--- a/src/plugins/mmapstorage/mmapstorage.c
+++ b/src/plugins/mmapstorage/mmapstorage.c
@@ -177,6 +177,12 @@ static int lockFileShared (int fd, Key * parentKey)
 	l.l_start = 0;
 	l.l_len = 0;
 
+	if (fcntl (fd, F_SETLK, &l) != -1)
+	{
+		return 1;
+	}
+
+	sleep (1);
 	if (fcntl (fd, F_SETLK, &l) == -1)
 	{
 		ELEKTRA_SET_ERRORF (ELEKTRA_ERROR_CONFLICT, parentKey, "could not lock file: %s", strerror (errno));
@@ -202,6 +208,12 @@ static int unlockFile (int fd, Key * parentKey)
 	l.l_start = 0;
 	l.l_len = 0;
 
+	if (fcntl (fd, F_SETLK, &l) != -1)
+	{
+		return 1;
+	}
+
+	sleep (1);
 	if (fcntl (fd, F_SETLK, &l) == -1)
 	{
 		ELEKTRA_SET_ERRORF (ELEKTRA_ERROR_CONFLICT, parentKey, "could not unlock file: %s", strerror (errno));

--- a/src/plugins/mmapstorage/mmapstorage.c
+++ b/src/plugins/mmapstorage/mmapstorage.c
@@ -1079,11 +1079,11 @@ static void saveLinkedFile (Key * key, KeySet * mappedFiles, KeySet * returned, 
 	ELEKTRA_LOG_DEBUG ("unlink: new file, adding to my list. file: %s", keyString (key));
 
 	char mmapAddrString[SIZEOF_ADDR_STRING];
-	snprintf (mmapAddrString, SIZEOF_ADDR_STRING - 1, "%p", (void *) (mappedRegion));
+	snprintf (mmapAddrString, SIZEOF_ADDR_STRING, "%p", (void *) (mappedRegion));
 	mmapAddrString[SIZEOF_ADDR_STRING - 1] = '\0';
 	ELEKTRA_LOG_DEBUG ("mappedRegion ptr as string: %s", mmapAddrString);
 	char ksAddrString[SIZEOF_ADDR_STRING];
-	snprintf (ksAddrString, SIZEOF_ADDR_STRING - 1, "%p", (void *) returned);
+	snprintf (ksAddrString, SIZEOF_ADDR_STRING, "%p", (void *) returned);
 	ksAddrString[SIZEOF_ADDR_STRING - 1] = '\0';
 	ELEKTRA_LOG_DEBUG ("KeySet ptr as string: %s", ksAddrString);
 	keySetMeta (key, mmapAddrString, ksAddrString);

--- a/src/plugins/mmapstorage/testmod_mmapstorage.c
+++ b/src/plugins/mmapstorage/testmod_mmapstorage.c
@@ -17,6 +17,7 @@
 #include <sys/mman.h>  // mmap()
 #include <sys/stat.h>  // stat(), chmod()
 #include <sys/types.h> // ftruncate ()
+#include <sys/wait.h>  // waitpit()
 #include <unistd.h>    // ftruncate(), pipe(), fork()
 
 #include <kdbconfig.h>
@@ -769,7 +770,7 @@ static void test_mmap_bad_file_permissions (const char * tmpFile)
 	}
 	fclose (fp);
 
-	if (chmod (tmpFile, S_IRUSR) != 0)
+	if (chmod (tmpFile, 0) != 0)
 	{
 		yield_error ("chmod() failed");
 	}
@@ -810,15 +811,100 @@ static void test_mmap_lock_mapped_file (const char * tmpFile)
 	{
 		// child: open a config file and leave it mapped
 		int devnull = open ("/dev/null", O_RDWR);
-		if (devnull == -1) exit (EXIT_FAILURE);
+		if (devnull == -1) _Exit (EXIT_FAILURE);
 
 		// redirect any communication on standard file descriptors to /dev/null
 		close (STDIN_FILENO);
 		close (STDOUT_FILENO);
 		close (STDERR_FILENO);
-		if (dup (devnull) == -1) exit (EXIT_FAILURE);
-		if (dup (devnull) == -1) exit (EXIT_FAILURE);
-		if (dup (devnull) == -1) exit (EXIT_FAILURE);
+		if (dup (devnull) == -1) _Exit (EXIT_FAILURE);
+		if (dup (devnull) == -1) _Exit (EXIT_FAILURE);
+		if (dup (devnull) == -1) _Exit (EXIT_FAILURE);
+		close (childPipe[0]);
+		close (parentPipe[1]);
+
+		Key * parentKey = keyNew (TEST_ROOT_KEY, KEY_VALUE, tmpFile, KEY_END);
+		KeySet * conf = ksNew (0, KS_END);
+		PLUGIN_OPEN ("mmapstorage");
+
+		KeySet * ks = ksNew (0, KS_END);
+		// succeed_if (plugin->kdbSet (plugin, ks, parentKey) == 1, "kdbSet was not successful");
+		succeed_if (plugin->kdbGet (plugin, ks, parentKey) == 1, "kdbGet was not successful");
+
+		if (write (childPipe[1], "a", 1) != 1) _Exit (EXIT_FAILURE); // signal parent that we are ready
+		close (childPipe[1]);
+		if (read (parentPipe[0], &buf, 1) != 1) _Exit (EXIT_FAILURE); // wait for parent
+		close (parentPipe[0]);
+
+		KeySet * expected = ksNew (0, KS_END);
+		compare_keyset (expected, ks);
+		compare_keyset (ks, expected);
+		ksDel (expected);
+		keyDel (parentKey);
+		ksDel (ks);
+		PLUGIN_CLOSE ();
+
+		_Exit (EXIT_SUCCESS);
+	}
+	else
+	{
+		// parent: try and destroy the file that the child has mapped
+		close (childPipe[1]);
+		close (parentPipe[0]);
+		if (read (childPipe[0], &buf, 1) != 1) _Exit (EXIT_FAILURE); // wait for child
+		close (childPipe[0]);
+
+		Key * parentKey = keyNew (TEST_ROOT_KEY, KEY_VALUE, tmpFile, KEY_END);
+		KeySet * conf = ksNew (0, KS_END);
+		PLUGIN_OPEN ("mmapstorage");
+
+		KeySet * ks = metaTestKeySet ();
+		succeed_if (plugin->kdbSet (plugin, ks, parentKey) == ELEKTRA_PLUGIN_STATUS_ERROR,
+			    "kdbSet has overwritten a currently mapped file");
+		if (write (parentPipe[1], "a", 1) != 1) _Exit (EXIT_FAILURE); // signal child that we are done
+		close (parentPipe[1]);
+
+		int status;
+		waitpid (pid, &status, 0);
+		if (status != 0) yield_error ("child process did not exit successfully.");
+
+		keyDel (parentKey);
+		ksDel (ks);
+		PLUGIN_CLOSE ();
+	}
+}
+
+static void test_mmap_unlock_mapped_file (const char * tmpFile)
+{
+	int parentPipe[2];
+	int childPipe[2];
+	if (pipe (parentPipe) != 0 || pipe (childPipe) != 0)
+	{
+		yield_error ("pipe() error");
+	}
+
+	pid_t pid;
+	char buf;
+	pid = fork ();
+
+	if (pid == -1)
+	{
+		yield_error ("fork() error");
+		return;
+	}
+	else if (pid == 0)
+	{
+		// child: open a config file and close
+		int devnull = open ("/dev/null", O_RDWR);
+		if (devnull == -1) _Exit (EXIT_FAILURE);
+
+		// redirect any communication on standard file descriptors to /dev/null
+		close (STDIN_FILENO);
+		close (STDOUT_FILENO);
+		close (STDERR_FILENO);
+		if (dup (devnull) == -1) _Exit (EXIT_FAILURE);
+		if (dup (devnull) == -1) _Exit (EXIT_FAILURE);
+		if (dup (devnull) == -1) _Exit (EXIT_FAILURE);
 		close (childPipe[0]);
 		close (parentPipe[1]);
 
@@ -830,26 +916,27 @@ static void test_mmap_lock_mapped_file (const char * tmpFile)
 		succeed_if (plugin->kdbSet (plugin, ks, parentKey) == 1, "kdbSet was not successful");
 		succeed_if (plugin->kdbGet (plugin, ks, parentKey) == 1, "kdbGet was not successful");
 
-		write (childPipe[1], "a", 1); // signal parent that we are ready
-		close (childPipe[1]);
-		read (parentPipe[0], &buf, 1); // wait for parent
-		close (parentPipe[0]);
-
 		KeySet * expected = simpleTestKeySet ();
 		compare_keyset (expected, ks);
 		compare_keyset (ks, expected);
-
+		ksDel (expected);
 		keyDel (parentKey);
 		ksDel (ks);
-		PLUGIN_CLOSE ();
-		exit (EXIT_SUCCESS);
+		PLUGIN_CLOSE (); // triggers unlinking of keyset and releases file lock
+
+		if (write (childPipe[1], "a", 1) != 1) _Exit (EXIT_FAILURE); // signal parent that we are ready
+		close (childPipe[1]);
+		if (read (parentPipe[0], &buf, 1) != 1)
+			_Exit (EXIT_FAILURE); // wait for parent (otherwise file lock is released implicitly)
+		close (parentPipe[0]);
+		_Exit (EXIT_SUCCESS);
 	}
 	else
 	{
-		// parent: try and destroy the file that the child has mapped
+		// parent: try to overwrite file (child should have unlocked it)
 		close (childPipe[1]);
 		close (parentPipe[0]);
-		read (childPipe[0], &buf, 1); // wait for child
+		if (read (childPipe[0], &buf, 1) != 1) _Exit (EXIT_FAILURE); // wait for child
 		close (childPipe[0]);
 
 		Key * parentKey = keyNew (TEST_ROOT_KEY, KEY_VALUE, tmpFile, KEY_END);
@@ -857,14 +944,21 @@ static void test_mmap_lock_mapped_file (const char * tmpFile)
 		PLUGIN_OPEN ("mmapstorage");
 
 		KeySet * ks = metaTestKeySet ();
-		succeed_if (plugin->kdbSet (plugin, ks, parentKey) == ELEKTRA_PLUGIN_STATUS_ERROR,
-			    "kdbSet has overwritten a currently mapped file");
-		write (parentPipe[1], "a", 1); // signal child that we are done
-		close (parentPipe[1]);
+		succeed_if (plugin->kdbSet (plugin, ks, parentKey) == 1, "kdbSet failed, mmap file was not unlocked properly");
 
+		KeySet * expected = metaTestKeySet ();
+		compare_keyset (expected, ks);
+		ksDel (expected);
 		keyDel (parentKey);
 		ksDel (ks);
 		PLUGIN_CLOSE ();
+
+		if (write (parentPipe[1], "a", 1) != 1) _Exit (EXIT_FAILURE); // signal child that we are done
+		close (parentPipe[1]);
+
+		int status;
+		waitpid (pid, &status, 0);
+		if (status != 0) yield_error ("child process did not exit successfully.");
 	}
 }
 
@@ -983,7 +1077,9 @@ int main (int argc, char ** argv)
 
 	test_mmap_open_pipe ();
 	test_mmap_bad_file_permissions (tmpFile);
+
 	test_mmap_lock_mapped_file (tmpFile);
+	test_mmap_unlock_mapped_file (tmpFile);
 
 	printf ("\ntestmod_mmapstorage RESULTS: %d test(s) done. %d error(s).\n", nbTest, nbError);
 


### PR DESCRIPTION
## Basics

Lock mapped files with advisory locks such that competing plugin instances can not
overwrite the files. Includes regression tests for said problem and some other minor improvements.

## Checklist

Check relevant points but **please do not remove entries**.
For docu fixes, spell checking, and similar none of these points below
need to be checked.

- [x] I added unit tests
- [x] I ran all tests locally and everything went fine
- [x] affected documentation is fixed
- [x] I added code comments, logging, and assertions (see doc/CODING.md)
- [x] meta data is updated (e.g. README.md of plugins)

## Review

Remove the line below and add the "work in progress" label if you do
not want the PR to be reviewed:
