### PR TITLE
Documentation: Add Badge for LGTM

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![Travis Build Status](https://travis-ci.org/ElektraInitiative/libelektra.svg?branch=master)](https://travis-ci.org/ElektraInitiative/libelektra)
 [![Cirrus Build Status](https://api.cirrus-ci.com/github/ElektraInitiative/libelektra.svg)](https://cirrus-ci.com/github/ElektraInitiative/libelektra)
 [![Coverage Status](https://img.shields.io/coveralls/github/ElektraInitiative/libelektra.svg)](https://coveralls.io/github/ElektraInitiative/libelektra)
+[![Total alerts](https://img.shields.io/lgtm/alerts/g/ElektraInitiative/libelektra.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/ElektraInitiative/libelektra/alerts)
 
 _Elektra serves as a universal and secure framework to access configuration
 settings in a global, hierarchical key database._

--- a/doc/news/_preparation_next_release.md
+++ b/doc/news/_preparation_next_release.md
@@ -182,7 +182,7 @@ you up to date with the multi-language support provided by Elektra.
   compiler errors. This update has the advantage, that certain tools such as [TextMate](https://macromates.com) are able to convert the
   location data, providing additional features, such as clickable links to the error source. _(René Schwaiger)_
 
-- <<TODO>>
+- We added a badge for [LGTM](https://lgtm.com) to the [main ReadMe file](https://master.libelektra.org/README.md). _(René Schwaiger)_
 - <<TODO>>
 
 ## Tests

--- a/scripts/check-env-dep
+++ b/scripts/check-env-dep
@@ -19,7 +19,7 @@ fi
 
 printf '%s\n' "$ENV" | while IFS='' read -r env; do
 	# The script does **not** handle environment variables that contain newlines properly!
-	printf '%s' "$env" | grep -Eq '.+=.*' || continue
+	printf '%s' "$env" | grep -Eq '^[_a-zA-Z][_a-zA-Z]*=.*' || continue
 	NAME="$(echo "$env" | cut -d '=' -f1 2> /dev/null)"
 	if [ "$NAME" = "KDB" ] || [ "$NAME" = "PATH" ]; then
 		continue


### PR DESCRIPTION
# Description

[LGTM](https://lgtm.com) provides automated source code checks for repositories. Currently the [LGTM page for Elektra](https://lgtm.com/projects/g/ElektraInitiative/libelektra) lists about 80 problems we should probably fix, or at least take a look at.

I think it would also make sense to activate LGTM’s [automated checks for pull request](https://lgtm.com/projects/g/ElektraInitiative/libelektra/ci/). I would do it myself, but I do not have the required administrator rights for the repository.

# Badge Preview

[![Total alerts](https://img.shields.io/lgtm/alerts/g/ElektraInitiative/libelektra.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/ElektraInitiative/libelektra/alerts)