### PR TITLE
Global plugins: global keyset handle

### DIFF
--- a/doc/decisions/global_plugins.md
+++ b/doc/decisions/global_plugins.md
@@ -213,9 +213,13 @@ which needs to store internal information for the KDB. Some of the information i
 and can not be stored in metadata.
 
 To make the communication between global plugins easier, global plugins will additionally
-get a handle to a global keyset. The global keyset is initialized at the beginning of kdbGet() and
-kdbSet() and deinitialized at the end of the respective KDB function. In other words, the global
-keyset is tied to a KDB handle and is ksClear()-ed before the KDB function returns.
+get a handle to a global keyset. The global keyset is tied to a KDB handle, initialized on kdbOpen() and
+deleted on kdbClose().
+
+The resolver plugin is an exception and also gets a handle to the global keyset. This way it
+can store and compare timestamps of config files and cache files.
+
+Plugins are responsible for cleaning up their part of the global keyset.
 
 ## Notes
 

--- a/doc/decisions/global_plugins.md
+++ b/doc/decisions/global_plugins.md
@@ -40,9 +40,11 @@ Configuration will be in arrays below the keys:
                                  /rollback
                                  /postrollback
                                  /getresolver
+                                 /pregetcache
                                  /pregetstorage
                                  /getstorage
                                  /postgetstorage
+                                 /postgetcache
                                  /setresolver
                                  /presetstorage
                                  /setstorage
@@ -202,6 +204,17 @@ State diagrams of plugins need to be redrawn to also include global plugin
 states.
 
 ## Related decisions
+
+### Global KeySet handle
+
+Some global plugins need to communicate more data than is possible to do with metadata.
+This can limit the functionality of global plugins. One example is a global cache plugin,
+which needs to store internal information for the KDB, some of which is binary.
+
+To make the communication between global plugins easier, global plugins will additionally
+get a handle to a global keyset. The global keyset is initialized at the beginning of kdbGet() and
+kdbSet() and deinitialized at the end of the respective KDB function. In other words, the global
+keyset is tied to a KDB handle and is ksClear()-ed before the KDB function returns.
 
 ## Notes
 

--- a/doc/decisions/global_plugins.md
+++ b/doc/decisions/global_plugins.md
@@ -209,7 +209,8 @@ states.
 
 Some global plugins need to communicate more data than is possible to do with metadata.
 This can limit the functionality of global plugins. One example is a global cache plugin,
-which needs to store internal information for the KDB, some of which is binary.
+which needs to store internal information for the KDB. Some of the information is binary
+and can not be stored in metadata.
 
 To make the communication between global plugins easier, global plugins will additionally
 get a handle to a global keyset. The global keyset is initialized at the beginning of kdbGet() and

--- a/doc/news/_preparation_next_release.md
+++ b/doc/news/_preparation_next_release.md
@@ -127,8 +127,7 @@ compiled against an older 0.8 version of Elektra will continue to work
 
 ### Core
 
-- Global plugins now get a handle to a global keyset. The keyset is available throughout a kdbGet() and kdbSet() function,
-  but is cleared before the function returns. This makes communication between global plugins easier. *(Mihael Pranjić)*
+- Global plugins now get a handle to a global keyset, which makes communication between global plugins easier. *(Mihael Pranjić)*
 - <<TODO>>
 - <<TODO>>
 

--- a/doc/news/_preparation_next_release.md
+++ b/doc/news/_preparation_next_release.md
@@ -127,7 +127,8 @@ compiled against an older 0.8 version of Elektra will continue to work
 
 ### Core
 
-- <<TODO>>
+- Global plugins now get a handle to a global keyset. The keyset is available throughout a kdbGet() and kdbSet() function,
+  but is cleared before the function returns. This makes communication between global plugins easier. *(Mihael Pranjić)*
 - <<TODO>>
 - <<TODO>>
 

