### PR TITLE
Tcl: Fix Name of Boost Include Directory

### DIFF
--- a/doc/news/_preparation_next_release.md
+++ b/doc/news/_preparation_next_release.md
@@ -46,6 +46,10 @@ The following section lists news about the [modules](https://www.libelektra.org/
 - The error message, if non of the gopts variants can be compiled, was improved. _(Klemens Böswirth)_
 - A better error, if the plugin fails to load `argv` from the system, was added. _(Klemens Böswirth)_
 
+### Tcl
+
+- We made sure that building the plugin works, if you use the latest version of CMake (`3.15.3`) and Boost (`1.71`). _(René Schwaiger)_
+
 ### YAwn
 
 - We removed the plugin in favor of [Yan LR](../../src/plugins/yanlr/README.md). _(René Schwaiger)_

--- a/src/plugins/tcl/CMakeLists.txt
+++ b/src/plugins/tcl/CMakeLists.txt
@@ -6,7 +6,7 @@ if (DEPENDENCY_PHASE)
 endif ()
 
 add_plugin (tcl CPP
-	    INCLUDE_SYSTEM_DIRECTORIES ${Boost_INCLUDE_DIR}
+	    INCLUDE_SYSTEM_DIRECTORIES ${Boost_INCLUDE_DIRS}
 	    SOURCES tcl.hpp
 		    tcl.cpp
 		    action.hpp


### PR DESCRIPTION
I think it makes sense to merge this as soon as possible, since the [Travis build job `🍏 GCC` will continue to fail](https://travis-ci.org/ElektraInitiative/libelektra/jobs/581677651) otherwise.