### PR TITLE
mmapstorage: change unlinking approach

### DIFF
--- a/doc/news/_preparation_next_release.md
+++ b/doc/news/_preparation_next_release.md
@@ -40,27 +40,27 @@ You can also read the news [on our website](https://www.libelektra.org/news/0.8.
   The `mmapstorage_crc` variant enables CRC32 checksums for critical data,
   while the `mmapstorage` variant omits the checksum for maximum performance.
 
-  We ran a synthetic benchmark with 127 iterations using 40k keys in a keyset,
+  We ran a synthetic benchmark with 257 iterations using 40k keys in a keyset,
   and compared the performance to the `dump` storage plugin.
 
   Median write time in microseconds:
 
   | Plugin | Time |
   | --- | --- |
-  | `dump` | 63794 |
-  | `mmapstorage` | 4325 |
-  | `mmapstorage_crc` | 9072 |
+  | `dump` | 71079 |
+  | `mmapstorage` | 2964 |
+  | `mmapstorage_crc` | 7644 |
 
   Median read time in microseconds:
 
   | Plugin | Time |
   | --- | --- |
-  | `dump` | 76419 |
-  | `mmapstorage` | 1115 |
-  | `mmapstorage_crc` | 5338 |
+  | `dump` | 82737 |
+  | `mmapstorage` | 1145 |
+  | `mmapstorage_crc` | 5744 |
 
-  In our benchmark, the `mmapstorage` plugin writes more than 14x faster,
-  and reads more than 68x faster than the `dump` storage plugin. *(Mihael Pranjić)*
+  In our benchmark, the `mmapstorage` plugin writes more than 23x faster,
+  and reads more than 72x faster than the `dump` storage plugin. *(Mihael Pranjić)*
 
 
 - Hybrid Search Algorithm for `ksLookup (...)`

--- a/doc/news/_preparation_next_release.md
+++ b/doc/news/_preparation_next_release.md
@@ -47,20 +47,20 @@ You can also read the news [on our website](https://www.libelektra.org/news/0.8.
 
   | Plugin | Time |
   | --- | --- |
-  | `dump` | 63692 |
-  | `mmapstorage` | 4338 |
-  | `mmapstorage_crc` | 8813 |
+  | `dump` | 63794 |
+  | `mmapstorage` | 4325 |
+  | `mmapstorage_crc` | 9072 |
 
   Median read time in microseconds:
 
   | Plugin | Time |
   | --- | --- |
-  | `dump` | 74889 |
-  | `mmapstorage` | 1116 |
-  | `mmapstorage_crc` | 5250 |
+  | `dump` | 76419 |
+  | `mmapstorage` | 1115 |
+  | `mmapstorage_crc` | 5338 |
 
   In our benchmark, the `mmapstorage` plugin writes more than 14x faster,
-  and reads more than 67x faster than the `dump` storage plugin. *(Mihael Pranjić)*
+  and reads more than 68x faster than the `dump` storage plugin. *(Mihael Pranjić)*
 
 
 - Hybrid Search Algorithm for `ksLookup (...)`

--- a/src/include/kdbprivate.h
+++ b/src/include/kdbprivate.h
@@ -57,12 +57,6 @@
  * to which mountpoint. */
 #define KDB_SYSTEM_ELEKTRA "system/elektra"
 
-/** Magic number used in mmap format */
-#define ELEKTRA_MAGIC_MMAP_NUMBER (0x0A6172746B656C45)
-
-/** Mmap format version */
-#define ELEKTRA_MMAP_FORMAT_VERSION (1)
-
 
 #ifdef __cplusplus
 namespace ckdb
@@ -74,8 +68,6 @@ typedef struct _Trie Trie;
 typedef struct _Split Split;
 typedef struct _Backend Backend;
 
-/* Metadata needed for mmap file format */
-typedef struct _mmapMetaData MmapMetaData;
 
 /* These define the type for pointers to all the kdb functions */
 typedef int (*kdbOpenPtr) (Plugin *, Key * errorKey);
@@ -182,15 +174,6 @@ typedef enum {
 		 It prevents erroneous free() calls on these arrays. */
 } ksflag_t;
 
-/**
- * Mmap Flags.
- *
- * Control flags needed for mmap
- */
-typedef enum {
-	MMAP_FLAG_DELETED = 1, /*!<
-		 KeySet was deleted, no need to unlink. */
-} mmapflag_t;
 
 /**
  * The private Key struct.
@@ -288,11 +271,6 @@ struct _KeySet
 	 * Some control and internal flags.
 	 */
 	ksflag_t flags;
-
-	/**
-	 * Mmap meta-data struct
-	 */
-	MmapMetaData * mmapMetaData;
 
 #ifdef ELEKTRA_ENABLE_OPTIMIZATIONS
 	/**
@@ -483,21 +461,6 @@ struct _Split
 				Is either the mountpoint of the backend
 				or "user", "system", "spec" for the split root/cascading backends */
 	splitflag_t * syncbits; /*!< Bits for various options, see #splitflag_t for documentation */
-};
-
-
-/**
- * Mmap meta-data
- */
-struct _mmapMetaData
-{
-	char * destAddr;	/**<Base pointer to allocated destination */
-
-	size_t numKeySets;	/**<Number of KeySets inlcuding meta KS */
-	size_t ksAlloc;		/**<Sum of all KeySet->alloc sizes */
-	size_t numKeys;		/**<Number of Keys including meta Keys */
-
-	mmapflag_t flags;	/**<Control flags for mmap */
 };
 
 

--- a/src/libs/elektra/keyset.c
+++ b/src/libs/elektra/keyset.c
@@ -441,10 +441,6 @@ int ksDel (KeySet * ks)
 
 #endif
 
-	if (ks->mmapMetaData)
-	{
-		set_bit (ks->mmapMetaData->flags, MMAP_FLAG_DELETED);
-	}
 	if (!test_bit (ks->flags, KS_FLAG_MMAP_STRUCT))
 	{
 		elektraFree (ks);
@@ -2695,7 +2691,6 @@ int ksInit (KeySet * ks)
 	ks->size = 0;
 	ks->alloc = 0;
 	ks->flags = 0;
-	ks->mmapMetaData = 0;
 
 	ksRewind (ks);
 

--- a/src/plugins/mmapstorage/README.md
+++ b/src/plugins/mmapstorage/README.md
@@ -83,5 +83,4 @@ sudo kdb umount user/tests/mmapstorage
 
 ## Limitations
 
-Currently mapped files shall not be altered, otherwise the behaviour is undefined. Therefore we set an
-advisory lock with `flock()`, such that competing KDB instances can not overwrite mapped files.
+Currently mapped files shall not be altered, otherwise the behaviour is undefined.

--- a/src/plugins/mmapstorage/README.md
+++ b/src/plugins/mmapstorage/README.md
@@ -80,3 +80,8 @@ kdb rm -r user/tests/mmapstorage
 # Unmount mmapstorage
 sudo kdb umount user/tests/mmapstorage
 ```
+
+## Limitations
+
+Currently mapped files shall not be altered, otherwise the behaviour is undefined. Therefore we set an
+advisory lock with `flock()`, such that competing KDB instances can not overwrite mapped files.

--- a/src/plugins/mmapstorage/README.md
+++ b/src/plugins/mmapstorage/README.md
@@ -83,4 +83,4 @@ sudo kdb umount user/tests/mmapstorage
 
 ## Limitations
 
-Currently mapped files shall not be altered, otherwise the behaviour is undefined.
+Mapped files shall not be altered, otherwise the behaviour is undefined.

--- a/src/plugins/mmapstorage/internal.h
+++ b/src/plugins/mmapstorage/internal.h
@@ -24,11 +24,6 @@
 /** Minimum size (lower bound) of mapped region (header, metadata, footer) */
 #define ELEKTRA_MMAP_MINSIZE (SIZEOF_MMAPHEADER + (SIZEOF_MMAPMETADATA * 2) + SIZEOF_KEYSET + SIZEOF_KEY + SIZEOF_MMAPFOOTER)
 
-/** Size to store a 64-bit (max.) address.
- * format: 0xADDR -> ADDR in hex, for 64bit addr: 2 bytes (0x) + 16 bytes (ADDR) + 1 byte (ending null)
- */
-#define SIZEOF_ADDR_STRING (3 + (sizeof (void *) * 2))
-
 /** Flag for mmap file format. Defines whether file was written with checksum on or off. */
 #define ELEKTRA_MMAP_CHECKSUM_ON (1)
 

--- a/src/plugins/mmapstorage/internal.h
+++ b/src/plugins/mmapstorage/internal.h
@@ -27,7 +27,7 @@
 /** Size to store a 64-bit (max.) address.
  * format: 0xADDR -> ADDR in hex, for 64bit addr: 2 bytes (0x) + 16 bytes (ADDR) + 1 byte (ending null)
  */
-#define SIZEOF_ADDR_STRING (19)
+#define SIZEOF_ADDR_STRING (3 + (sizeof (void *) * 2))
 
 /** Flag for mmap file format. Defines whether file was written with checksum on or off. */
 #define ELEKTRA_MMAP_CHECKSUM_ON (1)

--- a/src/plugins/mmapstorage/internal.h
+++ b/src/plugins/mmapstorage/internal.h
@@ -30,6 +30,12 @@
 /** Magic byte order marker, as used by UTF. */
 #define ELEKTRA_MMAP_MAGIC_BOM (0xFEFF)
 
+/** Magic number used in mmap format */
+#define ELEKTRA_MAGIC_MMAP_NUMBER (0x0A6172746B656C45)
+
+/** Mmap format version */
+#define ELEKTRA_MMAP_FORMAT_VERSION (1)
+
 /**
  * Internal MmapAddr structure.
  * Used for functions passing around relevant pointers into the mmap region.
@@ -52,8 +58,9 @@ struct _mmapAddr
 
 typedef struct _mmapAddr MmapAddr;
 
-/* Header and footer needed for mmap file format */
+/* Header, metadata and footer needed for mmap file format */
 typedef struct _mmapHeader MmapHeader;
+typedef struct _mmapMetaData MmapMetaData;
 typedef struct _mmapFooter MmapFooter;
 
 /**
@@ -71,6 +78,20 @@ struct _mmapHeader
 	uint32_t checksum;		/**<Checksum of the data */
 	uint8_t formatFlags;		/**<Mmap format flags (e.g. checksum ON/OFF) */
 	uint8_t formatVersion;		/**<Mmap format version */
+	// clang-format on
+};
+
+/**
+ * Mmap meta-data
+ */
+struct _mmapMetaData
+{
+	// clang-format off
+	char * destAddr;	/**<Base pointer to allocated destination */
+
+	size_t numKeySets;	/**<Number of KeySets inlcuding meta KS */
+	size_t ksAlloc;		/**<Sum of all KeySet->alloc sizes */
+	size_t numKeys;		/**<Number of Keys including meta Keys */
 	// clang-format on
 };
 

--- a/src/plugins/mmapstorage/mmapstorage.c
+++ b/src/plugins/mmapstorage/mmapstorage.c
@@ -270,7 +270,6 @@ static void initMagicKeySet (const uintptr_t magicNumber)
 	magicKeySet.cursor = (Key *) ~magicNumber;
 	magicKeySet.current = SIZE_MAX / 2;
 	magicKeySet.flags = KS_FLAG_MMAP_ARRAY | KS_FLAG_SYNC;
-	magicKeySet.mmapMetaData = (MmapMetaData *) ELEKTRA_MMAP_MAGIC_BOM;
 #ifdef ELEKTRA_ENABLE_OPTIMIZATIONS
 	magicKeySet.opmphm = (Opmphm *) ELEKTRA_MMAP_MAGIC_BOM;
 	magicKeySet.opmphmPredictor = 0;
@@ -305,7 +304,6 @@ static void initMagicMmapMetaData (const uintptr_t magicNumber)
 	magicMmapMetaData.numKeySets = SIZE_MAX;
 	magicMmapMetaData.ksAlloc = 0;
 	magicMmapMetaData.numKeys = SIZE_MAX / 2;
-	magicMmapMetaData.flags = MMAP_FLAG_DELETED;
 }
 
 /**
@@ -682,7 +680,6 @@ static void mmapToKeySet (char * mappedRegion, KeySet * returned)
 	returned->array = keySet->array;
 	returned->size = keySet->size;
 	returned->alloc = keySet->alloc;
-	returned->mmapMetaData = (MmapMetaData *) (mappedRegion + OFFSET_REAL_MMAPMETADATA);
 	// to be able to free() the returned KeySet, just set the array flag here
 	returned->flags = KS_FLAG_MMAP_ARRAY;
 	// we intentionally do not change the KeySet->opmphm here!

--- a/src/plugins/mmapstorage/mmapstorage.c
+++ b/src/plugins/mmapstorage/mmapstorage.c
@@ -827,7 +827,11 @@ int ELEKTRA_PLUGIN_FUNCTION (mmapstorage, get) (Plugin * handle ELEKTRA_UNUSED, 
 	if (sbuf.st_size == 0)
 	{
 		// empty mmap file
-		close (fd);
+		if (close (fd) != 0)
+		{
+			ELEKTRA_LOG_WARNING ("could not close");
+			goto error;
+		}
 		return ELEKTRA_PLUGIN_STATUS_SUCCESS;
 	}
 

--- a/src/plugins/mmapstorage/mmapstorage.c
+++ b/src/plugins/mmapstorage/mmapstorage.c
@@ -1079,11 +1079,11 @@ static void saveLinkedFile (Key * key, KeySet * mappedFiles, KeySet * returned, 
 	ELEKTRA_LOG_DEBUG ("unlink: new file, adding to my list. file: %s", keyString (key));
 
 	char mmapAddrString[SIZEOF_ADDR_STRING];
-	snprintf (mmapAddrString, SIZEOF_ADDR_STRING - 1, "%p", (void *) (mappedRegion));
+	snprintf (mmapAddrString, SIZEOF_ADDR_STRING, "%p", (void *) (mappedRegion));
 	mmapAddrString[SIZEOF_ADDR_STRING - 1] = '\0';
 	ELEKTRA_LOG_DEBUG ("mappedRegion ptr as string: %s", mmapAddrString);
 	char ksAddrString[SIZEOF_ADDR_STRING];
-	snprintf (ksAddrString, SIZEOF_ADDR_STRING - 1, "%p", (void *) returned);
+	snprintf (ksAddrString, SIZEOF_ADDR_STRING, "%p", (void *) returned);
 	ksAddrString[SIZEOF_ADDR_STRING - 1] = '\0';
 	ELEKTRA_LOG_DEBUG ("KeySet ptr as string: %s", ksAddrString);
 	keySetMeta (key, mmapAddrString, ksAddrString);

--- a/src/plugins/mmapstorage/testmod_mmapstorage.c
+++ b/src/plugins/mmapstorage/testmod_mmapstorage.c
@@ -17,6 +17,7 @@
 #include <sys/mman.h>  // mmap()
 #include <sys/stat.h>  // stat(), chmod()
 #include <sys/types.h> // ftruncate ()
+#include <sys/wait.h>  // waitpit()
 #include <unistd.h>    // ftruncate(), pipe(), fork()
 
 #include <kdbconfig.h>
@@ -769,7 +770,7 @@ static void test_mmap_bad_file_permissions (const char * tmpFile)
 	}
 	fclose (fp);
 
-	if (chmod (tmpFile, S_IRUSR) != 0)
+	if (chmod (tmpFile, 0) != 0)
 	{
 		yield_error ("chmod() failed");
 	}
@@ -810,15 +811,100 @@ static void test_mmap_lock_mapped_file (const char * tmpFile)
 	{
 		// child: open a config file and leave it mapped
 		int devnull = open ("/dev/null", O_RDWR);
-		if (devnull == -1) exit (EXIT_FAILURE);
+		if (devnull == -1) _Exit (EXIT_FAILURE);
 
 		// redirect any communication on standard file descriptors to /dev/null
 		close (STDIN_FILENO);
 		close (STDOUT_FILENO);
 		close (STDERR_FILENO);
-		if (dup (devnull) == -1) exit (EXIT_FAILURE);
-		if (dup (devnull) == -1) exit (EXIT_FAILURE);
-		if (dup (devnull) == -1) exit (EXIT_FAILURE);
+		if (dup (devnull) == -1) _Exit (EXIT_FAILURE);
+		if (dup (devnull) == -1) _Exit (EXIT_FAILURE);
+		if (dup (devnull) == -1) _Exit (EXIT_FAILURE);
+		close (childPipe[0]);
+		close (parentPipe[1]);
+
+		Key * parentKey = keyNew (TEST_ROOT_KEY, KEY_VALUE, tmpFile, KEY_END);
+		KeySet * conf = ksNew (0, KS_END);
+		PLUGIN_OPEN ("mmapstorage");
+
+		KeySet * ks = ksNew (0, KS_END);
+		// succeed_if (plugin->kdbSet (plugin, ks, parentKey) == 1, "kdbSet was not successful");
+		succeed_if (plugin->kdbGet (plugin, ks, parentKey) == 1, "kdbGet was not successful");
+
+		if (write (childPipe[1], "a", 1) != 1) _Exit (EXIT_FAILURE); // signal parent that we are ready
+		close (childPipe[1]);
+		if (read (parentPipe[0], &buf, 1) != 1) _Exit (EXIT_FAILURE); // wait for parent
+		close (parentPipe[0]);
+
+		KeySet * expected = ksNew (0, KS_END);
+		compare_keyset (expected, ks);
+		compare_keyset (ks, expected);
+		ksDel (expected);
+		keyDel (parentKey);
+		ksDel (ks);
+		PLUGIN_CLOSE ();
+
+		_Exit (EXIT_SUCCESS);
+	}
+	else
+	{
+		// parent: try and destroy the file that the child has mapped
+		close (childPipe[1]);
+		close (parentPipe[0]);
+		if (read (childPipe[0], &buf, 1) != 1) _Exit (EXIT_FAILURE); // wait for child
+		close (childPipe[0]);
+
+		Key * parentKey = keyNew (TEST_ROOT_KEY, KEY_VALUE, tmpFile, KEY_END);
+		KeySet * conf = ksNew (0, KS_END);
+		PLUGIN_OPEN ("mmapstorage");
+
+		KeySet * ks = metaTestKeySet ();
+		succeed_if (plugin->kdbSet (plugin, ks, parentKey) == ELEKTRA_PLUGIN_STATUS_ERROR,
+			    "kdbSet has overwritten a currently mapped file");
+		if (write (parentPipe[1], "a", 1) != 1) _Exit (EXIT_FAILURE); // signal child that we are done
+		close (parentPipe[1]);
+
+		int status;
+		waitpid (pid, &status, 0);
+		if (status != 0) yield_error ("child process did not exit successfully.");
+
+		keyDel (parentKey);
+		ksDel (ks);
+		PLUGIN_CLOSE ();
+	}
+}
+
+static void test_mmap_unlock_mapped_file (const char * tmpFile)
+{
+	int parentPipe[2];
+	int childPipe[2];
+	if (pipe (parentPipe) != 0 || pipe (childPipe) != 0)
+	{
+		yield_error ("pipe() error");
+	}
+
+	pid_t pid;
+	char buf;
+	pid = fork ();
+
+	if (pid == -1)
+	{
+		yield_error ("fork() error");
+		return;
+	}
+	else if (pid == 0)
+	{
+		// child: open a config file and close
+		int devnull = open ("/dev/null", O_RDWR);
+		if (devnull == -1) _Exit (EXIT_FAILURE);
+
+		// redirect any communication on standard file descriptors to /dev/null
+		close (STDIN_FILENO);
+		close (STDOUT_FILENO);
+		close (STDERR_FILENO);
+		if (dup (devnull) == -1) _Exit (EXIT_FAILURE);
+		if (dup (devnull) == -1) _Exit (EXIT_FAILURE);
+		if (dup (devnull) == -1) _Exit (EXIT_FAILURE);
 		close (childPipe[0]);
 		close (parentPipe[1]);
 
@@ -830,26 +916,27 @@ static void test_mmap_lock_mapped_file (const char * tmpFile)
 		succeed_if (plugin->kdbSet (plugin, ks, parentKey) == 1, "kdbSet was not successful");
 		succeed_if (plugin->kdbGet (plugin, ks, parentKey) == 1, "kdbGet was not successful");
 
-		write (childPipe[1], "a", 1); // signal parent that we are ready
-		close (childPipe[1]);
-		read (parentPipe[0], &buf, 1); // wait for parent
-		close (parentPipe[0]);
-
 		KeySet * expected = simpleTestKeySet ();
 		compare_keyset (expected, ks);
 		compare_keyset (ks, expected);
-
+		ksDel (expected);
 		keyDel (parentKey);
 		ksDel (ks);
-		PLUGIN_CLOSE ();
-		exit (EXIT_SUCCESS);
+		PLUGIN_CLOSE (); // triggers unlinking of keyset and releases file lock
+
+		if (write (childPipe[1], "a", 1) != 1) _Exit (EXIT_FAILURE); // signal parent that we are ready
+		close (childPipe[1]);
+		if (read (parentPipe[0], &buf, 1) != 1)
+			_Exit (EXIT_FAILURE); // wait for parent (otherwise file lock is released implicitly)
+		close (parentPipe[0]);
+		_Exit (EXIT_SUCCESS);
 	}
 	else
 	{
-		// parent: try and destroy the file that the child has mapped
+		// parent: try to overwrite file (child should have unlocked it)
 		close (childPipe[1]);
 		close (parentPipe[0]);
-		read (childPipe[0], &buf, 1); // wait for child
+		if (read (childPipe[0], &buf, 1) != 1) _Exit (EXIT_FAILURE); // wait for child
 		close (childPipe[0]);
 
 		Key * parentKey = keyNew (TEST_ROOT_KEY, KEY_VALUE, tmpFile, KEY_END);
@@ -857,14 +944,21 @@ static void test_mmap_lock_mapped_file (const char * tmpFile)
 		PLUGIN_OPEN ("mmapstorage");
 
 		KeySet * ks = metaTestKeySet ();
-		succeed_if (plugin->kdbSet (plugin, ks, parentKey) == ELEKTRA_PLUGIN_STATUS_ERROR,
-			    "kdbSet has overwritten a currently mapped file");
-		write (parentPipe[1], "a", 1); // signal child that we are done
-		close (parentPipe[1]);
+		succeed_if (plugin->kdbSet (plugin, ks, parentKey) == 1, "kdbSet failed, mmap file was not unlocked properly");
 
+		KeySet * expected = metaTestKeySet ();
+		compare_keyset (expected, ks);
+		ksDel (expected);
 		keyDel (parentKey);
 		ksDel (ks);
 		PLUGIN_CLOSE ();
+
+		if (write (parentPipe[1], "a", 1) != 1) _Exit (EXIT_FAILURE); // signal child that we are done
+		close (parentPipe[1]);
+
+		int status;
+		waitpid (pid, &status, 0);
+		if (status != 0) yield_error ("child process did not exit successfully.");
 	}
 }
 
@@ -983,7 +1077,9 @@ int main (int argc, char ** argv)
 
 	test_mmap_open_pipe ();
 	test_mmap_bad_file_permissions (tmpFile);
+
 	test_mmap_lock_mapped_file (tmpFile);
+	test_mmap_unlock_mapped_file (tmpFile);
 
 	printf ("\ntestmod_mmapstorage RESULTS: %d test(s) done. %d error(s).\n", nbTest, nbError);
 

--- a/src/plugins/mmapstorage/testmod_mmapstorage.c
+++ b/src/plugins/mmapstorage/testmod_mmapstorage.c
@@ -683,41 +683,6 @@ static void test_mmap_ksCopy (const char * tmpFile)
 	PLUGIN_CLOSE ();
 }
 
-static void test_mmap_unlink_dirty_plugindata (const char * tmpFile)
-{
-	// insert dirty metadata into plugin data, regression test for unlinking error handling
-	Key * parentKey = keyNew (TEST_ROOT_KEY, KEY_VALUE, tmpFile, KEY_END);
-	KeySet * conf = ksNew (0, KS_END);
-	PLUGIN_OPEN ("mmapstorage");
-
-	KeySet * ks = simpleTestKeySet ();
-	succeed_if (plugin->kdbSet (plugin, ks, parentKey) == 1, "kdbSet was not successful");
-	succeed_if (plugin->kdbGet (plugin, ks, parentKey) == 1, "kdbGet was not successful");
-
-	// we know that plugin data has a key (the linked file from kdbGet above)
-	KeySet * mappedFiles = (KeySet *) elektraPluginGetData (plugin);
-	Key * found = ksLookup (mappedFiles, parentKey, 0);
-	if (found)
-	{
-		keySetMeta (found, "some erroneous key", "which should not exist here");
-		char tooLarge[1024];
-		sprintf (tooLarge, "%llu", ULLONG_MAX);
-		tooLarge[1023] = '\0';
-		keySetMeta (found, tooLarge, "0xZZZZ");
-	}
-	else
-	{
-		yield_error ("test eror, missing key in plugin data for unlinking");
-	}
-
-	// trigger unlinking via kdbSet
-	succeed_if (plugin->kdbSet (plugin, ks, parentKey) == 1, "kdbSet was not successful");
-
-	keyDel (parentKey);
-	ksDel (ks);
-	PLUGIN_CLOSE ();
-}
-
 static void test_mmap_open_pipe (void)
 {
 	// try writing to an invalid file, we simply use a pipe here
@@ -775,9 +740,8 @@ static void test_mmap_bad_file_permissions (const char * tmpFile)
 		yield_error ("chmod() failed");
 	}
 
-	// fopen() call should fail because file permissions were wrong
+	// open() call should fail because file permissions were wrong
 	succeed_if (plugin->kdbGet (plugin, ks, parentKey) == ELEKTRA_PLUGIN_STATUS_ERROR, "kdbGet did not detect bad file permissions");
-	succeed_if (plugin->kdbSet (plugin, ks, parentKey) == ELEKTRA_PLUGIN_STATUS_ERROR, "kdbSet did not detect bad file permissions");
 
 	if (chmod (tmpFile, sbuf.st_mode) != 0)
 	{
@@ -789,8 +753,9 @@ static void test_mmap_bad_file_permissions (const char * tmpFile)
 	PLUGIN_CLOSE ();
 }
 
-static void test_mmap_lock_mapped_file (const char * tmpFile)
+static void test_mmap_unlink (const char * tmpFile)
 {
+	// test file unlinking by overwriting config file while mapped
 	int parentPipe[2];
 	int childPipe[2];
 	if (pipe (parentPipe) != 0 || pipe (childPipe) != 0)
@@ -827,8 +792,8 @@ static void test_mmap_lock_mapped_file (const char * tmpFile)
 		KeySet * conf = ksNew (0, KS_END);
 		PLUGIN_OPEN ("mmapstorage");
 
-		KeySet * ks = ksNew (0, KS_END);
-		// succeed_if (plugin->kdbSet (plugin, ks, parentKey) == 1, "kdbSet was not successful");
+		KeySet * ks = simpleTestKeySet ();
+		succeed_if (plugin->kdbSet (plugin, ks, parentKey) == 1, "kdbSet was not successful");
 		succeed_if (plugin->kdbGet (plugin, ks, parentKey) == 1, "kdbGet was not successful");
 
 		if (write (childPipe[1], "a", 1) != 1) _Exit (EXIT_FAILURE); // signal parent that we are ready
@@ -836,7 +801,7 @@ static void test_mmap_lock_mapped_file (const char * tmpFile)
 		if (read (parentPipe[0], &buf, 1) != 1) _Exit (EXIT_FAILURE); // wait for parent
 		close (parentPipe[0]);
 
-		KeySet * expected = ksNew (0, KS_END);
+		KeySet * expected = simpleTestKeySet ();
 		compare_keyset (expected, ks);
 		compare_keyset (ks, expected);
 		ksDel (expected);
@@ -859,106 +824,17 @@ static void test_mmap_lock_mapped_file (const char * tmpFile)
 		PLUGIN_OPEN ("mmapstorage");
 
 		KeySet * ks = metaTestKeySet ();
-		succeed_if (plugin->kdbSet (plugin, ks, parentKey) == ELEKTRA_PLUGIN_STATUS_ERROR,
-			    "kdbSet has overwritten a currently mapped file");
-		if (write (parentPipe[1], "a", 1) != 1) _Exit (EXIT_FAILURE); // signal child that we are done
-		close (parentPipe[1]);
-
-		int status;
-		waitpid (pid, &status, 0);
-		if (status != 0) yield_error ("child process did not exit successfully.");
-
-		keyDel (parentKey);
-		ksDel (ks);
-		PLUGIN_CLOSE ();
-	}
-}
-
-static void test_mmap_unlock_mapped_file (const char * tmpFile)
-{
-	int parentPipe[2];
-	int childPipe[2];
-	if (pipe (parentPipe) != 0 || pipe (childPipe) != 0)
-	{
-		yield_error ("pipe() error");
-	}
-
-	pid_t pid;
-	char buf;
-	pid = fork ();
-
-	if (pid == -1)
-	{
-		yield_error ("fork() error");
-		return;
-	}
-	else if (pid == 0)
-	{
-		// child: open a config file and close
-		int devnull = open ("/dev/null", O_RDWR);
-		if (devnull == -1) _Exit (EXIT_FAILURE);
-
-		// redirect any communication on standard file descriptors to /dev/null
-		close (STDIN_FILENO);
-		close (STDOUT_FILENO);
-		close (STDERR_FILENO);
-		if (dup (devnull) == -1) _Exit (EXIT_FAILURE);
-		if (dup (devnull) == -1) _Exit (EXIT_FAILURE);
-		if (dup (devnull) == -1) _Exit (EXIT_FAILURE);
-		close (childPipe[0]);
-		close (parentPipe[1]);
-
-		Key * parentKey = keyNew (TEST_ROOT_KEY, KEY_VALUE, tmpFile, KEY_END);
-		KeySet * conf = ksNew (0, KS_END);
-		PLUGIN_OPEN ("mmapstorage");
-
-		KeySet * ks = simpleTestKeySet ();
 		succeed_if (plugin->kdbSet (plugin, ks, parentKey) == 1, "kdbSet was not successful");
-		succeed_if (plugin->kdbGet (plugin, ks, parentKey) == 1, "kdbGet was not successful");
-
-		KeySet * expected = simpleTestKeySet ();
-		compare_keyset (expected, ks);
-		compare_keyset (ks, expected);
-		ksDel (expected);
-		keyDel (parentKey);
-		ksDel (ks);
-		PLUGIN_CLOSE (); // triggers unlinking of keyset and releases file lock
-
-		if (write (childPipe[1], "a", 1) != 1) _Exit (EXIT_FAILURE); // signal parent that we are ready
-		close (childPipe[1]);
-		if (read (parentPipe[0], &buf, 1) != 1)
-			_Exit (EXIT_FAILURE); // wait for parent (otherwise file lock is released implicitly)
-		close (parentPipe[0]);
-		_Exit (EXIT_SUCCESS);
-	}
-	else
-	{
-		// parent: try to overwrite file (child should have unlocked it)
-		close (childPipe[1]);
-		close (parentPipe[0]);
-		if (read (childPipe[0], &buf, 1) != 1) _Exit (EXIT_FAILURE); // wait for child
-		close (childPipe[0]);
-
-		Key * parentKey = keyNew (TEST_ROOT_KEY, KEY_VALUE, tmpFile, KEY_END);
-		KeySet * conf = ksNew (0, KS_END);
-		PLUGIN_OPEN ("mmapstorage");
-
-		KeySet * ks = metaTestKeySet ();
-		succeed_if (plugin->kdbSet (plugin, ks, parentKey) == 1, "kdbSet failed, mmap file was not unlocked properly");
-
-		KeySet * expected = metaTestKeySet ();
-		compare_keyset (expected, ks);
-		ksDel (expected);
-		keyDel (parentKey);
-		ksDel (ks);
-		PLUGIN_CLOSE ();
-
 		if (write (parentPipe[1], "a", 1) != 1) _Exit (EXIT_FAILURE); // signal child that we are done
 		close (parentPipe[1]);
 
 		int status;
 		waitpid (pid, &status, 0);
 		if (status != 0) yield_error ("child process did not exit successfully.");
+
+		keyDel (parentKey);
+		ksDel (ks);
+		PLUGIN_CLOSE ();
 	}
 }
 
@@ -1072,14 +948,10 @@ int main (int argc, char ** argv)
 	clearStorage (tmpFile);
 	test_mmap_ksCopy (tmpFile);
 
-	clearStorage (tmpFile);
-	test_mmap_unlink_dirty_plugindata (tmpFile);
-
 	test_mmap_open_pipe ();
 	test_mmap_bad_file_permissions (tmpFile);
 
-	test_mmap_lock_mapped_file (tmpFile);
-	test_mmap_unlock_mapped_file (tmpFile);
+	test_mmap_unlink (tmpFile);
 
 	printf ("\ntestmod_mmapstorage RESULTS: %d test(s) done. %d error(s).\n", nbTest, nbError);
 


### PR DESCRIPTION
Resolves #2248. Unlinking is now implemented by simply calling `unlink()` instead of a custom approach that was error prone.
Includes some other small cleanups and fixes.

## Checklist

Check relevant points but **please do not remove entries**.
For docu fixes, spell checking, and similar none of these points below
need to be checked.

- [x] I added unit tests
- [x] I ran all tests locally and everything went fine
- [x] affected documentation is fixed
- [x] I added code comments, logging, and assertions (see doc/CODING.md)
- [x] meta data is updated (e.g. README.md of plugins)
- [x] I removed references to old unlinking and locking approaches.

