### PR TITLE
Reformat CMake: Fix Version Detection

### DIFF
--- a/doc/news/2019-02-26_0.8.26.md
+++ b/doc/news/2019-02-26_0.8.26.md
@@ -111,8 +111,7 @@ The following section lists news about the [plugins](https://www.libelektra.org/
                                                         ^
   ```
 
-  . The inspiration for this feature was taken from the book
-  [“The Definitive ANTLR 4 Reference”](https://pragprog.com/book/tpantlr2/the-definitive-antlr-4-reference) by Terence Parr.
+  . The inspiration for this feature was taken from the book “The Definitive ANTLR 4 Reference” by Terence Parr.
   _(René Schwaiger)_
 
 - Yan LR’s lexer now

--- a/doc/news/_preparation_next_release.md
+++ b/doc/news/_preparation_next_release.md
@@ -144,7 +144,7 @@ you up to date with the multi-language support provided by Elektra.
 
 ### Other
 
-- The reformatting script now checks that the correct version of `cmake-format` is used. _(Klemens Böswirth)_
+- The reformatting script now checks that the correct version of `cmake-format` is used. _(Klemens Böswirth, René Schwaiger)_
 
 ## Infrastructure
 

--- a/scripts/reformat-cmake
+++ b/scripts/reformat-cmake
@@ -15,7 +15,10 @@ if [ -z "${CMAKE_FORMAT}" ] || [ "$CMAKE_FORMAT_VERSION" != "0.5.4" ]; then
 	exit 1
 fi
 
-cd "$SOURCE" || exit 1
+cd "$SOURCE" || {
+	printf >&2 'Unable to change into source directory'
+	exit 1
+}
 
 output=$("${CMAKE_FORMAT}" 2>&1 CMakeLists.txt)
 

--- a/scripts/reformat-cmake
+++ b/scripts/reformat-cmake
@@ -8,8 +8,7 @@
 SCRIPTS_DIR=$(dirname "$0")
 . "${SCRIPTS_DIR}/include-common"
 
-CMAKE_FORMAT=$(which cmake-format)
-CMAKE_FORMAT_VERSION=$("$CMAKE_FORMAT" --version)
+CMAKE_FORMAT=$(which cmake-format) && CMAKE_FORMAT_VERSION=$("$CMAKE_FORMAT" --version)
 
 if [ -z "${CMAKE_FORMAT}" ] || [ "$CMAKE_FORMAT_VERSION" != "0.5.4" ]; then
 	printf 2>&1 'Please install `cmake-format` version 0.5.4\n'

--- a/scripts/reformat-cmake
+++ b/scripts/reformat-cmake
@@ -11,7 +11,7 @@ SCRIPTS_DIR=$(dirname "$0")
 # The command `cmake-format --version` seems to print the version number either to `stdout` or `stderr`, depending on the current system.
 # To make sure we always capture the version number correctly we therefore redirect `stderr` to the same file descriptor as `stdout`,
 # before we save the output of the command.
-CMAKE_FORMAT=$(which cmake-format) && CMAKE_FORMAT_VERSION=$("$CMAKE_FORMAT" 2>&1 --version)
+CMAKE_FORMAT="$(which cmake-format)" && CMAKE_FORMAT_VERSION="$("$CMAKE_FORMAT" 2>&1 --version)"
 
 if [ -z "${CMAKE_FORMAT}" ] || [ "$CMAKE_FORMAT_VERSION" != "0.5.4" ]; then
 	printf >&2 'cmake-format: %s\n' "$CMAKE_FORMAT"

--- a/scripts/reformat-cmake
+++ b/scripts/reformat-cmake
@@ -8,7 +8,10 @@
 SCRIPTS_DIR=$(dirname "$0")
 . "${SCRIPTS_DIR}/include-common"
 
-CMAKE_FORMAT=$(which cmake-format) && CMAKE_FORMAT_VERSION=$("$CMAKE_FORMAT" --version)
+# The command `cmake-format --version` seems to print the version number either to `stdout` or `stderr`, depending on the current system.
+# To make sure we always capture the version number correctly we therefore redirect `stderr` to the same file descriptor as `stdout`,
+# before we save the output of the command.
+CMAKE_FORMAT=$(which cmake-format) && CMAKE_FORMAT_VERSION=$("$CMAKE_FORMAT" 2>&1 --version)
 
 if [ -z "${CMAKE_FORMAT}" ] || [ "$CMAKE_FORMAT_VERSION" != "0.5.4" ]; then
 	printf >&2 'cmake-format: %s\n' "$CMAKE_FORMAT"

--- a/scripts/reformat-cmake
+++ b/scripts/reformat-cmake
@@ -11,6 +11,8 @@ SCRIPTS_DIR=$(dirname "$0")
 CMAKE_FORMAT=$(which cmake-format) && CMAKE_FORMAT_VERSION=$("$CMAKE_FORMAT" --version)
 
 if [ -z "${CMAKE_FORMAT}" ] || [ "$CMAKE_FORMAT_VERSION" != "0.5.4" ]; then
+	printf >&2 'cmake-format: %s\n' "$CMAKE_FORMAT"
+	printf >&2 'Version:      %s\n' "$CMAKE_FORMAT_VERSION"
 	printf >&2 'Please install `cmake-format` version 0.5.4\n'
 	exit 1
 fi

--- a/scripts/reformat-cmake
+++ b/scripts/reformat-cmake
@@ -11,7 +11,7 @@ SCRIPTS_DIR=$(dirname "$0")
 CMAKE_FORMAT=$(which cmake-format) && CMAKE_FORMAT_VERSION=$("$CMAKE_FORMAT" --version)
 
 if [ -z "${CMAKE_FORMAT}" ] || [ "$CMAKE_FORMAT_VERSION" != "0.5.4" ]; then
-	printf 2>&1 'Please install `cmake-format` version 0.5.4\n'
+	printf >&2 'Please install `cmake-format` version 0.5.4\n'
 	exit 1
 fi
 
@@ -23,12 +23,12 @@ cd "$SOURCE" || {
 output=$("${CMAKE_FORMAT}" 2>&1 CMakeLists.txt)
 
 if [ $? != 0 ]; then
-	printf 2>&1 'It seems your local installation of `cmake-format` is broken:\n\n%s' "$output"
+	printf >&2 'It seems your local installation of `cmake-format` is broken:\n\n%s' "$output"
 	exit 1
 fi
 
 if [ -z "$(which sponge)" ]; then
-	printf 2>&1 'Please install `sponge`\n'
+	printf >&2 'Please install `sponge`\n'
 	exit 1
 fi
 


### PR DESCRIPTION
As far as I can tell the test `testscr_check_formatting` now fails in the

- [Travis](https://travis-ci.org/ElektraInitiative/libelektra/builds/571743570),
- [Cirrus](https://cirrus-ci.com/build/5150337176961024), and
- [Jenkins](https://build.libelektra.org/jenkins/blue/organizations/jenkins/libelektra/detail/PR-2877/1/pipeline/315)

build jobs, if a CMake file contains improperly formatted code.