### PR TITLE
Fix compilation without deprecated OpenSSL APIs

### DIFF
--- a/doc/news/_preparation_next_release.md
+++ b/doc/news/_preparation_next_release.md
@@ -349,6 +349,7 @@ The following section lists news about the [modules](https://www.libelektra.org/
 
 - Empty GPG key IDs in the plugin configuration are being ignored by the [crypto](https://www.libelektra.org/plugins/crypto) plugin and the [fcrypt](https://www.libelektra.org/plugins/fcrypt) plugin. Adding empty GPG key IDs would lead to an error when `gpg` is being invoked._(Peter Nirschl)_
 - Apply Base64 encoding to the master password, which is stored within the plugin configuration. This fixes a problem that occurs if ini is used as default storage (see [2591](https://github.com/ElektraInitiative/libelektra/issues/2591))._(Peter Nirschl)_
+- Fix compilation without deprecated OpenSSL APIs. Initialization and deinitialization is not needed anymore. _(Rosen Penev)_
 
 ### Cache
 

--- a/src/plugins/crypto/openssl_operations.c
+++ b/src/plugins/crypto/openssl_operations.c
@@ -24,6 +24,10 @@
 #include <stdlib.h>
 #include <string.h>
 
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
+#define EVP_CIPHER_CTX_reset EVP_CIPHER_CTX_cleanup
+#endif
+
 #define KEY_BUFFER_SIZE (ELEKTRA_CRYPTO_SSL_KEYSIZE + ELEKTRA_CRYPTO_SSL_BLOCKSIZE)
 
 /*
@@ -148,8 +152,10 @@ int elektraCryptoOpenSSLInit (Key * errorKey ELEKTRA_UNUSED)
 	// initialize OpenSSL according to
 	// https://wiki.openssl.org/index.php/Library_Initialization
 	pthread_mutex_lock (&mutex_ssl);
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
 	OpenSSL_add_all_algorithms ();
 	ERR_load_crypto_strings ();
+#endif
 	pthread_mutex_unlock (&mutex_ssl);
 	return 1;
 }
@@ -250,8 +256,8 @@ void elektraCryptoOpenSSLHandleDestroy (elektraCryptoHandle * handle)
 	if (handle)
 	{
 		pthread_mutex_lock (&mutex_ssl);
-		EVP_CIPHER_CTX_cleanup (handle->encrypt);
-		EVP_CIPHER_CTX_cleanup (handle->decrypt);
+		EVP_CIPHER_CTX_reset (handle->encrypt);
+		EVP_CIPHER_CTX_reset (handle->decrypt);
 		EVP_CIPHER_CTX_free (handle->encrypt);
 		EVP_CIPHER_CTX_free (handle->decrypt);
 		pthread_mutex_unlock (&mutex_ssl);


### PR DESCRIPTION
Initialization and deinitialization is not needed anymore.