### PR TITLE
Jenkins: Disable Failing Tests

### DIFF
--- a/doc/news/_preparation_next_release.md
+++ b/doc/news/_preparation_next_release.md
@@ -154,7 +154,18 @@ you up to date with the multi-language support provided by Elektra.
 
 ### Jenkins
 
-- <<TODO>>
+- We disabled the tests:
+
+  - `testmod_crypto_botan`,
+  - `testmod_crypto_openssl`,
+  - `testmod_dbus`,
+  - `testmod_dbusrecv`,
+  - `testmod_fcrypt`,
+  - `testmod_gpgme`, and
+  - `testmod_zeromqsend`
+
+  , since they are [known to fail in high load scenarios](https://issues.libelektra.org/2439). _(René Schwaiger)_
+
 - <<TODO>>
 - <<TODO>>
 

--- a/doc/todo/TESTING
+++ b/doc/todo/TESTING
@@ -8,6 +8,20 @@ tests/shell/check_merge.sh   for INI
 tests/shell/shell_recorder/mathcheck.esr     for INI (hard-coded ni)
 src/plugins/semlock/CMakeLists.txt   disable due to /dev/shm problems, see #1122 and #1260
 
+### Jenkins
+
+We disabled the tests
+
+- `testmod_crypto_botan`,
+- `testmod_crypto_openssl`,
+- `testmod_dbus`,
+- `testmod_dbusrecv`,
+- `testmod_fcrypt`,
+- `testmod_gpgme`, and
+- `testmod_zeromqsend`
+
+in the function `ctest` in the file `scripts/jenkins/Jenkinsfile`, since they are known to
+[cause problems in high load scenarios](https://issues.libelektra.org/2439).
 
 ## error
 

--- a/scripts/jenkins/Jenkinsfile
+++ b/scripts/jenkins/Jenkinsfile
@@ -1200,8 +1200,23 @@ def cpuCount() {
  * @param target What target to pass to ctest
  */
 def ctest(target = "Test") {
+  /*
+     We disable the tests:
+
+     - `testmod_crypto_botan`,
+     - `testmod_crypto_openssl`,
+     - `testmod_dbus`,
+     - `testmod_dbusrecv`,
+     - `testmod_fcrypt`,
+     - `testmod_gpgme`, and
+     - `testmod_zeromqsend`
+
+     , since they are known to fail in scenarios with high load.
+     See also: https://issues.libelektra.org/2439
+  */
   sh """ctest -j ${env.CTEST_PARALLEL_LEVEL} --force-new-ctest-process \
-          --output-on-failure --no-compress-output -T ${target}"""
+          --output-on-failure --no-compress-output -T ${target} \
+          -E 'testmod_(crypto_(botan|openssl)|dbus(recv)?|fcrypt|gpgme|zeromqsend)'"""
 }
 
 /* Helper for ctest to run MemCheck without memleak tagged tests


### PR DESCRIPTION
This update should get rid of most of the temporary test failures reported in issue [#2439](https://issues.libelektra.org/2439).