### PR TITLE
Let kdb get -v display if value comes from default

### DIFF
--- a/doc/help/kdb-get.md
+++ b/doc/help/kdb-get.md
@@ -51,17 +51,48 @@ This command will return the following values as an exit status:
 
 ## EXAMPLES
 
-To get the value of a key:<br>
-`kdb get user/example/key`
+```sh
+# Backup-and-Restore: user/tests/get/examples
 
-To get the value of a key using a cascading lookup:<br>
-`kdb get /example/key`
+# Create the keys we use for the examples
+kdb set user/tests/get/examples/kdb-get/key myKey
+kdb setmeta /tests/get/examples/kdb-get/anotherKey default defaultValue
 
-To get the value of a key without adding a newline to the end of it:<br>
-`kdb get -n /example/key`
+# To get the value of a key:
+kdb get user/tests/get/examples/kdb-get/key
+#> myKey
 
-To explain why a specific key was used (for cascading keys):<br>
-`kdb get -v /example/key`
+# To get the value of a key using a cascading lookup:
+kdb get /tests/get/examples/kdb-get/key
+#> myKey
+
+# To get the value of a key without adding a newline to the end of it:
+kdb get -n /tests/get/examples/kdb-get/key
+#> myKey
+
+# To explain why a specific key was used (for cascading keys):
+kdb get -v /tests/get/examples/kdb-get/key
+#> got 3 keys
+#> searching spec/tests/get/examples/kdb-get/key, found: <nothing>, options: KDB_O_CALLBACK
+#>     searching proc/tests/get/examples/kdb-get/key, found: <nothing>, options: 
+#>     searching dir/tests/get/examples/kdb-get/key, found: <nothing>, options: 
+#>     searching user/tests/get/examples/kdb-get/key, found: user/tests/get/examples/kdb-get/key, options: 
+#> The resulting keyname is user/tests/get/examples/kdb-get/key
+#> The resulting value size is 6
+#> myKey
+
+# Output if only a default value is set for a key:
+kdb get -v /tests/get/examples/kdb-get/anotherKey
+#> got 3 keys
+#> searching spec/tests/get/examples/kdb-get/anotherKey, found: spec/tests/get/examples/kdb-get/anotherKey, options: KDB_O_CALLBACK
+#> The key was not found in any other namespace, taking the default from the metadata
+#> The resulting keyname is /tests/get/examples/kdb-get/anotherKey
+#> The resulting value size is 13
+#> defaultValue
+
+kdb rm user/tests/get/examples/kdb-get/key
+kdb rmmeta spec/tests/get/examples/kdb-get/anotherKey default
+```
 
 To use bookmarks:<br>
 `kdb get +kdb/format`

--- a/doc/help/kdb-get.md
+++ b/doc/help/kdb-get.md
@@ -74,9 +74,9 @@ kdb get -n /tests/get/examples/kdb-get/key
 kdb get -v /tests/get/examples/kdb-get/key
 #> got 3 keys
 #> searching spec/tests/get/examples/kdb-get/key, found: <nothing>, options: KDB_O_CALLBACK
-#>     searching proc/tests/get/examples/kdb-get/key, found: <nothing>, options: 
-#>     searching dir/tests/get/examples/kdb-get/key, found: <nothing>, options: 
-#>     searching user/tests/get/examples/kdb-get/key, found: user/tests/get/examples/kdb-get/key, options: 
+#>     searching proc/tests/get/examples/kdb-get/key, found: <nothing>
+#>     searching dir/tests/get/examples/kdb-get/key, found: <nothing>
+#>     searching user/tests/get/examples/kdb-get/key, found: user/tests/get/examples/kdb-get/key
 #> The resulting keyname is user/tests/get/examples/kdb-get/key
 #> The resulting value size is 6
 #> myKey
@@ -91,7 +91,7 @@ kdb get -v /tests/get/examples/kdb-get/anotherKey
 #> defaultValue
 
 kdb rm user/tests/get/examples/kdb-get/key
-kdb rmmeta spec/tests/get/examples/kdb-get/anotherKey default
+kdb rm spec/tests/get/examples/kdb-get/anotherKey
 ```
 
 To use bookmarks:<br>

--- a/doc/help/kdb-get.md
+++ b/doc/help/kdb-get.md
@@ -54,6 +54,10 @@ This command will return the following values as an exit status:
 ```sh
 # Backup-and-Restore: user/tests/get/examples
 
+# We use the `dump` plugin, since some storage plugins, e.g. INI,
+# create intermediate keys.
+sudo kdb mount get.ecf user/tests/get/examples/kdb-get dump
+
 # Create the keys we use for the examples
 kdb set user/tests/get/examples/kdb-get/key myKey
 kdb setmeta /tests/get/examples/kdb-get/anotherKey default defaultValue
@@ -92,6 +96,7 @@ kdb get -v /tests/get/examples/kdb-get/anotherKey
 
 kdb rm user/tests/get/examples/kdb-get/key
 kdb rm spec/tests/get/examples/kdb-get/anotherKey
