### PR TITLE
Logger: Fix Minor Problems

### DIFF
--- a/doc/dev/logging.md
+++ b/doc/dev/logging.md
@@ -71,7 +71,7 @@ If you want to only log messages below a specific directory prefix, then please 
 
    ```c
    #ifndef NO_FILTER
-   	if (strncmp (file, "src/postfix/", sizeof ("src/postfix"))) goto end;
+   	if (strncmp (file, "src/postfix/", sizeof ("src/postfix"))) return -1;
    #endif
    ```
 
@@ -79,7 +79,7 @@ If you want to only log messages below a specific directory prefix, then please 
 
    ```c
    #ifndef NO_FILTER
-   	if (strncmp (file, "src/plugins/yamlcpp/", sizeof ("src/plugins/yamlcpp"))) goto end;
+   	if (strncmp (file, "src/plugins/yamlcpp/", sizeof ("src/plugins/yamlcpp"))) return -1;
    #endif
    ```
 
@@ -90,7 +90,7 @@ If you want to only log messages below a specific directory prefix, then please 
    #ifndef NO_FILTER
    	if (strncmp (file, "src/plugins/directoryvalue/", sizeof ("src/plugins/directoryvalue")) &&
    	    strncmp (file, "src/plugins/yamlcpp/", sizeof ("src/plugins/yamlcpp")))
-   		goto end;
+   		return -1;
    #endif
    ```
 

--- a/doc/dev/logging.md
+++ b/doc/dev/logging.md
@@ -96,7 +96,7 @@ If you want to only log messages below a specific directory prefix, then please 
 
    .
 
-### Enabling and disabling sinks
+### Enabling and Disabling Sinks
 
 The logging framework has 3 sinks: stderr, syslog and file.
 

--- a/doc/news/_preparation_next_release.md
+++ b/doc/news/_preparation_next_release.md
@@ -274,6 +274,7 @@ compiled against an older 0.8 version of Elektra will continue to work
 - Logging in Elektra was changed with this release. If Elektra is compiled with `ENABLE_LOGGER` enabled, we now log warnings and errors to
   stderr and everything except debug messages to syslog. If `ENABLE_DEBUG` is also enabled, debug messages are logged to syslog as well.
   Previously you had to make some manual changes to the code, to see most of the logging messages. _(Klemens Böswirth)_
+- The logger does not truncate the file name incorrectly anymore, if `__FILE__` contains a relative (instead of an absolute) filepath. _(René Schwaiger)_
 - <<TODO>>
 
 ### Ease

--- a/doc/news/_preparation_next_release.md
+++ b/doc/news/_preparation_next_release.md
@@ -273,7 +273,7 @@ compiled against an older 0.8 version of Elektra will continue to work
 - Fixed a double cleanup error (segmentation fault) when mounting global plugins. _(Mihael Pranjić)_
 - Logging in Elektra was changed with this release. If Elektra is compiled with `ENABLE_LOGGER` enabled, we now log warnings and errors to
   stderr and everything except debug messages to syslog. If `ENABLE_DEBUG` is also enabled, debug messages are logged to syslog as well.
-  Previously only you had to make some manual changes to the code, to see most of the logging messages. _(Klemens Böswirth)_
+  Previously you had to make some manual changes to the code, to see most of the logging messages. _(Klemens Böswirth)_
 - <<TODO>>
 
 ### Ease

--- a/src/include/kdblogger.h
+++ b/src/include/kdblogger.h
@@ -66,7 +66,7 @@ enum ElektraLogLevel
 
 };
 
-#ifdef DEBUG
+#if DEBUG
 /**
  * @brief Sets the global minimum log level
  */

--- a/src/libs/elektra/log.c
+++ b/src/libs/elektra/log.c
@@ -135,9 +135,17 @@ static void replaceChars (char * str)
 
 int elektraVLog (int level, const char * function, const char * absFile, int line, const char * mmsg, va_list args)
 {
-	size_t lenOfLogFileName = sizeof ("src/libs/elektra/log.c") - 1;
-	size_t lenOfLogPathName = strlen (__FILE__) - lenOfLogFileName;
-	const char * file = &absFile[lenOfLogPathName];
+	const char * file;
+	if (absFile[0] == '/' || absFile[0] == '.')
+	{
+		size_t lenOfLogFileName = sizeof ("src/libs/elektra/log.c") - 1;
+		size_t lenOfLogPathName = strlen (__FILE__) - lenOfLogFileName;
+		file = &absFile[lenOfLogPathName];
+	}
+	else
+	{
+		file = absFile;
+	}
 
 	int ret = -1;
 #ifndef NO_FILTER

--- a/src/libs/elektra/log.c
+++ b/src/libs/elektra/log.c
@@ -45,7 +45,7 @@ static int elektraLogStdErr (int level ELEKTRA_UNUSED, const char * function ELE
 {
 #ifndef NO_FILTER
 	// XXX Filter here for specific sink
-	if (level <= ELEKTRA_LOG_LEVEL_STDERR) return -1;
+	if (level < ELEKTRA_LOG_LEVEL_STDERR) return -1;
 #endif
 	int ret = fprintf (stderr, "%s", msg);
 	fflush (stderr);
@@ -61,7 +61,7 @@ static int elektraLogSyslog (int level ELEKTRA_UNUSED, const char * function ELE
 {
 #ifndef NO_FILTER
 	// XXX Filter here for specific sink
-	if (level <= ELEKTRA_LOG_LEVEL_SYSLOG) return -1;
+	if (level < ELEKTRA_LOG_LEVEL_SYSLOG) return -1;
 #endif
 	int vlevel;
 	switch (level)
@@ -104,7 +104,7 @@ static int elektraLogFile (int level ELEKTRA_UNUSED, const char * function ELEKT
 {
 #ifndef NO_FILTER
 	// XXX Filter here for specific sink
-	if (level <= ELEKTRA_LOG_LEVEL_FILE) return -1;
+	if (level < ELEKTRA_LOG_LEVEL_FILE) return -1;
 #endif
 	if (!elektraLoggerFileHandle)
 	{
@@ -142,7 +142,7 @@ int elektraVLog (int level, const char * function, const char * absFile, int lin
 	int ret = -1;
 #ifndef NO_FILTER
 	// XXX Filter level here globally (for every sink)
-	if (level <= ELEKTRA_LOG_LEVEL_GLOBAL) return -1;
+	if (level < ELEKTRA_LOG_LEVEL_GLOBAL) return -1;
 
 	// or e.g. discard everything, but log statements from simpleini.c:
 	// if (strcmp (file, "src/plugins/simpleini/simpleini.c")) return -1;

--- a/src/libs/elektra/log.c
+++ b/src/libs/elektra/log.c
@@ -159,7 +159,14 @@ int elektraVLog (int level, const char * function, const char * absFile, int lin
 #endif
 
 	char * str;
-	// XXX Change here default format for messages
+	// XXX Change here default format for messages.
+	//
+	// For example, to use a style similar to the default one used by compilers such as Clang and GCC, replace the following statement
+	// with:
+	//
+	//     str = elektraFormat ("%s:%d:%s: %s\n", file, line, function, mmsg);
+	//
+	// .
 	str = elektraFormat ("%s (in %s at %s:%d)\n", mmsg, function, file, line);
 	char * msg = elektraVFormat (str, args);
 	replaceChars (msg);


### PR DESCRIPTION
After this update the logger

- adds debug messages to the system log, if you enable the CMake variable `DEBUG`
- also logs messages at the specified minimum log level
- does not truncate relative file paths incorrectly anymore

.