--- a/src/include/kdbplugin.h
+++ b/src/include/kdbplugin.h
@@ -108,8 +108,8 @@ Plugin * elektraPluginExport (const char * pluginName, ...);
 KeySet * elektraPluginGetConfig (Plugin * handle);
 void elektraPluginSetData (Plugin * plugin, void * handle);
 void * elektraPluginGetData (Plugin * plugin);
-void elektraPluginSetGlobalKeySet (Plugin * plugin, KeySet * ks);
-KeySet * elektraPluginGetGlobalKeySet (Plugin * plugin);
+void elektraPluginSetGlobal (Plugin * plugin, KeySet * ks);
+KeySet * elektraPluginGetGlobal (Plugin * plugin);
 
 #define PLUGINVERSION "1"
 

--- a/src/include/kdbplugin.h
+++ b/src/include/kdbplugin.h
@@ -108,8 +108,8 @@ Plugin * elektraPluginExport (const char * pluginName, ...);
 KeySet * elektraPluginGetConfig (Plugin * handle);
 void elektraPluginSetData (Plugin * plugin, void * handle);
 void * elektraPluginGetData (Plugin * plugin);
-void elektraPluginSetGlobal (Plugin * plugin, KeySet * ks);
-KeySet * elektraPluginGetGlobal (Plugin * plugin);
+
+KeySet * elektraPluginGetGlobalKeySet (Plugin * plugin);
 
 #define PLUGINVERSION "1"
 

--- a/src/include/kdbplugin.h
+++ b/src/include/kdbplugin.h
@@ -108,7 +108,8 @@ Plugin * elektraPluginExport (const char * pluginName, ...);
 KeySet * elektraPluginGetConfig (Plugin * handle);
 void elektraPluginSetData (Plugin * plugin, void * handle);
 void * elektraPluginGetData (Plugin * plugin);
-
+void elektraPluginSetGlobalKeySet (Plugin * plugin, KeySet * ks);
+KeySet * elektraPluginGetGlobalKeySet (Plugin * plugin);
 
 #define PLUGINVERSION "1"
 

--- a/src/include/kdbprivate.h
+++ b/src/include/kdbprivate.h
@@ -587,9 +587,9 @@ int keyNameIsSystem (const char * keyname);
 int keyNameIsUser (const char * keyname);
 
 /* global plugin calls */
-void elektraGlobalGet (KDB * handle, KeySet * ks, Key * parentKey, int position, int subPosition);
-void elektraGlobalSet (KDB * handle, KeySet * ks, Key * parentKey, int position, int subPosition);
-void elektraGlobalError (KDB * handle, KeySet * ks, Key * parentKey, int position, int subPosition);
+int elektraGlobalGet (KDB * handle, KeySet * ks, Key * parentKey, int position, int subPosition);
+int elektraGlobalSet (KDB * handle, KeySet * ks, Key * parentKey, int position, int subPosition);
+int elektraGlobalError (KDB * handle, KeySet * ks, Key * parentKey, int position, int subPosition);
 
 /** Test a bit. @see set_bit(), clear_bit() */
 #define test_bit(var, bit) ((var) & (bit))

--- a/src/include/kdbprivate.h
+++ b/src/include/kdbprivate.h
@@ -326,10 +326,8 @@ struct _KDB
 	Plugin * notificationPlugin; /*!< reference to global plugin for notifications.*/
 	ElektraNotificationCallbackContext * notificationCallbackContext; /*!< reference to context for notification callbacks.*/
 
-	KeySet * global; /*!< This keyset can be used by global plugins to pass data through
-			the KDB and communicate with other global plugins during a KDB call.
-			It is initialized at beginning of kdbGet()/kdbSet() and is
-			ksClear()-ed before the functions return.*/
+	KeySet * global; /*!< This keyset can be used by global plugins and the resolver
+			to pass data through the KDB and communicate with other global plugins.*/
 };
 
 
