### PR TITLE
Restyled: Add Configuration for `shfmt`

### DIFF
--- a/.restyled.yaml
+++ b/.restyled.yaml
@@ -1,0 +1,5 @@
+restylers:
+  - shfmt:
+      arguments:
+        - -s
+        - -sr

--- a/.restyled.yaml
+++ b/.restyled.yaml
@@ -1,5 +1,6 @@
 auto: true
 restylers:
+  - prettier
   - shfmt:
       arguments:
         - -s

--- a/.restyled.yaml
+++ b/.restyled.yaml
@@ -1,3 +1,4 @@
+auto: true
 restylers:
   - shfmt:
       arguments:

--- a/doc/news/_preparation_next_release.md
+++ b/doc/news/_preparation_next_release.md
@@ -718,6 +718,12 @@ mounted, use `kdb gen -F <plugin>:<file> elektra <parentKey> <outputName>` to lo
 - We improved the exclusion patterns for the [Coveralls coverage analysis](https://coveralls.io/github/ElektraInitiative/libelektra). _(René Schwaiger)_
 - We now again build the API docu of [master](https://doc.libelektra.org/api/master) and we now also build the API docu of [PRs](https://doc.libelektra.org/api/pr/). _(Markus Raab)_
 
+### Restyled
+
+- We added a [configuration file](../../.restyled.yaml) for [Restyled][]. Currently [Restyled][] monitors changes to Shell code in pull requests and fixes code that does not fit the [coding guideline](../CODING.md), by adding additional formatting commit to PRs. _(René Schwaiger)_
+
+[restyled]: https://restyled.io
+
 ### Travis
 
 - We removed the build job for the [Haskell binding](../../src/bindings/haskell/README.md) and [Haskell plugin](../../src/plugins/haskell/README.md). For more information, please take a look [here](https://issues.libelektra.org/2751). _(Klemens Böswirth)_


### PR DESCRIPTION
# Description

The changes in this PR should get rid of problems regarding the formatting style of Shell files in pull requests. Unfortunately [Restyled](https://restyled.io) does not support 

- [`clang-format`](https://github.com/restyled-io/restyled.io/issues/161) and
- [`cmake-format`](https://github.com/restyled-io/restyled.io/issues/162)

. The tool does support `prettier`, but currently [only for `JavaScript` and `YAML` code](https://github.com/restyled-io/restyled.io/wiki/Available-Restylers).

## Integration

For the Restyled integration to work, someone with administrator rights has to [install the GitHub application](https://github.com/apps/restyled-io/installations/new) and grant it rights to Elektra’s main repository.