### PR TITLE
default value calculation

### DIFF
--- a/src/plugins/default-value-calculation/Findings.md
+++ b/src/plugins/default-value-calculation/Findings.md
@@ -1,0 +1,131 @@
+# Default value calculation
+
+This Markdown file shortly describes my found requirements for default value calculation:
+
+1) Default to a part of the keyname
+
+    Example in lcdexec:
+    ```ini
+    # definition of a menu
+    [CPUinfo]
+    DisplayName="Show CPU"
+    ```
+    In the above example the `DisplayName` which is set to "Show CPU" should have the default value `CPUinfo` which is part of its keyname.
+
+2) Default depends on a value of another key
+
+    Example in LCDd:
+    ```ini
+    [CwLnx]
+
+    # Select the LCD model [default: 12232; legal: 12232, 12832, 1602]
+    Model=12232
+
+    # Select the LCD size. Default depends on model:
+    # 12232: 20x4
+    # 12832: 21x4
+    # 1602: 16x2
+    Size=20x4
+    ```
+
+    This basically boils down to a simple `switch` statement.
+
+3) The default copies the value of another key
+
+    Example in Cassandra:
+    ```yaml
+    roles_validity_in_ms: 2000
+
+    #If roles_validity_in_ms is non-zero, then this must be also.
+    # Defaults to the same value as roles_validity_in_ms.
+    roles_update_interval_in_ms: 2000
+
+    # Leaving this blank will set it to the same value as listen_address
+    broadcast_address: 1.2.3.4
+    ```
+    Many more examples such as this are there too
+
+    Basically a conditional block
+
+4) Computation + if condition + setting
+
+    ```yaml
+    # If max_mutation_size_in_kb is set explicitly then commitlog_segment_size_in_mb must be set to at least twice the size of max_mutation_size_in_kb / 1024
+    commitlog_segment_size_in_mb: 32
+
+    # memtable_cleanup_threshold defaults to 1 / (memtable_flush_writers + 1)
+    memtable_cleanup_threshold: 0.11
+    ```
+
+# Auto-Detection
+
+Cassandra:
+
+1) Some examples of calculations based on the target system
+
+```yaml
+# Default value ("auto") is 1/256th of the heap or 10MB, whichever is greater
+prepared_statements_cache_size_mb:
+
+# Default value ("auto") is 1/256th of the heap or 10MB, whichever is greater
+thrift_prepared_statements_cache_size_mb:
+
+# "auto" means (min(5% of Heap (in MB), 100MB)). Set to 0 to disable key cache.
+key_cache_size_in_mb:
+
+# "auto" means (min(2.5% of Heap (in MB), 50MB)). Set to 0 to disable counter cache.
+# NOTE: if you perform counter deletes and rely on low gcgs, you should disable the counter cache.
+counter_cache_size_in_mb:
+
+# the ideal number of "concurrent_writes" is dependent on the number of cores in
+# your system; (8 * number_of_cores) is a good rule of thumb.
+concurrent_writes: 32
+
+# "concurrent_reads" should be set to (16 * number_of_drives) in
+# order to allow the operations to enqueue low enough in the stack
+# that the OS and drives can reorder them. Same applies to
+# "concurrent_counter_writes", since counter writes read the current
+# values before incrementing and writing them back.
+concurrent_reads: 32
+concurrent_counter_writes: 32
+
+# Defaults to the smaller of 1/4 of heap or 512MB.
+file_cache_size_in_mb: 512
+
+# Cassandra will set both to 1/4 the size of the heap.
+memtable_heap_space_in_mb: 2048
+memtable_offheap_space_in_mb: 2048
+
+# The default value is the smaller of 8192, and 1/4 of the total space
+# of the commitlog volume.
+commitlog_total_space_in_mb: 8192
+
+# memtable_flush_writers defaults to two for a single data directory.
+# This means that two  memtables can be flushed concurrently to the single data directory. If you have multiple data directories the default is one memtable flushing at a time but the flush will use a thread per data directory so you will get two or more writers.
+memtable_flush_writers: 2
+
+# The default value is the min of 4096 mb and 1/8th of the total space
+# of the drive where cdc_raw_directory resides.
+cdc_total_space_in_mb: 4096
+
+# If left empty, this will default to 5% of the heap size
+index_summary_capacity_in_mb:
+
+# The default is sync because on Windows hsha is about 30% slower.  On Linux,
+# sync/hsha performance is about the same, with hsha of course using less memory.
+rpc_server_type: sync
+
+# concurrent_compactors defaults to the smaller of (number of disks,
+# number of cores), with a minimum of 2 and a maximum of 8.
+concurrent_compactors: 1
+```
+
+# Misc
+
+Also auto detection but should throw error if not installed. So its hybrid between spec and auto detection in my opinion.
+
+```yaml
+# Warning: before enabling this property make sure to ntp is installed
+# and the times are synchronized between the nodes.
+cross_node_timeout: false
+```