@@ -419,10 +417,10 @@ struct _Plugin
 	void * data; /*!< This handle can be used for a plugin to store
 	 any data its want to. */
 
-	KeySet * global; /*!< This keyset can be used by global plugins to pass data through
-			the KDB and communicate with other global plugins during a KDB call.
-			It is initialized at beginning of kdbGet()/kdbSet() and is
-			ksClear()-ed before the functions return.*/
+	KeySet * global; /*!< This keyset can be used by global plugins and the resolver
+			to pass data through the KDB and communicate with other global plugins.
+			Plugins shall clean up their parts of the global keyset, which
+			they do not need any more.*/
 };
 
 

--- a/src/include/kdbprivate.h
+++ b/src/include/kdbprivate.h
@@ -315,6 +315,11 @@ struct _KDB
 
 	KeySet * modules; /*!< A list of all modules loaded at the moment.*/
 
+	KeySet * global; /*!< This keyset can be used by global plugins to pass data through
+			the KDB and communicate with other global plugins during a KDB call.
+			It is initialized at beginning of kdbGet()/kdbSet() and is
+			ksClear()-ed before the functions return.*/
+
 	Backend * defaultBackend; /*!< The default backend as fallback when nothing else is found.*/
 
 	Backend * initBackend; /*!< The init backend for bootstrapping.*/
@@ -413,6 +418,11 @@ struct _Plugin
 
 	void * data; /*!< This handle can be used for a plugin to store
 	 any data its want to. */
+
+	KeySet * global; /*!< This keyset can be used by global plugins to pass data through
+			the KDB and communicate with other global plugins during a KDB call.
+			It is initialized at beginning of kdbGet()/kdbSet() and is
+			ksClear()-ed before the functions return.*/
 };
 
 

--- a/src/include/kdbprivate.h
+++ b/src/include/kdbprivate.h
@@ -315,11 +315,6 @@ struct _KDB
 
 	KeySet * modules; /*!< A list of all modules loaded at the moment.*/
 
-	KeySet * global; /*!< This keyset can be used by global plugins to pass data through
-			the KDB and communicate with other global plugins during a KDB call.
-			It is initialized at beginning of kdbGet()/kdbSet() and is
-			ksClear()-ed before the functions return.*/
-
 	Backend * defaultBackend; /*!< The default backend as fallback when nothing else is found.*/
 
 	Backend * initBackend; /*!< The init backend for bootstrapping.*/
@@ -330,6 +325,11 @@ struct _KDB
 
 	Plugin * notificationPlugin; /*!< reference to global plugin for notifications.*/
 	ElektraNotificationCallbackContext * notificationCallbackContext; /*!< reference to context for notification callbacks.*/
+
+	KeySet * global; /*!< This keyset can be used by global plugins to pass data through
+			the KDB and communicate with other global plugins during a KDB call.
+			It is initialized at beginning of kdbGet()/kdbSet() and is
+			ksClear()-ed before the functions return.*/
 };
 
 

--- a/src/libs/elektra/global.c
+++ b/src/libs/elektra/global.c
@@ -14,29 +14,35 @@
  * Helper functions to execute global plugins
  */
 
-void elektraGlobalGet (KDB * handle, KeySet * ks, Key * parentKey, int position, int subPosition)
+int elektraGlobalGet (KDB * handle, KeySet * ks, Key * parentKey, int position, int subPosition)
 {
+	int ret = 0;
 	Plugin * plugin;
 	if (handle && (plugin = handle->globalPlugins[position][subPosition]))
 	{
-		plugin->kdbGet (plugin, ks, parentKey);
+		ret = plugin->kdbGet (plugin, ks, parentKey);
 	}
+	return ret;
 }
 
