### PR TITLE
Formatting improvements

### DIFF
--- a/doc/news/_preparation_next_release.md
+++ b/doc/news/_preparation_next_release.md
@@ -285,6 +285,10 @@ you up to date with the multi-language support provided by Elektra.
 
 - The `reformat-source` script now also formats `tests/shell/include_common.sh.in`. Additionally it ensures that the file is 1000 lines long,
   so that line numbers of files using it are easier to read. _(Klemens Böswirth)_
+- The `reformat-*` scripts now allow you to specify a list of files that should be formatted. Only files actual suitable for the reformat script,
+  will reformat. So e.g. calling `reformat-cmake src/include/kdbprivate.h` doesn't change any files. _(Klemens Böswirth)_
+- The script `scripts/reformat-all` is a new convenience script that calls all other `reformat-*` scripts. _(Klemens Böswirth)_
+- The script `scripts/pre-commit-check-formatting` can be used as a pre-commit hook, to ensure files are formatted before committing. _(Klemens Böswirth)_
 
 [lgtm]: https://lgtm.com
 

--- a/scripts/pre-commit-check-formatting
+++ b/scripts/pre-commit-check-formatting
@@ -1,0 +1,76 @@
+#!/bin/sh
+# @author Klemens Böswirth <k.boeswirth+git@gmail.com>
+# @brief Pre-commit hook that checks formatting
+# @date 29.03.2019
+# @tags reformat
+
+# HOW TO USE
+#
+# If this is the only pre-commit hook you want to use,
+# you can simply use a symlink:
+#
+# ln -s ../../scripts/pre-commit-check-formatting .git/hooks/pre-commit
+#
+# If you want to use multiple pre-commit hooks, you have
+# to use a script, that calls all of your hooks, including this one.
+
+DATE=$(date +%s)
+SRC_ROOT=$(git rev-parse --show-toplevel)
+
+# check for unstaged changes
+UNSTAGED=$(git diff --name-only)
+if [ -n "$UNSTAGED" ]; then
+	# create temporary commit for staged changes
+	git commit --no-verify --message "WIP" --quiet
+
+	# stash away unstaged changes and remember stash id
+	echo "$UNSTAGED" | xargs git add
+	git stash push -q -m "pre-commit-$DATE"
+	UNSTAGED_STASH=$(git rev-parse -q --verify refs/stash)
+
+	# undo temporary commit
+	git reset --quiet --soft HEAD^
+fi
+
+# ensure that all unstaged changes are gone
+if ! git diff --quiet; then
+	printf >&2 "Couldn't stash away unstaged changes, aborting!\n"
+	exit 1
+fi
+
+# get changed files
+STAGED_FILES="$(git diff --cached --name-only --diff-filter=ACMR)"
+
+# run reformat script
+echo "$STAGED_FILES" | xargs "$SRC_ROOT/scripts/reformat-all" > /dev/null
+
+# get files changed by reformatting
+UNFORMATTED_FILES="$(git diff --name-only)"
+
+# create patch
+PATCH_FILE="/tmp/elektra-$DATE-reformat.patch"
+git diff > "$PATCH_FILE"
+
+# undo formatting
+echo "$UNFORMATTED_FILES" | xargs git checkout --quiet --
+
+if [ -n "$UNSTAGED" ]; then
+	# convert stash hash to stash ref
+	STASH_REF=$(git reflog stash --format='%H %gd' | awk -v h="$UNSTAGED_STASH" '$1 == h { print $2 }')
+
+	# restore unstaged changes
+	git stash pop --quiet "$STASH_REF"
+fi
+
+if [ -n "$UNFORMATTED_FILES" ]; then
+	echo "The following files are not correctly formatted:"
+	printf "%s\n" "$UNFORMATTED_FILES"
+
+	echo "A diff of the formatting changes is stored at:"
+	echo "$PATCH_FILE"
+
+	echo "You can try to apply it with, but unstaged changes may cause conflicts:"
+	echo "git apply $PATCH_FILE"
+
+	exit 1
+fi

--- a/scripts/reformat-all
+++ b/scripts/reformat-all
@@ -1,0 +1,17 @@
+#!/bin/sh
+#
+# @author Klemens Böswirth <k.boeswirth+git@gmail.com>
+# @brief Calls all other reformat scripts
+# @date 29.03.2019
+# @tags reformat
+
+SCRIPTS_DIR=$(dirname "$0")
+. "${SCRIPTS_DIR}/include-common"
+
+cd "$SOURCE"
+
+for reformat in $(ls "$SCRIPTS_DIR"/reformat-*); do
+	[ "$reformat" = "scripts/reformat-all" ] && continue
+	echo "running $reformat..."
+	$reformat
+done

