### PR TITLE
Augeas: Change Prefix for Lens Directory on macOS

### DIFF
--- a/cmake/Modules/FindAugeas.cmake
+++ b/cmake/Modules/FindAugeas.cmake
@@ -30,7 +30,7 @@ else (LIBAUGEAS_INCLUDE_DIR)
 
 	if (NOT _LIBAUGEAS_PREFIX)
 		if (APPLE)
-			set (_LIBAUGEAS_PREFIX "/usr/local/opt/augeas")
+			set (_LIBAUGEAS_PREFIX "/usr/local")
 		else (APPLE)
 			set (_LIBAUGEAS_PREFIX "/usr")
 		endif (APPLE)

--- a/doc/news/_preparation_next_release.md
+++ b/doc/news/_preparation_next_release.md
@@ -89,8 +89,8 @@ The following section lists news about the [modules](https://www.libelektra.org/
 
 ### Augeas
 
-- We changed the default [Augeas](http://augeas.net) directory prefix on macOS to the default [Homebrew](https://brew.sh) Augeas
-  installation directory: `/usr/local/opt/augeas`. *(René Schwaiger)*
+- We changed the default [Augeas](http://augeas.net) directory prefix for the lenses directory on macOS to the one used by
+  [Homebrew](https://brew.sh): `/usr/local`. *(René Schwaiger)*
 
 ### network
 


### PR DESCRIPTION
It seems `/usr/local` is the correct directory, which is also used by some Linux distributions according to the [documentation of the Augeas plugin](https://master.libelektra.org/src/plugins/augeas/README.md#mounting-and-configuration).