### PR TITLE
Link checker: deduplicate links

### DIFF
--- a/doc/news/_preparation_next_release.md
+++ b/doc/news/_preparation_next_release.md
@@ -124,7 +124,8 @@ you up to date with the multi-language support provided by Elektra.
 
 - The script [run_icheck](../../scripts/run_icheck) now also work correctly, if the last entry of [`icheck.suppression`](../../tests/icheck.suppression) does not end with a newline character. _(René Schwaiger)_
 - The script [`draw-all-plugins`](../../scripts/draw-all-plugins) now also works properly, if the repository path contains space characters. _(René Schwaiger)_
-- The script [link-checker](../../scripts/link-checker) now deduplicates the list of links before checking them. The timeout and amount of retries was also reduced. _(Klemens Böswirth)_
+- The script [`link-checker`](../../scripts/link-checker) now deduplicates the list of links before checking them. The timeout and amount of retries was also reduced.
+  Lastly the script now supports a whitelist. Any link stored in [`tests/linkchecker.whitelist`](../../tests/linkchecker.whitelist) will not be checked. _(Klemens Böswirth)_
 
 ## Documentation
 

--- a/doc/news/_preparation_next_release.md
+++ b/doc/news/_preparation_next_release.md
@@ -124,7 +124,7 @@ you up to date with the multi-language support provided by Elektra.
 
 - The script [run_icheck](../../scripts/run_icheck) now also work correctly, if the last entry of [`icheck.suppression`](../../tests/icheck.suppression) does not end with a newline character. _(René Schwaiger)_
 - The script [`draw-all-plugins`](../../scripts/draw-all-plugins) now also works properly, if the repository path contains space characters. _(René Schwaiger)_
-- <<TODO>>
+- The script [link-checker](../../scripts/link-checker) now deduplicates the list of links before checking them. The timeout and amount of retries was also reduced. _(Klemens Böswirth)_
 
 ## Documentation
 

--- a/scripts/link-checker
+++ b/scripts/link-checker
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-# @author Kurt Micheli <kurt.micheli@libelektra.org>
+# @author Kurt Micheli <kurt.micheli@libelektra.org>, Klemens Böswirth <k.boeswirth+git@gmail.com>
 # @brief Checks http, https and ftp links if they are broken.
 # @date 05.09.2016
 # @tags validation
@@ -9,6 +9,8 @@ if [ -z "$1" ]; then
 	echo "Usage: link-checker <linkfile>"
 	exit
 fi
+
+SCRIPT_DIR="$(dirname "$0")"
 
 LINKFILE=$(mktemp)
 awk -F '|' '
@@ -38,14 +40,20 @@ END {
 	print data
 }' > "$LINKFILE"
 