+sudo kdb umount user/tests/get/examples/kdb-get
 ```
 
 To use bookmarks:<br>

--- a/doc/news/_preparation_next_release.md
+++ b/doc/news/_preparation_next_release.md
@@ -179,6 +179,7 @@ you up to date with the multi-language support provided by Elektra.
 
 ## Tools
 
+- `kdb get -v` now displays if the resulting value is a default-value defined by the metadata of the key. _(Thomas Bretterbauer)_
 - <<TODO>>
 - <<TODO>>
 - <<TODO>>

--- a/doc/todo/TESTING
+++ b/doc/todo/TESTING
@@ -7,6 +7,7 @@ src/plugins/python2/CMakeLists.txt
 tests/shell/check_merge.sh   for INI
 tests/shell/shell_recorder/mathcheck.esr     for INI (hard-coded ni)
 src/plugins/semlock/CMakeLists.txt   disable due to /dev/shm problems, see #1122 and #1260
+doc/help/kdb-get.md   for INI
 
 ### Jenkins
 

--- a/src/tools/kdb/get.cpp
+++ b/src/tools/kdb/get.cpp
@@ -157,6 +157,10 @@ int GetCommand::execute (Cmdline const & cl)
 	{
 		if (cl.verbose)
 		{
+			if (k.getName ()[0] == '/')
+			{
+				cout << "The key was not found in any other namespace, taking the default from the metadata" << std::endl;
+			}
 			cout << "The resulting keyname is " << k.getName () << std::endl;
 			cout << "The resulting value size is " << k.getStringSize () << std::endl;
 		}

--- a/src/tools/kdb/get.cpp
+++ b/src/tools/kdb/get.cpp
@@ -88,9 +88,13 @@ ckdb::Key * printTrace (ELEKTRA_UNUSED ckdb::KeySet * ks, ckdb::Key * key, ckdb:
 		std::cout << " ";
 
 	std::cout << "searching " << (k.getName ()[0] == '/' ? "default of spec" : "") << k.getName ()
-		  << ", found: " << (found ? f.getName () : "<nothing>") << ", options: ";
+		  << ", found: " << (found ? f.getName () : "<nothing>");
 
-	printOptions (options);
+	if (options)
+	{
+		std::cout << ", options: ";
+		printOptions (options);
+	}
 	std::cout << std::endl;
 
 	if (k.getName ().substr (0, 5) == "spec/" && (options & ckdb::KDB_O_CALLBACK))

--- a/tests/shell/shell_recorder/tutorial_wrapper/CMakeLists.txt
+++ b/tests/shell/shell_recorder/tutorial_wrapper/CMakeLists.txt
@@ -4,7 +4,7 @@ include (LibAddTest)
 # = Help =
 # ========
 
-add_msr_test (kdb_get "${CMAKE_SOURCE_DIR}/doc/help/kdb-get.md")
+add_msr_test (kdb_get "${CMAKE_SOURCE_DIR}/doc/help/kdb-get.md REQUIRED_PLUGINS dump")
 add_msr_test (kdb_complete "${CMAKE_SOURCE_DIR}/doc/help/kdb-complete.md")
 add_msr_test (kdb_global_umount "${CMAKE_SOURCE_DIR}/doc/help/kdb-global-umount.md" REQUIRED_PLUGINS spec tracer)
 add_msr_test (kdb_ls "${CMAKE_SOURCE_DIR}/doc/help/kdb-ls.md" REQUIRED_PLUGINS sync)

--- a/tests/shell/shell_recorder/tutorial_wrapper/CMakeLists.txt
+++ b/tests/shell/shell_recorder/tutorial_wrapper/CMakeLists.txt
@@ -4,6 +4,7 @@ include (LibAddTest)
 # = Help =
 # ========
 
+add_msr_test (kdb_get "${CMAKE_SOURCE_DIR}/doc/help/kdb-get.md")
 add_msr_test (kdb_complete "${CMAKE_SOURCE_DIR}/doc/help/kdb-complete.md")
 add_msr_test (kdb_global_umount "${CMAKE_SOURCE_DIR}/doc/help/kdb-global-umount.md" REQUIRED_PLUGINS spec tracer)
 add_msr_test (kdb_ls "${CMAKE_SOURCE_DIR}/doc/help/kdb-ls.md" REQUIRED_PLUGINS sync)


### PR DESCRIPTION
src/tools/kdb/get.cpp
I've added the check after the final key-lookup inside the execute-method. If the printTrace-method is the better place for this please let me know and I'll find a way to retrieve the information there.
Close #2474

## Checklist

Check relevant points but **please do not remove entries**.
For docu fixes, spell checking, and similar none of these points below
need to be checked.

- [ ] I added unit tests
- [X] I ran all tests locally and everything went fine
- [ ] affected documentation is fixed
- [ ] I added code comments, logging, and assertions (see doc/CODING.md)
- [ ] meta data is updated (e.g. README.md of plugins)

## Review

@markus2330 please review my pull request
