### PR TITLE
move reference resolving into libease

### DIFF
--- a/doc/news/_preparation_next_release.md
+++ b/doc/news/_preparation_next_release.md
@@ -123,11 +123,10 @@ compiled against an older 0.8 version of Elektra will continue to work
 - <<TODO>>
 - <<TODO>>
 
-### <<Library1>>
+### Ease
 
-- <<TODO>>
-- <<TODO>>
-- <<TODO>>
+- The functions for reference resolving used in the [reference plugin](https://www.libelektra.org/plugins/reference) have been extracted
+  into libease. This lets other parts of Elektra easily use references and ensures a consistent syntax for them. _(Klemens Böswirth)_
 
 ### <<Library2>>
 

--- a/src/include/kdbease.h
+++ b/src/include/kdbease.h
@@ -25,6 +25,9 @@ Key * elektraArrayGetNextKey (KeySet * arrayKeys);
 keyswitch_t keyCompare (const Key * key1, const Key * key2);
 keyswitch_t keyCompareMeta (const Key * key1, const Key * key2);
 
+int elektraIsReferenceRedundant (const char * reference);
+char * elektraResolveReference (const char * reference, const Key * baseKey, const Key * parentKey);
+
 #ifdef __cplusplus
 }
 }

--- a/src/libs/ease/reference.c
+++ b/src/libs/ease/reference.c
@@ -1,0 +1,85 @@
+/**
+ * @file
+ *
+ * @brief Reference methods.
+ *
+ * @copyright BSD License (see LICENSE.md or https://www.libelektra.org)
+ */
+
+#include "kdbease.h"
+
+#include "kdbhelper.h"
+
+#include <string.h>
+
+
+/**
+ * Check whether a reference is redundant (i.e. it can be expressed in less characters) or not.
+ *
+ * @param reference the reference to check
+ * @retval 1 if the reference is redundant
+ * @retval 0 otherwise
+ */
+int elektraIsReferenceRedundant (const char * reference)
+{
+	const char * cur = reference;
+	while (strncmp (cur, "../", 3) == 0)
+	{
+		cur += 3;
+	}
+
+	return strstr (reference, "/./") != NULL || strstr (cur, "/../") != NULL ? 1 : 0;
+}
+
+/**
+ * Resolve reference into a full keyname.
+ *
+ * References operate like UNIX paths, with some additions:
+ *  - '.' refers to the current key
+ *  - '..' refers to the parent of the current key
+ *  - '@' refers to the parentKey of KDB
+ *  - references starting with anything but './', '../' and '@/' as absolute,
+ *    only embedded '/./' and '/../' as well as '/.' and '/..' at the end will
+ *    be resolved (like in any keySetName call)
+ *
+ * @param reference The reference to resolve
+ * @param baseKey   The key identified by the reference "./"
+ * @param parentKey The key identified by the reference "@/"
+ *
+ * @return a newly allocated string, containing the full keyname;
+ *         has to be disposed with elektraFree()
+ */
+char * elektraResolveReference (const char * reference, const Key * baseKey, const Key * parentKey)
+{
+	if (reference == NULL || strlen (reference) == 0)
+	{
+		return NULL;
+	}
+
+	Key * fullReference = keyNew ("", KEY_END);
+
+	if (elektraStrNCmp (reference, "@/", 2) == 0)
+	{
+		keySetName (fullReference, keyName (parentKey));
+		keyAddName (fullReference, &reference[2]);
+	}
+	else if (elektraStrNCmp (reference, "./", 2) == 0)
+	{
+		keySetName (fullReference, keyName (baseKey));
+		keyAddName (fullReference, &reference[2]);
+	}
+	else if (elektraStrNCmp (reference, "../", 3) == 0)
+	{
+		keySetName (fullReference, keyName (baseKey));
+		keyAddName (fullReference, reference);
+	}
+	else
+	{
+		keySetName (fullReference, reference);
+	}
+
+	char * result = elektraStrDup (keyName (fullReference));
+	keyDel (fullReference);
+
+	return result;
+}

--- a/tests/icheck.suppression
+++ b/tests/icheck.suppression
@@ -2,6 +2,5 @@
 // To ignore a function just add the function definition as regex here.
 // For example, to ignore the function `int elektraArrayDecName(Key * key)` you can use
 // the following entry: elektraArrayDecName
-
 elektraIsReferenceRedundant
 elektraResolveReference

--- a/tests/icheck.suppression
+++ b/tests/icheck.suppression
@@ -2,3 +2,6 @@
 // To ignore a function just add the function definition as regex here.
 // For example, to ignore the function `int elektraArrayDecName(Key * key)` you can use
 // the following entry: elektraArrayDecName
+
+elektraIsReferenceRedundant
+elektraResolveReference


### PR DESCRIPTION
This simply moves reference resolution from the reference plugin into libease. That way it can be used by other parts of Elektra, in particular code generation.

@markus2330 please review my pull request
