### PR TITLE
kdb: Don't fail if target-key has same value as source-key

### DIFF
--- a/doc/help/kdb-cp.md
+++ b/doc/help/kdb-cp.md
@@ -56,6 +56,7 @@ This command will return the following values as an exit status:
 kdb set user/tests/cp/examples/kdb-cp/key key1
 kdb set user/tests/cp/examples/kdb-cp/key/first key
 kdb set user/tests/cp/examples/kdb-cp/key/second key
+kdb set user/tests/cp/examples/kdb-cp/cpkey key1
 kdb set user/tests/cp/examples/kdb-cp/cpkey/first key
 kdb set user/tests/cp/examples/kdb-cp/cpkey/second key
 kdb set user/tests/cp/examples/kdb-cp/cpkeyerror/first key

--- a/doc/help/kdb-cp.md
+++ b/doc/help/kdb-cp.md
@@ -49,12 +49,40 @@ This command will return the following values as an exit status:
 
 ## EXAMPLES
 
-To copy multiple keys:<br>
-`kdb cp -r user/example1 user/example2`
+```sh
+# Backup-and-Restore: user/tests/cp/examples
 
-To copy a single key:<br>
-`kdb cp user/example/key1 user/example/key2`
+# Create the keys we use for the examples
+kdb set user/tests/cp/examples/kdb-cp/key key1
+kdb set user/tests/cp/examples/kdb-cp/key/first key
+kdb set user/tests/cp/examples/kdb-cp/key/second key
+kdb set user/tests/cp/examples/kdb-cp/cpkey/first key
+kdb set user/tests/cp/examples/kdb-cp/cpkey/second key
+kdb set user/tests/cp/examples/kdb-cp/cpkeyerror/first key
+kdb set user/tests/cp/examples/kdb-cp/cpkeyerror/second anotherValue
+kdb set user/tests/cp/examples/kdb-cp/another/key one
+kdb set user/tests/cp/examples/kdb-cp/another/value two
 
-To copy keys below an existing key:<br>
-`kdb cp -r user/example user/example/key1`<br>
-Note that in this example, all keys in the example directory will be copied below `key1` **except** `key1`.
+# To copy a single key:
+kdb cp user/tests/cp/examples/kdb-cp/key user/tests/cp/examples/kdb-cp/key2
+#>
+
+# To copy multiple keys:
+kdb cp -r user/tests/cp/examples/kdb-cp/key user/tests/cp/examples/kdb-cp/copied
+#>
+
+# If the target-key already exists and has a different value, cp fails:
+kdb cp -r user/tests/cp/examples/kdb-cp/key user/tests/cp/examples/kdb-cp/cpkeyerror
+# RET: 11
+
+# If the target-key already exists and has the same value as the source, everything is fine:
+kdb cp -r user/tests/cp/examples/kdb-cp/key user/tests/cp/examples/kdb-cp/cpkey
+#>
+
+# To copy keys below an existing key:
+kdb cp -r user/tests/cp/examples/kdb-cp/another user/tests/cp/examples/kdb-cp/another/key
+#>
+# Note that in this example, all keys in the `another` directory will be copied below `key` **except** `key`.
+
+kdb rm -r user/tests/cp/examples/kdb-cp/
+```

--- a/doc/news/_preparation_next_release.md
+++ b/doc/news/_preparation_next_release.md
@@ -279,7 +279,7 @@ you up to date with the multi-language support provided by Elektra.
 ## Tools
 
 - `kdb get -v` now displays if the resulting value is a default-value defined by the metadata of the key. _(Thomas Bretterbauer)_
-- <<TODO>>
+- `kdb cp` now succeeds if target-keys already have the same values as the source-keys. _(Thomas Bretterbauer)_
 - <<TODO>>
 - <<TODO>>
 

--- a/src/tools/kdb/cp.cpp
+++ b/src/tools/kdb/cp.cpp
@@ -30,12 +30,24 @@ void copySingleKey (Cmdline const & cl, Key const & rk, KeySet & tmpConf, KeySet
 	{
 		tmpConf.lookup (rk, KDB_O_POP);
 	}
-	else if (tmpConf.lookup (rk))
+	else
 	{
-		throw CommandAbortException (
-			std::string ("Copy will not be done, because " + rk.getName () + " already exists, use -f to force copy"), 11);
+		Key key = tmpConf.lookup (rk);
+		if (key != nullptr)
+		{
+			if (key.getString () != rk.getString ())
+			{
+				throw CommandAbortException (std::string ("Copy will not be done, because " + rk.getName () +
+									  " already exists and has a different value"
+									  ", use -f to force copy"),
+							     11);
+			}
+		}
+		else
+		{
+			newConf.append (rk);
+		}
 	}
-	newConf.append (rk);
 }
 } // namespace
 

--- a/tests/shell/shell_recorder/tutorial_wrapper/CMakeLists.txt
+++ b/tests/shell/shell_recorder/tutorial_wrapper/CMakeLists.txt
@@ -6,6 +6,7 @@ include (LibAddTest)
 
 add_msr_test (kdb_get "${CMAKE_SOURCE_DIR}/doc/help/kdb-get.md REQUIRED_PLUGINS dump")
 add_msr_test (kdb_complete "${CMAKE_SOURCE_DIR}/doc/help/kdb-complete.md")
+add_msr_test (kdb_cp "${CMAKE_SOURCE_DIR}/doc/help/kdb-cp.md")
 add_msr_test (kdb_global_umount "${CMAKE_SOURCE_DIR}/doc/help/kdb-global-umount.md" REQUIRED_PLUGINS spec tracer)
 add_msr_test (kdb_ls "${CMAKE_SOURCE_DIR}/doc/help/kdb-ls.md" REQUIRED_PLUGINS sync)
 


### PR DESCRIPTION
src/tools/kdb/cp.cpp
Added ckeck of key-values of target- and source-key. If the values are identical, 'kdb cp' now succeeds.
Close #2560 

## Basics

Check relevant points but **please do not remove entries**.
Do not describe the purpose of this PR in the PR description but:

- [X] Short descriptions should be in the release notes (added as entry in
      `doc/news/_preparation_next_release.md` which contains `_(my name)_`)
      **Please always add something to the the release notes.**
- [ ] Longer descriptions should be in documentation or in design decisions.
- [ ] Describe details of how you changed the code in commit messages
      (first line should have `module: short statement` syntax)
- [ ] References to issues, e.g. `close #X`, should be in the commit messages.

## Checklist

Check relevant points but **please do not remove entries**.
For docu fixes, spell checking, and similar none of these points below
need to be checked.

- [X] I added unit tests
- [X] I ran all tests locally and everything went fine
- [ ] affected documentation is fixed
- [ ] I added code comments, logging, and assertions (see doc/CODING.md)
- [ ] meta data is updated (e.g. README.md of plugins and doc/METADATA.md)