+WHITELIST=$(mktemp)
+grep -v '^#' "$SCRIPT_DIR/../tests/linkchecker.whitelist" > "$WHITELIST"
+
 NUMTHREADS=10
 
 check() {
 	link=$(echo "$1" | grep -oE "(https|http|ftp):[^|]*")
 	files=$(echo "$1" | grep -oE "\|.*" | sed 's/|/ /g')
-	# The following link only works if you are logged into the build server
-	# See also: https://github.com/ElektraInitiative/libelektra/issues/2674
-	echo "$link" | grep -Eq 'https://build.libelektra.org/jenkins/job/libelektra/pipeline-syntax' && return
+
+	if grep -Fxq "$link" "$WHITELIST"; then
+		echo "whitelisted: $link"
+		printf "%i/%i\r" "$COUNTLINKS" "$NUMLINKS"
+		return
+	fi
 	if [ -z "$link" ]; then
 		echo "check the link format of $1"
 		return

--- a/scripts/link-checker
+++ b/scripts/link-checker
@@ -10,31 +10,60 @@ if [ -z "$1" ]; then
 	exit
 fi
 
+LINKFILE=$(mktemp)
+awk -F '|' '
+# Ignore links that contain version placeholder
+!/doc\/news\/_preparation_next_release\.md.*<<VERSION>>/ {
+	if($2 ~ /.*\//) {
+		sub("/$", "", $2)
+	}
+	sub("\\+", "%2B", $2)
+	print $2 "|"  $1
+}' "$1" | sort -t '|' -k1 | awk -F "|" '
+key != $1 || NR == 1 {
+	key = $1
+	if(data) {
+		print data
+	}
+	data = $0
+	next
+}
+
+{
+	sub($1,"",$0)
+	data = data""$0
+}
+
+END {
+	print data
+}' > "$LINKFILE"
+
 NUMTHREADS=10
 
 check() {
-	# Ignore links that contain version placeholder
-	echo "$1" | grep -Eq 'doc/news/_preparation_next_release\.md.*<<VERSION>>' && return
+	link=$(echo "$1" | grep -oE "(https|http|ftp):[^|]*")
+	files=$(echo "$1" | grep -oE "\|.*" | sed 's/|/ /g')
 	# The following link only works if you are logged into the build server
 	# See also: https://github.com/ElektraInitiative/libelektra/issues/2674
-	echo "$1" | grep -Eq 'https://build.libelektra.org/jenkins/job/libelektra/pipeline-syntax' && return
-	link=$(echo "$1" | grep -oE "(https|http|ftp):.*")
+	echo "$link" | grep -Eq 'https://build.libelektra.org/jenkins/job/libelektra/pipeline-syntax' && return
 	if [ -z "$link" ]; then
 		echo "check the link format of $1"
 		return
 	fi
-	wget --spider --quiet --timeout=10 "$link"
+	wget --spider --quiet --timeout=5 --tries=3 "$link"
 	if [ "$?" -ne "0" ]; then
-		wget -O - --quiet "$link" > /dev/null
+		wget -O - --quiet --timeout=5 --tries=3 "$link" > /dev/null
 		if [ "$?" -ne "0" ]; then
-			echo >&2 "$1"
+			for file in $files; do
+				echo >&2 "$file $link"
+			done
 		fi
 	fi
 }
 
 COUNTLINKS=0
 THREADCOUNT=0
-NUMLINKS=$(wc -l < "$1")
+NUMLINKS=$(wc -l < "$LINKFILE")
 PIDS=""
 
 while read -r line; do
@@ -50,7 +79,7 @@ while read -r line; do
 		PIDS=""
 		THREADCOUNT=1
 	fi
-done < "$1"
+done < "$LINKFILE"
 
 for pid in $PIDS; do
 	wait "$pid"

--- a/tests/linkchecker.whitelist
+++ b/tests/linkchecker.whitelist
@@ -1,0 +1,12 @@
+# Whitelist for the linkchecker
+#
+# Any lines starting with '#' will be stripped out.
+# If a link equals any other line, it will not be checked.
+#
+# The following link only works if you are logged into the build server
+# See also: https://github.com/ElektraInitiative/libelektra/issues/2674
+https://build.libelektra.org/jenkins/job/libelektra/pipeline-syntax
+# Webdemo doesn't work right now
+# see https://github.com/ElektraInitiative/libelektra/issues/2913
+http://webdemo.libelektra.org
+https://webdemo.libelektra.org


### PR DESCRIPTION
Changes the linkchecker so it de-duplicates before checking them (reduces from ~1100 to ~800 checks). In addition the timeout was reduced from 10s to 5s and the number of retries from 20 (default) to 3.

## Basics

- [x] Short descriptions should be in the release notes (added as entry in
      `doc/news/_preparation_next_release.md` which contains `_(my name)_`)
      **Please always add something to the the release notes.**
- [x] Longer descriptions should be in documentation or in design decisions.
- [x] Describe details of how you changed the code in commit messages
      (first line should have `module: short statement` syntax)
- [x] References to issues, e.g. `close #X`, should be in the commit messages.

## Checklist

- [ ] I added unit tests
- [ ] I ran all tests locally and everything went fine
- [ ] affected documentation is fixed
- [ ] I added code comments, logging, and assertions (see [Coding Guidelines](https://master.libelektra.org/doc/CODING.md))
- [ ] meta data is updated (e.g. README.md of plugins and [METADATA.ini](https://master.libelektra.org/doc/METADATA.ini))

## Review

- [ ] Code is conforming to [our Coding Guidelines](https://master.libelektra.org/doc/CODING.md)
- [ ] APIs are conforming to [our Design Guidelines](https://master.libelektra.org/doc/DESIGN.md)
- [ ] Code is consistent to [our Design Decisions](https://master.libelektra.org/doc/decisions)
- [ ] Documentation is concise and good to read
- [ ] Examples are well chosen and understandable
