### PR TITLE
fix color completition

### DIFF
--- a/doc/news/_preparation_next_release.md
+++ b/doc/news/_preparation_next_release.md
@@ -491,6 +491,7 @@ you up to date with the multi-language support provided by Elektra.
 - `kdb list-tools` now supports `KDB_EXEC_PATH` environment variables that contain spaces. _(René Schwaiger)_
 - `gen-gpg-testkey` is added to the default tools list (see [#2668](https://github.com/ElektraInitiative/libelektra/issues/2668))._(Peter Nirschl)_
 - `kdb getenv` now executed correctly from within tests _(Markus Raab)_
+- `kdb-bash-completion` was fixed (see [#2836](https://github.com/ElektraInitiative/libelektra/pull/2836)). _(Eduardo Santana)_
 - <<TODO>>
 
 - <<TODO>>

--- a/scripts/kdb-bash-completion
+++ b/scripts/kdb-bash-completion
@@ -23,7 +23,7 @@ _kdb() {
 	# only kdb was entered yet, print a list of available commands
 	if [[ $COMP_CWORD -eq 1 ]]; then
 		local IFS=$'\n'
-		local commands=($(${kdbpath} 2> /dev/null | sed -e '0,/^Known commands are/d' | awk '{print $1}' | sed -r "s/\x1B\[([0-9]{1,3}((;[0-9]{1,3})*)?)?[m|K]//g" ))
+		local commands=($(${kdbpath} list-commands))
 		COMPREPLY=($(compgen -W '${commands[@]}' -- "${cur}"))
 		return
 	fi

--- a/scripts/kdb-bash-completion
+++ b/scripts/kdb-bash-completion
@@ -23,7 +23,7 @@ _kdb() {
 	# only kdb was entered yet, print a list of available commands
 	if [[ $COMP_CWORD -eq 1 ]]; then
 		local IFS=$'\n'
-		local commands=($(${kdbpath} 2> /dev/null | sed -e '0,/^Known commands are/d' | awk '{print $1}'))
+		local commands=($(${kdbpath} 2> /dev/null | sed -e '0,/^Known commands are/d' | awk '{print $1}' | sed -r "s/\x1B\[([0-9]{1,3}((;[0-9]{1,3})*)?)?[m|K]//g" ))
 		COMPREPLY=($(compgen -W '${commands[@]}' -- "${cur}"))
 		return
 	fi


### PR DESCRIPTION
see #2835

**Short release notes**: Fix bash completion
**Longer description**: Now you can call kdb <TAB><TAB> and it will return

```
check          fstab          import         mount          shell
complete       get            info           mv             smount
convert        getmeta        list           remount        spec-mount
cp             global-mount   list-commands  rm             test
editor         global-umount  list-tools     rmmeta         umount
export         gmount         ls             set            vset
file           gumount        lsmeta         setmeta        
find           help           merge          sget
```

## Basics

Check relevant points but **please do not remove entries**.
Do not describe the purpose of this PR in the PR description but:

- [ ] Short descriptions should be in the release notes (added as entry in
      `doc/news/_preparation_next_release.md` which contains `_(my name)_`)
      **Fix Please always add something to the the release notes.**
- [ ] Longer descriptions should be in documentation or in design decisions.
- [ ] Describe details of how you changed the code in commit messages
      (first line should have `module: short statement` syntax)
- [ ] References to issues, e.g. `close #X`, should be in the commit messages.

## Checklist

Check relevant points but **please do not remove entries**.
For docu fixes, spell checking, and similar none of these points below
need to be checked.

- [ ] I added unit tests
- [X] I ran all tests locally and everything went fine
- [ ] affected documentation is fixed
- [ ] I added code comments, logging, and assertions (see [Coding Guidelines](https://master.libelektra.org/doc/CODING.md))
- [ ] meta data is updated (e.g. README.md of plugins and [METADATA.ini](https://master.libelektra.org/doc/METADATA.ini))

## Review

Reviewers will usually check the following:

- [ ] Code is conforming to [our Coding Guidelines](https://master.libelektra.org/doc/CODING.md)
- [ ] APIs are conforming to [our Design Guidelines](https://master.libelektra.org/doc/DESIGN.md)
- [ ] Code is consistent to [our Design Decisions](https://master.libelektra.org/doc/decisions)
- [ ] Documentation is concise and good to read
- [ ] Examples are well chosen and understandable

## Labels

- Add the "work in progress" label if you do not want the PR to be reviewed yet.
- Add the "ready to merge" label **if the build server is happy** and also you
  say that everything is ready to be merged.
