### PR TITLE
reference: fix README

### DIFF
--- a/doc/METADATA.ini
+++ b/doc/METADATA.ini
@@ -932,6 +932,12 @@ usedby/plugin= reference
 type= string
 description= Globbing pattern used to restrict valid references
 
+[check/reference/restrict/#]
+status= implemented
+usedby/plugin= reference
+type= string
+description= Same as `check/reference/restrict` but in array notation for multiple restrictions
+
 [trigger/warnings]
 usedby/plugin= error
 type= long

--- a/doc/news/_preparation_next_release.md
+++ b/doc/news/_preparation_next_release.md
@@ -113,6 +113,10 @@ The following section lists news about the [modules](https://www.libelektra.org/
 - [quickdump](https://www.libelektra.org/plugins/quickdump) is a new storage plugin. It implements a more concise form of the
   [dump](https://www.libelektra.org/plugins/dump) format, which is also quicker too read. _(Klemens Böswirth)_
 
+### Reference
+
+- Fixed missing Metadata in README and METADATA.ini.
+
 ### Specload
 
 - The [specload](https://www.libelektra.org/plugins/specload) plugin is a special storage plugin. Instead of using a storage file

--- a/doc/news/_preparation_next_release.md
+++ b/doc/news/_preparation_next_release.md
@@ -115,7 +115,7 @@ The following section lists news about the [modules](https://www.libelektra.org/
 
 ### Reference
 
-- Fixed missing Metadata in README and METADATA.ini.
+- Fixed missing Metadata in README and METADATA.ini. _(Michael Zronek)_
 
 ### Specload
 

--- a/src/plugins/reference/README.md
+++ b/src/plugins/reference/README.md
@@ -6,7 +6,7 @@
 - infos/recommends =
 - infos/placements = presetstorage
 - infos/status = maintained unittest libc writeonly
-- infos/metadata = check/reference check/reference/restrict
+- infos/metadata = check/reference check/reference/restrict check/reference/restrict/#
 - infos/description = Plugin for validating singular or recursive references
 
 ## Introduction


### PR DESCRIPTION
This PR is a fix for the reference plugin because I received the following error when trying to mount a specification:

```
kdb spec-mount '/sw/lcdproc/lcdexec/#0/current'
#> The command kdb spec-mount terminated unsuccessfully with the info:
#> No plugin that provides check/reference/restrict/# could be found
#> Please report the issue at https://issues.libelektra.org/
```

I hope it is ok that I do not add something in the news doc because it is not that relevant