-void elektraGlobalSet (KDB * handle, KeySet * ks, Key * parentKey, int position, int subPosition)
+int elektraGlobalSet (KDB * handle, KeySet * ks, Key * parentKey, int position, int subPosition)
 {
+	int ret = 0;
 	Plugin * plugin;
 	if (handle && (plugin = handle->globalPlugins[position][subPosition]))
 	{
-		plugin->kdbSet (plugin, ks, parentKey);
+		ret = plugin->kdbSet (plugin, ks, parentKey);
 	}
+	return ret;
 }
 
-void elektraGlobalError (KDB * handle, KeySet * ks, Key * parentKey, int position, int subPosition)
+int elektraGlobalError (KDB * handle, KeySet * ks, Key * parentKey, int position, int subPosition)
 {
+	int ret = 0;
 	Plugin * plugin;
 	if (handle && (plugin = handle->globalPlugins[position][subPosition]))
 	{
-		plugin->kdbError (plugin, ks, parentKey);
+		ret = plugin->kdbError (plugin, ks, parentKey);
 	}
+	return ret;
 }

--- a/src/libs/elektra/kdb.c
+++ b/src/libs/elektra/kdb.c
@@ -784,6 +784,7 @@ int kdbGet (KDB * handle, KeySet * ks, Key * parentKey)
 
 	int errnosave = errno;
 	Key * initialParent = keyDup (parentKey);
+	ksClear (handle->global);
 
 	ELEKTRA_LOG ("now in new kdbGet (%s)", keyName (parentKey));
 
@@ -815,6 +816,7 @@ int kdbGet (KDB * handle, KeySet * ks, Key * parentKey)
 		elektraGlobalGet (handle, ks, parentKey, POSTGETSTORAGE, INIT);
 		elektraGlobalGet (handle, ks, parentKey, POSTGETSTORAGE, MAXONCE);
 		elektraGlobalGet (handle, ks, parentKey, POSTGETSTORAGE, DEINIT);
+		ksClear (handle->global);
 		splitUpdateFileName (split, handle, parentKey);
 		keyDel (initialParent);
 		splitDel (split);
@@ -901,6 +903,7 @@ int kdbGet (KDB * handle, KeySet * ks, Key * parentKey)
 	keySetName (parentKey, keyName (initialParent));
 
 	splitUpdateFileName (split, handle, parentKey);
+	ksClear (handle->global);
 	keyDel (initialParent);
 	keyDel (oldError);
 	splitDel (split);
@@ -913,6 +916,7 @@ error:
 	elektraGlobalError (handle, ks, parentKey, POSTGETSTORAGE, MAXONCE);
 	elektraGlobalError (handle, ks, parentKey, POSTGETSTORAGE, DEINIT);
 
+	ksClear (handle->global);
 	keySetName (parentKey, keyName (initialParent));
 	if (handle) splitUpdateFileName (split, handle, parentKey);
 	keyDel (initialParent);
@@ -1191,6 +1195,7 @@ int kdbSet (KDB * handle, KeySet * ks, Key * parentKey)
 
 	int errnosave = errno;
 	Key * initialParent = keyDup (parentKey);
+	ksClear (handle->global);
 
 	ELEKTRA_LOG ("now in new kdbSet (%s) %p %zd", keyName (parentKey), (void *) handle, ksGetSize (ks));
 
@@ -1236,6 +1241,7 @@ int kdbSet (KDB * handle, KeySet * ks, Key * parentKey)
 		{
 			ELEKTRA_SET_ERROR (107, parentKey, keyName (split->parents[-syncstate - 2]));
 		}
+		ksClear (handle->global);
 		keyDel (initialParent);
 		splitDel (split);
 		errno = errnosave;
@@ -1282,6 +1288,7 @@ int kdbSet (KDB * handle, KeySet * ks, Key * parentKey)
 		clear_bit (ks->array[i]->flags, KEY_FLAG_SYNC);
 	}
 
+	ksClear (handle->global);
 	keySetName (parentKey, keyName (initialParent));
 	keyDel (initialParent);
 	splitDel (split);
