### PR TITLE
LGTM: Add Initial Version of Configuration File

### DIFF
--- a/doc/news/_preparation_next_release.md
+++ b/doc/news/_preparation_next_release.md
@@ -210,7 +210,7 @@ you up to date with the multi-language support provided by Elektra.
 
 ## Tests
 
-- <<TODO>>
+- We now check the source code of the repository with [LGTM](https://lgtm.com). _(René Schwaiger)_
 - <<TODO>>
 - <<TODO>>
 

--- a/lgtm.yml
+++ b/lgtm.yml
@@ -1,0 +1,12 @@
+extraction:
+  cpp:
+    after_prepare:
+      # Since LGTM does not allow a project to
+      # [download source files](https://lgtm.com/help/lgtm/analysis-faqs#whats-the-default-build-environment-for-cpp-projects),
+      # we download Google Test manually.
+      - cd "$LGTM_WORKSPACE"
+      - mkdir -p "googletest"
+      - curl -o gtest.tar.gz -L https://github.com/google/googletest/archive/release-1.8.1.tar.gz
+      - tar -zxvf gtest.tar.gz --strip-components=1 -C googletest
+      - rm gtest.tar.gz
+      - export GTEST_ROOT="$LGTM_WORKSPACE/googletest"


### PR DESCRIPTION
Please ignore the failed build job [“LGTM analysis: C/C++”](
https://lgtm.com/projects/g/ElektraInitiative/libelektra/rev/pr-02da0df8383b852d5cc447d0a37cd56a044b80f5). The reason why this build job fails is that LGTM is currently not able to build Elektra from the `master` branch of the repository. This pull request should [fix this issue](https://lgtm.com/projects/g/ElektraInitiative/libelektra/logs/rev/pr-02da0df8383b852d5cc447d0a37cd56a044b80f5/lang:cpp/stage:Build%20merge_2c5a5488b802bd666dcab1ac2b4a1b68cb6236b4).