--- a/src/plugins/default-value-calculation/README.md
+++ b/src/plugins/default-value-calculation/README.md
@@ -1,0 +1,95 @@
+- infos = Information about the conditionals plugin is in keys below
+- infos/author = TBD
+- infos/licence = BSD
+- infos/provides =
+- infos/needs =
+- infos/recommends =
+- infos/placements = pregetstorage
+- infos/status = idea
+- infos/metadata =
+- infos/description = the plugin calculates the default value of a given key if no value is present
+
+## Introduction
+
+The plugin is used to calculate default values if no specific value was given.
+
+## Description
+
+The plugin can be used to calculate or use values which it fetches from others keys.
+Basically the functionality can be splitted into three components:
+
+1. Getting the value of other keys
+2. Arithmetic expressions
+3. Conditional expressions
+
+Those three components can be used alone or together such as fetching the value
+of 2 keys, adding them up and wrapping it in a conditional block.
+
+Returning a specific value for the current key is done via the `return`
+statement. For some examples look into the examples section.
+
+The following sections give more detailed descriptions of all components.
+
+### 1. Getting the value of other keys
+
+The syntax for fetching the value of another key is simply either
+
+- relative upwards: eg. ../upper/key
+- relative downwards: eg. ./deeper/key
+- relative to the parent: eg. @/some/key
+- absolute: eg. /some/path/some/key
+
+### 2. Arithmetic expressions
+
+Arithmetic expressions are limited to `+ - / * %` and can be keys or constants.
+So for example if you want to add up two keys you could do it like this:
+
+```
+../key/A + ../key/B  #via keys
+../key/A + 5             #key and constant
+```
+
+### 3. Conditional expressions
+
+The basic syntax of conditionals are
+`if(expression){BLOCK}`, `else if(expression){BLOCK}`, `else{BLOCK}` statements.
+
+`expression` has to be a valid condition in the form of
+
+`Key` *Operation* `('String' | constant | Key)`
+
+where *Operation* stands for
+`!=, ==, <, <=, =>, >` which are comparisons as in C.
+
+A `BLOCK` can either be
+
+1. a nested conditional expression
+2. a `return` statement which can either be another key, constant or
+arithmetic expression
+
+#### Testing if Key exists
+`(! ../key/B)` evaluates to true if the key `../key/A` doesn't exist, to false if it exists.
+
+## Open Questions
+
+Imagine the following case:
+```
+Key A = int
+Key B = int
+Key C = A + B
+```
+Every time the user uses `kdb get` on C the value gets calculated.
+Now a user unintentionally assigns a String to Key A.
+
+When calling `kdb get` the default value calculation will inevitably fail
+and cannot return any value at all.
+I see 3 remedies in this case:
+
+1. Assume that every other value is type checked and adheres its specification
+2. On every `kdb set` execute the default value calculation at least once
+to be sure that a value can be calculated
+3. Require a fallback
+
+## Examples
+
+Will come soon...


### PR DESCRIPTION
After finishing Cassandra + LCDproc's configuration investigations, here are my findings until now.

I tried to filter between default value calculation and auto-detection. My criteria for which settings goes into which bucket was based on the need for system information. If it could be done alone via elektra (e.g. just information from another key) I added it to default value calculation.

I did not add it to the issue as the README is much more readable this way. 