@@ -1314,6 +1321,7 @@ error:
 	elektraGlobalError (handle, ks, parentKey, POSTROLLBACK, MAXONCE);
 	elektraGlobalError (handle, ks, parentKey, POSTROLLBACK, DEINIT);
 
+	ksClear (handle->global);
 	keySetName (parentKey, keyName (initialParent));
 	keyDel (initialParent);
 	splitDel (split);

--- a/src/libs/elektra/kdb.c
+++ b/src/libs/elektra/kdb.c
@@ -263,6 +263,7 @@ KDB * kdbOpen (Key * errorKey)
 	KDB * handle = elektraCalloc (sizeof (struct _KDB));
 	Key * initialParent = keyDup (errorKey);
 
+	handle->global = ksNew (0, KS_END);
 	handle->modules = ksNew (0, KS_END);
 	if (elektraModulesInit (handle->modules, errorKey) == -1)
 	{
@@ -432,6 +433,8 @@ int kdbClose (KDB * handle, Key * errorKey)
 	{
 		ELEKTRA_ADD_WARNING (47, errorKey, "modules were not open");
 	}
+
+	if (handle->global) ksDel (handle->global);
 
 	elektraFree (handle);
 

--- a/src/libs/elektra/kdb.c
+++ b/src/libs/elektra/kdb.c
@@ -798,8 +798,6 @@ int kdbGet (KDB * handle, KeySet * ks, Key * parentKey)
 		goto error;
 	}
 
-	ksClear (handle->global);
-
 	elektraGlobalGet (handle, ks, parentKey, PREGETSTORAGE, INIT);
 	elektraGlobalGet (handle, ks, parentKey, PREGETSTORAGE, MAXONCE);
 	elektraGlobalGet (handle, ks, parentKey, PREGETSTORAGE, DEINIT);
@@ -819,7 +817,6 @@ int kdbGet (KDB * handle, KeySet * ks, Key * parentKey)
 		elektraGlobalGet (handle, ks, parentKey, POSTGETSTORAGE, INIT);
 		elektraGlobalGet (handle, ks, parentKey, POSTGETSTORAGE, MAXONCE);
 		elektraGlobalGet (handle, ks, parentKey, POSTGETSTORAGE, DEINIT);
-		ksClear (handle->global);
 		splitUpdateFileName (split, handle, parentKey);
 		keyDel (initialParent);
 		splitDel (split);
@@ -906,7 +903,6 @@ int kdbGet (KDB * handle, KeySet * ks, Key * parentKey)
 	keySetName (parentKey, keyName (initialParent));
 
 	splitUpdateFileName (split, handle, parentKey);
-	ksClear (handle->global);
 	keyDel (initialParent);
 	keyDel (oldError);
 	splitDel (split);
@@ -920,11 +916,7 @@ error:
 	elektraGlobalError (handle, ks, parentKey, POSTGETSTORAGE, DEINIT);
 
 	keySetName (parentKey, keyName (initialParent));
-	if (handle)
-	{
-		splitUpdateFileName (split, handle, parentKey);
-		if (handle->global) ksClear (handle->global);
-	}
+	if (handle) splitUpdateFileName (split, handle, parentKey);
 	keyDel (initialParent);
 	keyDel (oldError);
 	splitDel (split);
@@ -1201,7 +1193,6 @@ int kdbSet (KDB * handle, KeySet * ks, Key * parentKey)
 
 	int errnosave = errno;
 	Key * initialParent = keyDup (parentKey);
-	ksClear (handle->global);
 
 	ELEKTRA_LOG ("now in new kdbSet (%s) %p %zd", keyName (parentKey), (void *) handle, ksGetSize (ks));
 
@@ -1247,7 +1238,6 @@ int kdbSet (KDB * handle, KeySet * ks, Key * parentKey)
 		{
 			ELEKTRA_SET_ERROR (107, parentKey, keyName (split->parents[-syncstate - 2]));
 		}
