### PR TITLE
WIP: Yajl: Empty arrays with metakey

### DIFF
--- a/doc/news/_preparation_next_release.md
+++ b/doc/news/_preparation_next_release.md
@@ -88,6 +88,8 @@ The following section lists news about the [modules](https://www.libelektra.org/
 
 - The plugin no longer lists empty parent keys with `kdb ls`. _(Philipp Gackstatter)_
 
+- The plugin signifies arrays with the metakey array according to the [array decision](../../doc/decisions/array.md). _(Philipp Gackstatter)_
+
 ### YAMBi
 
 - [YAMBi](https://www.libelektra.org/plugins/yambi) is now able detect multiple syntax errors in a file. _(René Schwaiger)_

--- a/src/plugins/yajl/testmod_yajl.c
+++ b/src/plugins/yajl/testmod_yajl.c
@@ -187,6 +187,7 @@ KeySet *getArrayKeys(void)
 {
 	KeySet *ks = ksNew(30,
 			keyNew("user/tests/yajl/array",
+				KEY_META, "array", "#_12",
 			       KEY_END),
 			keyNew("user/tests/yajl/array/#0",
 			       KEY_VALUE, "true",
@@ -256,7 +257,7 @@ KeySet *getArrayKeys(void)
 KeySet *getOpenICCKeys(void)
 {
 	KeySet *ks = ksNew(60,
-keyNew("user/tests/yajl/org/freedesktop/openicc/device/camera", KEY_END),
+keyNew("user/tests/yajl/org/freedesktop/openicc/device/camera", KEY_META, "array", "#1", KEY_END),
 keyNew("user/tests/yajl/org/freedesktop/openicc/device/camera/#0/prefix",
 		KEY_VALUE, "EXIF_",
 		KEY_END),
@@ -306,7 +307,7 @@ keyNew("user/tests/yajl/org/freedesktop/openicc/device/camera/#1/expire_date",
 // keyNew("user/tests/yajl/org/freedesktop/openicc/device/camera/#1/automatic_assignment",
 keyNew("user/tests/yajl/org/freedesktop/openicc/device/camera/#1/automatic_assigment",
 		KEY_VALUE, "1", KEY_END),
-keyNew("user/tests/yajl/org/freedesktop/openicc/device/monitor", KEY_END),
+keyNew("user/tests/yajl/org/freedesktop/openicc/device/monitor", KEY_META, "array", "#1", KEY_END),
 keyNew("user/tests/yajl/org/freedesktop/openicc/device/monitor/#0/prefix",
 		KEY_VALUE, "EDID_", KEY_END),
 keyNew("user/tests/yajl/org/freedesktop/openicc/device/monitor/#0/EDID_mnft_id",

--- a/src/plugins/yajl/yajl_gen.c
+++ b/src/plugins/yajl/yajl_gen.c
@@ -93,7 +93,8 @@ static int elektraGenOpenValue (yajl_gen g, const Key * next)
 
 	ELEKTRA_LOG_DEBUG ("next: \"%.*s\"", (int) last.size, last.current);
 
-	if (!strcmp (last.current, "###empty_array"))
+	const char * meta = keyString (keyGetMeta (next, "array"));
+	if (*meta == '\0')
 	{
 		ELEKTRA_LOG_DEBUG ("GEN empty array in value");
 		yajl_gen_array_open (g);
@@ -202,8 +203,9 @@ int elektraGenEmpty (yajl_gen g, KeySet * returned, Key * parentKey)
 	else if (ksGetSize (returned) == 2) // maybe just parent+specialkey
 	{
 		Key * toCheck = keyDup (parentKey);
-		keyAddBaseName (toCheck, "###empty_array");
-		if (!strcmp (keyName (ksTail (returned)), keyName (toCheck)))
+
+		const char * meta = keyString (keyGetMeta (ksTail (returned), "array"));
+		if (*meta == '\0')
 		{
 			ELEKTRA_LOG_DEBUG ("GEN empty array (got %s)", keyName (ksTail (returned)));
 			yajl_gen_array_open (g);


### PR DESCRIPTION
This PR replaces the `###empty_array` syntax of yajl with the metakey according to the [array decision](https://github.com/ElektraInitiative/libelektra/blob/master/doc/decisions/array.md), #182 and #2477.

## Basics

Check relevant points but **please do not remove entries**.
Do not describe the purpose of this PR in the PR description but:

- [x] Short descriptions should be in the release notes (added as entry in
      `doc/news/_preparation_next_release.md` which contains `_(my name)_`)
      **Please always add something to the the release notes.**
- [ ] Longer descriptions should be in documentation or in design decisions.
- [x] Describe details of how you changed the code in commit messages
      (first line should have `module: short statement` syntax)
- [ ] References to issues, e.g. `close #X`, should be in the commit messages.

## Checklist

Check relevant points but **please do not remove entries**.
For docu fixes, spell checking, and similar none of these points below
need to be checked.

- [x] I modified unit tests appropriately
- [x] I ran all tests locally and everything went fine
- [ ] affected documentation is fixed
- [ ] I added code comments, logging, and assertions (see doc/CODING.md)
- [ ] meta data is updated (e.g. README.md of plugins and doc/METADATA.md)

## Review

Remove the line below and add the "work in progress" label if you do
not want the PR to be reviewed:

## Merging

Please add the "ready to merge" label when the build server and you say
that everything is ready to be merged.
