### PR TITLE
 Documentation: Add List of Available Packages

### DIFF
--- a/doc/INSTALL.md
+++ b/doc/INSTALL.md
@@ -1,5 +1,10 @@
 # Install
 
+## Status
+
+The graph below shows an (incomplete) list of available packages for Elektra.
+
+[![Packaging status](https://repology.org/badge/vertical-allrepos/elektra.svg)](https://repology.org/metapackage/elektra/versions)
 
 ## Linux
 

--- a/doc/news/_preparation_next_release.md
+++ b/doc/news/_preparation_next_release.md
@@ -225,7 +225,7 @@ you up to date with the multi-language support provided by Elektra.
 -  We added a [Markdown Shell Recorder][] test for the [`shell` plugin ](https://www.libelektra.org/plugins/shell). *(René Schwaiger)*
 - Added many storage plugin tests. Most tests use the keyset, key name and value APIs.
   Currently, the tests are only active for `dump` and `mmapstorage`. *(Mihael Pranjić)*
-- <<TODO>>
+- The test `testcpp_contextual_basic` now compiles without warnings, if we use Clang 7 as compiler. *(René Schwaiger)*
 
 [Markdown Shell Recorder]: https://master.libelektra.org/tests/shell/shell_recorder/tutorial_wrapper
 

--- a/src/bindings/cpp/tests/CMakeLists.txt
+++ b/src/bindings/cpp/tests/CMakeLists.txt
@@ -4,9 +4,16 @@ include_directories (${CMAKE_CURRENT_SOURCE_DIR})
 add_headers (HDR_FILES)
 add_cppheaders (HDR_FILES)
 
+set (CLANG_7_OR_LATER ${CMAKE_CXX_COMPILER_ID} MATCHES "Clang" AND NOT (${CMAKE_CXX_COMPILER_VERSION} VERSION_LESS 7))
+
 file (GLOB TESTS
 	   testcpp_*.cpp)
 foreach (file ${TESTS})
+
+	if (file MATCHES testcpp_contextual_basic.cpp AND ${CLANG_7_OR_LATER})
+		set_source_files_properties (${file} PROPERTIES COMPILE_FLAGS "-Wno-self-assign-overloaded")
+	endif (file MATCHES testcpp_contextual_basic.cpp AND ${CLANG_7_OR_LATER})
+
 	get_filename_component (name ${file} NAME_WE)
 	add_gtest (${name}
 		   LINK_ELEKTRA elektra-kdb


### PR DESCRIPTION
# Description

While reading the documentation for [PEGTL](https://github.com/taocpp/PEGTL), I stumbled upon a diagram that shows [the status of available packages for the library](https://github.com/taocpp/PEGTL/blob/master/doc/Installing-and-Using.md#installation-packages). Since the graph looked nice, I thought it makes sense to add a list of available packages to our documentation too.

# Preview

## Status

The graph below shows an (incomplete) list of available packages for Elektra.

[![Packaging status](https://repology.org/badge/vertical-allrepos/elektra.svg)](https://repology.org/metapackage/elektra/versions)