-		ksClear (handle->global);
 		keyDel (initialParent);
 		splitDel (split);
 		errno = errnosave;
@@ -1294,7 +1284,6 @@ int kdbSet (KDB * handle, KeySet * ks, Key * parentKey)
 		clear_bit (ks->array[i]->flags, KEY_FLAG_SYNC);
 	}
 
-	ksClear (handle->global);
 	keySetName (parentKey, keyName (initialParent));
 	keyDel (initialParent);
 	splitDel (split);
@@ -1327,7 +1316,6 @@ error:
 	elektraGlobalError (handle, ks, parentKey, POSTROLLBACK, MAXONCE);
 	elektraGlobalError (handle, ks, parentKey, POSTROLLBACK, DEINIT);
 
-	if (handle->global) ksClear (handle->global);
 	keySetName (parentKey, keyName (initialParent));
 	keyDel (initialParent);
 	splitDel (split);

--- a/src/libs/elektra/mount.c
+++ b/src/libs/elektra/mount.c
@@ -375,6 +375,9 @@ int mountGlobals (KDB * kdb, KeySet * keys, KeySet * modules, Key * errorKey)
 				else
 					kdb->globalPlugins[i][MAXONCE] = plugin;
 
+				// set handle to global keyset
+				plugin->global = kdb->global;
+
 				// load plugins in explicit placements
 				const char * placementName = keyName (cur);
 				Key * placementKey = ksLookupByName (global, placementName, 0);

--- a/src/libs/plugin/plugin.c
+++ b/src/libs/plugin/plugin.c
@@ -142,33 +142,19 @@ void * elektraPluginGetData (Plugin * plugin)
 }
 
 /**
- * @brief Store a pointer to the global keyset.
- *
- * Only initialized for global plugins.
- *
- * @see elektraPluginGetGlobal
- * @param plugin a pointer to the plugin
- * @param ks the pointer to the global keyset
- * @ingroup plugin
- */
-void elektraPluginSetGlobal (Plugin * plugin, KeySet * ks)
-{
-	plugin->global = ks;
-}
-
-/**
  * @brief Get a pointer to the global keyset.
  *
- * Only initialized for global plugins.
+ * Only initialized for global plugins and the resolver.
  *
- * If elektraPluginSetGlobal() was not called earlier, NULL will be returned.
+ * Plugins using this keyset are responsible for cleaning up
+ * their parts of the keyset which they do not need any more.
  *
- * @see elektraPluginSetGlobal
+ * If kdbOpen() was not called earlier, NULL will be returned.
  * @param plugin a pointer to the plugin
  * @return a pointer to the global keyset
  * @ingroup plugin
  */
-KeySet * elektraPluginGetGlobal (Plugin * plugin)
+KeySet * elektraPluginGetGlobalKeySet (Plugin * plugin)
 {
 	return plugin->global;
 }

--- a/src/libs/plugin/plugin.c
+++ b/src/libs/plugin/plugin.c
@@ -140,3 +140,35 @@ void * elektraPluginGetData (Plugin * plugin)
 {
 	return plugin->data;
 }
+
+/**
+ * @brief Store a pointer to the global keyset.
+ *
+ * Only initialized for global plugins.
+ *
+ * @see elektraPluginGetGlobal
+ * @param plugin a pointer to the plugin
+ * @param ks the pointer to the global keyset
+ * @ingroup plugin
+ */
+void elektraPluginSetGlobal (Plugin * plugin, KeySet * ks)
+{
+	plugin->global = ks;
+}
+
+/**
+ * @brief Get a pointer to the global keyset.
+ *
+ * Only initialized for global plugins.
+ *
+ * If elektraPluginSetGlobal() was not called earlier, NULL will be returned.
+ *
+ * @see elektraPluginSetGlobal
+ * @param plugin a pointer to the plugin
+ * @return a pointer to the global keyset
+ * @ingroup plugin
+ */
+KeySet * elektraPluginGetGlobal (Plugin * plugin)
+{
+	return plugin->global;
+}

