### PR TITLE
Command line argument parsing

### DIFF
--- a/doc/METADATA.ini
+++ b/doc/METADATA.ini
@@ -313,21 +313,199 @@ description= indicate that the mount point needs some
 
 
 #
-# Needed for specification of code generation
+# Needed for specification of command line options and environment variables
 #
 
 [opt]
+type= char
 status= implemented
 usedby/tool= gen
+usedby/plugin= getopt
+usedby/api= elektraGetOpts kdbopts.h
+description= set a short command line option for this key.
+	Per default an option is required, to have an argument.
+
+	short options will be preferred over long options and
+	environment variables
+
+	an option can only be specified on a single key
+
+	if the key with this metadata is an array (basename = '#'),
+	the option can be repeated an all occurrences will be
+	collected into the given array
+
+	must be specified on a key in the 'spec' namespace
 
 [opt/long]
+type= string
 status= implemented
 usedby/tool= gen
+usedby/plugin= getopts
+usedby/api= elektraGetOpts kdbopts.h
+description= set a long command line option for this key.
+	Per default an option is required, to have an argument.
+
+	short options will be preferred over long options;
+	long options will be preferred over environment variables
+
+	an option can only be specified on a single key
+
+	if the key with this metadata is an array (basename = '#'),
+	the option can be repeated an all occurrences will be
+	collected into the given array
+
+	must be specified on a key in the 'spec' namespace
+
+[opt/arg]
+type= enum
+	required
+	optional
+	none
+status= implemented
+usedby/plugin= getopts
+usedby/api= elektraGetOpts kdbopts.h
+description= set the argument mode of this option;
+	will be ignored, if neither 'opt' nor 'opt/long' are set
+
+	if set to 'optional' only long options using the '--name=value'
+	syntax can be used to specify an argument, all other kinds
+	of options behave as if 'none' were set
+
+	if set to 'none' the key will be set to "1" or 'opt/flagvalue'
+
+	must be specified on a key in the 'spec' namespace
+
+[opt/flagvalue]
+type= string
+status= implemented
+usedby/plugin= getopts
+useby/api= elektraGetOpts kdbopts.h
+description= set the flag-value of this option
+	will be ignored, if neither 'opt' nor 'opt/long' are set
+
+	'opt/arg' must be set to 'none' or 'optional', if the option
+	does not have an argument instead of the default "1" the
+	given value will be used
+
+	must be specified on a key in the 'spec' namespace
+
+[opt/help]
+type= string
+status= implemented
+usedby/plugin= getopts
+usedby/api= elektraGetOpts kdbopts.h
+description= set the help message for this option
+	will be ignored, if neither 'opt' nor 'opt/long' are set
+
+	must be specified on a key in the 'spec' namespace
+
+[opt/#]
+type= char
+status= implemented
+usedby/plugin= getopts
+usedby/api= elektraGetOpts kdbopts.h
+description= set multiple short command line options for this key.
+	only one of these options can be used at the same time
+
+	otherwise the same as 'opt'
+
+[opt/#/long]
+type= string
+status= implemented
+usedby/tool= gen
+usedby/plugin= getopts
+usedby/api= elektraGetOpts kdbopts.h
+description= set a long command line option for this key.
+	only one of these options can be used at the same time
+
+	otherwise the same as 'opt/long'
+
+[opt/#/arg]
+type= enum
+	required
+	optional
+	none
+status= implemented
+usedby/plugin= getopts
+usedby/api= elektraGetOpts kdbopts.h
+description= set the argument mode for option at index #
+	will be ignored, if neither 'opt/#' nor 'opt/#/long' are set for
+	the same index
+
+	otherwise the same as 'opt/arg'
+
+[opt/#/flagvalue]
+type= string
+status= implemented
+usedby/plugin= getopts
+useby/api= elektraGetOpts kdbopts.h
+description= set the flag-value for option at index #
+	will be ignored, if neither 'opt/#' nor 'opt/#/long' are set for
+	the same index
+
+	otherwise the same as 'opt/flagvalue'
+
+[opt/#/help]
+type= string
+status= implemented
+usedby/plugin= getopts
+usedby/api= elektraGetOpts kdbopts.h
+description= set the help message for option at index #
+	will be ignored, if neither 'opt/#' nor 'opt/#/long' are set for
+	the same index
+
+	otherwise the same as 'opt/help'
 
 [env]
-status= proposed
+type= regex [^=]+
+status= implemented
+usedby/plugin= getopts
+usedby/api= elektraGetOpts kdbopts.h
+description= set an environment variable for this key.
+	the value of the given environment variable will be
+	assigned to this key.
 
+	short and long options will be preferred over environment
+	variables
 
+	environment variables can only be specified on a single key
+
+	if the key with this metadata is an array (basename = '#'),
+	the environment variable's value will be split at the character
+	';' on Windows and at ':' on any other OS and the result is
+	collected into the given array
+
+	must be specified on a key in the 'spec' namespace
+
+[env/help]
+type= string
+status= implemented
+usedby/plugin= getopts
+usedby/api= elektraGetOpts kdbopts.h
+description= set the help message for this environment variable
+	will be ignored, if 'env' is not set
+
+	otherwise the same as 'env/help'
+
+[env/#]
+type= regex [^=]+
+status= implemented
+usedby/plugin= getopts
+usedby/api= elektraGetOpts kdbopts.h
+description= set multiple environment variables for this key.
+	only one of these variables can be used at the same time.
+
+	otherwise the same as 'env'
+
+[env/#/help]
+type= string
+status= implemented
+usedby/plugin= getopts
+usedby/api= elektraGetOpts kdbopts.h
+description= set the help message for environment variable at index #
+	will be ignored, if 'env/#' is not set for the same index
+
+	otherwise the same as 'env/help'
 
 #
 # Needed for documentation
@@ -352,10 +530,16 @@ description= Information based on which requirement the configuration
 
 [description]
 usedby/tool = web
+usedby/plugin= getopts
+usedby/api= elektraGetOpts kdbopts.h
 description = this is information provided from the developer/maintainer
 	for administrators.
 	It is not written directly in the configuration files but is instead
 	part of the spec-namespace.
+
+	elektraGetOpts and the getopts plugin use this information in the help
+	message, if 'opt/help' or 'env/help' ('opt/#/help' or 'env/#/help')
+	is not provided.
 note= For information in other namespaces, use `comment/#` instead.
 
 [example]

--- a/doc/METADATA.ini
+++ b/doc/METADATA.ini
@@ -394,7 +394,18 @@ type= string
 status= implemented
 usedby/plugin= getopts
 usedby/api= elektraGetOpts kdbopts.h
-description= set the help message for this option
+description= set the help message for this key
+	will be ignored, if neither 'opt' nor 'opt/long' are set
+	overrides the 'description' metadata
+
+	must be specified on a key in the 'spec' namespace
+
+[opt/hidden]
+type= string
+status= implemented
+usedby/plugin= getopts
+usedby/api= elektraGetOpts kdbopts.h
+description= hides this option from the help message, if set to 1
 	will be ignored, if neither 'opt' nor 'opt/long' are set
 
 	must be specified on a key in the 'spec' namespace
@@ -445,16 +456,15 @@ description= set the flag-value for option at index #
 
 	otherwise the same as 'opt/flagvalue'
 
-[opt/#/help]
+[opt/#/hidden]
 type= string
 status= implemented
 usedby/plugin= getopts
 usedby/api= elektraGetOpts kdbopts.h
-description= set the help message for option at index #
-	will be ignored, if neither 'opt/#' nor 'opt/#/long' are set for
-	the same index
+description= hides option at index # from the help message, if set to 1
+	will be ignored, if neither 'opt' nor 'opt/long' are set
 
-	otherwise the same as 'opt/help'
+	must be specified on a key in the 'spec' namespace
 
 [env]
 type= regex [^=]+
@@ -477,16 +487,6 @@ description= set an environment variable for this key.
 
 	must be specified on a key in the 'spec' namespace
 
-[env/help]
-type= string
-status= implemented
-usedby/plugin= getopts
-usedby/api= elektraGetOpts kdbopts.h
-description= set the help message for this environment variable
-	will be ignored, if 'env' is not set
-
-	otherwise the same as 'env/help'
-
 [env/#]
 type= regex [^=]+
 status= implemented
@@ -496,16 +496,6 @@ description= set multiple environment variables for this key.
 	only one of these variables can be used at the same time.
 
 	otherwise the same as 'env'
-
-[env/#/help]
-type= string
-status= implemented
-usedby/plugin= getopts
-usedby/api= elektraGetOpts kdbopts.h
-description= set the help message for environment variable at index #
-	will be ignored, if 'env/#' is not set for the same index
-
-	otherwise the same as 'env/help'
 
 #
 # Needed for documentation
@@ -538,8 +528,7 @@ description = this is information provided from the developer/maintainer
 	part of the spec-namespace.
 
 	elektraGetOpts and the getopts plugin use this information in the help
-	message, if 'opt/help' or 'env/help' ('opt/#/help' or 'env/#/help')
-	is not provided.
+	message, if 'opt/help' is not provided.
 note= For information in other namespaces, use `comment/#` instead.
 
 [example]

--- a/doc/help/elektra-glossary.md
+++ b/doc/help/elektra-glossary.md
@@ -41,6 +41,11 @@ elektra-glossary(7) -- glossary of Elektra
 - **Elektra Initiative**:
   is a community that develops LibElektra, expands SpecElektra,
   improves Elektra's tooling and helps to elektrify applications.
+  
+- **Option**, more specifically **Command-line option**:
+  is a special argument passed on the command-line. **Short options**
+  are single characters prefixed with '-'; **Long options** are
+  arbitrarily long and start with '--'.
 
 
 ## Technical Concepts

--- a/doc/news/_preparation_next_release.md
+++ b/doc/news/_preparation_next_release.md
@@ -168,7 +168,7 @@ compiled against an older 0.8 version of Elektra will continue to work
   environment variables and add their values to keys in the proc namespace.
 
   You can use `opt`, `opt/long` and `env` to specify a short, a long option and an environment variable. For more information take
-  a look at the documentation of `elektraGetOpts`. *(Klemens Böswirth)*
+  a look at [the tutorial](/doc/tutorials/command-line-options.md). *(Klemens Böswirth)*
 
 
 ### <<Library3>>

--- a/doc/news/_preparation_next_release.md
+++ b/doc/news/_preparation_next_release.md
@@ -154,8 +154,7 @@ compiled against an older 0.8 version of Elektra will continue to work
 
   , please update your code to check for a valid array element name like this:
 
-  ```c
-  if (elektraArrayValidateBaseNameString(baseName) >= 1) …;
+  ```c  if (elektraArrayValidateBaseNameString(baseName) >= 1) …;
   ```
 
   . *(René Schwaiger)*
@@ -163,11 +162,13 @@ compiled against an older 0.8 version of Elektra will continue to work
 - <<TODO>>
 
 
-### <<Library2>>
+### Libopts
 
-- <<TODO>>
-- <<TODO>>
-- <<TODO>>
+- This is a new lib containing only the function `elektraGetOpts`. This function can be used to parse command line arguments and
+  environment variables and add their values to keys in the proc namespace.
+
+  You can use `opt`, `opt/long` and `env` to specify a short, a long option and an environment variable. For more information take
+  a look at the documentation of `elektraGetOpts`. *(Klemens Böswirth)*
 
 
 ### <<Library3>>

--- a/doc/tutorials/README.md
+++ b/doc/tutorials/README.md
@@ -29,6 +29,7 @@ provides.
 - [Code Generation](/src/tools/gen/README.md)
 - [Notifications](notifications.md)
 - [High Level API](/src/libs/highlevel/README.md)
+- [Command Line Options](command-line-options.md)
 
 ## System Administrators
 

--- a/doc/tutorials/command-line-options.md
+++ b/doc/tutorials/command-line-options.md
@@ -1,0 +1,182 @@
+# Command-line Options
+
+## Introduction
+Many applications use command-line options and environment variables as a way to override configuration values.
+In Elektra this can be automated by providing a specification that maps command-line options and environment variables
+to keys in the KDB.
+
+The function `elektraGetOpts` uses this specification together with `argv` and `envp` and creates new keys in the `proc`
+namespace for any command-line option or environment variable it finds. Because the `proc` namespace is uses, these values
+will be preferred over any stored values in a cascading lookup.
+
+## Setup
+
+To use `elektraGetOpts` you need to link against `elektra-opts`, `elektra-meta` and `elektra-ease`.
+
+## Options
+To define a command-line option either set the `opt` meta-key to the short option you want to use, or set `opt/long` to
+the long option you want to use. For short options, only the first character of the given value will be used ('\0' is ignored).
+Short and long options can be used simultaneously.
+
+Additionally a key can also be associated with multiple short/long options. To achieve this treat `opt` as an array.
+For example for two options `-a` and `-b` you would set `opt=#1`, `opt/#0=a` and `opt/#1=b`. If not explicitly stated
+otherwise, you can replace `opt` with any `opt/#` array element in all meta-keys mentioned in this document. This of course
+includes long options (i.e. `opt/#0/long`, etc.).
+
+While you can specify multiple options (or environment variables, see below) for a single key, only one of them can be used
+at the same time. Using two or more options (or variables) that are all linked to the same key, will result in an error.
+
+### Option Arguments
+Per default an option is expected to have an argument. Arguments to short and long options are given in the same way
+as with `getopt_long(3)` (i.e. `-oarg`, `-o arg`, `--option arg` or `--option=arg`).
+
+To change whether an option expects an argument set `opt/arg` to either `"none"` or `"optional"` (the default is `"required"`).
+
+* If you choose `"none"`, the corresponding key will be set to `"1"`, if the option is used. This value can be changed
+  by setting `opt/flagvalue`.
+* An option that is set to `"optional"` is treated the same as with `"none"`, except that you can also set the value
+  with the long option form `--option=value`. This also means that `opt/flagvalue` is used, if no argument is given.
+  Contrary to `getopt_long(3)` options with optional arguments can still have short forms. They just cannot have an
+  argument in this form.
+
+## Environment Variables
+Elektra also supports parsing environment variables in a similar manner. For these there are however, less configuration
+options. You can simply specify one or more environment variables for a key using the `env` meta-key (or `env/#` meta-array
+for multiple).
+
+## Arrays
+Both options and environment variables expose special behaviour, if used in combination with arrays.
+
+If an option is specified on a key with basename `#`, the option can be used repeatedly. All occurrences will be collected
+into the array.
+
+Environment variables obviously cannot be repeated, instead a behaviour similar that used for PATH is adopted. On Windows
+the variable will be split at each ';' character. On all other systems ':' is used as a separator.
+
+## Arguments (Parameters)
+All unused elements of `argv` are be collected into an array. You can access this array by specifying `args=remaining` on a
+key with basename `#`. The array will be copied into this key. As is the case with getopt(3) processing of options will stop,
+if `--` is encountered in `argv`.
+
+## Help Message
+When one of the help options `-h` and `--help` is encountered in `argv`, `elektraGetOpts` only reads the specification, but
+does not create any keys in the `proc` namespace. It will however, generate a help message that can be accessed with
+`elektraGetOptsHelpMessage`.
+
+The help message consists of a usage line and an options list. The program name for the usage line is taken from `argv[0]`.
+If the value contains a slash (`/`) it will be considered a path and only the part after the last slash will be used.
+
+The options list will contain exactly one entry for each key that has at least one option. Each entry has to parts. First
+all the options for the key are listed and then (possibly on the next line, if there are a lot of options), the description
+for the key is listed. The description is taken from the `opt/help` or alternatively the `description` meta-key.
+
+**Note:** `opt/help` is specified *only once per key*. That means even if the key uses `opt/#0`, `opt/#1`, etc. (unlike most
+other metadata) the description will always be taken from `opt/help` directly, because there can only be one description. In
+general we recommend using `description`, because it is used by other parts of Elektra as well. `opt/help` is intended to 
+provide a less verbose description more suitable for the command-line.
+
+The help message can be modified in a few different ways:
+* The `usage` argument of `elektraGetOptsHelpMessage` can be used to replace the default usage line.
+* The `prefix` argument of `elektraGetOptsHelpMessage` can be used to insert text between the usage line and the options list.
+* An option can can be hidden from the help message by setting `opt/hidden` to `"1"`. This hides both the long and short form
+  of the option. If you want to hide just one form, use an array of two options an hide just one index.
+* If the option has an `"optional"` or `"required"` argument, the string `ARG` will be used as a placeholder by default. You
+  can change this, by setting `opt/arg/help` for the corresponding option.
+
+## Precedence
+The order of precedence is simple:
+* If a short option for a key is found, it will always be used. 
+* If none of the short options for a key are found, we look for long options.
+* Neither short nor long options are found, environment variables are considered.
+
+## Limitations
+* Both options and environment variables can only be specified on a single key. If you need to have the
+  value of one option/environment variable in multiple keys, you may use `fallback`s.
+* `-` and `h` cannot be used as short options, because they would collide with, the "option end marker" and the help option
+  respectively. `help` cannot be used as a long option, because it would collide with the help option.
+
+## Examples
+
+The following specification describes the command line interface similar to the one used by `rm`. (It is based of `rm (GNU coreutils) 8.30`).
+
+```ini
+[force]
+opt = f
+opt/long = force
+opt/arg = none
+description = ignore nonexistent files and arguments, never prompt
+
+[interactive]
+opt = #1
+opt/#0 = i
+opt/#0/long = interactive
+opt/#0/arg = optional
+opt/#0/flagvalue = always
+opt/#1 = I
+opt/#1/flagvalue = once
+opt/#1/arg = none
+opt/arg/name = WHEN
+description = prompt according to WHEN: never, once (-I), or always (-i); without WHEN, prompt always
+
+[singlefs]
+opt/long = one-file-system
+opt/arg = none
+description = when removing a hierarchy recursively, skip any directory that is on a file system different from that of the corresponding line argument
+
+[nopreserve]
+opt/long = no-preserve-root
+opt/arg = none
+description = do not treat '/' specially
+
+[preserve]
+opt/long = preserve-root
+opt/arg = optional
+opt/arg/name = all
+opt/flagvalue = root
+description = do not remove '/' (default); with 'all', reject any command line argument on a separate device from its parent
+
+[recursive]
+opt = #1
+opt/#0 = r
+opt/#0/long = recursive
+opt/#0/arg = none
+opt/#1 = R
+opt/#1/arg = none
+description = remove directories and their contents recursively
+
+[emptydirs]
+opt = d
+opt/long = dir
+opt/arg = none
+description = remove empty directories
+
+[verbose]
+opt = v
+opt/long = verbose
+opt/arg = none
+description = explain what is being done
+
+[showversion]
+opt/long = version
+opt/arg = none
+description = output version information and exit
+
+[files/#]
+args = remaining
+description = the files that shall be deleted
+ ```
+
+If this specification is used in a program called `erm` (for Elektra rm), which is called like this:
+
+```
+erm -fi --recursive
+```
+
+The following keys will be created by `elektraGetOpts` (assuming the specification is mounted at `spec/sw/org/erm/#0/current`:
+
+* `proc/sw/org/erm/#0/current/force = "1"`
+* `proc/sw/org/erm/#0/current/interactive = "always"`
+* `proc/sw/org/erm/#0/current/recursive = "1"`
+
+You can find a full working example [here](https://www.libelektra.org/examples/cascading). However, it uses a hard-coded
+specification which is a bit harder to read.

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -35,6 +35,7 @@ target_link_elektra (kdbopen elektra-kdb)
 target_link_elektra (kdbset elektra-kdb)
 target_link_elektra (set_key elektra-kdb)
 target_link_elektra (opts elektra-opts)
+target_link_elektra (optsSnippets elektra-opts)
 
 # Notification examples
 

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -34,6 +34,7 @@ target_link_elektra (kdbintro elektra-kdb)
 target_link_elektra (kdbopen elektra-kdb)
 target_link_elektra (kdbset elektra-kdb)
 target_link_elektra (set_key elektra-kdb)
+target_link_elektra (opts elektra-opts)
 
 # Notification examples
 

--- a/examples/opts.c
+++ b/examples/opts.c
@@ -1,0 +1,165 @@
+/**
+ * @file
+ *
+ * @brief
+ *
+ * @copyright BSD License (see LICENSE.md or https://www.libelektra.org)
+ */
+
+#include <kdbease.h>
+#include <kdbhelper.h>
+#include <kdbopts.h>
+
+#include <stdio.h>
+#include <stdlib.h>
+
+extern char ** environ;
+
+#define BASE_KEY "/sw/org/erm/#0/current"
+#define SPEC_BASE_KEY "spec" BASE_KEY
+
+static KeySet * createSpec (void)
+{
+	return ksNew (
+		9,
+		keyNew (SPEC_BASE_KEY "/emptydirs", KEY_META, "description", "remove empty directories", KEY_META, "opt", "d", KEY_META,
+			"opt/arg", "none", KEY_META, "opt/long", "dir", KEY_END),
+		keyNew (SPEC_BASE_KEY "/force", KEY_META, "description", "ignore nonexistent files and arguments, never prompt", KEY_META,
+			"opt", "f", KEY_META, "opt/arg", "none", KEY_META, "opt/long", "force", KEY_END),
+		keyNew (SPEC_BASE_KEY "/interactive", KEY_META, "description",
+			"prompt according to WHEN: never, once (-I), or always (-i), without WHEN, prompt always", KEY_META, "opt", "#1",
+			KEY_META, "opt/#0", "i", KEY_META, "opt/#0/arg", "optional", KEY_META, "opt/#0/flagvalue", "always", KEY_META,
+			"opt/#0/long", "interactive", KEY_META, "opt/#1", "I", KEY_META, "opt/#1/arg", "none", KEY_META, "opt/#1/flagvalue",
+			"once", KEY_META, "opt/arg/name", "WHEN", KEY_END),
+		keyNew (SPEC_BASE_KEY "/nopreserve", KEY_META, "description", "do not treat '/' specially", KEY_META, "opt/arg", "none",
+			KEY_META, "opt/long", "no-preserve-root", KEY_END),
+		keyNew (SPEC_BASE_KEY "/preserve", KEY_META, "description",
+			"do not remove '/' (default), with 'all', reject any command line argument on a separate device from its parent",
+			KEY_META, "opt/arg", "optional", KEY_META, "opt/arg/name", "all", KEY_META, "opt/flagvalue", "root", KEY_META,
+			"opt/long", "preserve-root", KEY_END),
+		keyNew (SPEC_BASE_KEY "/recursive", KEY_META, "description", "remove directories and their contents recursively", KEY_META,
+			"opt", "#1", KEY_META, "opt/#0", "r", KEY_META, "opt/#0/arg", "none", KEY_META, "opt/#0/long", "recursive",
+			KEY_META, "opt/#1", "R", KEY_META, "opt/#1/arg", "none", KEY_END),
+		keyNew (SPEC_BASE_KEY "/showversion", KEY_META, "description", "output version information and exit", KEY_META, "opt/arg",
+			"none", KEY_META, "opt/long", "version", KEY_END),
+		keyNew (SPEC_BASE_KEY "/singlefs", KEY_META, "description",
+			"when removing a hierarchy recursively, skip any directory that is on a file system different from that of the "
+			"corresponding line argument",
+			KEY_META, "opt/arg", "none", KEY_META, "opt/long", "one-file-system", KEY_END),
+		keyNew (SPEC_BASE_KEY "/verbose", KEY_META, "description", "explain what is being done", KEY_META, "opt", "v", KEY_META,
+			"opt/arg", "none", KEY_META, "opt/long", "verbose", KEY_END),
+		keyNew (SPEC_BASE_KEY "/files/#", KEY_META, "description", "the files that shall be deleted", KEY_META, "args", "remaining",
+			KEY_END),
+		KS_END);
+}
+
+int main (int argc, const char ** argv)
+{
+	KeySet * ks = createSpec ();
+	Key * errorKey = keyNew (BASE_KEY, KEY_END);
+
+	int result = elektraGetOpts (ks, argc, argv, (const char **) environ, errorKey);
+	if (result == -1)
+	{
+		fprintf (stderr, "ERROR: %s\n", keyString (keyGetMeta (errorKey, "error/reason")));
+		keyDel (errorKey);
+		ksDel (ks);
+		return EXIT_FAILURE;
+	}
+
+	if (result == 1)
+	{
+		char * help = elektraGetOptsHelpMessage (errorKey, NULL, NULL);
+		fprintf (stderr, "%s\n", help);
+		elektraFree (help);
+		keyDel (errorKey);
+		ksDel (ks);
+		return EXIT_SUCCESS;
+	}
+
+	printf ("When called with the same arguments 'rm' \n");
+
+	Key * lookup = ksLookupByName (ks, BASE_KEY "/emptydirs", 0);
+	if (lookup != NULL && elektraStrCmp (keyString (lookup), "1") == 0)
+	{
+		printf ("will delete empty directories\n");
+	}
+
+	lookup = ksLookupByName (ks, BASE_KEY "/force", 0);
+	if (lookup != NULL && elektraStrCmp (keyString (lookup), "1") == 0)
+	{
+		printf ("will use force mode\n");
+	}
+
+	lookup = ksLookupByName (ks, BASE_KEY "/interactive", 0);
+	if (lookup != NULL && elektraStrCmp (keyString (lookup), "never") == 0)
+	{
+		printf ("will not use interactive mode\n");
+	}
+	else if (lookup != NULL && elektraStrCmp (keyString (lookup), "once") == 0)
+	{
+		printf ("will use interactive mode; ask once\n");
+	}
+	else if (lookup != NULL && elektraStrCmp (keyString (lookup), "always") == 0)
+	{
+		printf ("will use interactive mode; always ask\n");
+	}
+
+	lookup = ksLookupByName (ks, BASE_KEY "/nopreserve", 0);
+	if (lookup != NULL && elektraStrCmp (keyString (lookup), "1") == 0)
+	{
+		printf ("will not treat '/' specially\n");
+	}
+
+	lookup = ksLookupByName (ks, BASE_KEY "/preserve", 0);
+	if (lookup != NULL && elektraStrCmp (keyString (lookup), "root") == 0)
+	{
+		printf ("will never remove '/'");
+	}
+	else if (lookup != NULL && elektraStrCmp (keyString (lookup), "all") == 0)
+	{
+		printf ("will reject any argument on separate device from its parent\n");
+	}
+
+	lookup = ksLookupByName (ks, BASE_KEY "/recursive", 0);
+	if (lookup != NULL && elektraStrCmp (keyString (lookup), "1") == 0)
+	{
+		printf ("will delete recursively\n");
+	}
+
+	lookup = ksLookupByName (ks, BASE_KEY "/showversion", 0);
+	if (lookup != NULL && elektraStrCmp (keyString (lookup), "1") == 0)
+	{
+		printf ("will show version and exit\n");
+	}
+
+	lookup = ksLookupByName (ks, BASE_KEY "/singlefs", 0);
+	if (lookup != NULL && elektraStrCmp (keyString (lookup), "1") == 0)
+	{
+		printf ("will skip directories on different file systems\n");
+	}
+
+	lookup = ksLookupByName (ks, BASE_KEY "/verbose", 0);
+	if (lookup != NULL && elektraStrCmp (keyString (lookup), "1") == 0)
+	{
+		printf ("will explain what is being done\n");
+	}
+
+	printf ("will remove the following files:\n");
+
+	Key * arrayParent = ksLookupByName (ks, BASE_KEY "/files", 0);
+	KeySet * files = elektraArrayGet (arrayParent, ks);
+
+	ksRewind (files);
+	Key * cur = NULL;
+	while ((cur = ksNext (files)) != NULL)
+	{
+		printf ("  %s\n", keyString (cur));
+	}
+	printf ("\n");
+
+	keyDel (errorKey);
+	ksDel (ks);
+
+	return EXIT_SUCCESS;
+}

--- a/examples/optsSnippets.c
+++ b/examples/optsSnippets.c
@@ -14,7 +14,7 @@
 
 extern char ** environ;
 
-int basicUse (int argc, const char ** argv)
+static int basicUse (int argc, const char ** argv)
 {
 	Key * parentKey = keyNew ("");
 	//! [basic use]
@@ -43,4 +43,9 @@ int basicUse (int argc, const char ** argv)
 	}
 	//! [basic use]
 	return EXIT_SUCCESS;
+}
+
+int main (int argc, const char ** argv)
+{
+	return basicUse(argc, argv);
 }

--- a/examples/optsSnippets.c
+++ b/examples/optsSnippets.c
@@ -47,5 +47,5 @@ static int basicUse (int argc, const char ** argv)
 
 int main (int argc, const char ** argv)
 {
-	return basicUse(argc, argv);
+	return basicUse (argc, argv);
 }

--- a/examples/optsSnippets.c
+++ b/examples/optsSnippets.c
@@ -6,6 +6,7 @@
  * @copyright BSD License (see LICENSE.md or https://www.libelektra.org)
  */
 
+#include <kdbhelper.h>
 #include <kdbopts.h>
 
 #include <stdio.h>
@@ -41,4 +42,5 @@ int basicUse (int argc, const char ** argv)
 		return EXIT_SUCCESS;
 	}
 	//! [basic use]
+	return EXIT_SUCCESS;
 }

--- a/examples/optsSnippets.c
+++ b/examples/optsSnippets.c
@@ -8,6 +8,9 @@
 
 #include <kdbopts.h>
 
+#include <stdio.h>
+#include <stdlib.h>
+
 extern char ** environ;
 
 int basicUse (int argc, const char ** argv)
@@ -19,10 +22,10 @@ int basicUse (int argc, const char ** argv)
 
 	kdbGet (kdb, ks, parentKey);
 
-	int result = elektraGetOpts (ks, argc, argv, (const char **) environ, errorKey);
+	int result = elektraGetOpts (ks, argc, argv, (const char **) environ, parentKey);
 	if (result == -1)
 	{
-		fprintf (stderr, "ERROR: %s\n", keyString (keyGetMeta (errorKey, "error/reason")));
+		fprintf (stderr, "ERROR: %s\n", keyString (keyGetMeta (parentKey, "error/reason")));
 		keyDel (parentKey);
 		ksDel (ks);
 		return EXIT_FAILURE;
@@ -30,7 +33,7 @@ int basicUse (int argc, const char ** argv)
 
 	if (result == 1)
 	{
-		char * help = elektraGetOptsHelpMessage (errorKey, NULL, NULL);
+		char * help = elektraGetOptsHelpMessage (parentKey, NULL, NULL);
 		fprintf (stderr, "%s\n", help);
 		elektraFree (help);
 		keyDel (parentKey);

--- a/examples/optsSnippets.c
+++ b/examples/optsSnippets.c
@@ -1,0 +1,41 @@
+/**
+ * @file
+ *
+ * @brief
+ *
+ * @copyright BSD License (see LICENSE.md or https://www.libelektra.org)
+ */
+
+#include <kdbopts.h>
+
+extern char ** environ;
+
+int basicUse (int argc, const char ** argv)
+{
+	Key * parentKey = keyNew ("");
+	//! [basic use]
+	KDB * kdb = kdbOpen (parentKey);
+	KeySet * ks = ksNew (0, KS_END);
+
+	kdbGet (kdb, ks, parentKey);
+
+	int result = elektraGetOpts (ks, argc, argv, (const char **) environ, errorKey);
+	if (result == -1)
+	{
+		fprintf (stderr, "ERROR: %s\n", keyString (keyGetMeta (errorKey, "error/reason")));
+		keyDel (parentKey);
+		ksDel (ks);
+		return EXIT_FAILURE;
+	}
+
+	if (result == 1)
+	{
+		char * help = elektraGetOptsHelpMessage (errorKey, NULL, NULL);
+		fprintf (stderr, "%s\n", help);
+		elektraFree (help);
+		keyDel (parentKey);
+		ksDel (ks);
+		return EXIT_SUCCESS;
+	}
+	//! [basic use]
+}

--- a/src/error/specification
+++ b/src/error/specification
@@ -1292,3 +1292,33 @@ description:Connection Error occured
 severity:error
 ingroup:plugin
 module:network
+
+number:206
+description:An unknown option was found.
+severity:error
+ingroup:opts
+macro:OPTS_UNKNOWN_OPTION
+
+number:207
+description:An option is missing an argument.
+severity:error
+ingroup:opts
+macro:OPTS_MISSING_ARGUMENT
+
+number:208
+description:The flagvalue metadata can only be used, if the opt/arg metadata is set to 'none'.
+severity:error
+ingroup:opts
+macro:OPTS_FLAGVALUE_ARG
+
+number:209
+description:A non-repeatable option was repeated.
+severity:error
+ingroup:opts
+macro:OPTS_ILLEGAL_REPEAT
+
+number:210
+description:Duplicate option specified.
+severity:error
+ingroup:opts
+macro:OPTS_DUPLICATE

--- a/src/error/specification
+++ b/src/error/specification
@@ -1294,31 +1294,19 @@ ingroup:plugin
 module:network
 
 number:206
-description:An unknown option was found.
+description:An unknown option was found (see reason).
 severity:error
 ingroup:opts
 macro:OPTS_UNKNOWN_OPTION
 
 number:207
-description:An option is missing an argument.
+description:An option was used in an unsupported way (see reason).
 severity:error
 ingroup:opts
-macro:OPTS_MISSING_ARGUMENT
+macro:OPTS_ILLEGAL_USE
 
 number:208
-description:The flagvalue metadata can only be used, if the opt/arg metadata is set to 'none'.
+description:The opts specification contains mistakes (see reason).
 severity:error
 ingroup:opts
-macro:OPTS_FLAGVALUE_ARG
-
-number:209
-description:A non-repeatable option was repeated.
-severity:error
-ingroup:opts
-macro:OPTS_ILLEGAL_REPEAT
-
-number:210
-description:Duplicate option specified.
-severity:error
-ingroup:opts
-macro:OPTS_DUPLICATE
+macro:OPTS_ILLEGAL_SPEC

--- a/src/include/CMakeLists.txt
+++ b/src/include/CMakeLists.txt
@@ -85,6 +85,7 @@ install (FILES "${CMAKE_CURRENT_BINARY_DIR}/kdbconfig.h"
 	       "${CMAKE_CURRENT_BINARY_DIR}/kdb.h"
 	       kdbmodule.h
 	       kdbos.h
+	       kdbopts.h
 	       kdbplugin.h
 	       kdbpluginprocess.h
 	       kdbprivate.h

--- a/src/include/kdbopts.h
+++ b/src/include/kdbopts.h
@@ -13,5 +13,6 @@
 #include <kdb.h>
 
 int elektraGetOpts (KeySet * ks, int argc, const char ** argv, const char ** envp, Key * errorKey);
+char * elektraGetOptsHelpMessage (Key * errorKey, const char * usage, const char * prefix);
 
 #endif // ELEKTRA_KDBOPTS_H

--- a/src/include/kdbopts.h
+++ b/src/include/kdbopts.h
@@ -1,0 +1,17 @@
+/**
+ * @file
+ *
+ * @brief
+ *
+ * @copyright BSD License (see LICENSE.md or https://www.libelektra.org)
+ */
+
+
+#ifndef ELEKTRA_KDBOPTS_H
+#define ELEKTRA_KDBOPTS_H
+
+#include <kdb.h>
+
+int elektraGetOpts (KeySet * ks, int argc, const char ** argv, const char ** envp, Key * errorKey);
+
+#endif // ELEKTRA_KDBOPTS_H

--- a/src/libs/CMakeLists.txt
+++ b/src/libs/CMakeLists.txt
@@ -26,6 +26,8 @@ add_subdirectory (notification)
 
 add_subdirectory (highlevel)
 
+add_subdirectory (opts)
+
 # The subdirectory for LibElektra must be the last entry!
 add_subdirectory (elektra)
 

--- a/src/libs/opts/CMakeLists.txt
+++ b/src/libs/opts/CMakeLists.txt
@@ -1,0 +1,4 @@
+file (GLOB SOURCES
+	   *.c)
+
+add_lib (opts SOURCES ${SOURCES} LINK_ELEKTRA elektra-meta)

--- a/src/libs/opts/opts.c
+++ b/src/libs/opts/opts.c
@@ -622,7 +622,7 @@ KeySet * parseEnvp (const char ** envp)
 		const char * eq = strchr (*cur, '=');
 		Key * key = keyNew ("/", KEY_VALUE, eq + 1, KEY_END);
 		size_t len = eq - *cur;
-		char * name = elektraStrNDup (*cur, len);
+		char * name = elektraStrNDup (*cur, len + 1);
 		name[len] = '\0';
 		keyAddBaseName (key, name);
 		ksAppendKey (ks, key);

--- a/src/libs/opts/opts.c
+++ b/src/libs/opts/opts.c
@@ -621,10 +621,12 @@ KeySet * parseEnvp (const char ** envp)
 	{
 		const char * eq = strchr (*cur, '=');
 		Key * key = keyNew ("/", KEY_VALUE, eq + 1, KEY_END);
-		char * name = strndup (*cur, eq - *cur); // elektraStrNDup does not terminate string
+		size_t len = eq - *cur;
+		char * name = elektraStrNDup (*cur, len);
+		name[len] = '\0';
 		keyAddBaseName (key, name);
 		ksAppendKey (ks, key);
-		free (name);
+		elektraFree (name);
 
 		cur++;
 	}

--- a/src/libs/opts/opts.c
+++ b/src/libs/opts/opts.c
@@ -653,8 +653,9 @@ bool processLongOptSpec (struct Specification * spec, struct OptionData * option
 	const char * argName = optionData->argName;
 	bool hidden = optionData->hidden;
 
-	const char * longMeta = elektraFormat ("%s/long", optionData->metaKey);
+	char * longMeta = elektraFormat ("%s/long", optionData->metaKey);
 	const char * longOpt = keyGetMetaString (key, longMeta);
+	elektraFree (longMeta);
 
 	if (longOpt == NULL)
 	{

--- a/src/libs/opts/opts.c
+++ b/src/libs/opts/opts.c
@@ -94,8 +94,8 @@ static bool parseShortOptions (KeySet * optionsSpec, KeySet * options, int argc,
  * is specified PER KEY not per option, even if the key has multiple options. This is because all the
  * options for one key have to be equivalent and therefore only require one description.
  *
- * If `opt/nohelp` is set to "1", the option will not appear in the help message. The same applies to
- * `env`s and `env/nohelp`.
+ * If `opt/hidden` is set to "1", the option will not appear in the help message. The same applies to
+ * `env`s and `env/hidden`.
  *
  * If `opt/arg/help` is set, its value will be used as the argument name for long options. Otherwise
  * "ARG" will be used. This value can be set for each option individually.
@@ -152,8 +152,7 @@ static bool parseShortOptions (KeySet * optionsSpec, KeySet * options, int argc,
  * by specifying `args = remaining` on a key with basename '#'. The array will be copied into this key. As is
  * the case with getopt(3) processing of options will stop if '--' is encountered in @p argv.
  *
- * NOTE: Both options and environment variables can only be specified on a single key. This is because
- * otherwise e.g. the help message ('opt/help', 'env/help') may be ambiguous. If you need to have the
+ * NOTE: Both options and environment variables can only be specified on a single key. If you need to have the
  * value of one option/environment variable in multiple keys, you may use fallbacks.
  *
  * NOTE: Per default option processing DOES NOT stop, when a non-option string is encountered in @p argv.
@@ -529,13 +528,13 @@ bool readOptionData (struct OptionData * optionData, Key * key, const char * met
 	}
 
 	strncpy (metaBuffer, metaKey, ELEKTRA_MAX_ARRAY_SIZE + 3); // 3 = opt/ - null byte from ELEKTRA_MAX_SIZE
-	strncat (metaBuffer, "/nohelp", 11);			   // 11 = remaining space in metaBuffer
+	strncat (metaBuffer, "/hidden", 11);			   // 11 = remaining space in metaBuffer
 
-	bool nohelp = false;
-	const char * nohelpStr = keyGetMetaString (key, metaBuffer);
-	if (nohelpStr != NULL && elektraStrCmp (nohelpStr, "1") == 0)
+	bool hidden = false;
+	const char * hiddenStr = keyGetMetaString (key, metaBuffer);
+	if (hiddenStr != NULL && elektraStrCmp (hiddenStr, "1") == 0)
 	{
-		nohelp = true;
+		hidden = true;
 	}
 
 	const char * kind = "single";
@@ -549,7 +548,7 @@ bool readOptionData (struct OptionData * optionData, Key * key, const char * met
 	optionData->hasArg = hasArg;
 	optionData->flagValue = flagValue;
 	optionData->argName = argNameMeta;
-	optionData->hidden = nohelp;
+	optionData->hidden = hidden;
 	optionData->kind = kind;
 
 	return true;
@@ -570,7 +569,7 @@ bool processShortOptSpec (struct Specification * spec, struct OptionData * optio
 	const char * hasArg = optionData->hasArg;
 	const char * kind = optionData->kind;
 	const char * flagValue = optionData->flagValue;
-	bool nohelp = optionData->hidden;
+	bool hidden = optionData->hidden;
 
 	const char * shortOptStr = keyGetMetaString (optionData->specKey, optionData->metaKey);
 	if (shortOptStr == NULL || shortOptStr[0] == '\0')
@@ -621,7 +620,7 @@ bool processShortOptSpec (struct Specification * spec, struct OptionData * optio
 	}
 	elektraMetaArrayAdd (*keyWithOpt, "opt", keyName (shortOptSpec));
 
-	if (!nohelp)
+	if (!hidden)
 	{
 		char * newShortOptLine = elektraFormat ("%s-%c, ", *shortOptLine, shortOpt);
 		elektraFree (*shortOptLine);

--- a/src/libs/opts/opts.c
+++ b/src/libs/opts/opts.c
@@ -198,10 +198,11 @@ int elektraGetOpts (KeySet * ks, int argc, const char ** argv, const char ** env
 					{
 						ELEKTRA_SET_ERRORF (
 							ELEKTRA_ERROR_OPTS_ILLEGAL_SPEC, errorKey,
-							"The option '-%c' has already been specified for the key '%s'. Offending key: %s",
+							"The option '-%c' has already been specified for the key '%s'. Additional key: %s",
 							shortOpt[0], keyGetMetaString (existing, "key"), keyName (cur));
 						keyDel (optSpec);
 						keyDel (existing);
+						ksDel (opts);
 						ksDel (optionsSpec);
 						ksDel (keysWithOpts);
 						return -1;
@@ -233,10 +234,11 @@ int elektraGetOpts (KeySet * ks, int argc, const char ** argv, const char ** env
 					{
 						ELEKTRA_SET_ERRORF (
 							ELEKTRA_ERROR_OPTS_ILLEGAL_SPEC, errorKey,
-							"The option '--%s' has already been specified for the key '%s'. Offending key: %s",
+							"The option '--%s' has already been specified for the key '%s'. Additional key: %s",
 							longOpt, keyGetMetaString (existing, "key"), keyName (cur));
 						keyDel (optSpec);
 						keyDel (existing);
+						ksDel (opts);
 						ksDel (optionsSpec);
 						ksDel (keysWithOpts);
 						return -1;
@@ -304,11 +306,10 @@ int elektraGetOpts (KeySet * ks, int argc, const char ** argv, const char ** env
 	}
 
 	KeySet * options = parseArgs (optionsSpec, argc, argv, errorKey);
-	ksDel (optionsSpec);
 
 	if (options == NULL)
 	{
-		ksDel (options);
+		ksDel (optionsSpec);
 		ksDel (keysWithOpts);
 		return -1;
 	}
@@ -332,10 +333,11 @@ int elektraGetOpts (KeySet * ks, int argc, const char ** argv, const char ** env
 		keySetString (errorKey, help);
 		elektraFree (help);
 		ksDel (options);
+		ksDel (optionsSpec);
 		ksDel (keysWithOpts);
 		return 1;
 	}
-
+	ksDel (optionsSpec);
 
 	KeySet * envValues = parseEnvp (envp);
 
@@ -424,6 +426,7 @@ int elektraGetOpts (KeySet * ks, int argc, const char ** argv, const char ** env
 							    "The environment variable '%s' cannot be used, because another variable has "
 							    "already been used for the key '%s'.",
 							    keyBaseName (envKey), keyName (cur));
+					keyDel (envValueKey);
 					ksDel (envMetas);
 					ksDel (envValues);
 					ksDel (options);
@@ -568,6 +571,7 @@ int addProcKey (KeySet * ks, const Key * key, Key * valueKey)
 
 		keySetString (procKey, keyBaseName (insertKey));
 		keyDel (insertKey);
+		ksDel (values);
 	}
 	else
 	{

--- a/src/libs/opts/opts.c
+++ b/src/libs/opts/opts.c
@@ -95,6 +95,10 @@ static bool parseShortOptions (KeySet * optionsSpec, KeySet * options, int argc,
  * The basic usage of this function is as follows:
  * @snippet optsSnippets.c basic use
  *
+ * If you got @p ks from kdbGet(), make sure to use ksCut() to remove any spec keys from other applications,
+ * like in the snippet above. Otherwise you may get an unexpected error, because another application uses the
+ * same option.
+ *
  * @param ks	The KeySet containing the specification for the options.
  * @param argc	The number of strings in argv.
  * @param argv	The arguments to be processed.

--- a/src/libs/opts/opts.c
+++ b/src/libs/opts/opts.c
@@ -162,9 +162,9 @@ int elektraGetOpts (KeySet * ks, int argc, const char ** argv, const char ** env
 			Key * k;
 			while ((k = ksNext (opts)) != NULL)
 			{
-				char metaBuffer[ELEKTRA_MAX_ARRAY_SIZE + 14];		       // 14 = opt//flagvalue
+				char metaBuffer[ELEKTRA_MAX_ARRAY_SIZE + 15]; // 14 = opt//flagvalue (1 extra to circumvent warning)
 				strncpy (metaBuffer, keyName (k), ELEKTRA_MAX_ARRAY_SIZE + 3); // 3 = opt/ - null byte from ELEKTRA_MAX_SIZE
-				strncat (metaBuffer, "/arg", 10);			       // 10 = remaining space in metaBuffer
+				strncat (metaBuffer, "/arg", 11);			       // 11 = remaining space in metaBuffer
 
 				const char * hasArg = keyGetMetaString (cur, metaBuffer);
 				if (hasArg == NULL)
@@ -173,7 +173,7 @@ int elektraGetOpts (KeySet * ks, int argc, const char ** argv, const char ** env
 				}
 
 				strncpy (metaBuffer, keyName (k), ELEKTRA_MAX_ARRAY_SIZE + 3); // 3 = opt/ - null byte from ELEKTRA_MAX_SIZE
-				strncat (metaBuffer, "/flagvalue", 10);			       // 10 = remaining space in metaBuffer
+				strncat (metaBuffer, "/flagvalue", 11);			       // 11 = remaining space in metaBuffer
 
 				const char * flagValue = keyGetMetaString (cur, metaBuffer);
 				if (flagValue == NULL)

--- a/src/libs/opts/opts.c
+++ b/src/libs/opts/opts.c
@@ -1,0 +1,636 @@
+/**
+ * @file
+ *
+ * @brief
+ *
+ * @copyright BSD License (see LICENSE.md or https://www.libelektra.org)
+ */
+
+#include <kdbopts.h>
+
+#include <stdlib.h>
+#include <string.h>
+
+#include <kdbease.h>
+#include <kdbhelper.h>
+#include <kdbmeta.h>
+
+#include <kdberrors.h>
+
+#ifdef _WIN32
+static const char SEP_ENV_VALUE = ';';
+#else
+static const char SEP_ENV_VALUE = ':';
+#endif
+
+static inline const char * keyGetMetaString (const Key * key, const char * meta)
+{
+	const Key * mk = keyGetMeta (key, meta);
+	const char * value = mk == NULL ? NULL : keyString (mk);
+	return value[0] == '\0' ? NULL : value;
+}
+
+static bool addProcKey (KeySet * ks, const Key * key, Key * valueKey);
+static KeySet * parseEnvp (const char ** envp);
+
+static KeySet * parseArgs (KeySet * optionsSpec, int argc, const char ** argv, Key * errorKey);
+static void setOption (Key * option, const char * value, bool repeated);
+
+static Key * splitEnvValue (const Key * envKey);
+
+static KeySet * ksMetaGetSingleOrArray (Key * key, const char * metaName);
+
+/**
+ * This functions parses a specification of program options, together with a list of arguments
+ * and environment variables to extract the option values.
+ *
+ * The options have to defined in the metadata of keys in the spec namespace. If an option value
+ * is found for any of the given keys, a new key with the same path but inside the proc namespace
+ * will be inserted into @p ks. This enables a cascading lookup to find these values.
+ *
+ * To define a command line option set the `opt` meta-key to the short option. Only the first
+ * character of the given value will be used. You can also set `opt/long`, if to use a long option.
+ * Each option can have a short version, a long version or both.
+ * Per default an option is expected to have an argument. To change this behaviour set `opt/arg` to
+ * either 'none' or 'optional' (the default is 'required'). The behaviour of short options, long
+ * options, required and optional arguments is the same as produced by getopt_long(3).
+ *
+ * If `opt/arg` is set to `none` the the corresponding key will have the value "1", if the option is
+ * provided. This value can be changed by setting `opt/flagvalue` to something else.
+ *
+ * A key can also be associated with multiple options. To achieve this, simply follow the instructions
+ * above, but replace `opt` with `opt/#XXX` (XXX being the index of the option) in all keynames. Each
+ * option can have a different setting for none/required/optional arguments and flagvalue too.
+ *
+ * In addition to command line options this function also supports environment variables. These are
+ * specified with `env` (or `env/#XXX` if multiple are used).
+ *
+ * Lastly, if the key for which the options are defined, has the basename '#', an option can be repeated.
+ * All occurrences will be collected into an array. Environment variables obviously cannot be repeated,
+ * instead a behaviour similar that used for PATH is adopted. On Windows the variable will be split at
+ * each ';' character. On all other systems ':' is used as a separator.
+ *
+ * In case multiple versions (short, long, env-var) of an option are found, the order of precedence is:
+ * <ul>
+ * 	<li> Short options always win. </li>
+ * 	<li> Long options are used if no short option is present. </li>
+ * 	<li> If neither a long nor short option is found, environment variables are considered. </li>
+ * </ul>
+ * NOTE: for array-type options (basename '#') the order of precedence is respected as well. Different
+ * options of the same type (e.g. '-s' and '-a', or '--add' and '--append') or multiple environment
+ * variables are found for the same key, the resulting arrays will be merged.
+ *
+ * NOTE: While environment variable can be used on multiple keys, options (short and long) can only be
+ * used for a single key. This is because options could be configured with different behaviour (arg,
+ * flagvalue, repeatability) on separate keys. There is not good way to handle this, so it is prohibited.
+ * Environment variables meanwhile always behave the same way. The only difference is whether or not they
+ * are split into multiple strings. This does not result in any conflicts, so it is possible to use on
+ * variable for multiple keys (although there really isn't any reason to do so).
+ * If you need to have the values of one option in more than one key, consider fallbacks.
+ *
+ * @param ks	The KeySet containing the specification for the options.
+ * @param argc	The number of strings in argv.
+ * @param argv	The arguments to be processed.
+ * @param envp	A list of environment variables. This needs to be a null-terminated list of
+ * 		strings of the format 'KEY=VALUE'.
+ * @param errorKey A key to store an error in, if one occurs.
+ *
+ * @retval 0 on success
+ * @retval -1 on error, the error will be added to @p errorKey
+ */
+int elektraGetOpts (KeySet * ks, int argc, const char ** argv, const char ** envp, Key * errorKey)
+{
+	// TODO: check for duplicate use of option
+	KeySet * keysWithOpts = ksNew (0, KS_END);
+	KeySet * optionsSpec = ksNew (0, KS_END);
+
+	cursor_t initial = ksGetCursor (ks);
+
+	ksRewind (ks);
+	Key * cur;
+	while ((cur = ksNext (ks)) != NULL)
+	{
+		if (keyGetNamespace (cur) != KEY_NS_SPEC)
+		{
+			continue;
+		}
+
+		const char * hasArg = keyGetMetaString (cur, "opt/arg");
+		if (hasArg == NULL)
+		{
+			hasArg = "required";
+		}
+
+		const char * kind = "single";
+		if (strcmp (keyBaseName (cur), "#") == 0)
+		{
+			kind = "array";
+		}
+
+		const char * flagValue = keyGetMetaString (cur, "opt/flagvalue");
+		if (flagValue == NULL)
+		{
+			hasArg = "1";
+		}
+		else if (strcmp (hasArg, "none") != 0)
+		{
+			ELEKTRA_SET_ERROR (ELEKTRA_ERROR_OPTS_FLAGVALUE_ARG, errorKey, "");
+		}
+
+		Key * key = NULL;
+
+		KeySet * shortOpts = ksMetaGetSingleOrArray (cur, "opt");
+		if (shortOpts != NULL)
+		{
+			ksRewind (shortOpts);
+			Key * k;
+			while ((k = ksNext (shortOpts)) != NULL)
+			{
+				const char * shortOpt = keyString (k);
+				if (shortOpt != NULL && shortOpt[0] != '\0')
+				{
+					Key * optSpec = keyNew ("short", KEY_META, "key", keyName (cur), KEY_META, "hasarg", hasArg,
+								KEY_META, "kind", kind, KEY_META, "flagvalue", flagValue, KEY_END);
+					keyAddBaseName (optSpec, (char[]){ shortOpt[0], '\0' });
+
+					Key * existing = ksLookup (optionsSpec, optSpec, 0);
+					if (existing != NULL)
+					{
+						ELEKTRA_SET_ERRORF (ELEKTRA_ERROR_OPTS_DUPLICATE, errorKey,
+								    "The option '-%c' has already been used for the key '%s'.", shortOpt[0],
+								    keyGetMetaString (existing, "key"));
+						keyDel (optSpec);
+						ksDel (optionsSpec);
+						ksDel (keysWithOpts);
+						return -1;
+					}
+
+					ksAppendKey (optionsSpec, optSpec);
+
+					if (key == NULL)
+					{
+						key = keyNew (keyName (cur), KEY_END);
+					}
+					elektraMetaArrayAdd (key, "opt", keyName (optSpec));
+				}
+			}
+		}
+
+
+		KeySet * longOpts = ksMetaGetSingleOrArray (cur, "opt/long");
+		if (longOpts != NULL)
+		{
+			ksRewind (longOpts);
+			Key * k;
+			while ((k = ksNext (longOpts)) != NULL)
+			{
+				const char * longOpt = keyString (k);
+				if (longOpt != NULL)
+				{
+					Key * optSpec = keyNew ("long", KEY_META, "key", keyName (cur), KEY_META, "has_arg", hasArg,
+								KEY_META, "kind", kind, KEY_META, "flagvalue", flagValue, KEY_END);
+					keyAddBaseName (optSpec, longOpt);
+
+					Key * existing = ksLookup (optionsSpec, optSpec, 0);
+					if (existing != NULL)
+					{
+						ELEKTRA_SET_ERRORF (ELEKTRA_ERROR_OPTS_DUPLICATE, errorKey,
+								    "The option '--%s' has already been used for the key '%s'.", longOpt,
+								    keyGetMetaString (existing, "key"));
+						keyDel (optSpec);
+						ksDel (optionsSpec);
+						ksDel (keysWithOpts);
+						return -1;
+					}
+
+					ksAppendKey (optionsSpec, optSpec);
+
+					if (key == NULL)
+					{
+						key = keyNew (keyName (cur), KEY_END);
+					}
+					elektraMetaArrayAdd (key, "opt", keyName (optSpec));
+				}
+			}
+		}
+
+		KeySet * envVars = ksMetaGetSingleOrArray (cur, "env");
+		if (envVars != NULL)
+		{
+			ksRewind (envVars);
+			Key * k;
+			while ((k = ksNext (envVars)) != NULL)
+			{
+				const char * envVar = keyString (k);
+				if (envVar != NULL)
+				{
+					if (key == NULL)
+					{
+						key = keyNew (keyName (cur), KEY_END);
+					}
+					elektraMetaArrayAdd (key, "env", envVar);
+				}
+			}
+		}
+
+		if (key != NULL)
+		{
+			ksAppendKey (keysWithOpts, key);
+		}
+	}
+
+	KeySet * options = parseArgs (optionsSpec, argc, argv, errorKey);
+	ksDel (optionsSpec);
+
+	if (options == NULL)
+	{
+		ksDel (options);
+		ksDel (keysWithOpts);
+		return -1;
+	}
+
+	KeySet * envValues = parseEnvp (envp);
+
+	ksRewind (options);
+	while ((cur = ksNext (keysWithOpts)) != NULL)
+	{
+		bool valueFound = false;
+
+		KeySet * optMetas = elektraMetaArrayToKS (cur, "opt");
+		if (optMetas != NULL)
+		{
+			ksRewind (optMetas);
+			Key * optMeta;
+			while ((optMeta = ksNext (optMetas)) != NULL)
+			{
+				Key * optKey = ksLookupByName (options, keyString (optMeta), 0);
+				if (addProcKey (ks, cur, optKey))
+				{
+					valueFound = true;
+					break;
+				}
+			}
+		}
+		ksDel (optMetas);
+
+		if (valueFound)
+		{
+			continue;
+		}
+
+		KeySet * envMetas = elektraMetaArrayToKS (cur, "env");
+		if (envMetas != NULL)
+		{
+			ksRewind (envMetas);
+			Key * envMeta;
+			while ((envMeta = ksNext (envMetas)) != NULL)
+			{
+				Key * envKey = ksLookupByName (envValues, keyString (envMeta), 0);
+				Key * envValueKey = splitEnvValue (envKey);
+
+				bool added = addProcKey (ks, cur, envValueKey);
+				keyDel (envValueKey);
+
+				if (added)
+				{
+					break;
+				}
+			}
+		}
+		ksDel (envMetas);
+	}
+
+	ksDel (envValues);
+	ksDel (options);
+	ksDel (keysWithOpts);
+
+	ksSetCursor (ks, initial);
+
+	return 0;
+}
+
+Key * splitEnvValue (const Key * envKey)
+{
+	Key * valueKey = keyNew (keyName (envKey), KEY_END);
+
+	char * envValue = elektraStrDup (keyString (envKey));
+
+	char * c = strchr (envValue, SEP_ENV_VALUE);
+	if (c == NULL)
+	{
+		keySetString (valueKey, envValue);
+	}
+	else
+	{
+		keySetString (valueKey, NULL);
+
+		while (c != NULL)
+		{
+			*c = '\0';
+
+			elektraMetaArrayAdd (valueKey, "values", envValue);
+
+			envValue = c + 1;
+			c = strchr (envValue, SEP_ENV_VALUE);
+		}
+	}
+
+	return valueKey;
+}
+
+/**
+ * @retval true if a proc key was added to ks
+ * @retval false otherwise
+ */
+bool addProcKey (KeySet * ks, const Key * key, Key * valueKey)
+{
+	if (ks == NULL || key == NULL || valueKey == NULL)
+	{
+		return false;
+	}
+
+	Key * procKey = keyNew ("proc", KEY_END);
+	keyAddName (procKey, keyName (key));
+
+	Key * existing = ksLookup (ks, procKey, 0);
+	if (existing != NULL)
+	{
+		keyDel (procKey);
+		procKey = existing;
+	}
+
+	KeySet * values = elektraMetaArrayToKS (valueKey, "values");
+	if (values == NULL)
+	{
+		keySetString (procKey, keyString (valueKey));
+	}
+	else
+	{
+		ksRewind (values);
+		Key * cur;
+		char indexBuffer[ELEKTRA_MAX_ARRAY_SIZE];
+		int index = 0;
+		while ((cur = ksNext (values)) != NULL)
+		{
+			elektraWriteArrayNumber (indexBuffer, index);
+
+			Key * k = keyDup (procKey);
+			keyAddBaseName (k, indexBuffer);
+			keySetString (k, keyString (cur));
+			ksAppendKey (ks, k);
+
+			index++;
+		}
+		elektraWriteArrayNumber (indexBuffer, index - 1); // last index written to
+		keySetString (procKey, indexBuffer);
+	}
+
+
+	return ksAppendKey (ks, procKey) > 0;
+}
+
+KeySet * parseEnvp (const char ** envp)
+{
+	KeySet * ks = ksNew (0, KS_END);
+
+	const char ** cur = envp;
+	while (*cur != NULL)
+	{
+		const char * eq = strchr (*cur, '=');
+		ksAppendKey (ks, keyNew (strndup (*cur, eq - *cur), KEY_VALUE, eq, KEY_END));
+
+		cur++;
+	}
+
+	return ks;
+}
+
+KeySet * parseArgs (KeySet * optionsSpec, int argc, const char ** argv, Key * errorKey)
+{
+	KeySet * options = ksNew (0, KS_END);
+	for (int i = 1; i < argc; ++i)
+	{
+		const char * cur = argv[i];
+		if (cur[0] == '-')
+		{
+			// possible option
+			if (cur[1] == '-')
+			{
+				if (cur[2] == '\0')
+				{
+					// end of options
+					break;
+				}
+
+				// long option
+				Key * longOpt = keyNew ("long", KEY_END);
+
+				char * opt = elektraStrDup (&cur[2]);
+				char * eq = strchr (opt, '=');
+				if (eq != NULL)
+				{
+					// mark end of option
+					*eq = '\0';
+				}
+
+				keyAddBaseName (longOpt, opt);
+				elektraFree (opt);
+
+				// lookup spec
+				Key * optSpec = ksLookup (optionsSpec, longOpt, KDB_O_DEL);
+
+				if (optSpec == NULL)
+				{
+					ELEKTRA_SET_ERRORF (ELEKTRA_ERROR_OPTS_UNKNOWN_OPTION, errorKey, "Unknown long option: --%s",
+							    keyBaseName (longOpt));
+					ksDel (options);
+					return NULL;
+				}
+
+				const char * hasArg = keyGetMetaString (optSpec, "hasarg");
+				const char * kind = keyGetMetaString (optSpec, "kind");
+				const char * flagValue = keyGetMetaString (optSpec, "flagvalue");
+
+				bool repeated = strcmp (kind, "array") == 0;
+
+				Key * option = ksLookupByName (options, keyName (longOpt), 0);
+				if (option == NULL)
+				{
+					option = keyNew (keyName (longOpt), KEY_META, "key", keyGetMetaString (optSpec, "key"), KEY_END);
+					ksAppendKey (options, option);
+				}
+				else if (!repeated)
+				{
+					ELEKTRA_SET_ERRORF (ELEKTRA_ERROR_OPTS_ILLEGAL_REPEAT, errorKey,
+							    "This option cannot be repeated: --%s", keyBaseName (longOpt));
+					ksDel (options);
+					return NULL;
+				}
+				else if (keyGetMetaString (option, "short") != NULL)
+				{
+					// short option found already ignore long version
+					continue;
+				}
+
+				if (strcmp (hasArg, "required") == 0)
+				{
+					// extract argument
+					if (eq != NULL)
+					{
+						// use '=' arg
+						setOption (option, eq + 1, repeated);
+					}
+					else
+					{
+						if (i >= argc - 1)
+						{
+							ELEKTRA_SET_ERRORF (ELEKTRA_ERROR_OPTS_MISSING_ARGUMENT, errorKey,
+									    "Missing argument for long option: --%s",
+									    keyBaseName (longOpt));
+							ksDel (options);
+							return NULL;
+						}
+						// use next as arg and skip
+						setOption (option, argv[++i], repeated);
+					}
+				}
+				else if (strcmp (hasArg, "optional") == 0)
+				{
+					if (eq != NULL)
+					{
+						// only use '=' argument
+						setOption (option, eq + 1, repeated);
+					}
+					else if (flagValue != NULL)
+					{
+						// use flag value
+						setOption (option, flagValue, repeated);
+					}
+				}
+				else if (flagValue != NULL)
+				{
+					// use flag value
+					setOption (option, flagValue, repeated);
+				}
+
+				continue;
+			}
+
+			for (const char * c = &cur[1]; *c != '\0'; ++c)
+			{
+				// short option
+				Key * shortOpt = keyNew ("short", KEY_END);
+				keyAddBaseName (shortOpt, (char[]){ *c, '\0' });
+
+				Key * optSpec = keyDup (ksLookup (optionsSpec, shortOpt, KDB_O_DEL));
+
+				if (optSpec == NULL)
+				{
+					ELEKTRA_SET_ERRORF (ELEKTRA_ERROR_OPTS_UNKNOWN_OPTION, errorKey, "Unknown short option: -%c",
+							    keyBaseName (shortOpt)[0]);
+					ksDel (options);
+					return NULL;
+				}
+
+				const char * hasArg = keyGetMetaString (optSpec, "hasarg");
+				const char * kind = keyGetMetaString (optSpec, "kind");
+				const char * flagValue = keyGetMetaString (optSpec, "flagvalue");
+
+				bool repeated = strcmp (kind, "array") == 0;
+
+				Key * option = ksLookupByName (options, keyName (shortOpt), 0);
+				if (option == NULL)
+				{
+					option = keyNew (keyName (shortOpt), KEY_META, "key", keyGetMetaString (optSpec, "key"), KEY_END);
+					ksAppendKey (options, option);
+				}
+				else if (!repeated)
+				{
+					ELEKTRA_SET_ERRORF (ELEKTRA_ERROR_OPTS_ILLEGAL_REPEAT, errorKey,
+							    "This option cannot be repeated: -%c", keyBaseName (shortOpt)[0]);
+					ksDel (options);
+					return NULL;
+				}
+
+				bool last = false;
+				if (strcmp (hasArg, "required") == 0)
+				{
+					if (*(c + 1) == '\0')
+					{
+						if (i >= argc - 1)
+						{
+							ELEKTRA_SET_ERRORF (ELEKTRA_ERROR_OPTS_MISSING_ARGUMENT, errorKey,
+									    "Missing argument for short option: -%c",
+									    keyBaseName (shortOpt)[0]);
+							keyDel (option);
+							ksDel (options);
+							return NULL;
+						}
+						// use next as arg and skip
+						setOption (option, argv[++i], repeated);
+					}
+					else
+					{
+						// use rest as argument
+						setOption (option, c + 1, repeated);
+						last = true;
+					}
+				}
+				else if (flagValue != NULL)
+				{
+					// use flag value
+					setOption (option, flagValue, repeated);
+				}
+
+				keySetMeta (option, "short", "1");
+				ksAppendKey (options, option);
+
+				if (last)
+				{
+					break;
+				}
+			}
+		}
+	}
+	return options;
+}
+
+void setOption (Key * option, const char * value, bool repeated)
+{
+	if (repeated)
+	{
+		elektraMetaArrayAdd (option, "values", value);
+	}
+	else
+	{
+		keySetString (option, value);
+	}
+}
+
+KeySet * ksMetaGetSingleOrArray (Key * key, const char * metaName)
+{
+	const Key * k = keyGetMeta (key, metaName);
+	if (k == NULL)
+	{
+		return NULL;
+	}
+
+	const char * value = keyString (k);
+	if (value[0] != '#')
+	{
+		return ksNew (1, k, KS_END);
+	}
+
+	Key * testKey = keyDup (k);
+	keyAddBaseName (testKey, keyString (k));
+
+	const Key * test = keyGetMeta (k, keyName (testKey));
+	keyDel (testKey);
+
+	if (test == NULL)
+	{
+		return ksNew (1, k, KS_END);
+	}
+
+	return elektraMetaArrayToKS (key, metaName);
+}

--- a/tests/ctest/CMakeLists.txt
+++ b/tests/ctest/CMakeLists.txt
@@ -38,3 +38,5 @@ target_link_elektra (test_proposal elektra-proposal)
 target_link_elektra (test_utility elektra-utility)
 
 target_link_elektra (test_globbing elektra-globbing)
+
+target_link_elektra (test_opts elektra-opts)

--- a/tests/ctest/test_opts.c
+++ b/tests/ctest/test_opts.c
@@ -14,12 +14,16 @@
 #define PROC_BASE_KEY "proc/tests/opts"
 #define SPEC_BASE_KEY "spec/tests/opts"
 
+// version 6 and 7 of clang-format don't agree whether it is supposed to be *[] or * [] so disable it here
+// TODO: re-enable clang-format once version 7 is used on build server
+// clang-format off
 #define NUMARGS(...) (sizeof ((void *[]){ __VA_ARGS__ }) / sizeof (void *))
 #define ARGS(...) NUMARGS ("prog", __VA_ARGS__), ((const char *[]){ "prog", __VA_ARGS__, NULL })
 #define NO_ARGS 1, ((const char *[]){ "prog" })
 
 #define ENVP(...) ((const char *[]){ __VA_ARGS__, NULL })
 #define NO_ENVP ((const char *[]){ NULL })
+// clang-format on
 
 #define xstr(a) str (a)
 #define str(a) #a

--- a/tests/ctest/test_opts.c
+++ b/tests/ctest/test_opts.c
@@ -733,9 +733,9 @@ static void test_help (void)
 	const char * expectedHelp =
 		"Usage: prog [OPTION]... [ARG]...\n"
 		"OPTIONS\n"
-		"  -a, -b, -C, --apple, --banana=BANANA, --cherry=[ARG]\n"
+		"  -a, -b BANANA, -C, --apple, --banana=BANANA, --cherry=[ARG]\n"
 		"                                Apple/Banana/Cherry description\n"
-		"  -p                          A pear is not an apple, nor a banana, nor a cherry.\n";
+		"  -p ARG                      A pear is not an apple, nor a banana, nor a cherry.\n";
 
 	Key * k = keyNew (SPEC_BASE_KEY "/apple", KEY_END);
 	keySetMeta (k, "opt", "#3");

--- a/tests/ctest/test_opts.c
+++ b/tests/ctest/test_opts.c
@@ -738,7 +738,7 @@ static void test_help (void)
 		"  -p                          A pear is not an apple, nor a banana, nor a cherry.\n";
 
 	Key * k = keyNew (SPEC_BASE_KEY "/apple", KEY_END);
-	keySetMeta (k, "opt", "#2");
+	keySetMeta (k, "opt", "#3");
 	keySetMeta (k, "opt/#0", "a");
 	keySetMeta (k, "opt/#0/long", "apple");
 	keySetMeta (k, "opt/#0/arg", "none");
@@ -748,12 +748,14 @@ static void test_help (void)
 	keySetMeta (k, "opt/#2", "C");
 	keySetMeta (k, "opt/#2/long", "cherry");
 	keySetMeta (k, "opt/#2/arg", "optional");
+	keySetMeta (k, "opt/#3", "d");
+	keySetMeta (k, "opt/#3/hidden", "1");
 	keySetMeta (k, "description", "Apple/Banana/Cherry description");
 	ks = ksNew (4, k,
 		    keyNew (SPEC_BASE_KEY "/pear", KEY_META, "opt", "p", KEY_META, "description",
 			    "A pear is not an apple, nor a banana, nor a cherry.", KEY_END),
 		    keyNew (SPEC_BASE_KEY "/args/#", KEY_META, "args", "remaining", KEY_END),
-		    keyNew (SPEC_BASE_KEY "/none", KEY_META, "opt", "n", KEY_META, "opt/nohelp", "1", KEY_END), KS_END);
+		    keyNew (SPEC_BASE_KEY "/none", KEY_META, "opt", "n", KEY_META, "opt/hidden", "1", KEY_END), KS_END);
 	errorKey = keyNew (SPEC_BASE_KEY, KEY_END);
 
 	succeed_if (elektraGetOpts (ks, ARGS ("-h"), NO_ENVP, errorKey) == 1, "help not generated");

--- a/tests/ctest/test_opts.c
+++ b/tests/ctest/test_opts.c
@@ -1,0 +1,371 @@
+/**
+ * @file
+ *
+ * @brief
+ *
+ * @copyright BSD License (see LICENSE.md or https://www.libelektra.org)
+ */
+
+#include <kdberrors.h>
+#include <kdbopts.h>
+
+#include "tests.h"
+
+#define PROC_BASE_KEY "proc/tests/opts"
+#define SPEC_BASE_KEY "spec/tests/opts"
+
+#define NUMARGS(...) (sizeof ((void *[]){ __VA_ARGS__ }) / sizeof (void *))
+#define ARGS(...) NUMARGS ("prog", __VA_ARGS__), ((const char *[]){ "prog", __VA_ARGS__, NULL })
+#define NO_ARGS 1, ((const char *[]){ "prog" })
+
+#define ENVP(...) ((const char *[]){ __VA_ARGS__, NULL })
+#define NO_ENVP ((const char *[]){ NULL })
+
+#define xstr(a) str (a)
+#define str(a) #a
+
+#define RUN_TEST(ks, args, envp)                                                                                                           \
+	{                                                                                                                                  \
+		Key * ek = keyNew (SPEC_BASE_KEY, KEY_END);                                                                                \
+		if (elektraGetOpts (ks, args, envp, ek) != 0)                                                                              \
+		{                                                                                                                          \
+			yield_error ("error found");                                                                                       \
+			output_error (ek);                                                                                                 \
+		}                                                                                                                          \
+		keyDel (ek);                                                                                                               \
+	}
+
+#define RUN_TEST_ERROR(ks, errorKey, args, envp)                                                                                           \
+	{                                                                                                                                  \
+		errorKey = keyNew (SPEC_BASE_KEY, KEY_END);                                                                                \
+		if (elektraGetOpts (ks, args, envp, errorKey) == 0)                                                                        \
+		{                                                                                                                          \
+			yield_error ("should have failed");                                                                                \
+		}                                                                                                                          \
+	}
+
+static inline Key * keyWithOpt (const char * name, const char shortOpt, const char * longOpt, const char * envVar)
+{
+	return keyNew (name, KEY_META, "opt", (const char[]){ shortOpt, '\0' }, KEY_META, "opt/long", longOpt, KEY_META, "env", envVar,
+		       KEY_END);
+}
+
+static bool checkValue (KeySet * ks, const char * name, const char * expected)
+{
+	Key * key = ksLookupByName (ks, name, 0);
+	if (key == NULL)
+	{
+		return false;
+	}
+
+	const char * actual = keyString (key);
+	return actual != NULL && strcmp (actual, expected) == 0;
+}
+
+static bool checkError (Key * errorKey, const char * expectedNumber, const char * expectedReason)
+{
+	const Key * metaError = keyGetMeta (errorKey, "error");
+	if (metaError == NULL)
+	{
+		return false;
+	}
+
+	const char * actualNumber = keyString (keyGetMeta (errorKey, "error/number"));
+	const char * actualReason = keyString (keyGetMeta (errorKey, "error/reason"));
+
+	bool result = strcmp (actualNumber, expectedNumber) == 0 && strcmp (actualReason, expectedReason) == 0;
+
+	keyDel (errorKey);
+
+	return result;
+}
+
+static void clearValues (KeySet * ks)
+{
+	cursor_t cursor = ksGetCursor (ks);
+
+	ksRewind (ks);
+	Key * cur;
+	while ((cur = ksNext (ks)) != NULL)
+	{
+		keySetString (cur, NULL);
+	}
+
+	ksSetCursor (ks, cursor);
+}
+
+static void test_simple (void)
+{
+	KeySet * ks = ksNew (50, keyWithOpt (SPEC_BASE_KEY "/apple", 'a', "apple", "APPLE"), KS_END);
+
+	RUN_TEST (ks, ARGS ("-a", "short"), NO_ENVP);
+	succeed_if (checkValue (ks, PROC_BASE_KEY "/apple", "short"), "short option failed");
+	clearValues (ks);
+
+	RUN_TEST (ks, ARGS ("-ashort"), NO_ENVP);
+	succeed_if (checkValue (ks, PROC_BASE_KEY "/apple", "short"), "short option (combined) failed");
+	clearValues (ks);
+
+	RUN_TEST (ks, ARGS ("--apple", "long"), NO_ENVP);
+	succeed_if (checkValue (ks, PROC_BASE_KEY "/apple", "long"), "long option failed");
+	clearValues (ks);
+
+	RUN_TEST (ks, ARGS ("--apple=long"), NO_ENVP);
+	succeed_if (checkValue (ks, PROC_BASE_KEY "/apple", "long"), "long option (combined) failed");
+	clearValues (ks);
+
+	RUN_TEST (ks, NO_ARGS, ENVP ("APPLE=env"));
+	succeed_if (checkValue (ks, PROC_BASE_KEY "/apple", "env"), "env-var failed");
+	clearValues (ks);
+
+	ksDel (ks);
+}
+
+static void test_flag (void)
+{
+	Key * k = keyWithOpt (SPEC_BASE_KEY "/apple", 'a', "apple", NULL);
+	keySetMeta (k, "opt/arg", "none");
+	KeySet * ks = ksNew (50, k, KS_END);
+
+	RUN_TEST (ks, ARGS ("-a"), NO_ENVP);
+	succeed_if (checkValue (ks, PROC_BASE_KEY "/apple", "1"), "short flag failed");
+	clearValues (ks);
+
+	RUN_TEST (ks, ARGS ("-a", "short"), NO_ENVP);
+	succeed_if (checkValue (ks, PROC_BASE_KEY "/apple", "1"), "short flag (with arg) failed");
+	clearValues (ks);
+
+	Key * errorKey;
+	RUN_TEST_ERROR (ks, errorKey, ARGS ("-ashort"), NO_ENVP);
+	succeed_if (checkError (errorKey, xstr (ELEKTRA_ERROR_OPTS_UNKNOWN_OPTION), "Unknown short option: -s"),
+		    "short flag (with arg, combined) should have failed");
+	clearValues (ks);
+
+	RUN_TEST (ks, ARGS ("--apple"), NO_ENVP);
+	succeed_if (checkValue (ks, PROC_BASE_KEY "/apple", "1"), "long flag failed");
+	clearValues (ks);
+
+	RUN_TEST (ks, ARGS ("--apple", "long"), NO_ENVP);
+	succeed_if (checkValue (ks, PROC_BASE_KEY "/apple", "1"), "long flag (with arg) failed");
+	clearValues (ks);
+
+	RUN_TEST_ERROR (ks, errorKey, ARGS ("--apple=long"), NO_ENVP);
+	succeed_if (checkError (errorKey, xstr (ELEKTRA_ERROR_OPTS_ILLEGAL_USE), "This option cannot have an argument: --apple"),
+		    "long flag (with arg, combined) should have failed");
+	clearValues (ks);
+
+	ksDel (ks);
+}
+
+static void test_flag_value (void)
+{
+	Key * k = keyWithOpt (SPEC_BASE_KEY "/apple", 'a', "apple", NULL);
+	keySetMeta (k, "opt/arg", "none");
+	keySetMeta (k, "opt/flagvalue", "set");
+	KeySet * ks = ksNew (50, k, KS_END);
+
+	RUN_TEST (ks, ARGS ("-a"), NO_ENVP);
+	succeed_if (checkValue (ks, PROC_BASE_KEY "/apple", "set"), "short flag with value failed");
+	clearValues (ks);
+
+	RUN_TEST (ks, ARGS ("-a", "short"), NO_ENVP);
+	succeed_if (checkValue (ks, PROC_BASE_KEY "/apple", "set"), "short flag with value (with arg) failed");
+	clearValues (ks);
+
+	Key * errorKey;
+	RUN_TEST_ERROR (ks, errorKey, ARGS ("-ashort"), NO_ENVP);
+	succeed_if (checkError (errorKey, xstr (ELEKTRA_ERROR_OPTS_UNKNOWN_OPTION), "Unknown short option: -s"),
+		    "short flag with value (with arg, combined) should have failed");
+	clearValues (ks);
+
+	RUN_TEST (ks, ARGS ("--apple"), NO_ENVP);
+	succeed_if (checkValue (ks, PROC_BASE_KEY "/apple", "set"), "long flag with value failed");
+	clearValues (ks);
+
+	RUN_TEST (ks, ARGS ("--apple", "long"), NO_ENVP);
+	succeed_if (checkValue (ks, PROC_BASE_KEY "/apple", "set"), "long flag with value (with arg) failed");
+	clearValues (ks);
+
+	RUN_TEST_ERROR (ks, errorKey, ARGS ("--apple=long"), NO_ENVP);
+	succeed_if (checkError (errorKey, xstr (ELEKTRA_ERROR_OPTS_ILLEGAL_USE), "This option cannot have an argument: --apple"),
+		    "long flag with value (with arg, combined) should have failed");
+	clearValues (ks);
+
+	ksDel (ks);
+}
+
+static void test_optional (void)
+{
+	Key * k = keyWithOpt (SPEC_BASE_KEY "/apple", 'a', "apple", NULL);
+	keySetMeta (k, "opt/arg", "optional");
+	KeySet * ks = ksNew (50, k, KS_END);
+
+	RUN_TEST (ks, ARGS ("-a"), NO_ENVP);
+	succeed_if (checkValue (ks, PROC_BASE_KEY "/apple", "1"), "short flag failed");
+	clearValues (ks);
+
+	RUN_TEST (ks, ARGS ("-a", "short"), NO_ENVP);
+	succeed_if (checkValue (ks, PROC_BASE_KEY "/apple", "1"), "short flag (with arg) failed");
+	clearValues (ks);
+
+	Key * errorKey;
+	RUN_TEST_ERROR (ks, errorKey, ARGS ("-ashort"), NO_ENVP);
+	succeed_if (checkError (errorKey, xstr (ELEKTRA_ERROR_OPTS_UNKNOWN_OPTION), "Unknown short option: -s"),
+		    "short flag (with arg, combined) should have failed");
+	clearValues (ks);
+
+	RUN_TEST (ks, ARGS ("--apple"), NO_ENVP);
+	succeed_if (checkValue (ks, PROC_BASE_KEY "/apple", "1"), "long flag failed");
+	clearValues (ks);
+
+	RUN_TEST (ks, ARGS ("--apple", "long"), NO_ENVP);
+	succeed_if (checkValue (ks, PROC_BASE_KEY "/apple", "1"), "long flag (with arg) failed");
+	clearValues (ks);
+
+	RUN_TEST (ks, ARGS ("--apple=long"), NO_ENVP);
+	succeed_if (checkValue (ks, PROC_BASE_KEY "/apple", "long"), "long option (combined) failed");
+	clearValues (ks);
+
+	ksDel (ks);
+}
+
+static void test_optional_value (void)
+{
+	Key * k = keyWithOpt (SPEC_BASE_KEY "/apple", 'a', "apple", NULL);
+	keySetMeta (k, "opt/arg", "optional");
+	keySetMeta (k, "opt/flagvalue", "set");
+	KeySet * ks = ksNew (50, k, KS_END);
+
+	RUN_TEST (ks, ARGS ("-a"), NO_ENVP);
+	succeed_if (checkValue (ks, PROC_BASE_KEY "/apple", "set"), "short flag with value failed");
+	clearValues (ks);
+
+	RUN_TEST (ks, ARGS ("-a", "short"), NO_ENVP);
+	succeed_if (checkValue (ks, PROC_BASE_KEY "/apple", "set"), "short flag with value (with arg) failed");
+	clearValues (ks);
+
+	Key * errorKey;
+	RUN_TEST_ERROR (ks, errorKey, ARGS ("-ashort"), NO_ENVP);
+	succeed_if (checkError (errorKey, xstr (ELEKTRA_ERROR_OPTS_UNKNOWN_OPTION), "Unknown short option: -s"),
+		    "short flag with value (with arg, combined) should have failed");
+	clearValues (ks);
+
+	RUN_TEST (ks, ARGS ("--apple"), NO_ENVP);
+	succeed_if (checkValue (ks, PROC_BASE_KEY "/apple", "set"), "long flag with value failed");
+	clearValues (ks);
+
+	RUN_TEST (ks, ARGS ("--apple", "long"), NO_ENVP);
+	succeed_if (checkValue (ks, PROC_BASE_KEY "/apple", "set"), "long flag with value (with arg) failed");
+	clearValues (ks);
+
+	RUN_TEST (ks, ARGS ("--apple=long"), NO_ENVP);
+	succeed_if (checkValue (ks, PROC_BASE_KEY "/apple", "long"), "long option (combined) failed");
+	clearValues (ks);
+
+	ksDel (ks);
+}
+
+static void test_precedence (void)
+{
+	// TODO
+}
+
+static void test_repeated (void)
+{
+	// TODO
+}
+
+static void test_multiple (void)
+{
+	Key * k = keyNew (SPEC_BASE_KEY "/apple", KEY_END);
+	keySetMeta (k, "opt", "#1");
+	keySetMeta (k, "opt/#0", "a");
+	keySetMeta (k, "opt/#0/long", "apple");
+	keySetMeta (k, "opt/#1", "b");
+	keySetMeta (k, "opt/#1/long", "banana");
+	keySetMeta (k, "env", "#1");
+	keySetMeta (k, "env/#0", "APPLE");
+	keySetMeta (k, "env/#1", "BANANA");
+	KeySet * ks = ksNew (50, k, KS_END);
+
+	RUN_TEST (ks, ARGS ("-a", "short"), NO_ENVP);
+	succeed_if (checkValue (ks, PROC_BASE_KEY "/apple", "short"), "short option failed");
+	clearValues (ks);
+
+	RUN_TEST (ks, ARGS ("-ashort"), NO_ENVP);
+	succeed_if (checkValue (ks, PROC_BASE_KEY "/apple", "short"), "short option (combined) failed");
+	clearValues (ks);
+
+	RUN_TEST (ks, ARGS ("--apple", "long"), NO_ENVP);
+	succeed_if (checkValue (ks, PROC_BASE_KEY "/apple", "long"), "long option failed");
+	clearValues (ks);
+
+	RUN_TEST (ks, ARGS ("--apple=long"), NO_ENVP);
+	succeed_if (checkValue (ks, PROC_BASE_KEY "/apple", "long"), "long option (combined) failed");
+	clearValues (ks);
+
+	RUN_TEST (ks, NO_ARGS, ENVP ("APPLE=env"));
+	succeed_if (checkValue (ks, PROC_BASE_KEY "/apple", "env"), "env-var failed");
+	clearValues (ks);
+
+	RUN_TEST (ks, ARGS ("-b", "short"), NO_ENVP);
+	succeed_if (checkValue (ks, PROC_BASE_KEY "/apple", "short"), "short option failed");
+	clearValues (ks);
+
+	RUN_TEST (ks, ARGS ("-bshort"), NO_ENVP);
+	succeed_if (checkValue (ks, PROC_BASE_KEY "/apple", "short"), "short option (combined) failed");
+	clearValues (ks);
+
+	RUN_TEST (ks, ARGS ("--banana", "long"), NO_ENVP);
+	succeed_if (checkValue (ks, PROC_BASE_KEY "/apple", "long"), "long option failed");
+	clearValues (ks);
+
+	RUN_TEST (ks, ARGS ("--banana=long"), NO_ENVP);
+	succeed_if (checkValue (ks, PROC_BASE_KEY "/apple", "long"), "long option (combined) failed");
+	clearValues (ks);
+
+	RUN_TEST (ks, NO_ARGS, ENVP ("BANANA=env"));
+	succeed_if (checkValue (ks, PROC_BASE_KEY "/apple", "env"), "env-var failed");
+	clearValues (ks);
+
+	ksDel (ks);
+}
+
+static void test_multiple_repeated (void)
+{
+	// TODO
+}
+
+static void test_illegal_spec (void)
+{
+	// TODO
+}
+
+static void test_illegal_use (void)
+{
+	// TODO
+}
+
+int main (int argc, char ** argv)
+{
+	printf (" OPTS   TESTS\n");
+	printf ("==================\n\n");
+
+	init (argc, argv);
+
+	test_simple ();
+	test_flag ();
+	test_flag_value ();
+	test_optional ();
+	test_optional_value ();
+	test_precedence ();
+	test_repeated ();
+	test_multiple ();
+	test_multiple_repeated ();
+	test_illegal_spec ();
+	test_illegal_use ();
+
+	print_result ("test_opts");
+
+	return nbError;
+}

--- a/tests/ctest/test_opts.c
+++ b/tests/ctest/test_opts.c
@@ -560,6 +560,40 @@ static void test_illegal_spec (void)
 	clearValues (ks);
 
 	ksDel (ks);
+
+	// ---
+	// 'h' option
+	// ---
+
+	k = keyNew (SPEC_BASE_KEY "/apple", KEY_END);
+	keySetMeta (k, "opt", "h");
+	ks = ksNew (1, k, KS_END);
+
+	RUN_TEST_ERROR (ks, errorKey, NO_ARGS, NO_ENVP);
+	succeed_if (checkError (errorKey, xstr (ELEKTRA_ERROR_OPTS_ILLEGAL_SPEC),
+				"'h' cannot be used as a short option. It would collide with the "
+				"help option '-h'. Offending key: " SPEC_BASE_KEY "/apple"),
+		    "'h' option should be illegal");
+	clearValues (ks);
+
+	ksDel (ks);
+
+	// ---
+	// 'help' option
+	// ---
+
+	k = keyNew (SPEC_BASE_KEY "/apple", KEY_END);
+	keySetMeta (k, "opt/long", "help");
+	ks = ksNew (1, k, KS_END);
+
+	RUN_TEST_ERROR (ks, errorKey, NO_ARGS, NO_ENVP);
+	succeed_if (checkError (errorKey, xstr (ELEKTRA_ERROR_OPTS_ILLEGAL_SPEC),
+				"'help' cannot be used as a long option. It would collide with the "
+				"help option '--help'. Offending key: " SPEC_BASE_KEY "/apple"),
+		    "'help' option should be illegal");
+	clearValues (ks);
+
+	ksDel (ks);
 }
 
 static void test_illegal_use (void)


### PR DESCRIPTION
Implementation of #1252. The name was changed to `elektraGetOpts` to avoid confusion with the old [getenv](https://master.libelektra.org/src/bindings/intercept/env).

## Basics

- [x] Short descriptions should be in the release notes (added as entry in
      doc/news/_preparation_next_release.md which contains `*(my name)*`)
      **Please always add something to the the release notes.**
- [x] Longer descriptions should be in documentation or in design decisions.
- [x] Describe details of how you changed the code in commit messages
      (first line should have `module: short statement` syntax)
- [x] References to issues, e.g. `close #X`, should be in the commit messages.

## Checklist

- [x] I added unit tests
- [x] I ran all tests locally and everything went fine
- [x] affected documentation is fixed
- [x] I added code comments, logging, and assertions (see doc/CODING.md)
- [x] meta data is updated (e.g. README.md of plugins)
