### PR TITLE
Travis: Mitigate Timeout Problems

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,13 @@ before_cache:
 matrix:
   include:
 
+    - os: osx
+      name: 🍏 Check Source
+      osx_image: xcode10.0
+      compiler: clang
+      env:
+        - TEST_COMMAND="ctest --output-on-failure -R 'testscr_check_(bashisms|doc|formatting|meta|oclint|plugins)'"
+
     # ASAN: Enable AddressSanitizer
 
     - os: osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -197,6 +197,8 @@ matrix:
       name: 🍏 Clang
       osx_image: xcode10.0
       compiler: clang
+      env:
+        - *testNoSourceCheck
 
     # HASKELL: Only build Haskell binding and plugin
 
@@ -250,6 +252,7 @@ matrix:
         - KDB_DEFAULT_STORAGE=mmapstorage
         - KDB_DB_FILE=default.mmap
         - KDB_DB_INIT=elektra.mmap
+        - *testNoSourceCheck
 
 before_install:
   - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ matrix:
         # [timeout]: https://docs.travis-ci.com/user/customizing-the-build/#build-timeouts
         - TOOLS=kdb
         - BINDINGS=cpp
-        - "PLUGINS='\
+        - &minimalPluginList "PLUGINS='\
           ALL;\
           -augeas;\
           -base64;\
@@ -151,7 +151,7 @@ matrix:
         # Build less stuff so the build does not hit the timeout limit that often
         - TOOLS=kdb
         - BINDINGS=cpp
-        - PLUGINS='ALL;-camel;-directoryvalue;-mini;-yambi;-yamlcpp;-yanlr'
+        - *minimalPluginList
         - TEST_COMMAND="ctest --output-on-failure -E 'testscr_check_(bashisms|doc|formatting|meta|oclint|plugins)'"
 
     - os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -132,7 +132,7 @@ matrix:
           -zeromqrecv;\
           -zeromqsend;\
           '"
-        - TEST_COMMAND="ctest --output-on-failure -E 'testscr_check_(bashisms|doc|formatting|meta|oclint|plugins)'"
+        - &testNoSourceCheck TEST_COMMAND="ctest --output-on-failure -E 'testscr_check_(bashisms|doc|formatting|meta|oclint|plugins)'"
 
     - os: linux
       name: 🐧 GCC ASAN
@@ -152,7 +152,7 @@ matrix:
         - TOOLS=kdb
         - BINDINGS=cpp
         - *minimalPluginList
-        - TEST_COMMAND="ctest --output-on-failure -E 'testscr_check_(bashisms|doc|formatting|meta|oclint|plugins)'"
+        - *testNoSourceCheck
 
     - os: linux
       name: 🐧 Clang ASAN

--- a/doc/news/_preparation_next_release.md
+++ b/doc/news/_preparation_next_release.md
@@ -281,8 +281,9 @@ you up to date with the multi-language support provided by Elektra.
 ### Travis
 
 - Travis now also checks the code for memory leaks in the build job `🍏 Clang ASAN`. *(René Schwaiger)*
-- The Travis build job `🍏 Clang ASAN` now only translates a minimal set of plugins, since we had various timeout problems with this job
-  before. We explicitly excluded plugins, to make sure that the build job still tests newly added plugins. *(René Schwaiger)*
+- The Travis build jobs `🍏 Clang ASAN` and `🐧 GCC ASAN` now only translates a minimal set of plugins, since we had various timeout
+  problems with these jobs before. We explicitly excluded plugins, to make sure that the build jobs still test newly added plugins.
+  *(René Schwaiger)*
 - Added travis build job `🍏 mmap` on macOS with `mmapstorage` as the default storage. *(Mihael Pranjić)*
 - Travis now prints the CMake configuration for each build job. *(René Schwaiger)*
 - We now test Elektra using the latest version of Xcode (`10.0`). *(René Schwaiger)*

--- a/doc/news/_preparation_next_release.md
+++ b/doc/news/_preparation_next_release.md
@@ -287,6 +287,9 @@ you up to date with the multi-language support provided by Elektra.
 - Added travis build job `🍏 mmap` on macOS with `mmapstorage` as the default storage. *(Mihael Pranjić)*
 - Travis now prints the CMake configuration for each build job. *(René Schwaiger)*
 - We now test Elektra using the latest version of Xcode (`10.0`). *(René Schwaiger)*
+- We added the build job `🍏 Check Source`, which only runs source code checks such as `testscr_check_oclint`. This update allows us to
+  remove the source code checks from the jobs `🍏 MMap` and `🍏 Clang`, which sometimes hit the
+  [timeout limit for public repositories](https://docs.travis-ci.com/user/customizing-the-build#build-timeouts) before.
 
 
 ## Website


### PR DESCRIPTION
# Description

This update should mitigate the timeout problems of some Travis build jobs (`🐧 GCC ASAN`, `🍏 Clang` and `🍏 MMap`) a little bit. From what I can tell, all build jobs should usually [execute in less than 40 minutes](https://travis-ci.org/sanssecours/elektra/builds/437064505) after the update. This update does increase the overall build time a little bit though. 