--- a/src/plugins/doc/doc.c
+++ b/src/plugins/doc/doc.c
@@ -147,6 +147,20 @@ int elektraDocGet (Plugin * plugin ELEKTRA_UNUSED, KeySet * returned, Key * pare
 	fclose (fp);
 	//![get storage]
 
+	//![get global keyset]
+	KeySet * globalKS = elektraPluginGetGlobalKeySet (plugin);
+	// now we can read something from the global keyset
+	// or add something for us or others to read
+	Key * important = keyNew ("user/global/myDocKey", KEY_VALUE, "global plugins can see me", KEY_END);
+	ksAppendKey (globalKS, important);
+	//![get global keyset]
+
+	//![get global keyset cleanup]
+	// clean up parts of the global keyset which we do not need
+	Key * cutKey = keyNew ("user/global/myDocKey", KEY_END);
+	KeySet * notNeeded = ksCut (globalKS, cutKey);
+	ksDel (notNeeded);
+	//![get global keyset cleanup]
 
 	//![get filter]
 	Key * k;

--- a/src/plugins/doc/doc.h
+++ b/src/plugins/doc/doc.h
@@ -102,6 +102,20 @@
  * Note that you also need to return -1 in the case of error.
  * See individual description of entry points to implement below.
  *
+ * @par Global KeySet Handle
+ *
+ * Global plugins and the resolver will get a handle to a global keyset.
+ * This allows them to exchange information with other global plugins.
+ *
+ * Obtain a handle to the global keyset and work with it:
+ *
+ * @snippet doc.c get global keyset
+ *
+ * Clean up keys which you do not need any more,
+ * to keep the global keyset compact:
+ *
+ * @snippet doc.c get global keyset cleanup
+ *
  * @par Further help
  * Do not hesitate to open an issue if anything
  * is unclear.

--- a/tests/icheck.suppression
+++ b/tests/icheck.suppression
@@ -2,5 +2,4 @@
 // To ignore a function just add the function definition as regex here.
 // For example, to ignore the function `int elektraArrayDecName(Key * key)` you can use
 // the following entry: elektraArrayDecName
-elektraPluginSetGlobal
-elektraPluginGetGlobal
+elektraPluginGetGlobalKeySet

--- a/tests/icheck.suppression
+++ b/tests/icheck.suppression
@@ -2,3 +2,5 @@
 // To ignore a function just add the function definition as regex here.
 // For example, to ignore the function `int elektraArrayDecName(Key * key)` you can use
 // the following entry: elektraArrayDecName
+elektraPluginSetGlobal
+elektraPluginGetGlobal


### PR DESCRIPTION
## Basics

Adds a global keyset handle for global plugins #2270. 
Get return value of global plugin calls.
See docs & release notes of PR.

Do not describe the purpose here but:

- [x] Short descriptions should be in the release notes (added as entry in
      doc/news/_preparation_next_release.md which contains `*(my name)*`)
      **Please always add something to the the release notes.**
- [x] Longer descriptions should be in documentation or in design decisions.
- [x] Describe details of how you changed the code in commit messages
      (first line should have `module: short statement` syntax)
- [ ] References to issues, e.g. `close #X`, should be in the commit messages.

## Checklist

Check relevant points but **please do not remove entries**.
For docu fixes, spell checking, and similar none of these points below
need to be checked.

- [ ] I added unit tests
- [x] I ran all tests locally and everything went fine
- [x] affected documentation is fixed
- [ ] I added code comments, logging, and assertions (see doc/CODING.md)
- [ ] meta data is updated (e.g. README.md of plugins)

## Review

Remove the line below and add the "work in progress" label if you do
not want the PR to be reviewed:

