### PR TITLE
Ruby bindings: kdb, do not use private headers

### DIFF
--- a/doc/news/_preparation_next_release.md
+++ b/doc/news/_preparation_next_release.md
@@ -204,7 +204,9 @@ compiled against an older 0.8 version of Elektra will continue to work
 Bindings allow you to utilize Elektra using [various programming languages](https://www.libelektra.org/bindings/readme). This section keeps
 you up to date with the multi-language support provided by Elektra.
 
-### <<Binding1>>
+### Ruby
+
+- Do not use private Elektra headers for Ruby bindings as preparation for a Ruby `libelektra` gem. *(Bernhard Denner)*
 
 
 ### <<Binding2>>


### PR DESCRIPTION
This is preparation for #1946 and #1293 but use a separate PR for this to get this merges soon.

## Review

Remove the line below and add the "work in progress" label if you do
not want the PR to be reviewed:

@markus2330 please review my pull request
