### PR TITLE
Array: Change Behavior of `elektraArrayValidateBaseNameString` Slightly

### DIFF
--- a/doc/news/_preparation_next_release.md
+++ b/doc/news/_preparation_next_release.md
@@ -94,9 +94,34 @@ compiled against an older 0.8 version of Elektra will continue to work
 - <<TODO>>
 - <<TODO>>
 
-### <<Library1>>
+### Libease
 
-- <<TODO>>
+- The function `elektraArrayValidateBaseNameString` now returns the offset to the first digit of the array index, if the given string
+  represents an array element containing an index. This update enhances the behavior of the function. Now it not only tells you if a name
+  represents a valid array element, but also the start position of the array index.
+
+  ```c
+  elektraArrayValidateBaseNameString ("#_10");
+  //                                     ~~^ Returns `2` (instead of `1`)
+
+  elektraArrayValidateBaseNameString ("#___1337");
+  //                                   ~~~~^ Returns `4` (instead of `1`)
+  ```
+
+  If your program already used `elektraArrayValidateBaseNameString` and you check for a valid array element using the equality operator
+  (`== 1`), then please use (`>= 1`) instead. For example, if you code that looks like this:
+
+  ```c
+  if (elektraArrayValidateBaseNameString(baseName) == 1) …;
+  ```
+
+  , please update your code to check for a valid array element name like this:
+
+  ```c
+  if (elektraArrayValidateBaseNameString(baseName) >= 1) …;
+  ```
+
+  . *(René Schwaiger)*
 - <<TODO>>
 - <<TODO>>
 

--- a/src/plugins/directoryvalue/directoryvalue_delegate.cpp
+++ b/src/plugins/directoryvalue/directoryvalue_delegate.cpp
@@ -168,20 +168,10 @@ CppKey convertToDirectChild (CppKey const & parent, CppKey const & child)
 bool inline isArrayElementOf (CppKey const & parent, CppKey const & child)
 {
 	char const * relative = elektraKeyGetRelativeName (*child, *parent);
-	if (relative[0] != '#') return false;
-	relative++; // Skip leading `#`
-	size_t underscores = 0;
-	while (relative[underscores] == '_')
-	{
-		underscores++;
-	}
-	relative = &relative[underscores]; // Skip underscores
-	// Check index
-	for (size_t digit = 0; digit <= underscores; digit++)
-	{
-		if (relative[digit] < '0' || relative[digit] > '9') return false;
-	}
-	relative = &relative[underscores + 1]; // Skip index
+	auto offsetIndex = elektraArrayValidateBaseNameString (relative);
+	if (offsetIndex <= 0) return false;
+	// Skip `#`, underscores and digits
+	relative += 2 * offsetIndex;
 	// The next character has to be the separation char (`/`) or end of string
 	if (relative[0] != '\0' && relative[0] != '/') return false;
 

--- a/src/plugins/yamlcpp/write.cpp
+++ b/src/plugins/yamlcpp/write.cpp
@@ -56,23 +56,9 @@ NameIterator relativeKeyIterator (Key const & key, Key const & parent)
 std::pair<bool, unsigned long long> isArrayIndex (NameIterator const & nameIterator)
 {
 	string const name = *nameIterator;
-	if (name.size () < 2 || name.front () != '#') return std::make_pair (false, 0);
-
-	auto errnoValue = errno;
-
-	try
-	{
-		return std::make_pair (true, stoull (name.substr (name.find_first_not_of ("#\\_"))));
-	}
-	catch (invalid_argument const &)
-	{
-		return std::make_pair (false, 0);
-	}
-	catch (out_of_range const &)
-	{
-		errno = errnoValue;
-		return std::make_pair (false, 0);
-	}
+	auto const offsetIndex = ckdb::elektraArrayValidateBaseNameString (name.c_str ());
+	auto const isArrayElement = offsetIndex >= 1;
+	return { isArrayElement, isArrayElement ? stoull (name.substr (offsetIndex)) : 0 };
 }
 
 /**

--- a/src/plugins/yamlcpp/write.cpp
+++ b/src/plugins/yamlcpp/write.cpp
@@ -154,7 +154,7 @@ void addEmptyArrayElements (YAML::Node & sequence, unsigned long long const numb
 	ELEKTRA_LOG_DEBUG ("Add %lld empty array elements", numberOfElements);
 	for (auto missingFields = numberOfElements; missingFields > 0; missingFields--)
 	{
-		sequence.push_back (YAML::Node ());
+		sequence.push_back ({});
 	}
 }
 

--- a/tests/ctest/test_array.c
+++ b/tests/ctest/test_array.c
@@ -190,8 +190,8 @@ static void test_baseName (void)
 
 	succeed_if (elektraArrayValidateBaseNameString ("#") == 0, "Start not detected correctly");
 	succeed_if (elektraArrayValidateBaseNameString ("#0") == 1, "#0 should be valid");
-	succeed_if (elektraArrayValidateBaseNameString ("#_10") == 1, "#_10 should be valid");
-	succeed_if (elektraArrayValidateBaseNameString ("#_________1234567890") == 1, "#_________1234567890 should be valid");
+	succeed_if (elektraArrayValidateBaseNameString ("#_10") == 2, "#_10 should be valid");
+	succeed_if (elektraArrayValidateBaseNameString ("#_________1234567890") == 10, "#_________1234567890 should be valid");
 	succeed_if (elektraArrayValidateBaseNameString ("#__________12345678901") == -1, "#__________12345678901 should not be valid");
 	succeed_if (elektraArrayValidateBaseNameString ("monkey") == -1, "monkey should not be valid");
 }


### PR DESCRIPTION
# Description

This pull request improves the behavior of `elektraArrayValidateBaseNameString`, which now returns the offset to the first digit of the array index for valid array elements:

```c
elektraArrayValidateBaseNameString ("#_10");
//                                     ~~^ Returns `2` (instead of `1`)
 elektraArrayValidateBaseNameString ("#___1337");
//                                    ~~~~^ Returns `4` (instead of `1`)
```

. While the updated behavior is slightly different from the current one, I think the increased utility makes up for breaking (hypothetical existing) user code that compares the return value of the function to `1` using the equality operator (instead of `>=`).