### PR TITLE
Spec improvements

### DIFF
--- a/doc/AUTHORS.md
+++ b/doc/AUTHORS.md
@@ -195,3 +195,11 @@ development of the mmapstorage plugin
 - email: mpranj@limun.org
 - github user: [mpranj](https://github.com/mpranj)
 - devel/test on: Fedora, Debian, macOS
+
+## Klemens Böswirth
+
+development of the highlevel API and code-generation; various other things
+
+- email: k.boeswirth+git@gmail.com
+- github user: [kodebach](https://github.com/kodebach)
+- devel/test on: Fedora

--- a/doc/METADATA.ini
+++ b/doc/METADATA.ini
@@ -594,24 +594,174 @@ description= stores the original name of the key as it was before the
 # Spec Plugin
 #
 
-[conflict/_]
-type = string
-status = proposed
-description = reports which metadata had a conflict because another
-	metadata was already present before.
-	Idea: use only one log, also for conflicts.
+[conflict/get/member]
+type = enum
+	ERROR
+	WARNING
+	INFO
+status = implemented
+description = sets the conflict handling for member conflicts in kdbGet, see spec plugin README
 
-[array/range]
-type = range
-status = proposed
-description = checks if the subkeys form a valid array and are not smaller/larger
-	than as given.
-example = 4-20
+[conflict/get/invalid]
+type = enum
+	ERROR
+	WARNING
+	INFO
+status = implemented
+description = sets the conflict handling for invalid conflicts in kdbGet, see spec plugin README
+
+[conflict/get/count]
+type = enum
+	ERROR
+	WARNING
+	INFO
+status = implemented
+description = sets the conflict handling for count conflicts in kdbGet, see spec plugin README
+
+[conflict/get/collision]
+type = enum
+	ERROR
+	WARNING
+	INFO
+status = implemented
+description = sets the conflict handling for collision conflicts in kdbGet, see spec plugin README
+
+[conflict/get/missing]
+type = enum
+	ERROR
+	WARNING
+	INFO
+status = implemented
+description = sets the conflict handling for missing key conflicts in kdbGet, see spec plugin README
+
+[conflict/get/member]
+type = enum
+	ERROR
+	WARNING
+	INFO
+status = implemented
+description = sets the conflict handling for range conflicts in kdbGet, see spec plugin README
+
+[conflict/get/member]
+type = enum
+	ERROR
+	WARNING
+	INFO
+status = implemented
+description = sets the conflict handling for member conflicts in kdbGet, see spec plugin README
+
+[conflict/get/invalid]
+type = enum
+	ERROR
+	WARNING
+	INFO
+status = implemented
+description = sets the conflict handling for invalid conflicts in kdbGet, see spec plugin README
+
+[conflict/get/count]
+type = enum
+	ERROR
+	WARNING
+	INFO
+status = implemented
+description = sets the conflict handling for count conflicts in kdbGet, see spec plugin README
+
+[conflict/get/collision]
+type = enum
+	ERROR
+	WARNING
+	INFO
+status = implemented
+description = sets the conflict handling for collision conflicts in kdbGet, see spec plugin README
+
+[conflict/get/missing]
+type = enum
+	ERROR
+	WARNING
+	INFO
+status = implemented
+description = sets the conflict handling for missing key conflicts in kdbGet, see spec plugin README
+
+[conflict/get/range]
+type = enum
+	ERROR
+	WARNING
+	INFO
+status = implemented
+description = sets the conflict handling for range conflicts in kdbGet, see spec plugin README
+
+[conflict/set/member]
+type = enum
+	ERROR
+	WARNING
+	INFO
+status = implemented
+description = sets the conflict handling for member conflicts in kdbSet, see spec plugin README
+
+[conflict/set/invalid]
+type = enum
+	ERROR
+	WARNING
+	INFO
+status = implemented
+description = sets the conflict handling for invalid conflicts in kdbSet, see spec plugin README
+
+[conflict/set/count]
+type = enum
+	ERROR
+	WARNING
+	INFO
+status = implemented
+description = sets the conflict handling for count conflicts in kdbSet, see spec plugin README
+
+[conflict/set/collision]
+type = enum
+	ERROR
+	WARNING
+	INFO
+status = implemented
+description = sets the conflict handling for collision conflicts in kdbSet, see spec plugin README
+
+[conflict/set/missing]
+type = enum
+	ERROR
+	WARNING
+	INFO
+status = implemented
+description = sets the conflict handling for missing key conflicts in kdbSet, see spec plugin README
+
+[conflict/set/range]
+type = enum
+	ERROR
+	WARNING
+	INFO
+status = implemented
+description = sets the conflict handling for range conflicts in kdbSet, see spec plugin README
+
+[array/min]
+type = array-index
+status = implemented
+description = Sets the minimum element of an array. See also spec plugin README.
+example = #1
+
+[array/max]
+type = array-index
+status = implemented
+description = Sets the maximum element of an array. See also spec plugin README.
+example = #_10
 
 [require]
-type = boolean
-status = unclear
-description = See spec plugin
+type = empty
+status = implemented
+usedby/pluign = spec
+description = Requires the key to be present. See also spec plugin README.
+
+[require/count]
+type = long_long
+status = implemented
+usedby/pluign = spec
+description = Requires the wildcard key to have a certain number of children. See also spec plugin README.
+
 
 [required]
 type = range

--- a/doc/METADATA.ini
+++ b/doc/METADATA.ini
@@ -756,6 +756,12 @@ status = implemented
 usedby/pluign = spec
 description = Requires the key to be present. See also spec plugin README.
 
+[required]
+type = range
+usedby/plugin = required
+status = unclear
+description = See required plugin.
+
 [mandatory]
 type = boolean
 usedby/plugin = required

--- a/doc/METADATA.ini
+++ b/doc/METADATA.ini
@@ -756,22 +756,6 @@ status = implemented
 usedby/pluign = spec
 description = Requires the key to be present. See also spec plugin README.
 
-[require/count]
-type = long_long
-status = implemented
-usedby/pluign = spec
-description = Requires the wildcard key to have a certain number of children. See also spec plugin README.
-
-
-[required]
-type = range
-usedby/plugin = required
-status = unclear
-description = See spec plugin
-	for _ as basename as array. Otherwise the presence determines
-	if a key is required.
-	In process of being replaced in favor of require.
-
 [mandatory]
 type = boolean
 usedby/plugin = required

--- a/doc/news/_preparation_next_release.md
+++ b/doc/news/_preparation_next_release.md
@@ -80,9 +80,9 @@ The following section lists news about the [modules](https://www.libelektra.org/
 
 ### spec
 
-- The spec plugin was partly rewritten to better support specifications for arrays. This includes some breaking changes.
-  To find out more about take a look at the [README](../../src/plugins/spec/README.md). It now better reflects the actually implemented
-  behaviour. _(Klemens Böswirth)_
+- The spec plugin was partly rewritten to better support specifications for arrays. This includes some breaking changes concering the less
+  used (and also less functional) parts of the plugin. To find out more about these changes take a look at the
+  [README](../../src/plugins/spec/README.md). It now better reflects the actually implemented behaviour. _(Klemens Böswirth)_
 
 ### mINI
 

--- a/doc/news/_preparation_next_release.md
+++ b/doc/news/_preparation_next_release.md
@@ -78,6 +78,12 @@ The following section lists news about the [modules](https://www.libelektra.org/
 
 - Support DOS newlines for the csvstorage plugin. _(Vlad - Ioan Balan)_
 
+### spec
+
+- The spec plugin was partly rewritten to better support specifications for arrays. This includes some breaking changes.
+  To find out more about take a look at the [README](../../src/plugins/spec/README.md). It now better reflects the actually implemented
+  behaviour. _(Klemens Böswirth)_
+
 ### mINI
 
 - We fixed compiler warnings reported by GCC 9 in the [unit test code](../../src/plugins/mini/testmod_mini.c) of the plugin. _(René Schwaiger)_

--- a/examples/spec/spec.ini
+++ b/examples/spec/spec.ini
@@ -14,14 +14,11 @@ testkey/test/#/a =
 [testkey/test/#]
  conflict/get/member = WARNING
  arrayMeta = array
- array = 1-3
+ array/min = #1
+ array/max = #3
 
 [testkey/test3/#/a]
  test = succeeded
-
-[testkey/test2/a/_]
- required = 5
- wildcardMeta = wildcard
 
 [testkey/test/#/a]
  require = 

--- a/src/libs/elektra/internal.c
+++ b/src/libs/elektra/internal.c
@@ -715,6 +715,21 @@ size_t elektraUnescapeKeyName (const char * source, char * dest)
 
 	ELEKTRA_ASSERT (sp != NULL && dp != NULL, "Got null pointer sp: %p dp: %p", (void *) sp, (void *) dp);
 
+	// if there is nothing to unescape, just make a copy and replace / with \0
+	if (strpbrk (sp, "\\%") == NULL)
+	{
+		strcpy (dest, sp);
+		char * last = dp;
+		while ((dp = strchr (dp, '/')) != NULL)
+		{
+			*dp = '\0';
+			++dp;
+			last = dp;
+		}
+		// add 1, if we didn't end with \0 already
+		return last - dest + strlen (last) + (*last != '\0');
+	}
+
 	if (*sp == '/')
 	{
 		// handling for cascading names

--- a/src/libs/elektra/keymeta.c
+++ b/src/libs/elektra/keymeta.c
@@ -306,7 +306,7 @@ int keyCopyMeta (Key * dest, const Key * source, const char * metaName)
 	{
 		Key * r;
 		r = ksLookup (dest->meta, ret, KDB_O_POP);
-		if (r)
+		if (r && r != ret)
 		{
 			/*It was already there, so lets drop that one*/
 			keyDel (r);

--- a/src/libs/elektra/keyset.c
+++ b/src/libs/elektra/keyset.c
@@ -783,10 +783,21 @@ ssize_t ksSearchInternal (const KeySet * ks, const Key * toAppend)
 	ssize_t left = 0;
 	ssize_t right = ks->size;
 	--right;
-	register int cmpresult = 1;
+	register int cmpresult;
 	ssize_t middle = -1;
 	ssize_t insertpos = 0;
 
+	if (ks->size == 0)
+	{
+		return -1;
+	}
+
+	cmpresult = keyCompareByNameOwner (&toAppend, &ks->array[right]);
+	if (cmpresult > 0)
+	{
+		return -ks->size - 1;
+	}
+	cmpresult = 1;
 
 	while (1)
 	{
@@ -1174,10 +1185,8 @@ KeySet * ksCut (KeySet * ks, const Key * cutpoint)
 	}
 
 	// search the cutpoint
-	while (it < ks->size && keyIsBelowOrSame (cutpoint, ks->array[it]) == 0)
-	{
-		++it;
-	}
+	ssize_t search = ksSearchInternal (ks, cutpoint);
+	it = search < 0 ? -search - 1 : search;
 
 	// we found nothing
 	if (it == ks->size) return ksNew (0, KS_END);

--- a/src/libs/elektra/keyset.c
+++ b/src/libs/elektra/keyset.c
@@ -795,7 +795,7 @@ ssize_t ksSearchInternal (const KeySet * ks, const Key * toAppend)
 	cmpresult = keyCompareByNameOwner (&toAppend, &ks->array[right]);
 	if (cmpresult > 0)
 	{
-		return -ks->size - 1;
+		return -((ssize_t) ks->size) - 1;
 	}
 	cmpresult = 1;
 

--- a/src/libs/elektra/keytest.c
+++ b/src/libs/elektra/keytest.c
@@ -322,11 +322,6 @@ int keyIsDirectBelow (const Key * key, const Key * check)
 	size_t sizeAbove = keyGetUnescapedNameSize (key);
 	size_t sizeBelow = keyGetUnescapedNameSize (check);
 
-	if (sizeAbove > sizeBelow)
-	{
-		return 0;
-	}
-
 	if (above[0] != '\0' && below[0] == '\0')
 	{
 		// cascading
@@ -341,6 +336,11 @@ int keyIsDirectBelow (const Key * key, const Key * check)
 		size_t len = strlen (below);
 		below += len;
 		sizeBelow -= len;
+	}
+
+	if (sizeAbove >= sizeBelow)
+	{
+		return 0;
 	}
 
 	size_t nextPartSize = strlen (below + sizeAbove);

--- a/src/libs/highlevel/elektra.c
+++ b/src/libs/highlevel/elektra.c
@@ -124,7 +124,10 @@ void elektraEnsure (Elektra * elektra, KeySet * contract, ElektraError ** error)
 	if (rc == 0)
 	{
 		// if successful, refresh config
-		kdbGet (elektra->kdb, elektra->config, elektra->parentKey);
+		if (kdbGet (elektra->kdb, elektra->config, parentKey) == -1)
+		{
+			*error = elektraErrorCreateFromKey (parentKey);
+		}
 	}
 	else if (rc == 1)
 	{

--- a/src/libs/tools/src/specreader.cpp
+++ b/src/libs/tools/src/specreader.cpp
@@ -65,7 +65,7 @@ bool isToBeIgnored (std::string const & name)
 	       startsWith (name, "exports") ||
 
 	       // spec-plugin
-	       startsWith (name, "conflict") || startsWith (name, "require") || startsWith (name, "array/") ||
+	       startsWith (name, "conflict") || startsWith (name, "require") || startsWith (name, "array") ||
 
 	       startsWith (name, "fallback") || startsWith (name, "override") || startsWith (name, "namespace") || name == "default" ||
 	       name == "context" ||

--- a/src/plugins/spec/CMakeLists.txt
+++ b/src/plugins/spec/CMakeLists.txt
@@ -4,4 +4,6 @@ add_plugin (spec
 	    SOURCES spec.h
 		    spec.c
 	    LINK_ELEKTRA elektra-ease
-			 elektra-meta)
+			 elektra-meta
+			 elektra-globbing
+	    ADD_TEST)

--- a/src/plugins/spec/README.md
+++ b/src/plugins/spec/README.md
@@ -1,75 +1,137 @@
 - infos = Information about the spec plugin is in keys below
-- infos/author = Thomas Waser <thomas.waser@libelektra.org>
+- infos/author = Thomas Waser <thomas.waser@libelektra.org>, Klemens Böswirth <k.boeswirth+git@gmail.com>
 - infos/licence = BSD
 - infos/needs =
 - infos/provides = check apply
 - infos/placements = postgetstorage presetstorage
-- infos/status = maintained nodep configurable global preview
-- infos/description = copies metadata from spec namespace to other namespaces
+- infos/status = maintained nodep configurable global recommended productive unfinished
+- infos/description = allows to give specifications for keys
 
 ## Introduction
 
-The spec plugin is a global plugin that copies metadata from the `spec`-namespace to other namespaces using their key names as globbing expressions.
-Globbing resembles regular expressions. They do not have the same expressive power, but are easier to use. The semantics are more suitable to match path names:
+The spec plugin is a global plugin that copies metadata from the `spec`-namespace to other namespaces using their key names as globbing
+expressions. Globbing resembles regular expressions. They do not have the same expressive power, but are easier to use. The semantics are
+more suitable to match path names:
 
-- `_` matches any key name of just one hierarchy. This means it complies with any character except slash or null.
+- `*` matches any key name of just one hierarchy. This means it complies with any character except slash or null.
 - `?` satisfies single characters with the same exclusion.
-- `#` matches Elektra array elements.
-- Additionally, there are ranges and character classes. They can also be inverted.
+- `#` matches Elektra array elements. (e.g. `#0`, `#_10`, `#__987`)
+- `_` matches anything that `*` matches, except array elements.
+- Additionally, there are ranges and character classes. They can also be inverted. For more infos take a look at the code documentation of
+  `elektraKeyGlob()`.
 
-The plugin copies the metadata of the corresponding `spec` key to every matching key in the other namespaces.
+The plugin copies the metadata of the corresponding `spec` key to every matching (see below) key in the other namespaces. The copied metadata
+is removed again during `kdbSet` (if remained unchanged).
 
 The spec plugin also provides basic validation and structural checking.
 Specifically it supports:
 
 - detection of invalid array key names
 - detection of missing keys
-- validation of array ranges
-- validating the number of subkeys
+- validation of array ranges (min/max array size)
+- validating the number of subkeys of `_`
+
+## Matching Algorithm
+
+The matching of the spec (globbing) keys to the keys in the other namespaces is based on `elektraKeyGlob()`, which in turn is based on the
+well known `fnmatch(3)`. However, there is special handling for array specifications (`#`) and wildcard specifications (`_`).
+
+### Array Specifications
+
+Keys which contain a part that is exactly `#` (e.g. `my/#/key` or `my/#`) are called array specifications. Instead of just matching the spec
+key to any existing keys in other namespaces, theses keys are "instantiated". This means we lookup the array size (defined by the `array`
+metakey) using a cascading `ksLookup`. This only looks at non-spec namespaces, if we don't find an array size their, we check the array
+parent in the spec namespace. If we still have no array size, the array is deemed to be empty. For empty arrays, we will simply validate
+that they are indeed empty.
+
+For non-empty arrays "instantiation" takes place. This means that we replace each `#` part in the spec key by all the valid array elements
+for this specification, up to the array size (which was already checked to be less than the allowed maximum). In other words, instead of
+actually matching the globbing expression, we create a separate but identical specification for all valid array elements.
+
+The purpose of "instantiation" is to allow specifying `default` values for array elements.
+
+### Wildcard Specifications
+
+Keys which contain a part that is exactly `_` (e.g. `my/_/key` or `my/_`) are called wildcard specifications. It would be nice to have
+an "instantiation" procedure for `_` similar to the one for arrays. However, this is not possible with the current implementation, since
+there is no way of knowing in advance, which keys matching the globbing expression may be requested via `ksLookup`.
+
+Instead `_` is simply treated like `*` during matching. Afterwards we check that no array elements were matched.
+
+## Specification and Validation
+
+The basic functionality of the plugin is to just copy (using `keyCopyMeta()` so we don't waste memory) the metadata of spec keys to all
+matching (as described above) keys in other namespaces. This ensures that other plugins can do their work as expected, without manually
+setting metadata on every key. If any metakey we want to copy already exists on the target key (with a different value), this causes a
+`collision` conflict.
+
+In addition to the basic functionality, the plugin does some validation itself.
+
+### Default Values
+
+If a spec key has the metakey `default` set and the key does not exist in other namespaces, we create a special (cascading) key that will
+be found by `ksLookup`. This key has the `default` value as its value. We also copy over metadata as always.
+
+A similar procedure takes place for `assign/condition`, but in this case, we don't set the value of the key. We only create it and copy
+metadata.
+
+### Required Keys
+
+If a spec key has the metakey `require` (the value of this metakey is irrelevant and ignored), we ensure that this key exists in at least
+one other namespace, i.e. it can be found using a cascading `ksLookup`. If the key cannot be found, this causes a `missing` conflict.
+
+### Array Size Validation
+
+As hinted to above, we validate array sizes. If a spec key `x/#` is given, and the spec key `x` has the metakey `array/min` or `array/max`
+set, we validate the array size (given as metakey `array` on `x`) is within the limits of `array/min` and `array/max`. Both `array/min` and
+`array/max` have to be valid array-elements similar to `array`. If the array size is out of bounds, this causes a `range` conflict.
+
+We also check that the array only contains actual array elements. If this not the case, this causes a `member` conflict.
+
+Note: We don't actually validate that the array doesn't contain elements above the given array size. This is because it doesn't have anything
+to do with the specification, whether the array contains additional elements. Note also that we only copy metadata onto elements within
+the bounds of the array size.
 
 ## Configuration
 
-### Actions
-
-- `ERROR` yields an error when a conflict occurs
-- `WARNING` adds a warning when a conflict occurs
-- `INFO` adds a metakey `logs/spec/info` which can be used by logging plugins
-- `IGNORE` ignores the conflict, this is the default value
+There are various ways in which a conflict can occur during the validation process. To handle these conflicts, we provide various
+configuration options.
 
 ### Conflicts
 
-- Invalid array `member`: an invalid array key has been detected. e.g. `/#abc`
-- Out of `range`: the array has more or less elements than specified by the `array` option.
-- Invalid number of subkeys `count`: a key matching a `_` expression has more or less subkeys than specified by the `required` option.
+The possible conflicts are:
+
+- Invalid array `member`: an invalid array key has been detected. e.g. `/#abc`, or `/x` (i.e. non-array-element) if array (`#`) was specified
+- Out of `range`: the array has more or less elements than specified by the `array/min` and `array/max` metakeys.
+- Missing keys `missing`: the key marked as `require`d wasn't found.
+- Invalid keys `invalid`: the specification or a key was invalid
 - Conflicting metadata `collision`: the metakey that's supposed to be added already exists.
-- Missing keys `missing`: the key structure doesn't contain the required subkeys flagged with the `require` metakey in the `spec` namespace.
-- Invalid keys `invalid`: keys that are subkeys of an invalid array member. e.g. `/#abc/key`
 
-### Basic Configuration
+#### Configuration Keys
 
-`conflict/set` and `conflict/get` are used to specify what actions should be taken on conflicts. e.g. `conflict/get = ERROR` yields an error on every conflict.
+To define what actions should be taken on on conflicts during `kdbGet` and `kdbSet` respectively use the keys `conflict/set` and
+`conflict/get` in the plugin configuration.
 
-### Per Conflict Configuration
-
-Actions can also be specified on a per conflict basis. Those actions take precedence over basic configuration options.
-
-Examples:
+This base configuration can be overridden on a per-conflict basis to provide more granularity. The keys for this are (replace `_` with
+`get` or `set` accordingly):
 
 ```
-conflict/get/member = WARNING
-conflict/set/range = ERROR
+conflict/_/member
+conflict/_/range
+conflict/_/missing
+conflict/_/invalid
+conflict/_/collision
 ```
 
-### Per Key Configuration
+For even more granularity, the above per-conflict metakeys can also be specified on individual keys.
 
-Actions can also be specified per-key. Those will take precedence over basic and per-conflict configurations.
+The allowed values for the conflict keys are always the same:
 
-Example:
-
-```
-spec/test/#
-    conflict/get/member = INFO
-```
+- `ERROR` yields an error when a conflict occurs
+- `WARNING` adds a warning when a conflict occurs
+- `INFO` adds a metakey `logs/spec/info` to the parent-key which can be used by logging plugins.
+  `logs/spec/info` is an array, each element is one conflict.
+- any other value ignores the conflict, this includes if the conflict key is not given (i.e. the default)
 
 ## Examples
 
@@ -107,3 +169,7 @@ kdb lsmeta /freedesktop/openicc/device/camera/#0/EXIF_serial   # seems like ther
 kdb set "/freedesktop/openicc/device/camera/#0/EXIF_serial" 203     # success, is a long
 kdb set "/freedesktop/openicc/device/camera/#0/EXIF_serial" x   # fails, not a long
 ```
+
+## Known issues
+
+Added metadata is not correctly removed during `kdbSet`, if the corresponding spec key was modified.

--- a/src/plugins/spec/README.md
+++ b/src/plugins/spec/README.md
@@ -170,6 +170,6 @@ kdb set "/freedesktop/openicc/device/camera/#0/EXIF_serial" 203     # success, i
 kdb set "/freedesktop/openicc/device/camera/#0/EXIF_serial" x   # fails, not a long
 ```
 
-## Known issues
+## Known Issues
 
 Added metadata is not correctly removed during `kdbSet`, if the corresponding spec key was modified.

--- a/src/plugins/spec/spec.c
+++ b/src/plugins/spec/spec.c
@@ -417,7 +417,7 @@ static KeySet * instantiateArraySpec (KeySet * ks, Key * arraySpec)
 					}
 
 					char elem[ELEKTRA_MAX_ARRAY_SIZE];
-					kdb_long_long_t i = 0; // FIXME: use min
+					kdb_long_long_t i = 0;
 					elektraWriteArrayNumber (elem, i);
 
 					while (strcmp (elem, arraySize) <= 0)

--- a/src/plugins/spec/spec.c
+++ b/src/plugins/spec/spec.c
@@ -44,6 +44,9 @@ typedef enum
 #define SIZE_CONFLICTS       sizeof(NO_CONFLICTS)
 // clang-format on
 
+#define CONFIG_BASE_NAME_GET "/conflict/get"
+#define CONFIG_BASE_NAME_SET "/conflict/set"
+
 typedef struct
 {
 	OnConflict member;
@@ -88,7 +91,7 @@ static OnConflict parseOnConflictKey (const Key * key)
 	}
 }
 
-static void parseConfig (KeySet * config, ConflictHandling * ch, const char baseName[20])
+static void parseConfig (KeySet * config, ConflictHandling * ch, const char baseName[14])
 {
 	char nameBuffer[32];
 	strcpy (nameBuffer, baseName);
@@ -122,7 +125,7 @@ static void parseConfig (KeySet * config, ConflictHandling * ch, const char base
 	ch->missing = key == NULL ? base : parseOnConflictKey (key);
 }
 
-static void parseLocalConfig (Key * specKey, ConflictHandling * ch, const char baseName[20])
+static void parseLocalConfig (Key * specKey, ConflictHandling * ch, const char baseName[14])
 {
 	char nameBuffer[32];
 	strcpy (nameBuffer, baseName);
@@ -310,7 +313,7 @@ static int handleConflicts (Key * key, Key * parentKey, Key * specKey, const Con
  * @retval  0 if no conflicts where found
  * @retval -1 otherwise
  */
-static int handleErrors (Key * key, Key * parentKey, KeySet * ks, Key * specKey, const ConflictHandling * ch, const char configBaseName[20])
+static int handleErrors (Key * key, Key * parentKey, KeySet * ks, Key * specKey, const ConflictHandling * ch, const char configBaseName[14])
 {
 	ConflictHandling localCh;
 	memcpy (&localCh, ch, sizeof (ConflictHandling));
@@ -671,7 +674,7 @@ static bool specMatches (Key * specKey, Key * otherKey)
  * @retval  0 on success
  * @retval -1 otherwise
  */
-static int processSpecKey (Key * specKey, Key * parentKey, KeySet * ks, const ConflictHandling * ch, const char configBaseName[20],
+static int processSpecKey (Key * specKey, Key * parentKey, KeySet * ks, const ConflictHandling * ch, const char configBaseName[14],
 			   bool isKdbGet)
 {
 	bool require = keyGetMeta (specKey, "require") != NULL;
@@ -789,7 +792,7 @@ int elektraSpecGet (Plugin * handle, KeySet * returned, Key * parentKey)
 	ConflictHandling ch;
 
 	KeySet * config = elektraPluginGetConfig (handle);
-	parseConfig (config, &ch, "/conflict/get");
+	parseConfig (config, &ch, CONFIG_BASE_NAME_GET);
 
 	// build spec
 	KeySet * specKS = ksNew (0, KS_END);
@@ -824,7 +827,7 @@ int elektraSpecGet (Plugin * handle, KeySet * returned, Key * parentKey)
 	int ret = ELEKTRA_PLUGIN_STATUS_SUCCESS;
 	while ((specKey = ksNext (specKS)) != NULL)
 	{
-		if (processSpecKey (specKey, parentKey, ks, &ch, "/conflict/get", true) != 0)
+		if (processSpecKey (specKey, parentKey, ks, &ch, CONFIG_BASE_NAME_GET, true) != 0)
 		{
 			ret = ELEKTRA_PLUGIN_STATUS_ERROR;
 		}
@@ -847,7 +850,7 @@ int elektraSpecSet (Plugin * handle, KeySet * returned, Key * parentKey)
 	ConflictHandling ch;
 
 	KeySet * config = elektraPluginGetConfig (handle);
-	parseConfig (config, &ch, "/conflict/set");
+	parseConfig (config, &ch, CONFIG_BASE_NAME_SET);
 
 	// build spec
 	KeySet * specKS = ksNew (0, KS_END);
@@ -882,7 +885,7 @@ int elektraSpecSet (Plugin * handle, KeySet * returned, Key * parentKey)
 	int ret = ELEKTRA_PLUGIN_STATUS_SUCCESS;
 	while ((specKey = ksNext (specKS)) != NULL)
 	{
-		if (processSpecKey (specKey, parentKey, ks, &ch, "/conflict/set", false) != 0)
+		if (processSpecKey (specKey, parentKey, ks, &ch, CONFIG_BASE_NAME_SET, false) != 0)
 		{
 			ret = ELEKTRA_PLUGIN_STATUS_ERROR;
 		}

--- a/src/plugins/spec/spec.c
+++ b/src/plugins/spec/spec.c
@@ -922,7 +922,7 @@ static int processSpecKeySet (Key * specKey, Key * parentKey, KeySet * ks, const
 			ret = -1;
 		}
 
-		removeMeta (cur, specKey);
+		// removeMeta (cur, specKey);
 	}
 
 	return ret;

--- a/src/plugins/spec/spec.c
+++ b/src/plugins/spec/spec.c
@@ -585,7 +585,7 @@ static void validateWildcardSubs (KeySet * ks, Key * key, Key * specKey)
 		ksDel (ksCopy);
 
 		Key * cur;
-		long subCount = 0;
+		kdb_long_long_t subCount = 0;
 		while ((cur = ksNext (subKeys)) != NULL)
 		{
 			if (keyIsDirectBelow (parent, cur))

--- a/src/plugins/spec/spec.c
+++ b/src/plugins/spec/spec.c
@@ -615,6 +615,7 @@ static void validateWildcardSubs (KeySet * ks, Key * key, Key * specKey)
 
 static bool specMatches (Key * specKey, Key * otherKey)
 {
+	// TODO: use globbing
 	const char * spec = keyUnescapedName (specKey);
 	size_t specNsLen = strlen (spec) + 1;
 	spec += specNsLen; // skip namespace

--- a/src/plugins/spec/spec.c
+++ b/src/plugins/spec/spec.c
@@ -738,10 +738,6 @@ static int processSpecKey (Key * specKey, Key * parentKey, KeySet * ks, const Co
 			{
 				Key * newKey = keyNew (strchr (keyName (specKey), '/'), KEY_CASCADING_NAME, KEY_END);
 				copyMeta (newKey, specKey);
-				if (!isKdbGet)
-				{
-					keySetMeta (newKey, "internal/spec/remove", "");
-				}
 				ksAppendKey (ks, newKey);
 			}
 			else if (keyGetMeta (specKey, "default") != NULL)
@@ -749,10 +745,6 @@ static int processSpecKey (Key * specKey, Key * parentKey, KeySet * ks, const Co
 				Key * newKey = keyNew (strchr (keyName (specKey), '/'), KEY_CASCADING_NAME, KEY_VALUE,
 						       keyString (keyGetMeta (specKey, "default")), KEY_END);
 				copyMeta (newKey, specKey);
-				if (!isKdbGet)
-				{
-					keySetMeta (newKey, "internal/spec/remove", "");
-				}
 				ksAppendKey (ks, newKey);
 			}
 		}

--- a/src/plugins/spec/spec.c
+++ b/src/plugins/spec/spec.c
@@ -494,6 +494,7 @@ static void validateArrayMembers (KeySet * ks, Key * arraySpec)
 	Key * arrayParent = ksLookup (ks, parentLookup, 0);
 	if (keyGetMeta (arrayParent, "internal/spec/array/validated") != NULL)
 	{
+		keyDel (parentLookup);
 		return;
 	}
 
@@ -602,6 +603,7 @@ static void validateWildcardSubs (KeySet * ks, Key * key, Key * specKey)
 			}
 		}
 		ksDel (subKeys);
+		keyDel (parent);
 
 		// TODO: conversion library?
 
@@ -815,6 +817,7 @@ int elektraSpecGet (Plugin * handle, KeySet * returned, Key * parentKey)
 			{
 				KeySet * specs = instantiateArraySpec (returned, cur);
 				ksAppend (specKS, specs);
+				ksDel (specs);
 			}
 
 			ksAppendKey (specKS, cur);
@@ -873,6 +876,7 @@ int elektraSpecSet (Plugin * handle, KeySet * returned, Key * parentKey)
 			{
 				KeySet * specs = instantiateArraySpec (returned, cur);
 				ksAppend (specKS, specs);
+				ksDel (specs);
 			}
 
 			ksAppendKey (specKS, cur);

--- a/src/plugins/spec/spec.c
+++ b/src/plugins/spec/spec.c
@@ -444,7 +444,10 @@ static void validateEmptyArray (KeySet * ks, Key * arraySpec, Key * parentKey, O
 	ksDel (subKeys);
 	keyDel (parentLookup);
 
-	keySetMeta (arrayParent, "internal/spec/array/validated", "");
+	if (!immediate)
+	{
+		keySetMeta (arrayParent, "internal/spec/array/validated", "");
+	}
 }
 
 static void validateArrayMembers (KeySet * ks, Key * arraySpec)

--- a/src/plugins/spec/spec.c
+++ b/src/plugins/spec/spec.c
@@ -917,6 +917,7 @@ int elektraSpecSet (Plugin * handle, KeySet * returned, Key * parentKey)
 
 	// cleanup
 	ksDel (ks);
+	ksDel (specKS);
 
 	return ret;
 }

--- a/src/plugins/spec/spec.c
+++ b/src/plugins/spec/spec.c
@@ -736,6 +736,10 @@ static int processSpecKey (Key * specKey, Key * parentKey, KeySet * ks, const Co
 			{
 				Key * newKey = keyNew (strchr (keyName (specKey), '/'), KEY_CASCADING_NAME, KEY_END);
 				copyMeta (newKey, specKey);
+				if (!isKdbGet)
+				{
+					keySetMeta (newKey, "internal/spec/remove", "");
+				}
 				ksAppendKey (ks, newKey);
 			}
 			else if (keyGetMeta (specKey, "default") != NULL)
@@ -743,6 +747,10 @@ static int processSpecKey (Key * specKey, Key * parentKey, KeySet * ks, const Co
 				Key * newKey = keyNew (strchr (keyName (specKey), '/'), KEY_CASCADING_NAME, KEY_VALUE,
 						       keyString (keyGetMeta (specKey, "default")), KEY_END);
 				copyMeta (newKey, specKey);
+				if (!isKdbGet)
+				{
+					keySetMeta (newKey, "internal/spec/remove", "");
+				}
 				ksAppendKey (ks, newKey);
 			}
 		}
@@ -902,7 +910,7 @@ int elektraSpecSet (Plugin * handle, KeySet * returned, Key * parentKey)
 	ksRewind (ks);
 	while ((cur = ksNext (ks)) != NULL)
 	{
-		if (keyGetNamespace (cur) == KEY_NS_CASCADING || keyGetNamespace (cur) == KEY_NS_SPEC)
+		if (keyGetNamespace (cur) == KEY_NS_SPEC)
 		{
 			continue;
 		}

--- a/src/plugins/spec/spec.h
+++ b/src/plugins/spec/spec.h
@@ -15,7 +15,6 @@
 
 int elektraSpecGet (Plugin * handle, KeySet * ks, Key * parentKey);
 int elektraSpecSet (Plugin * handle, KeySet * ks, Key * parentKey);
-int elektraSpecClose (Plugin * handle, Key * parentKey);
 
 Plugin * ELEKTRA_PLUGIN_EXPORT;
 

--- a/src/plugins/spec/testmod_spec.c
+++ b/src/plugins/spec/testmod_spec.c
@@ -1,0 +1,389 @@
+/**
+ * @file
+ *
+ * @brief
+ *
+ * @copyright BSD License (see doc/LICENSE.md or https://www.libelektra.org)
+ */
+
+#include "spec.h"
+
+#include <tests_plugin.h>
+
+#define PARENT_KEY "/tests/spec"
+
+#define TEST_BEGIN                                                                                                                         \
+	{                                                                                                                                  \
+		KeySet * conf = ksDup (_conf);                                                                                             \
+		PLUGIN_OPEN ("spec");                                                                                                      \
+		Key * parentKey = keyNew (PARENT_KEY, KEY_END);
+
+#define TEST_END                                                                                                                           \
+	keyDel (parentKey);                                                                                                                \
+	PLUGIN_CLOSE ();                                                                                                                   \
+	}
+
+
+void test_default (void)
+{
+	printf ("test default\n");
+
+	KeySet * _conf = ksNew (1, keyNew ("user/conflict/get", KEY_VALUE, "ERROR", KEY_END), KS_END);
+	TEST_BEGIN
+	{
+		KeySet * ks =
+			ksNew (10, keyNew ("spec" PARENT_KEY "/a", KEY_META, "default", "17", KEY_META, "othermeta", "", KEY_END), KS_END);
+
+		succeed_if (plugin->kdbGet (plugin, ks, parentKey) == ELEKTRA_PLUGIN_STATUS_SUCCESS, "kdbGet failed");
+
+		Key * lookup = ksLookupByName (ks, PARENT_KEY "/a", 0);
+
+		succeed_if (lookup != NULL, ".../a not found");
+		succeed_if_same_string (keyString (lookup), "17");
+		succeed_if (keyGetMeta (lookup, "othermeta") != NULL, "metadata missing");
+
+		ksDel (ks);
+	}
+	TEST_END
+
+	TEST_BEGIN
+	{
+		KeySet * ks = ksNew (10, keyNew ("spec" PARENT_KEY "/a", KEY_META, "default", "17", KEY_META, "othermeta", "", KEY_END),
+				     keyNew ("user" PARENT_KEY "/a", KEY_VALUE, "19", KEY_META, "default", "19", KEY_END), KS_END);
+
+		succeed_if (plugin->kdbGet (plugin, ks, parentKey) == ELEKTRA_PLUGIN_STATUS_ERROR, "kdbGet should fail");
+
+		ksDel (ks);
+	}
+	TEST_END
+}
+
+void test_assign_condition (void)
+{
+	printf ("test assign/condition\n");
+
+	KeySet * _conf = ksNew (1, keyNew ("user/conflict/get", KEY_VALUE, "ERROR", KEY_END), KS_END);
+
+	TEST_BEGIN
+	{
+		KeySet * ks =
+			ksNew (10, keyNew ("spec" PARENT_KEY "/a", KEY_META, "assign/condition", "17", KEY_META, "othermeta", "", KEY_END),
+			       KS_END);
+
+		succeed_if (plugin->kdbGet (plugin, ks, parentKey) == ELEKTRA_PLUGIN_STATUS_SUCCESS, "kdbGet failed");
+
+		Key * lookup = ksLookupByName (ks, PARENT_KEY "/a", 0);
+
+		succeed_if (lookup != NULL, ".../a not found");
+		succeed_if_same_string (keyString (lookup), "");
+		succeed_if_same_string (keyString (keyGetMeta (lookup, "assign/condition")), "17");
+		succeed_if (keyGetMeta (lookup, "othermeta") != NULL, "metadata missing");
+
+		ksDel (ks);
+	}
+	TEST_END
+}
+
+void test_wildcard (void)
+{
+	/* TODO: instantiated wildcards
+printf ("test wildcard (_)\n");
+
+KeySet * _conf = ksNew (1, keyNew ("user/conflict/get", KEY_VALUE, "ERROR", KEY_END), KS_END);
+
+TEST_BEGIN
+{
+	KeySet * ks = ksNew (10, keyNew ("spec" PARENT_KEY "/a/_", KEY_META, "default", "17", KEY_META, "othermeta", "", KEY_END),
+			     keyNew ("user" PARENT_KEY "/a/x", KEY_END), KS_END);
+
+	succeed_if (plugin->kdbGet (plugin, ks, parentKey) == ELEKTRA_PLUGIN_STATUS_SUCCESS, "kdbGet failed");
+
+	Key * lookup = ksLookupByName (ks, PARENT_KEY "/a/x", 0);
+
+	succeed_if (lookup != NULL, ".../a/x not found");
+	succeed_if_same_string (keyString (lookup), "17");
+	succeed_if_same_string (keyString (keyGetMeta (lookup, "default")), "17");
+	succeed_if (keyGetMeta (lookup, "othermeta") != NULL, "metadata missing");
+
+	ksDel (ks);
+}
+TEST_END
+	 */
+}
+
+void test_require (void)
+{
+	printf ("test require\n");
+
+	KeySet * _conf = ksNew (1, keyNew ("user/conflict/get", KEY_VALUE, "ERROR", KEY_END), KS_END);
+
+	TEST_BEGIN
+	{
+		KeySet * ks = ksNew (10, keyNew ("spec" PARENT_KEY "/a", KEY_META, "require", "", KEY_END), KS_END);
+
+		succeed_if (plugin->kdbGet (plugin, ks, parentKey) == ELEKTRA_PLUGIN_STATUS_ERROR, "kdbGet shouldn't succeed");
+
+		ksDel (ks);
+	}
+	TEST_END
+
+	TEST_BEGIN
+	{
+		KeySet * ks = ksNew (10, keyNew ("spec" PARENT_KEY "/a", KEY_META, "require", "", KEY_END),
+				     keyNew ("user" PARENT_KEY "/a", KEY_END), KS_END);
+
+		succeed_if (plugin->kdbGet (plugin, ks, parentKey) == ELEKTRA_PLUGIN_STATUS_SUCCESS, "kdbGet failed");
+
+		ksDel (ks);
+	}
+	TEST_END
+}
+
+void test_array (void)
+{
+	printf ("test array\n");
+
+	KeySet * _conf = ksNew (1, keyNew ("user/conflict/get", KEY_VALUE, "ERROR", KEY_END), KS_END);
+
+	TEST_BEGIN
+	{
+		KeySet * ks = ksNew (10, keyNew ("spec" PARENT_KEY "/a/#", KEY_META, "default", "7", KEY_END),
+				     keyNew ("spec" PARENT_KEY "/a", KEY_META, "array", "#5", KEY_END), KS_END);
+
+		succeed_if (plugin->kdbGet (plugin, ks, parentKey) == ELEKTRA_PLUGIN_STATUS_SUCCESS, "kdbGet failed");
+
+		Key * lookup = ksLookupByName (ks, PARENT_KEY "/a", 0);
+		succeed_if (lookup != NULL, ".../a not found");
+		succeed_if_same_string (keyString (keyGetMeta (lookup, "array")), "#5");
+
+		lookup = ksLookupByName (ks, PARENT_KEY "/a/#0", 0);
+		succeed_if (lookup != NULL, ".../a/#0 not found");
+		succeed_if_same_string (keyString (lookup), "7");
+		succeed_if_same_string (keyString (keyGetMeta (lookup, "default")), "7");
+
+		lookup = ksLookupByName (ks, PARENT_KEY "/a/#1", 0);
+		succeed_if (lookup != NULL, ".../a/#1 not found");
+		succeed_if_same_string (keyString (lookup), "7");
+		succeed_if_same_string (keyString (keyGetMeta (lookup, "default")), "7");
+
+		lookup = ksLookupByName (ks, PARENT_KEY "/a/#2", 0);
+		succeed_if (lookup != NULL, ".../a/#2 not found");
+		succeed_if_same_string (keyString (lookup), "7");
+		succeed_if_same_string (keyString (keyGetMeta (lookup, "default")), "7");
+
+		lookup = ksLookupByName (ks, PARENT_KEY "/a/#3", 0);
+		succeed_if (lookup != NULL, ".../a/#3 not found");
+		succeed_if_same_string (keyString (lookup), "7");
+		succeed_if_same_string (keyString (keyGetMeta (lookup, "default")), "7");
+
+		lookup = ksLookupByName (ks, PARENT_KEY "/a/#4", 0);
+		succeed_if (lookup != NULL, ".../a/#4 not found");
+		succeed_if_same_string (keyString (lookup), "7");
+		succeed_if_same_string (keyString (keyGetMeta (lookup, "default")), "7");
+
+		lookup = ksLookupByName (ks, PARENT_KEY "/a/#5", 0);
+		succeed_if (lookup != NULL, ".../a/#5 not found");
+		succeed_if_same_string (keyString (lookup), "7");
+		succeed_if_same_string (keyString (keyGetMeta (lookup, "default")), "7");
+
+		ksDel (ks);
+	}
+	TEST_END
+
+	TEST_BEGIN
+	{
+		KeySet * ks = ksNew (10, keyNew ("spec" PARENT_KEY "/a/#/b/#", KEY_META, "default", "7", KEY_END),
+				     keyNew ("spec" PARENT_KEY "/a", KEY_META, "array", "#0", KEY_END),
+				     keyNew ("spec" PARENT_KEY "/a/#/b", KEY_META, "array", "#2", KEY_END), KS_END);
+
+		succeed_if (plugin->kdbGet (plugin, ks, parentKey) == ELEKTRA_PLUGIN_STATUS_SUCCESS, "kdbGet failed");
+
+		Key * lookup = ksLookupByName (ks, PARENT_KEY "/a", 0);
+		succeed_if (lookup != NULL, ".../a not found");
+		succeed_if_same_string (keyString (keyGetMeta (lookup, "array")), "#0");
+
+		lookup = ksLookupByName (ks, PARENT_KEY "/a/#0/b", 0);
+		succeed_if (lookup != NULL, ".../a/#0/b not found");
+		succeed_if_same_string (keyString (keyGetMeta (lookup, "array")), "#2");
+
+		lookup = ksLookupByName (ks, PARENT_KEY "/a/#0/b/#0", 0);
+		succeed_if (lookup != NULL, ".../a/#0/b/#0 not found");
+		succeed_if_same_string (keyString (lookup), "7");
+		succeed_if_same_string (keyString (keyGetMeta (lookup, "default")), "7");
+
+		lookup = ksLookupByName (ks, PARENT_KEY "/a/#0/b/#1", 0);
+		succeed_if (lookup != NULL, ".../a/#0/b/#1 not found");
+		succeed_if_same_string (keyString (lookup), "7");
+		succeed_if_same_string (keyString (keyGetMeta (lookup, "default")), "7");
+
+		lookup = ksLookupByName (ks, PARENT_KEY "/a/#0/b/#2", 0);
+		succeed_if (lookup != NULL, ".../a/#0/b/#2 not found");
+		succeed_if_same_string (keyString (lookup), "7");
+		succeed_if_same_string (keyString (keyGetMeta (lookup, "default")), "7");
+
+		ksDel (ks);
+	}
+	TEST_END
+
+	TEST_BEGIN
+	{
+		KeySet * ks = ksNew (10, keyNew ("spec" PARENT_KEY "/a/#/b/#", KEY_META, "default", "7", KEY_END),
+				     keyNew ("spec" PARENT_KEY "/a", KEY_META, "array", "#0", KEY_END),
+				     keyNew ("spec" PARENT_KEY "/a/#/b", KEY_META, "array", "#2", KEY_END), KS_END);
+
+		succeed_if (plugin->kdbGet (plugin, ks, parentKey) == ELEKTRA_PLUGIN_STATUS_SUCCESS, "kdbGet failed");
+
+		Key * lookup = ksLookupByName (ks, PARENT_KEY "/a", 0);
+		succeed_if (lookup != NULL, ".../a not found");
+		succeed_if_same_string (keyString (keyGetMeta (lookup, "array")), "#0");
+
+		lookup = ksLookupByName (ks, PARENT_KEY "/a/#0/b", 0);
+		succeed_if (lookup != NULL, ".../a/#0/b not found");
+		succeed_if_same_string (keyString (keyGetMeta (lookup, "array")), "#2");
+
+		lookup = ksLookupByName (ks, PARENT_KEY "/a/#0/b/#0", 0);
+		succeed_if (lookup != NULL, ".../a/#0/b/#0 not found");
+		succeed_if_same_string (keyString (lookup), "7");
+		succeed_if_same_string (keyString (keyGetMeta (lookup, "default")), "7");
+
+		lookup = ksLookupByName (ks, PARENT_KEY "/a/#0/b/#1", 0);
+		succeed_if (lookup != NULL, ".../a/#0/b/#1 not found");
+		succeed_if_same_string (keyString (lookup), "7");
+		succeed_if_same_string (keyString (keyGetMeta (lookup, "default")), "7");
+
+		lookup = ksLookupByName (ks, PARENT_KEY "/a/#0/b/#2", 0);
+		succeed_if (lookup != NULL, ".../a/#0/b/#2 not found");
+		succeed_if_same_string (keyString (lookup), "7");
+		succeed_if_same_string (keyString (keyGetMeta (lookup, "default")), "7");
+
+		ksDel (ks);
+	}
+	TEST_END
+
+	TEST_BEGIN
+	{
+		KeySet * ks = ksNew (10, keyNew ("spec" PARENT_KEY "/a/#/b/#", KEY_META, "default", "7", KEY_END),
+				     keyNew ("spec" PARENT_KEY "/a", KEY_META, "array", "#3", KEY_END),
+				     keyNew ("user" PARENT_KEY "/a", KEY_META, "array", "#0", KEY_END),
+				     keyNew ("spec" PARENT_KEY "/a/#/b", KEY_META, "array", "#2", KEY_END), KS_END);
+
+		succeed_if (plugin->kdbGet (plugin, ks, parentKey) == ELEKTRA_PLUGIN_STATUS_SUCCESS, "kdbGet failed");
+
+		Key * lookup = ksLookupByName (ks, PARENT_KEY "/a", 0);
+		succeed_if (lookup != NULL, ".../a not found");
+		succeed_if_same_string (keyString (keyGetMeta (lookup, "array")), "#0");
+
+		lookup = ksLookupByName (ks, PARENT_KEY "/a/#0/b", 0);
+		succeed_if (lookup != NULL, ".../a/#0/b not found");
+		succeed_if_same_string (keyString (keyGetMeta (lookup, "array")), "#2");
+
+		lookup = ksLookupByName (ks, PARENT_KEY "/a/#0/b/#0", 0);
+		succeed_if (lookup != NULL, ".../a/#0/b/#0 not found");
+		succeed_if_same_string (keyString (lookup), "7");
+		succeed_if_same_string (keyString (keyGetMeta (lookup, "default")), "7");
+
+		lookup = ksLookupByName (ks, PARENT_KEY "/a/#0/b/#1", 0);
+		succeed_if (lookup != NULL, ".../a/#0/b/#1 not found");
+		succeed_if_same_string (keyString (lookup), "7");
+		succeed_if_same_string (keyString (keyGetMeta (lookup, "default")), "7");
+
+		lookup = ksLookupByName (ks, PARENT_KEY "/a/#0/b/#2", 0);
+		succeed_if (lookup != NULL, ".../a/#0/b/#2 not found");
+		succeed_if_same_string (keyString (lookup), "7");
+		succeed_if_same_string (keyString (keyGetMeta (lookup, "default")), "7");
+
+		ksDel (ks);
+	}
+	TEST_END
+
+	TEST_BEGIN
+	{
+		KeySet * ks = ksNew (10, keyNew ("spec" PARENT_KEY "/a/#/b/#", KEY_META, "default", "7", KEY_END),
+				     keyNew ("spec" PARENT_KEY "/a", KEY_META, "array/min", "#3", KEY_END),
+				     keyNew ("user" PARENT_KEY "/a", KEY_META, "array", "#0", KEY_END),
+				     keyNew ("spec" PARENT_KEY "/a/#/b", KEY_META, "array", "#2", KEY_END), KS_END);
+
+		succeed_if (plugin->kdbGet (plugin, ks, parentKey) == ELEKTRA_PLUGIN_STATUS_ERROR, "kdbGet shouldn't succeed");
+
+		ksDel (ks);
+	}
+	TEST_END
+
+	TEST_BEGIN
+	{
+		KeySet * ks = ksNew (10, keyNew ("spec" PARENT_KEY "/a/#/b/#", KEY_META, "default", "7", KEY_END),
+				     keyNew ("spec" PARENT_KEY "/a", KEY_META, "array", "#3", KEY_END),
+				     keyNew ("spec" PARENT_KEY "/a/#/b", KEY_META, "array", "#2", KEY_END),
+				     keyNew ("user" PARENT_KEY "/a/#0/b/c", KEY_END), KS_END);
+
+		// TODO: don't allow other elements inside arrays
+		succeed_if (plugin->kdbGet (plugin, ks, parentKey) == ELEKTRA_PLUGIN_STATUS_ERROR, "kdbGet shouldn't succeed");
+
+		ksDel (ks);
+	}
+	TEST_END
+}
+
+void test_require_array (void)
+{
+	printf ("test require array\n");
+
+	KeySet * _conf = ksNew (1, keyNew ("user/conflict/get", KEY_VALUE, "ERROR", KEY_END), KS_END);
+
+	TEST_BEGIN
+	{
+		KeySet * ks = ksNew (10, keyNew ("spec" PARENT_KEY "/a/#/b/#", KEY_META, "require", "", KEY_END),
+				     keyNew ("spec" PARENT_KEY "/a", KEY_META, "array", "#0", KEY_END),
+				     keyNew ("spec" PARENT_KEY "/a/#/b", KEY_META, "array", "#0", KEY_END), KS_END);
+
+		succeed_if (plugin->kdbGet (plugin, ks, parentKey) == ELEKTRA_PLUGIN_STATUS_ERROR, "kdbGet shouldn't succeed");
+
+		ksDel (ks);
+	}
+	TEST_END
+
+	TEST_BEGIN
+	{
+		KeySet * ks = ksNew (10, keyNew ("spec" PARENT_KEY "/a/#/b/#", KEY_META, "require", "", KEY_END),
+				     keyNew ("spec" PARENT_KEY "/a", KEY_META, "array", "#0", KEY_END),
+				     keyNew ("spec" PARENT_KEY "/a/#/b", KEY_META, "array", "#0", KEY_END),
+				     keyNew ("user" PARENT_KEY "/a/#0/b/#0", KEY_END), KS_END);
+
+		succeed_if (plugin->kdbGet (plugin, ks, parentKey) == ELEKTRA_PLUGIN_STATUS_SUCCESS, "kdbGet failed");
+
+		ksDel (ks);
+	}
+	TEST_END
+
+	TEST_BEGIN
+	{
+		KeySet * ks = ksNew (10, keyNew ("spec" PARENT_KEY "/a/#/b/#", KEY_META, "require", "", KEY_END),
+				     keyNew ("spec" PARENT_KEY "/a", KEY_META, "array", "#0", KEY_END),
+				     keyNew ("spec" PARENT_KEY "/a/#/b", KEY_META, "array", "#1", KEY_END),
+				     keyNew ("user" PARENT_KEY "/a/#0/b/#0", KEY_END), KS_END);
+
+		succeed_if (plugin->kdbGet (plugin, ks, parentKey) == ELEKTRA_PLUGIN_STATUS_ERROR, "kdbGet shouldn't succeed");
+
+		ksDel (ks);
+	}
+	TEST_END
+}
+
+int main (int argc, char ** argv)
+{
+	printf ("SPEC     TESTS\n");
+	printf ("==================\n\n");
+
+	init (argc, argv);
+
+	test_default ();
+	test_assign_condition ();
+	test_wildcard ();
+	test_require ();
+	test_array ();
+	test_require_array ();
+
+	print_result ("testmod_spec");
+
+	return nbError;
+}

--- a/src/plugins/spec/testmod_spec.c
+++ b/src/plugins/spec/testmod_spec.c
@@ -426,6 +426,7 @@ static void test_require_array (void)
 	ksDel (_conf);
 }
 
+/* TODO: find way to remove metadata safely after other plugins ran
 static void test_remove_meta (void)
 {
 	printf ("test remove meta\n");
@@ -458,6 +459,7 @@ static void test_remove_meta (void)
 	TEST_END
 	ksDel (_conf);
 }
+*/
 
 int main (int argc, char ** argv)
 {
@@ -472,7 +474,7 @@ int main (int argc, char ** argv)
 	test_require ();
 	test_array ();
 	test_require_array ();
-	test_remove_meta ();
+	// test_remove_meta ();
 
 	print_result ("testmod_spec");
 

--- a/src/plugins/spec/testmod_spec.c
+++ b/src/plugins/spec/testmod_spec.c
@@ -71,6 +71,7 @@ void test_default (void)
 		ksDel (ks);
 	}
 	TEST_END
+	ksDel (_conf);
 }
 
 void test_assign_condition (void)
@@ -98,6 +99,7 @@ void test_assign_condition (void)
 		ksDel (ks);
 	}
 	TEST_END
+	ksDel (_conf);
 }
 
 void test_wildcard (void)
@@ -170,6 +172,7 @@ void test_wildcard (void)
 		ksDel (ks);
 	}
 	TEST_END
+	ksDel (_conf);
 }
 
 void test_require (void)
@@ -199,6 +202,7 @@ void test_require (void)
 		ksDel (ks);
 	}
 	TEST_END
+	ksDel (_conf);
 }
 
 void test_array (void)
@@ -394,6 +398,7 @@ void test_array (void)
 		ksDel (ks);
 	}
 	TEST_END
+	ksDel (_conf);
 }
 
 void test_require_array (void)
@@ -440,6 +445,7 @@ void test_require_array (void)
 		ksDel (ks);
 	}
 	TEST_END
+	ksDel (_conf);
 }
 
 int main (int argc, char ** argv)

--- a/src/plugins/spec/testmod_spec.c
+++ b/src/plugins/spec/testmod_spec.c
@@ -209,7 +209,7 @@ void test_array (void)
 
 	TEST_BEGIN
 	{
-		KeySet * ks = ksNew (10, keyNew ("spec" PARENT_KEY "/a/#", KEY_META, "default", "7", KEY_END),
+		KeySet * ks = ksNew (10, keyNew ("spec" PARENT_KEY "/a/#", KEY_META, "default", "7", KEY_META, "type", "long", KEY_END),
 				     keyNew ("spec" PARENT_KEY "/a", KEY_META, "array", "#5", KEY_END), KS_END);
 
 		TEST_CHECK (plugin->kdbGet (plugin, ks, parentKey) == ELEKTRA_PLUGIN_STATUS_SUCCESS, "kdbGet failed");
@@ -218,36 +218,43 @@ void test_array (void)
 		Key * lookup = ksLookupByName (ks, PARENT_KEY "/a", 0);
 		succeed_if (lookup != NULL, ".../a not found");
 		succeed_if_same_string (keyString (keyGetMeta (lookup, "array")), "#5");
+		succeed_if (keyGetMeta (lookup, "type") == NULL, "parent shouldn't have copied metadata");
 
 		lookup = ksLookupByName (ks, PARENT_KEY "/a/#0", 0);
 		succeed_if (lookup != NULL, ".../a/#0 not found");
 		succeed_if_same_string (keyString (lookup), "7");
 		succeed_if_same_string (keyString (keyGetMeta (lookup, "default")), "7");
+		succeed_if_same_string (keyString (keyGetMeta (lookup, "type")), "long");
 
 		lookup = ksLookupByName (ks, PARENT_KEY "/a/#1", 0);
 		succeed_if (lookup != NULL, ".../a/#1 not found");
 		succeed_if_same_string (keyString (lookup), "7");
 		succeed_if_same_string (keyString (keyGetMeta (lookup, "default")), "7");
+		succeed_if_same_string (keyString (keyGetMeta (lookup, "type")), "long");
 
 		lookup = ksLookupByName (ks, PARENT_KEY "/a/#2", 0);
 		succeed_if (lookup != NULL, ".../a/#2 not found");
 		succeed_if_same_string (keyString (lookup), "7");
 		succeed_if_same_string (keyString (keyGetMeta (lookup, "default")), "7");
+		succeed_if_same_string (keyString (keyGetMeta (lookup, "type")), "long");
 
 		lookup = ksLookupByName (ks, PARENT_KEY "/a/#3", 0);
 		succeed_if (lookup != NULL, ".../a/#3 not found");
 		succeed_if_same_string (keyString (lookup), "7");
 		succeed_if_same_string (keyString (keyGetMeta (lookup, "default")), "7");
+		succeed_if_same_string (keyString (keyGetMeta (lookup, "type")), "long");
 
 		lookup = ksLookupByName (ks, PARENT_KEY "/a/#4", 0);
 		succeed_if (lookup != NULL, ".../a/#4 not found");
 		succeed_if_same_string (keyString (lookup), "7");
 		succeed_if_same_string (keyString (keyGetMeta (lookup, "default")), "7");
+		succeed_if_same_string (keyString (keyGetMeta (lookup, "type")), "long");
 
 		lookup = ksLookupByName (ks, PARENT_KEY "/a/#5", 0);
 		succeed_if (lookup != NULL, ".../a/#5 not found");
 		succeed_if_same_string (keyString (lookup), "7");
 		succeed_if_same_string (keyString (keyGetMeta (lookup, "default")), "7");
+		succeed_if_same_string (keyString (keyGetMeta (lookup, "type")), "long");
 
 		ksDel (ks);
 	}

--- a/src/plugins/spec/testmod_spec.c
+++ b/src/plugins/spec/testmod_spec.c
@@ -139,39 +139,6 @@ void test_wildcard (void)
 	}
 	TEST_END
 
-	TEST_BEGIN
-	{
-		KeySet * ks = ksNew (10, keyNew ("spec" PARENT_KEY "/a/_", KEY_META, "require/count", "2", KEY_END),
-				     keyNew ("user" PARENT_KEY "/a/x", KEY_END), keyNew ("user" PARENT_KEY "/a/y", KEY_END),
-				     keyNew ("user" PARENT_KEY "/a/z", KEY_END), KS_END);
-
-		TEST_CHECK (plugin->kdbGet (plugin, ks, parentKey) == ELEKTRA_PLUGIN_STATUS_ERROR, "kdbGet shouldn't succeed");
-
-		ksDel (ks);
-	}
-	TEST_END
-
-	TEST_BEGIN
-	{
-		KeySet * ks = ksNew (10, keyNew ("spec" PARENT_KEY "/a/_", KEY_META, "require/count", "2", KEY_END),
-				     keyNew ("user" PARENT_KEY "/a/x", KEY_END), KS_END);
-
-		TEST_CHECK (plugin->kdbGet (plugin, ks, parentKey) == ELEKTRA_PLUGIN_STATUS_ERROR, "kdbGet shouldn't succeed");
-
-		ksDel (ks);
-	}
-	TEST_END
-
-	TEST_BEGIN
-	{
-		KeySet * ks = ksNew (10, keyNew ("spec" PARENT_KEY "/a/_", KEY_META, "require/count", "2", KEY_END),
-				     keyNew ("user" PARENT_KEY "/a/x", KEY_END), keyNew ("user" PARENT_KEY "/a/#0", KEY_END), KS_END);
-
-		TEST_CHECK (plugin->kdbGet (plugin, ks, parentKey) == ELEKTRA_PLUGIN_STATUS_ERROR, "kdbGet shouldn't succeed");
-
-		ksDel (ks);
-	}
-	TEST_END
 	ksDel (_conf);
 }
 

--- a/tests/abi/testabi_key.c
+++ b/tests/abi/testabi_key.c
@@ -1379,6 +1379,10 @@ static void test_keyBelow (void)
 	succeed_if (keyIsBelow (key1, key2), "Key should be below");
 	succeed_if (!keyIsBelow (key2, key1), "Key should not be below");
 
+	keySetName (key1, "system/infos/constants");
+	keySetName (key2, "/infos/constants/syste");
+	succeed_if (keyIsBelow (key1, key2), "Key should be below");
+	succeed_if (!keyIsBelow (key2, key1), "Key should not be below");
 
 	keySetName (key1, "/");
 	keySetName (key2, "system/infos/constants");
@@ -1495,6 +1499,26 @@ static void test_keyBelow (void)
 	keySetName (key1, "user/tests/ini-section-write");
 	keySetName (key2, "user/tests/ini-section-write/akey\\/looking\\/like\\/sections");
 	succeed_if (keyIsDirectBelow (key1, key2), "looking like sections not recognised");
+	succeed_if (!keyIsDirectBelow (key2, key1), "Key should not be below");
+
+	keySetName (key1, "user/valid");
+	keySetName (key2, "/valid/valide");
+	succeed_if (keyIsDirectBelow (key1, key2), "Key should be below");
+	succeed_if (!keyIsDirectBelow (key2, key1), "Key should not be below");
+
+	keySetName (key1, "user/valid");
+	keySetName (key2, "/valid/non/valid");
+	succeed_if (!keyIsDirectBelow (key1, key2), "Key should not be below");
+	succeed_if (!keyIsDirectBelow (key2, key1), "Key should not be below");
+
+	keySetName (key1, "/valid");
+	keySetName (key2, "user/valid/valide");
+	succeed_if (keyIsDirectBelow (key1, key2), "Key should be below");
+	succeed_if (!keyIsDirectBelow (key2, key1), "Key should not be below");
+
+	keySetName (key1, "/valid");
+	keySetName (key2, "user/valid/non/valid");
+	succeed_if (!keyIsDirectBelow (key1, key2), "Key should not be below");
 	succeed_if (!keyIsDirectBelow (key2, key1), "Key should not be below");
 
 

--- a/tests/abi/testabi_ks.c
+++ b/tests/abi/testabi_ks.c
@@ -2814,10 +2814,9 @@ static void test_cascading_cutbelow (void)
 	printf ("Testing cutting below some keys (cascading)\n");
 
 	Key * cutpoint = keyNew ("/export", KEY_END);
-	KeySet * orig =
-		ksNew (30, keyNew ("/export/a", KEY_END), keyNew ("/export/c", KEY_END), keyNew ("/export/c/x", KEY_END),
-		       keyNew ("/export/c/x/b/blah", KEY_END), keyNew ("/export/xyz", KEY_END),
-		       keyNew ("/export-backup/b", KEY_END), keyNew ("/export-backup-2/x", KEY_END), KS_END);
+	KeySet * orig = ksNew (30, keyNew ("/export/a", KEY_END), keyNew ("/export/c", KEY_END), keyNew ("/export/c/x", KEY_END),
+			       keyNew ("/export/c/x/b/blah", KEY_END), keyNew ("/export/xyz", KEY_END),
+			       keyNew ("/export-backup/b", KEY_END), keyNew ("/export-backup-2/x", KEY_END), KS_END);
 	ksRewind (orig);
 	ksNext (orig);
 	succeed_if_same_string (keyName (ksCurrent (orig)), "/export/a");
@@ -2833,9 +2832,8 @@ static void test_cascading_cutbelow (void)
 	ksDel (orig);
 	ksDel (cmp_orig);
 
-	KeySet * cmp_part =
-		ksNew (15, keyNew ("/export/a", KEY_END), keyNew ("/export/c", KEY_END), keyNew ("/export/c/x", KEY_END),
-		       keyNew ("/export/c/x/b/blah", KEY_END), keyNew ("/export/xyz", KEY_END), KS_END);
+	KeySet * cmp_part = ksNew (15, keyNew ("/export/a", KEY_END), keyNew ("/export/c", KEY_END), keyNew ("/export/c/x", KEY_END),
+				   keyNew ("/export/c/x/b/blah", KEY_END), keyNew ("/export/xyz", KEY_END), KS_END);
 	compare_keyset (part, cmp_part);
 	ksDel (part);
 	ksDel (cmp_part);

--- a/tests/abi/testabi_ks.c
+++ b/tests/abi/testabi_ks.c
@@ -2809,6 +2809,39 @@ static void test_cutbelow (void)
 	keyDel (cutpoint);
 }
 
+static void test_cascading_cutbelow (void)
+{
+	printf ("Testing cutting below some keys (cascading)\n");
+
+	Key * cutpoint = keyNew ("/export", KEY_END);
+	KeySet * orig =
+		ksNew (30, keyNew ("/export/a", KEY_END), keyNew ("/export/c", KEY_END), keyNew ("/export/c/x", KEY_END),
+		       keyNew ("/export/c/x/b/blah", KEY_END), keyNew ("/export/xyz", KEY_END),
+		       keyNew ("/export-backup/b", KEY_END), keyNew ("/export-backup-2/x", KEY_END), KS_END);
+	ksRewind (orig);
+	ksNext (orig);
+	succeed_if_same_string (keyName (ksCurrent (orig)), "/export/a");
+	ksLookupByName (orig, "/export-backup/b", 0);
+	succeed_if_same_string (keyName (ksCurrent (orig)), "/export-backup/b");
+
+	KeySet * part = ksCut (orig, cutpoint);
+
+	succeed_if_same_string (keyName (ksCurrent (orig)), "/export-backup/b");
+
+	KeySet * cmp_orig = ksNew (15, keyNew ("/export-backup-2/x", KEY_END), keyNew ("/export-backup/b", KEY_END), KS_END);
+	compare_keyset (orig, cmp_orig);
+	ksDel (orig);
+	ksDel (cmp_orig);
+
+	KeySet * cmp_part =
+		ksNew (15, keyNew ("/export/a", KEY_END), keyNew ("/export/c", KEY_END), keyNew ("/export/c/x", KEY_END),
+		       keyNew ("/export/c/x/b/blah", KEY_END), keyNew ("/export/xyz", KEY_END), KS_END);
+	compare_keyset (part, cmp_part);
+	ksDel (part);
+	ksDel (cmp_part);
+	keyDel (cutpoint);
+}
+
 KeySet * set_simple (void)
 {
 	return ksNew (50, keyNew ("system/elektra/mountpoints/simple", KEY_END),
@@ -3222,6 +3255,7 @@ int main (int argc, char ** argv)
 	test_cutpointRoot ();
 	test_unique_cutpoint ();
 	test_cutbelow ();
+	test_cascading_cutbelow ();
 	test_simple ();
 	test_cursor ();
 	test_morecut ();

--- a/tests/kdb/testkdb_ensure.cpp
+++ b/tests/kdb/testkdb_ensure.cpp
@@ -38,6 +38,7 @@ protected:
 		kdb.get (ks, testRoot);
 
 		ks.append (Key (specRoot + "/speckey/#", KEY_META, "mymeta", "1", KEY_END));
+		ks.append (Key (userRoot + "/speckey", KEY_META, "array", "#0", KEY_END));
 		ks.append (Key (userRoot + "/speckey/#0", KEY_VALUE, "", KEY_END));
 		ks.append (Key (userRoot + "/errorkey", KEY_META, "trigger/warnings", "3", KEY_END));
 		// ks.append (Key (specRoot + "/goptskey", KEY_META, "opt", "1", KEY_END));

--- a/tests/shell/check_gen.sh
+++ b/tests/shell/check_gen.sh
@@ -83,7 +83,7 @@ for test_folder in "@CMAKE_SOURCE_DIR@"/tests/shell/gen/*/; do
 		cd "$old_dir"
 
 		if [ -e "$test_folder$test_name.stdout" ]; then
-			diff -u "$output_folder$test_name.stdout" "$test_folder$test_name.stdout" | sed -e "1d" -e "2d" > "$output_folder$test_name.stdout.diff"
+			diff -u "$test_folder$test_name.stdout" "$output_folder$test_name.stdout" | sed -e "1d" -e "2d" > "$output_folder$test_name.stdout.diff"
 
 			if [ -s "$output_folder$test_name.stdout.diff" ]; then
 				test "1" = "0"
@@ -104,7 +104,7 @@ for test_folder in "@CMAKE_SOURCE_DIR@"/tests/shell/gen/*/; do
 		if [ -e "$test_folder$test_name.stderr" ]; then
 			sed -e "s#$KDB#kdb#" -e '1!b' -e '/^The command kdb gen terminated unsuccessfully with the info:$/d' "$output_folder$test_name.stderr" > "$output_folder$test_name.stderr2"
 			mv "$output_folder$test_name.stderr2" "$output_folder$test_name.stderr"
-			diff -u "$output_folder$test_name.stderr" "$test_folder$test_name.stderr" | sed -e "1d" -e "2d" > "$output_folder$test_name.stderr.diff"
+			diff -u "$test_folder$test_name.stderr" "$output_folder$test_name.stderr" | sed -e "1d" -e "2d" > "$output_folder$test_name.stderr.diff"
 
 			if [ -s "$output_folder$test_name.stderr.diff" ]; then
 				test "1" = "0"
@@ -133,7 +133,7 @@ for test_folder in "@CMAKE_SOURCE_DIR@"/tests/shell/gen/*/; do
 				[ -f "$actual_part" ]
 				succeed_if "missing part $test_name.actual$part"
 
-				diff -u "$actual_part" "$expected_part" | sed -e "1s/.*/--- $test_name.expected$part/" -e "2s/.*/+++ $test_name.actual$part/" > "$diff_part"
+				diff -u "$expected_part" "$actual_part" | sed -e "1s/.*/--- $test_name.expected$part/" -e "2s/.*/+++ $test_name.actual$part/" > "$diff_part"
 
 				if [ -s "$diff_part" ]; then
 					test "1" = "0"

--- a/tests/shell/gen/elektra/context.check.sh
+++ b/tests/shell/gen/elektra/context.check.sh
@@ -13,7 +13,13 @@ cat << 'EOF' > dummy.c
 		exit(EXIT_FAILURE);                                                                                                            \
 	}
 
-#define VALUE_CHECK(expr, expected) if (expr != expected) exit(EXIT_FAILURE);
+#define VALUE_CHECK(expr, expected)                                                                                                    \
+	if ((expr) != (expected))                                                                                                          \
+	{                                                                                                                                  \
+		elektraClose (elektra);                                                                                                        \
+		fprintf (stderr, "value wrong %s\n", #expr);                                                                                   \
+		exit(EXIT_FAILURE);                                                                                                            \
+	}
 
 static void fatalErrorHandler (ElektraError * error)
 {
@@ -60,10 +66,10 @@ int main (int argc, const char ** argv)
 		return EXIT_FAILURE;
 	}
 
-	if (rc == 1)
+	if (rc == 2)
 	{
-		printHelpMessage (NULL, NULL);
-		return EXIT_SUCCESS;
+		fprintf (stderr, "unexpected help mode");
+		return EXIT_FAILURE;
 	}
 
 	elektraFatalErrorHandler (elektra, fatalErrorHandler);

--- a/tests/shell/gen/elektra/empty.check.sh
+++ b/tests/shell/gen/elektra/empty.check.sh
@@ -13,7 +13,13 @@ cat << 'EOF' > dummy.c
 		exit(EXIT_FAILURE);                                                                                                            \
 	}
 
-#define VALUE_CHECK(expr, expected) if (expr != expected) exit(EXIT_FAILURE);
+#define VALUE_CHECK(expr, expected)                                                                                                    \
+	if ((expr) != (expected))                                                                                                          \
+	{                                                                                                                                  \
+		elektraClose (elektra);                                                                                                        \
+		fprintf (stderr, "value wrong %s\n", #expr);                                                                                   \
+		exit(EXIT_FAILURE);                                                                                                            \
+	}
 
 static void fatalErrorHandler (ElektraError * error)
 {
@@ -40,10 +46,10 @@ int main (int argc, const char ** argv)
 		return EXIT_FAILURE;
 	}
 
-	if (rc == 1)
+	if (rc == 2)
 	{
-		printHelpMessage (NULL, NULL);
-		return EXIT_SUCCESS;
+		fprintf (stderr, "unexpected help mode");
+		return EXIT_FAILURE;
 	}
 
 	elektraFatalErrorHandler (elektra, fatalErrorHandler);

--- a/tests/shell/gen/elektra/empty.data.ini
+++ b/tests/shell/gen/elektra/empty.data.ini
@@ -1,2 +1,2 @@
 []
-mountpoint=tests_gen_elektra_context.ini
+mountpoint=tests_gen_elektra_empty.ini

--- a/tests/shell/gen/elektra/empty.expected.c
+++ b/tests/shell/gen/elektra/empty.expected.c
@@ -50,7 +50,7 @@ static Key * helpKey = NULL;
 int loadConfiguration (Elektra ** elektra, ElektraError ** error)
 {
 	KeySet * defaults = ksNew (1,
-	keyNew("", KEY_META, "mountpoint", "tests_gen_elektra_context.ini", KEY_END),
+	keyNew("", KEY_META, "mountpoint", "tests_gen_elektra_empty.ini", KEY_END),
 	KS_END);
 ;
 	Elektra * e = elektraOpen ("/tests/script/gen/elektra/empty", defaults, error);
@@ -111,7 +111,7 @@ void specloadCheck (int argc, const char ** argv)
 	}
 
 	KeySet * spec = ksNew (1,
-	keyNew("", KEY_META, "mountpoint", "tests_gen_elektra_context.ini", KEY_END),
+	keyNew("", KEY_META, "mountpoint", "tests_gen_elektra_empty.ini", KEY_END),
 	KS_END);
 ;
 

--- a/tests/shell/gen/elektra/enum.check.sh
+++ b/tests/shell/gen/elektra/enum.check.sh
@@ -26,7 +26,13 @@ cat << 'EOF' > dummy.c
 		exit(EXIT_FAILURE);                                                                                                            \
 	}
 
-#define VALUE_CHECK(expr, expected) if (expr != expected) exit(EXIT_FAILURE);
+#define VALUE_CHECK(expr, expected)                                                                                                    \
+	if ((expr) != (expected))                                                                                                          \
+	{                                                                                                                                  \
+		elektraClose (elektra);                                                                                                        \
+		fprintf (stderr, "value wrong %s\n", #expr);                                                                                   \
+		exit(EXIT_FAILURE);                                                                                                            \
+	}
 
 static void fatalErrorHandler (ElektraError * error)
 {
@@ -71,10 +77,10 @@ int main (int argc, const char ** argv)
 		return EXIT_FAILURE;
 	}
 
-	if (rc == 1)
+	if (rc == 2)
 	{
-		printHelpMessage (NULL, NULL);
-		return EXIT_SUCCESS;
+		fprintf (stderr, "unexpected help mode");
+		return EXIT_FAILURE;
 	}
 
 	elektraFatalErrorHandler (elektra, fatalErrorHandler);

--- a/tests/shell/gen/elektra/enum.data.ini
+++ b/tests/shell/gen/elektra/enum.data.ini
@@ -1,5 +1,5 @@
 []
-mountpoint=tests_gen_elektra_context.ini
+mountpoint=tests_gen_elektra_enum.ini
 
 [myenum]
 type=enum

--- a/tests/shell/gen/elektra/enum.expected.c
+++ b/tests/shell/gen/elektra/enum.expected.c
@@ -50,7 +50,7 @@ static Key * helpKey = NULL;
 int loadConfiguration (Elektra ** elektra, ElektraError ** error)
 {
 	KeySet * defaults = ksNew (6,
-	keyNew("", KEY_META, "mountpoint", "tests_gen_elektra_context.ini", KEY_END),
+	keyNew("", KEY_META, "mountpoint", "tests_gen_elektra_enum.ini", KEY_END),
 	keyNew ("/disjointed", KEY_VALUE, "black", KEY_META, "check/enum", "#__255", KEY_META, "check/enum/#0", "black",
 	KEY_META, "check/enum/#__255", "white", KEY_META, "default", "black", KEY_META, "type", "enum", KEY_END),
 	keyNew ("/existinggentype", KEY_VALUE, "cyan", KEY_META, "check/enum", "#2", KEY_META, "check/enum/#0", "cyan",
@@ -130,7 +130,7 @@ void specloadCheck (int argc, const char ** argv)
 	}
 
 	KeySet * spec = ksNew (6,
-	keyNew("", KEY_META, "mountpoint", "tests_gen_elektra_context.ini", KEY_END),
+	keyNew("", KEY_META, "mountpoint", "tests_gen_elektra_enum.ini", KEY_END),
 	keyNew ("/disjointed", KEY_VALUE, "black", KEY_META, "check/enum", "#__255", KEY_META, "check/enum/#0", "black",
 	KEY_META, "check/enum/#__255", "white", KEY_META, "default", "black", KEY_META, "type", "enum", KEY_END),
 	keyNew ("/existinggentype", KEY_VALUE, "cyan", KEY_META, "check/enum", "#2", KEY_META, "check/enum/#0", "cyan",

--- a/tests/shell/gen/elektra/nodefault.data.ini
+++ b/tests/shell/gen/elektra/nodefault.data.ini
@@ -1,5 +1,5 @@
 []
-mountpoint=tests_gen_elektra_context.ini
+mountpoint=tests_gen_elektra_nodefault.ini
 
 [nodefault]
 type=int

--- a/tests/shell/gen/elektra/notype.data.ini
+++ b/tests/shell/gen/elektra/notype.data.ini
@@ -1,5 +1,5 @@
 []
-mountpoint=tests_gen_elektra_context.ini
+mountpoint=tests_gen_elektra_notype.ini
 
 [notype]
 default=2

--- a/tests/shell/gen/elektra/notype.expected.c
+++ b/tests/shell/gen/elektra/notype.expected.c
@@ -50,7 +50,7 @@ static Key * helpKey = NULL;
 int loadConfiguration (Elektra ** elektra, ElektraError ** error)
 {
 	KeySet * defaults = ksNew (1,
-	keyNew("", KEY_META, "mountpoint", "tests_gen_elektra_context.ini", KEY_END),
+	keyNew("", KEY_META, "mountpoint", "tests_gen_elektra_notype.ini", KEY_END),
 	KS_END);
 ;
 	Elektra * e = elektraOpen ("/tests/script/gen/elektra/notype", defaults, error);
@@ -111,7 +111,7 @@ void specloadCheck (int argc, const char ** argv)
 	}
 
 	KeySet * spec = ksNew (1,
-	keyNew("", KEY_META, "mountpoint", "tests_gen_elektra_context.ini", KEY_END),
+	keyNew("", KEY_META, "mountpoint", "tests_gen_elektra_notype.ini", KEY_END),
 	KS_END);
 ;
 

--- a/tests/shell/gen/elektra/simple.data.ini
+++ b/tests/shell/gen/elektra/simple.data.ini
@@ -1,5 +1,5 @@
 []
-mountpoint=tests_gen_elektra_context.ini
+mountpoint=tests_gen_elektra_simple.ini
 
 [print]
 type = boolean
@@ -19,4 +19,4 @@ default = 0.0
 
 [myfloatarray/#]
 type = float
-default = 0.0
+default = 1.1

--- a/tests/shell/gen/elektra/simple.expected.c
+++ b/tests/shell/gen/elektra/simple.expected.c
@@ -50,9 +50,9 @@ static Key * helpKey = NULL;
 int loadConfiguration (Elektra ** elektra, ElektraError ** error)
 {
 	KeySet * defaults = ksNew (6,
-	keyNew("", KEY_META, "mountpoint", "tests_gen_elektra_context.ini", KEY_END),
+	keyNew("", KEY_META, "mountpoint", "tests_gen_elektra_simple.ini", KEY_END),
 	keyNew ("/mydouble", KEY_VALUE, "0.0", KEY_META, "default", "0.0", KEY_META, "type", "double", KEY_END),
-	keyNew ("/myfloatarray/#", KEY_VALUE, "0.0", KEY_META, "default", "0.0", KEY_META, "type", "float", KEY_END),
+	keyNew ("/myfloatarray/#", KEY_VALUE, "1.1", KEY_META, "default", "1.1", KEY_META, "type", "float", KEY_END),
 	keyNew ("/myint", KEY_VALUE, "0", KEY_META, "default", "0", KEY_META, "type", "long", KEY_END),
 	keyNew ("/mystring", KEY_META, "default", "", KEY_META, "type", "string", KEY_END),
 	keyNew ("/print", KEY_VALUE, "0", KEY_META, "default", "0", KEY_META, "type", "boolean", KEY_END),
@@ -116,9 +116,9 @@ void specloadCheck (int argc, const char ** argv)
 	}
 
 	KeySet * spec = ksNew (6,
-	keyNew("", KEY_META, "mountpoint", "tests_gen_elektra_context.ini", KEY_END),
+	keyNew("", KEY_META, "mountpoint", "tests_gen_elektra_simple.ini", KEY_END),
 	keyNew ("/mydouble", KEY_VALUE, "0.0", KEY_META, "default", "0.0", KEY_META, "type", "double", KEY_END),
-	keyNew ("/myfloatarray/#", KEY_VALUE, "0.0", KEY_META, "default", "0.0", KEY_META, "type", "float", KEY_END),
+	keyNew ("/myfloatarray/#", KEY_VALUE, "1.1", KEY_META, "default", "1.1", KEY_META, "type", "float", KEY_END),
 	keyNew ("/myint", KEY_VALUE, "0", KEY_META, "default", "0", KEY_META, "type", "long", KEY_END),
 	keyNew ("/mystring", KEY_META, "default", "", KEY_META, "type", "string", KEY_END),
 	keyNew ("/print", KEY_VALUE, "0", KEY_META, "default", "0", KEY_META, "type", "boolean", KEY_END),

--- a/tests/shell/gen/elektra/struct.check.sh
+++ b/tests/shell/gen/elektra/struct.check.sh
@@ -13,7 +13,13 @@ cat << 'EOF' > dummy.c
 		exit(EXIT_FAILURE);                                                                                                            \
 	}
 
-#define VALUE_CHECK(expr, expected) if (expr != expected) exit(EXIT_FAILURE);
+#define VALUE_CHECK(expr, expected)                                                                                                    \
+	if ((expr) != (expected))                                                                                                          \
+	{                                                                                                                                  \
+		elektraClose (elektra);                                                                                                        \
+		fprintf (stderr, "value wrong %s\n", #expr);                                                                                   \
+		exit(EXIT_FAILURE);                                                                                                            \
+	}
 
 static void fatalErrorHandler (ElektraError * error)
 {
@@ -56,10 +62,10 @@ int main (int argc, const char ** argv)
 		return EXIT_FAILURE;
 	}
 
-	if (rc == 1)
+	if (rc == 2)
 	{
-		printHelpMessage (NULL, NULL);
-		return EXIT_SUCCESS;
+		fprintf (stderr, "unexpected help mode");
+		return EXIT_FAILURE;
 	}
 
 	elektraFatalErrorHandler (elektra, fatalErrorHandler);

--- a/tests/shell/gen/elektra/struct.data.ini
+++ b/tests/shell/gen/elektra/struct.data.ini
@@ -1,5 +1,5 @@
 []
-mountpoint=tests_gen_elektra_context.ini
+mountpoint=tests_gen_elektra_struct.ini
 
 [mystruct]
 type=struct

--- a/tests/shell/gen/elektra/struct.expected.c
+++ b/tests/shell/gen/elektra/struct.expected.c
@@ -50,7 +50,7 @@ static Key * helpKey = NULL;
 int loadConfiguration (Elektra ** elektra, ElektraError ** error)
 {
 	KeySet * defaults = ksNew (13,
-	keyNew("", KEY_META, "mountpoint", "tests_gen_elektra_context.ini", KEY_END),
+	keyNew("", KEY_META, "mountpoint", "tests_gen_elektra_struct.ini", KEY_END),
 	keyNew ("/myotherstruct", KEY_META, "default", "", KEY_META, "gen/struct/depth", "2", KEY_META, "type", "struct",
 	KEY_END),
 	keyNew ("/myotherstruct/x", KEY_VALUE, "4", KEY_META, "default", "4", KEY_META, "type", "long", KEY_END),
@@ -128,7 +128,7 @@ void specloadCheck (int argc, const char ** argv)
 	}
 
 	KeySet * spec = ksNew (13,
-	keyNew("", KEY_META, "mountpoint", "tests_gen_elektra_context.ini", KEY_END),
+	keyNew("", KEY_META, "mountpoint", "tests_gen_elektra_struct.ini", KEY_END),
 	keyNew ("/myotherstruct", KEY_META, "default", "", KEY_META, "gen/struct/depth", "2", KEY_META, "type", "struct",
 	KEY_END),
 	keyNew ("/myotherstruct/x", KEY_VALUE, "4", KEY_META, "default", "4", KEY_META, "type", "long", KEY_END),


### PR DESCRIPTION
**NOTE:** Technically there are some breaking changes in this PR. However since, every breaking change that I know of concerns parts of `spec` that can already be considered broken, I don't think that is a problem.

---

Closes #2634 (only array part, new issue for _ needed)

Also improves `ksIsBelow` and friends (see #2727) and `ksSearchInternal` (see #2455). Changing `ksAppend` is more complicated, because we need to make sure the OPMPHM is not invalidated, when we append a subset of the current KeySet (i.e. no new keys).

`elektraUnescapeKeyName` now only does the full escaping procedure, if needed and `ksCut` utilises `ksSearchInternal` to find the start point of the cut.

## Basics

- [x] Short descriptions should be in the release notes (added as entry in
      `doc/news/_preparation_next_release.md` which contains `_(my name)_`)
      **Please always add something to the the release notes.**
- [x] Longer descriptions should be in documentation or in design decisions.
- [x] Describe details of how you changed the code in commit messages
      (first line should have `module: short statement` syntax)
- [x] References to issues, e.g. `close #X`, should be in the commit messages.

## Checklist

- [x] I added unit tests
- [x] I ran all tests locally and everything went fine
- [x] affected documentation is fixed
- [x] I added code comments, logging, and assertions (see doc/CODING.md)
- [x] meta data is updated (e.g. README.md of plugins and doc/METADATA.md)

## Review

@markus2330 please review my pull request
