### PR TITLE
cmake: add dependency from plugin tests to plugins

### DIFF
--- a/cmake/Modules/LibAddPlugin.cmake
+++ b/cmake/Modules/LibAddPlugin.cmake
@@ -124,6 +124,12 @@ function (add_plugintest testname)
 		add_executable (${testexename} ${TEST_SOURCES})
 		add_dependencies (${testexename} kdberrors_generated)
 
+		if (ARG_LINK_PLUGIN)
+			add_dependencies (${testexename} elektra-${ARG_LINK_PLUGIN})
+		else ()
+			add_dependencies (${testexename} elektra-${testname})
+		endif ()
+
 		# ~~~
 		# alternative approach to restore_variable
 		# get_target_property(TARGET_COMPILE_DEFINITIONS PLUGIN_TARGET_OBJS COMPILE_DEFINITIONS)

--- a/doc/news/_preparation_next_release.md
+++ b/doc/news/_preparation_next_release.md
@@ -237,6 +237,8 @@ you up to date with the multi-language support provided by Elektra.
   Currently, the tests are only active for `dump` and `mmapstorage`. *(Mihael Pranjić)*
 - The test `testcpp_contextual_basic` now compiles without warnings, if we use Clang 7 as compiler. *(René Schwaiger)*
 - crypto, fcrypt and gpgme properly shut down the gpg-agent after the unit test is done. See #1973 . *(Peter Nirschl)*
+- The CMake targets for plugin tests (`testmod_[plugin]`) now depend on the respective CMake targets for the plugins themselves 
+  (`elektra-[plugin]`). *(Klemens Böswirth)*
 
 [Markdown Shell Recorder]: https://master.libelektra.org/tests/shell/shell_recorder/tutorial_wrapper
 


### PR DESCRIPTION
Fixes #2265 

## Basics

- [x] Short descriptions should be in the release notes (added as entry in
      doc/news/_preparation_next_release.md which contains `*(my name)*`)

## Checklist

- [ ] I added unit tests
- [x] I ran all tests locally and everything went fine
- [ ] affected documentation is fixed
- [ ] I added code comments, logging, and assertions (see doc/CODING.md)
- [ ] meta data is updated (e.g. README.md of plugins)

## Review

@markus2330 please review my pull request