--- a/scripts/reformat-all
+++ b/scripts/reformat-all
@@ -11,7 +11,7 @@ SCRIPTS_DIR=$(dirname "$0")
 cd "$SOURCE"
 
 for reformat in $(ls "$SCRIPTS_DIR"/reformat-*); do
-	[ "$reformat" = "scripts/reformat-all" ] && continue
+	[ "$(basename "$reformat")" = "reformat-all" ] && continue
 	echo "running $reformat..."
-	$reformat
+	$reformat "$@"
 done

--- a/scripts/reformat-cmake
+++ b/scripts/reformat-cmake
@@ -29,7 +29,14 @@ if [ -z "$(which sponge)" ]; then
 	exit 1
 fi
 
-files=$(git ls-files '*.cmake' '*/CMakeLists.txt' 'CMakeLists.txt')
+if [ $# -gt 0 ]; then
+	files=$(printf "%s\n" "$@" | grep -x -E '.*\.cmake|.*/CMakeLists.txt|CMakeLists.txt')
+	if [ -z "$files" ]; then
+		exit 0
+	fi
+else
+	files=$(git ls-files '*.cmake' '*/CMakeLists.txt' 'CMakeLists.txt')
+fi
 printf "%s\n" "$files" | sed -nE 's/(.*)/'"'"'\1'"'"'/p' | xargs "$CMAKE_FORMAT" -i
 for file in $files; do
 	unexpand "$file" | sponge "$file"

--- a/scripts/reformat-markdown
+++ b/scripts/reformat-markdown
@@ -20,5 +20,12 @@ if [ -z "${PRETTIER}" ]; then
 	exit 1
 fi
 
-markdown_files=$(git ls-files '*.md')
+if [ $# -gt 0 ]; then
+	markdown_files=$(printf "%s\n" "$@" | grep -x '.*\.md')
+	if [ -z "$markdown_files" ]; then
+		exit 0
+	fi
+else
+	markdown_files=$(git ls-files '*.md')
+fi
 printf "%s\n" "$markdown_files" | sed -nE 's/(.*)/'"'"'\1'"'"'/p' | xargs "${PRETTIER}" --write --

--- a/scripts/reformat-shfmt
+++ b/scripts/reformat-shfmt
@@ -16,6 +16,13 @@ if ! which shfmt > /dev/null; then
 fi
 
 shell_files=$(shfmt -f 'scripts' 'src' 'tests/shell')
+if [ $# -gt 0 ]; then
+	tmpfile=$(mktemp /tmp/elektra-reformat-shfmt.XXXXXX)
+	printf "%s\n" "$@" > "$tmpfile"
+	shell_files=$(printf "%s\n" "$shell_files" | grep -x -F -f "$tmpfile")
+	rm "$tmpfile"
+fi
+
 non_ignored=$(printf "%s\n" "$shell_files" | sed -nE 's/(.*)/'"'"'\1'"'"'/p' | xargs git check-ignore -vn | sed -nE 's/^::[[:blank:]]*(.*)$/\1/p')
 printf "%s\n" "$non_ignored" | sed -nE 's/(.*)/'"'"'\1'"'"'/p' | xargs shfmt -s -sr -w
 shfmt -s -sr -w 'tests/shell/include_common.sh.in'

--- a/scripts/reformat-source
+++ b/scripts/reformat-source
@@ -32,5 +32,12 @@ cd "$SOURCE" || {
 	exit 1
 }
 
-source_files=$(git ls-files '*.c' '*.h' '*.cpp' '*.hpp' '*.c.in' '*.h.in' | grep -v '^src/tools/gen.*')
+if [ $# -gt 0 ]; then
+	source_files=$(printf "%s\n" "$@" | grep -x -E '.*\.(c|h|cpp|hpp|c\.in|h\.in)' | grep -v '^src/tools/gen.*')
+	if [ -z "$source_files" ]; then
+		exit 0
+	fi
+else
+	source_files=$(git ls-files '*.c' '*.h' '*.cpp' '*.hpp' '*.c.in' '*.h.in' | grep -v '^src/tools/gen.*')
+fi
 printf "%s\n" "$source_files" | sed -nE 's/(.*)/'"'"'\1'"'"'/p' | xargs "$CLANG_FORMAT" -style=file -i


### PR DESCRIPTION
This adds a `reformat-all` script. It also adds a `pre-commit` hook script to check formatting before every commit.

Note: the pre-commit hook only notifies you of unformatted files and provides a diff, it doesn't auto-apply formatting because unstaged changes may cause merge conflicts

@markus2330 please review my pull request
