### PR TITLE
Codegen: Ignore missing required keys in help mode

### DIFF
--- a/doc/decisions/README.md
+++ b/doc/decisions/README.md
@@ -21,6 +21,7 @@ section here.
 - [Elektra Web Structure](elektra_web.md)
 - [Elektra Web Recursive Structure](elektra_web_recursive.md)
 - [Cryptographic Key Handling](cryptograhic_key_handling.md)
+- [High-level API Help Message](highlevel_help_message.md)
 
 ## Decided
 

--- a/doc/decisions/highlevel_help_message.md
+++ b/doc/decisions/highlevel_help_message.md
@@ -1,0 +1,54 @@
+# High-level API Help Message
+
+This decision _does not_ assume code-generation is used. For the case of code-generation see the [Notes](#notes) section.
+
+## Problem
+
+We want to allow to print the help message no matter what errors happened in `kdbOpen` or `kdbGet`.
+
+## Constraints
+
+- `elektraOpen` should not return a broken `Elektra` instance.
+- The help message can only be printed, if `elektraOpen` returns an `Elektra` instance and no `ElektraError`.
+
+## Assumptions
+
+- We assume that the application in question was correctly installed.
+- We assume `gopts` was mounted.
+- We assume the application was called in _help mode_, i.e. with `-h` or `--help`.
+  Otherwise printing the help message is not possible, anyway.
+
+## Considered Alternatives
+
+- Ignore all errors (in help mode):
+  Not a feasible solution, because there may have been problems when reading the storage file and therefore,
+  the help message may be broken or incomplete.
+- Ignore all errors (in help mode), which occurred after the `gopts` plugin ran:
+  Complicated to implement (we need to know about plugin order, etc.).
+  Not actually necessary (see [Rationale](#rationale)).
+
+## Decision
+
+Ignore missing `require`d keys (in help mode), but fail for every other error.
+
+## Rationale
+
+Required keys **must** be provided by the user/admin and cannot come from another source (Elektra, app developer, etc.).
+Therefore they will be missing until the user makes changes to the KDB. Before that, no other error should occur (we
+assumed a correct installation). If a user runs `app` for the first time and receives an error about a missing required
+key, they will:
+
+- know what to do and add the key, thereby fixing the problem.
+- try `app -h`/`app --help` to find out more. The help message may or may not contain useful information. If not they may try 3.
+- read some other documentation to find out more. Ideally this leads them to 1.
+
+In any case after this the user definitely know how to interact with the KDB. Since we assumed that there won't be any
+errors before the KDB was changed, we can assume that the user caused other errors by changing the KDB.
+
+## Notes
+
+If code-generation is used, the situation is a little different. If the parameter `embedHelpFallback` is set to `1`, a
+fallback help message will be created from the specification originally passed to the code-generator and embedded into
+the application. The parameter also changes, how help mode is detected and ultimately allows the help message function
+(`printHelpMessage` by default) to always print a help message. Although it may not reflect changes the user made to the
+specification.

--- a/doc/help/kdb-gen-highlevel.md
+++ b/doc/help/kdb-gen-highlevel.md
@@ -60,6 +60,10 @@ For detailed information about the contents of the header file see [elektra-high
   Changes the name of the function that checks for "specload mode" (default: `exitForSpecload`)
 - `tagPrefix`:
   Changes the prefix of the generated tags (default: `ELEKTRA_TAG_`)
+- `embedHelpFallback`:
+  Switches whether a fallback help message should be embedded; allowed values: `1` (default), `0`
+  If enabled (`1`), a help message will be generated from the specification passed to the code-generator and embedded
+  into the application. This message will be used, if the normal help message could not be generated at runtime.
 - `enumConv`:
   Switches how enum conversion should be done; allowed values: `default` (default), `switch`, `strcmp`
   - `strcmp`: uses a simple series of `if (strcmp(*, *) == 0)` to convert strings into enums
@@ -69,7 +73,7 @@ For detailed information about the contents of the header file see [elektra-high
   Comma-separated (`,`) list of additional header files to include. For each of the listed headers we will generate an `#include "*"`
   statement
 - `genSetters`:
-  Switches whether setters should be generated at all; allowed values: `true` (default), `false`
+  Switches whether setters should be generated at all; allowed values: `1` (default), `0`
 - `embeddedSpec`:
   Changes how much of the specification is embedded into the application; allowed values: `full` (default), `defaults`, `none`.
   see [elektra-highlevel-gen(7)](elektra-highlevel-gen.md)

--- a/doc/man/man1/kdb-gen-highlevel.1
+++ b/doc/man/man1/kdb-gen-highlevel.1
@@ -80,6 +80,9 @@ For detailed information about the contents of the header file see elektra\-high
 \fBtagPrefix\fR: Changes the prefix of the generated tags (default: \fBELEKTRA_TAG_\fR)
 .
 .IP "\(bu" 4
+\fBembedHelpFallback\fR: Switches whether a fallback help message should be embedded; allowed values: \fB1\fR (default), \fB0\fR If enabled (\fB1\fR), a help message will be generated from the specification passed to the code\-generator and embedded into the application\. This message will be used, if the normal help message could not be generated at runtime\.
+.
+.IP "\(bu" 4
 .
 .IP "\(bu" 4
 \fBstrcmp\fR: uses a simple series of \fBif (strcmp(*, *) == 0)\fR to convert strings into enums
@@ -97,7 +100,7 @@ For detailed information about the contents of the header file see elektra\-high
 \fBheaders\fR: Comma\-separated (\fB,\fR) list of additional header files to include\. For each of the listed headers we will generate an \fB#include "*"\fR statement
 .
 .IP "\(bu" 4
-\fBgenSetters\fR: Switches whether setters should be generated at all; allowed values: \fBtrue\fR (default), \fBfalse\fR
+\fBgenSetters\fR: Switches whether setters should be generated at all; allowed values: \fB1\fR (default), \fB0\fR
 .
 .IP "\(bu" 4
 \fBembeddedSpec\fR: Changes how much of the specification is embedded into the application; allowed values: \fBfull\fR (default), \fBdefaults\fR, \fBnone\fR\. see elektra\-highlevel\-gen(7) \fIelektra\-highlevel\-gen\.md\fR

--- a/doc/man/man7/elektra-highlevel-gen.7
+++ b/doc/man/man7/elektra-highlevel-gen.7
@@ -13,18 +13,15 @@ This document focuses on the advanced features of the high\-level API code\-gene
 The parameters that are relevant to the concepts described here are (for the rest see `kdb\-gen\-highlevel(1) \fIkdb\-gen\-highlevel\.md\fR):
 .
 .IP "\(bu" 4
-\fBenumConv\fR: allowed values: \fBstrcmp\fR, \fBswitch\fR, \fBauto\fR (default)
-.
-.IP "\(bu" 4
 \fBembeddedSpec\fR: allowed values: \fBfull\fR (default), \fBdefaults\fR, \fBnone\fR
 .
 .IP "\(bu" 4
 \fBspecValidation\fR: allowed values: \fBnone\fR (default), \fBminimal\fR
 .
-.IP "" 0
+.IP "\(bu" 4
+\fBenumConv\fR: allowed values: \fBstrcmp\fR, \fBswitch\fR, \fBauto\fR (default)
 .
-.P
-The \fBenumConv\fR option is described \fIbelow\fR\.
+.IP "" 0
 .
 .P
 Using \fBembeddedSpec\fR you can configure how much of the specification is embedded into your application\. By default we use \fBfull\fR\. This means the full specification is embedded into your application\'s binary\. Since this can drastically increase the size of the binary, you can also choose \fBdefaults\fR or \fBnone\fR\. The \fBdefaults\fR setting embeds a reduced version of the specification, which only contains the metadata required by \fBelektraOpen\fR\. By setting \fBembeddedSpec=none\fR you can also remove this reduced specification\.

--- a/doc/news/_preparation_next_release.md
+++ b/doc/news/_preparation_next_release.md
@@ -38,7 +38,7 @@ If you specifically want to use it with the High-Level API take a look at [this 
 
 We also created a new CMake function that will be available, if you include Elektra via CMake's
 `find_package`. The function is called `elektra_kdb_gen` and can be used to tell CMake about files
-that are generated with `kdb gen`. _(Klemens Böswirth)_
+that are generated via `kdb gen`. _(Klemens Böswirth)_
 
 ### <<HIGHLIGHT2>>
 

--- a/doc/news/_preparation_next_release.md
+++ b/doc/news/_preparation_next_release.md
@@ -80,6 +80,10 @@ The following section lists news about the [modules](https://www.libelektra.org/
 
 - We now treat relative paths as relative to `KDB_DB_SPEC` instead of the current working directory. _(Klemens Böswirth)_
 
+### Spec
+
+- There is now the config key `missing/log` that allows logging of all missing `require`d keys. _(Klemens Böswirth)_
+
 ## Libraries
 
 The text below summarizes updates to the [C (and C++)-based libraries](https://www.libelektra.org/libraries/readme) of Elektra.

--- a/src/include/kdbopts.h
+++ b/src/include/kdbopts.h
@@ -12,7 +12,18 @@
 
 #include <kdb.h>
 
+#ifdef __cplusplus
+namespace ckdb
+{
+extern "C" {
+#endif
+
 int elektraGetOpts (KeySet * ks, int argc, const char ** argv, const char ** envp, Key * parentKey);
 char * elektraGetOptsHelpMessage (Key * errorKey, const char * usage, const char * prefix);
+
+#ifdef __cplusplus
+}
+}
+#endif
 
 #endif // ELEKTRA_KDBOPTS_H

--- a/src/libs/ease/symbols.map
+++ b/src/libs/ease/symbols.map
@@ -10,7 +10,9 @@ libelektra_0.8 {
 	elektraKeyGetRelativeName;
 	elektraKsFilter;
 	elektraResolveReference;
+};
 
+libelektra_0.9 {
 	## ToString;
 	elektraBooleanToString;
 	elektraCharToString;

--- a/src/plugins/gopts/gopts.c
+++ b/src/plugins/gopts/gopts.c
@@ -34,6 +34,35 @@ static void cleanupEnvp (char ** envp);
 #error "No implementation available"
 #endif
 
+/**
+ * Detects whether we are in help mode or not.
+ * DOES NOT set 'proc/elektra/gopts/help' for use with elektraGetOptsHelpMessage().
+ *
+ * @retval 1 if the -h or --help is part of argv
+ * @retval 0 otherwise
+ * @retval -1 on error (could not load argv)
+ */
+int elektraGOptsIsHelpMode (void)
+{
+	char ** argv = NULL;
+	int argc = loadArgs (&argv);
+
+	if (argv == NULL)
+	{
+		return -1;
+	}
+
+	for (int i = 0; i < argc; ++i)
+	{
+		if (strcmp (argv[i], "-h") == 0 || strcmp (argv[i], "--help") == 0)
+		{
+			return 1;
+		}
+	}
+
+	return 0;
+}
+
 
 int elektraGOptsGet (Plugin * handle ELEKTRA_UNUSED, KeySet * returned, Key * parentKey)
 {
@@ -43,6 +72,7 @@ int elektraGOptsGet (Plugin * handle ELEKTRA_UNUSED, KeySet * returned, Key * pa
 			ksNew (30, keyNew ("system/elektra/modules/gopts", KEY_VALUE, "gopts plugin waits for your orders", KEY_END),
 			       keyNew ("system/elektra/modules/gopts/exports", KEY_END),
 			       keyNew ("system/elektra/modules/gopts/exports/get", KEY_FUNC, elektraGOptsGet, KEY_END),
+			       keyNew ("system/elektra/modules/gopts/exports/ishelpmode", KEY_FUNC, elektraGOptsIsHelpMode, KEY_END),
 #include ELEKTRA_README
 			       keyNew ("system/elektra/modules/gopts/infos/version", KEY_VALUE, PLUGINVERSION, KEY_END), KS_END);
 		ksAppend (returned, contract);

--- a/src/plugins/spec/README.md
+++ b/src/plugins/spec/README.md
@@ -133,6 +133,10 @@ The allowed values for the conflict keys are always the same:
   `logs/spec/info` is an array, each element is one conflict.
 - any other value ignores the conflict, this includes if the conflict key is not given (i.e. the default)
 
+There is also the special key `missing/log`. If it is set to `1`, the plugin will create the meta array `logs/spec/missing/#`.
+This array will contain a list of the missing keys. The key `missing/log` can only be part of the main plugin configuration,
+not individual keys' metakeys. It also applies to `kdbGet` and `kdbSet` calls.
+
 ## Examples
 
 Ini files can be found in [/examples/spec](/examples/spec) which should be PWD

--- a/src/tools/kdb/CMakeLists.txt
+++ b/src/tools/kdb/CMakeLists.txt
@@ -36,6 +36,7 @@ if (BUILD_SHARED)
 			       elektra-core
 			       elektra-kdb
 			       elektratools
+			       elektra-opts
 			       elektra-merge)
 
 	install (TARGETS kdb DESTINATION bin)

--- a/src/tools/kdb/gen/highlevel/highlevel.cpp
+++ b/src/tools/kdb/gen/highlevel/highlevel.cpp
@@ -18,6 +18,7 @@
 #include <kdb.h>
 #include <kdbease.h>
 #include <kdbhelper.h>
+#include <kdbopts.h>
 #include <kdbplugin.h>
 #include <kdbtypes.h>
 
@@ -38,6 +39,7 @@ const char * HighlevelGenTemplate::Params::GenerateSetters = "genSetters";
 const char * HighlevelGenTemplate::Params::EmbeddedSpec = "embeddedSpec";
 const char * HighlevelGenTemplate::Params::SpecValidation = "specValidation";
 const char * HighlevelGenTemplate::Params::InstallPrefix = "installPrefix";
+const char * HighlevelGenTemplate::Params::EmbedHelpFallback = "embedHelpFallback";
 
 enum class EmbeddedSpec
 {
@@ -205,6 +207,25 @@ static kdb::KeySet cascadingToSpec (const kdb::KeySet & ks)
 	return result;
 }
 
+static std::string generateHelpMessage (const std::string & appName, const std::string & specParent, kdb::KeySet spec)
+{
+	std::vector<const char *> argv = { appName.c_str (), "-h" };
+
+	kdb::Key parentKey (specParent.c_str (), KEY_END);
+	int ret = ckdb::elektraGetOpts (spec.getKeySet (), argv.size (), argv.data (), NULL, parentKey.getKey ());
+
+	if (ret != 1)
+	{
+		throw CommandAbortException ("could not generate fallback help message");
+	}
+
+	char * help = ckdb::elektraGetOptsHelpMessage (parentKey.getKey (), NULL, NULL);
+	std::string result (help);
+	ckdb::elektraFree (help);
+
+	return result;
+}
+
 kainjow::mustache::data HighlevelGenTemplate::getTemplateData (const std::string & outputName, const std::string & part,
 							       const kdb::KeySet & keySet, const std::string & parentKey) const
 {
@@ -220,6 +241,7 @@ kainjow::mustache::data HighlevelGenTemplate::getTemplateData (const std::string
 	auto additionalHeaders = split (getParameter (Params::AdditionalHeaders), ',');
 	auto enumConversionString = getParameter (Params::EnumConversion, "auto");
 	auto generateSetters = getBoolParameter (Params::GenerateSetters, true);
+	auto embedHelpFallback = getBoolParameter (Params::EmbedHelpFallback, true);
 	auto specHandling = getParameter<EmbeddedSpec> (Params::EmbeddedSpec, { { "", EmbeddedSpec::Full },
 										{ "full", EmbeddedSpec::Full },
 										{ "defaults", EmbeddedSpec::Defaults },
@@ -263,6 +285,7 @@ kainjow::mustache::data HighlevelGenTemplate::getTemplateData (const std::string
 			    { "help_function_name", helpFunctionName },
 			    { "specload_function_name", specloadFunctionName },
 			    { "generate_setters?", generateSetters },
+			    { "embed_help_fallback?", embedHelpFallback },
 			    { "embed_spec?", specHandling == EmbeddedSpec::Full },
 			    { "embed_defaults?", specHandling == EmbeddedSpec::Defaults },
 			    { "spec_as_defaults?", specHandling == EmbeddedSpec::Full },
@@ -281,6 +304,7 @@ kainjow::mustache::data HighlevelGenTemplate::getTemplateData (const std::string
 	auto parentLength = specParentName.length ();
 
 	kdb::KeySet spec;
+	kdb::KeySet specWithParent;
 	kdb::KeySet defaults;
 
 	kdb::Key parent = ks.lookup (specParent).dup ();
@@ -332,6 +356,8 @@ kainjow::mustache::data HighlevelGenTemplate::getTemplateData (const std::string
 		kdb::Key specKey = key.dup ();
 		specKey.setName (specKey.getName ().substr (parentLength));
 		spec.append (specKey);
+
+		specWithParent.append (key);
 
 		if (!hasType (key))
 		{
@@ -549,6 +575,7 @@ kainjow::mustache::data HighlevelGenTemplate::getTemplateData (const std::string
 	data["defaults"] = keySetToCCode (defaults);
 	data["contract"] = keySetToCCode (contract);
 	data["specload_arg"] = "--elektra-spec";
+	data["help_fallback"] = generateHelpMessage (appName, specParentName, specWithParent);
 
 	if (part == ".spec.eqd")
 	{

--- a/src/tools/kdb/gen/highlevel/highlevel.cpp
+++ b/src/tools/kdb/gen/highlevel/highlevel.cpp
@@ -532,6 +532,9 @@ kainjow::mustache::data HighlevelGenTemplate::getTemplateData (const std::string
 	kdb::KeySet contract;
 	contract.append (kdb::Key ("system/elektra/ensure/plugins/global/gopts", KEY_VALUE, "mounted", KEY_END));
 
+	// make elektraOpen() succeed, if there are missing required keys, but we are in helpMode
+	contract.append (kdb::Key ("system/elektra/highlevel/helpmode/ignore/require", KEY_VALUE, "1", KEY_END));
+
 	if (specValidation == SpecValidation::Minimal)
 	{
 		contract.append (kdb::Key ("system/elektra/highlevel/validation", KEY_VALUE, "minimal", KEY_END));

--- a/src/tools/kdb/gen/highlevel/highlevel.hpp
+++ b/src/tools/kdb/gen/highlevel/highlevel.hpp
@@ -25,6 +25,7 @@ class HighlevelGenTemplate : public GenTemplate
 		static const char * EmbeddedSpec;
 		static const char * SpecValidation;
 		static const char * InstallPrefix;
+		static const char * EmbedHelpFallback;
 	};
 
 public:

--- a/src/tools/kdb/gen/templates/highlevel.c.mustache
+++ b/src/tools/kdb/gen/templates/highlevel.c.mustache
@@ -50,6 +50,23 @@ static KeySet * embeddedSpec (void)
 }
 /*%/ embed_spec? %*/
 
+/*%# embed_help_fallback? %*/
+static const char * helpFallback = "/*% help_fallback %*/";
+
+static int isHelpMode (void)
+{
+	ElektraInvokeHandle * gopts = elektraInvokeOpen ("gopts", NULL, NULL);
+
+	typedef int (*func) (void);
+	func goptsIsHelpMode = *(func *) elektraInvokeGetFunction (gopts, "ishelpmode");
+	
+	int ret = goptsIsHelpMode ();
+
+	elektraInvokeClose (gopts, NULL);
+	return ret == 1;
+}
+/*%/ embed_help_fallback? %*/
+
 /*%={{ }}=%*/
 /**
  * Initializes an instance of Elektra for the application '{{{ parent_key }}}'.
@@ -96,6 +113,15 @@ int /*%& init_function_name %*/ (Elektra ** elektra, ElektraError ** error)
 
 	if (e == NULL)
 	{
+		*elektra = NULL;
+		/*%# embed_help_fallback? %*/
+		if (isHelpMode ())
+		{
+			elektraErrorReset (error);
+			return 1;
+		}
+		/*%/ embed_help_fallback? %*/
+
 		return -1;
 	}
 
@@ -151,6 +177,14 @@ void /*%& specload_function_name %*/ (int argc, const char ** argv)
  */// {{=/*% %*/=}}
 void /*%& help_function_name %*/ (Elektra * elektra, const char * usage, const char * prefix)
 {
+	if (elektra == NULL)
+	{
+		/*%# embed_help_fallback? %*/
+		printf ("%s", helpFallback);
+		/*%/ embed_help_fallback? %*/
+		return;
+	}
+
 	Key * helpKey = elektraHelpKey (elektra);
 	if (helpKey == NULL)
 	{

--- a/tests/shell/gen/highlevel/empty.expected.c
+++ b/tests/shell/gen/highlevel/empty.expected.c
@@ -72,8 +72,9 @@ int loadConfiguration (Elektra ** elektra, ElektraError ** error)
 	KeySet * defaults = embeddedSpec ();
 	
 
-	KeySet * contract = ksNew (1,
+	KeySet * contract = ksNew (2,
 	keyNew ("system/elektra/ensure/plugins/global/gopts", KEY_VALUE, "mounted", KEY_END),
+	keyNew ("system/elektra/highlevel/helpmode/ignore/require", KEY_VALUE, "1", KEY_END),
 	KS_END);
 ;
 

--- a/tests/shell/gen/highlevel/empty.expected.c
+++ b/tests/shell/gen/highlevel/empty.expected.c
@@ -46,6 +46,21 @@ static KeySet * embeddedSpec (void)
 ;
 }
 
+static const char * helpFallback = "Usage: tests_script_gen_highlevel_empty\n";
+
+static int isHelpMode (void)
+{
+	ElektraInvokeHandle * gopts = elektraInvokeOpen ("gopts", NULL, NULL);
+
+	typedef int (*func) (void);
+	func goptsIsHelpMode = *(func *) elektraInvokeGetFunction (gopts, "ishelpmode");
+	
+	int ret = goptsIsHelpMode ();
+
+	elektraInvokeClose (gopts, NULL);
+	return ret == 1;
+}
+
 
 /**
  * Initializes an instance of Elektra for the application '/tests/script/gen/highlevel/empty'.
@@ -87,6 +102,13 @@ int loadConfiguration (Elektra ** elektra, ElektraError ** error)
 
 	if (e == NULL)
 	{
+		*elektra = NULL;
+		if (isHelpMode ())
+		{
+			elektraErrorReset (error);
+			return 1;
+		}
+
 		return -1;
 	}
 
@@ -140,6 +162,12 @@ void exitForSpecload (int argc, const char ** argv)
  */// 
 void printHelpMessage (Elektra * elektra, const char * usage, const char * prefix)
 {
+	if (elektra == NULL)
+	{
+		printf ("%s", helpFallback);
+		return;
+	}
+
 	Key * helpKey = elektraHelpKey (elektra);
 	if (helpKey == NULL)
 	{

--- a/tests/shell/gen/highlevel/enum.expected.c
+++ b/tests/shell/gen/highlevel/enum.expected.c
@@ -77,8 +77,9 @@ int loadConfiguration (Elektra ** elektra, ElektraError ** error)
 	KeySet * defaults = embeddedSpec ();
 	
 
-	KeySet * contract = ksNew (1,
+	KeySet * contract = ksNew (2,
 	keyNew ("system/elektra/ensure/plugins/global/gopts", KEY_VALUE, "mounted", KEY_END),
+	keyNew ("system/elektra/highlevel/helpmode/ignore/require", KEY_VALUE, "1", KEY_END),
 	KS_END);
 ;
 

--- a/tests/shell/gen/highlevel/enum.expected.c
+++ b/tests/shell/gen/highlevel/enum.expected.c
@@ -51,6 +51,21 @@ static KeySet * embeddedSpec (void)
 ;
 }
 
+static const char * helpFallback = "Usage: tests_script_gen_highlevel_enum\n";
+
+static int isHelpMode (void)
+{
+	ElektraInvokeHandle * gopts = elektraInvokeOpen ("gopts", NULL, NULL);
+
+	typedef int (*func) (void);
+	func goptsIsHelpMode = *(func *) elektraInvokeGetFunction (gopts, "ishelpmode");
+	
+	int ret = goptsIsHelpMode ();
+
+	elektraInvokeClose (gopts, NULL);
+	return ret == 1;
+}
+
 
 /**
  * Initializes an instance of Elektra for the application '/tests/script/gen/highlevel/enum'.
@@ -92,6 +107,13 @@ int loadConfiguration (Elektra ** elektra, ElektraError ** error)
 
 	if (e == NULL)
 	{
+		*elektra = NULL;
+		if (isHelpMode ())
+		{
+			elektraErrorReset (error);
+			return 1;
+		}
+
 		return -1;
 	}
 
@@ -145,6 +167,12 @@ void exitForSpecload (int argc, const char ** argv)
  */// 
 void printHelpMessage (Elektra * elektra, const char * usage, const char * prefix)
 {
+	if (elektra == NULL)
+	{
+		printf ("%s", helpFallback);
+		return;
+	}
+
 	Key * helpKey = elektraHelpKey (elektra);
 	if (helpKey == NULL)
 	{

--- a/tests/shell/gen/highlevel/externalspec.expected.c
+++ b/tests/shell/gen/highlevel/externalspec.expected.c
@@ -67,8 +67,9 @@ int loadConfiguration (Elektra ** elektra, ElektraError ** error)
 	
 	KeySet * defaults = NULL;
 
-	KeySet * contract = ksNew (1,
+	KeySet * contract = ksNew (2,
 	keyNew ("system/elektra/ensure/plugins/global/gopts", KEY_VALUE, "mounted", KEY_END),
+	keyNew ("system/elektra/highlevel/helpmode/ignore/require", KEY_VALUE, "1", KEY_END),
 	KS_END);
 ;
 

--- a/tests/shell/gen/highlevel/externalspec.expected.c
+++ b/tests/shell/gen/highlevel/externalspec.expected.c
@@ -40,6 +40,21 @@
 
 
 
+static const char * helpFallback = "Usage: tests_script_gen_highlevel_externalspec\n";
+
+static int isHelpMode (void)
+{
+	ElektraInvokeHandle * gopts = elektraInvokeOpen ("gopts", NULL, NULL);
+
+	typedef int (*func) (void);
+	func goptsIsHelpMode = *(func *) elektraInvokeGetFunction (gopts, "ishelpmode");
+	
+	int ret = goptsIsHelpMode ();
+
+	elektraInvokeClose (gopts, NULL);
+	return ret == 1;
+}
+
 
 /**
  * Initializes an instance of Elektra for the application '/tests/script/gen/highlevel/externalspec'.
@@ -82,6 +97,13 @@ int loadConfiguration (Elektra ** elektra, ElektraError ** error)
 
 	if (e == NULL)
 	{
+		*elektra = NULL;
+		if (isHelpMode ())
+		{
+			elektraErrorReset (error);
+			return 1;
+		}
+
 		return -1;
 	}
 
@@ -116,6 +138,12 @@ void exitForSpecload (int argc, const char ** argv)
  */// 
 void printHelpMessage (Elektra * elektra, const char * usage, const char * prefix)
 {
+	if (elektra == NULL)
+	{
+		printf ("%s", helpFallback);
+		return;
+	}
+
 	Key * helpKey = elektraHelpKey (elektra);
 	if (helpKey == NULL)
 	{

--- a/tests/shell/gen/highlevel/externalwithdefaults.expected.c
+++ b/tests/shell/gen/highlevel/externalwithdefaults.expected.c
@@ -40,6 +40,21 @@
 
 
 
+static const char * helpFallback = "Usage: tests_script_gen_highlevel_externalwithdefaults\n";
+
+static int isHelpMode (void)
+{
+	ElektraInvokeHandle * gopts = elektraInvokeOpen ("gopts", NULL, NULL);
+
+	typedef int (*func) (void);
+	func goptsIsHelpMode = *(func *) elektraInvokeGetFunction (gopts, "ishelpmode");
+	
+	int ret = goptsIsHelpMode ();
+
+	elektraInvokeClose (gopts, NULL);
+	return ret == 1;
+}
+
 
 /**
  * Initializes an instance of Elektra for the application '/tests/script/gen/highlevel/externalwithdefaults'.
@@ -89,6 +104,13 @@ int loadConfiguration (Elektra ** elektra, ElektraError ** error)
 
 	if (e == NULL)
 	{
+		*elektra = NULL;
+		if (isHelpMode ())
+		{
+			elektraErrorReset (error);
+			return 1;
+		}
+
 		return -1;
 	}
 
@@ -123,6 +145,12 @@ void exitForSpecload (int argc, const char ** argv)
  */// 
 void printHelpMessage (Elektra * elektra, const char * usage, const char * prefix)
 {
+	if (elektra == NULL)
+	{
+		printf ("%s", helpFallback);
+		return;
+	}
+
 	Key * helpKey = elektraHelpKey (elektra);
 	if (helpKey == NULL)
 	{

--- a/tests/shell/gen/highlevel/externalwithdefaults.expected.c
+++ b/tests/shell/gen/highlevel/externalwithdefaults.expected.c
@@ -74,8 +74,9 @@ int loadConfiguration (Elektra ** elektra, ElektraError ** error)
 ;
 	
 
-	KeySet * contract = ksNew (1,
+	KeySet * contract = ksNew (2,
 	keyNew ("system/elektra/ensure/plugins/global/gopts", KEY_VALUE, "mounted", KEY_END),
+	keyNew ("system/elektra/highlevel/helpmode/ignore/require", KEY_VALUE, "1", KEY_END),
 	KS_END);
 ;
 

--- a/tests/shell/gen/highlevel/nosetter.expected.c
+++ b/tests/shell/gen/highlevel/nosetter.expected.c
@@ -77,8 +77,9 @@ int loadConfiguration (Elektra ** elektra, ElektraError ** error)
 	KeySet * defaults = embeddedSpec ();
 	
 
-	KeySet * contract = ksNew (1,
+	KeySet * contract = ksNew (2,
 	keyNew ("system/elektra/ensure/plugins/global/gopts", KEY_VALUE, "mounted", KEY_END),
+	keyNew ("system/elektra/highlevel/helpmode/ignore/require", KEY_VALUE, "1", KEY_END),
 	KS_END);
 ;
 

--- a/tests/shell/gen/highlevel/nosetter.expected.c
+++ b/tests/shell/gen/highlevel/nosetter.expected.c
@@ -51,6 +51,21 @@ static KeySet * embeddedSpec (void)
 ;
 }
 
+static const char * helpFallback = "Usage: tests_script_gen_highlevel_nosetter\n";
+
+static int isHelpMode (void)
+{
+	ElektraInvokeHandle * gopts = elektraInvokeOpen ("gopts", NULL, NULL);
+
+	typedef int (*func) (void);
+	func goptsIsHelpMode = *(func *) elektraInvokeGetFunction (gopts, "ishelpmode");
+	
+	int ret = goptsIsHelpMode ();
+
+	elektraInvokeClose (gopts, NULL);
+	return ret == 1;
+}
+
 
 /**
  * Initializes an instance of Elektra for the application '/tests/script/gen/highlevel/nosetter'.
@@ -92,6 +107,13 @@ int loadConfiguration (Elektra ** elektra, ElektraError ** error)
 
 	if (e == NULL)
 	{
+		*elektra = NULL;
+		if (isHelpMode ())
+		{
+			elektraErrorReset (error);
+			return 1;
+		}
+
 		return -1;
 	}
 
@@ -145,6 +167,12 @@ void exitForSpecload (int argc, const char ** argv)
  */// 
 void printHelpMessage (Elektra * elektra, const char * usage, const char * prefix)
 {
+	if (elektra == NULL)
+	{
+		printf ("%s", helpFallback);
+		return;
+	}
+
 	Key * helpKey = elektraHelpKey (elektra);
 	if (helpKey == NULL)
 	{

--- a/tests/shell/gen/highlevel/notype.expected.c
+++ b/tests/shell/gen/highlevel/notype.expected.c
@@ -47,6 +47,21 @@ static KeySet * embeddedSpec (void)
 ;
 }
 
+static const char * helpFallback = "Usage: tests_script_gen_highlevel_notype\n";
+
+static int isHelpMode (void)
+{
+	ElektraInvokeHandle * gopts = elektraInvokeOpen ("gopts", NULL, NULL);
+
+	typedef int (*func) (void);
+	func goptsIsHelpMode = *(func *) elektraInvokeGetFunction (gopts, "ishelpmode");
+	
+	int ret = goptsIsHelpMode ();
+
+	elektraInvokeClose (gopts, NULL);
+	return ret == 1;
+}
+
 
 /**
  * Initializes an instance of Elektra for the application '/tests/script/gen/highlevel/notype'.
@@ -88,6 +103,13 @@ int loadConfiguration (Elektra ** elektra, ElektraError ** error)
 
 	if (e == NULL)
 	{
+		*elektra = NULL;
+		if (isHelpMode ())
+		{
+			elektraErrorReset (error);
+			return 1;
+		}
+
 		return -1;
 	}
 
@@ -141,6 +163,12 @@ void exitForSpecload (int argc, const char ** argv)
  */// 
 void printHelpMessage (Elektra * elektra, const char * usage, const char * prefix)
 {
+	if (elektra == NULL)
+	{
+		printf ("%s", helpFallback);
+		return;
+	}
+
 	Key * helpKey = elektraHelpKey (elektra);
 	if (helpKey == NULL)
 	{

--- a/tests/shell/gen/highlevel/notype.expected.c
+++ b/tests/shell/gen/highlevel/notype.expected.c
@@ -73,8 +73,9 @@ int loadConfiguration (Elektra ** elektra, ElektraError ** error)
 	KeySet * defaults = embeddedSpec ();
 	
 
-	KeySet * contract = ksNew (1,
+	KeySet * contract = ksNew (2,
 	keyNew ("system/elektra/ensure/plugins/global/gopts", KEY_VALUE, "mounted", KEY_END),
+	keyNew ("system/elektra/highlevel/helpmode/ignore/require", KEY_VALUE, "1", KEY_END),
 	KS_END);
 ;
 

--- a/tests/shell/gen/highlevel/simple.data.ini
+++ b/tests/shell/gen/highlevel/simple.data.ini
@@ -2,8 +2,12 @@
 mountpoint=tests_gen_elektra_simple.ini
 
 [print]
+description = "enable/disable printing"
 type = boolean
 default = 0
+opt = p
+opt/arg = none
+opt/help = "enable printing"
 
 [mystring]
 type = string

--- a/tests/shell/gen/highlevel/simple.expected.c
+++ b/tests/shell/gen/highlevel/simple.expected.c
@@ -77,8 +77,9 @@ int loadConfiguration (Elektra ** elektra, ElektraError ** error)
 	KeySet * defaults = embeddedSpec ();
 	
 
-	KeySet * contract = ksNew (1,
+	KeySet * contract = ksNew (2,
 	keyNew ("system/elektra/ensure/plugins/global/gopts", KEY_VALUE, "mounted", KEY_END),
+	keyNew ("system/elektra/highlevel/helpmode/ignore/require", KEY_VALUE, "1", KEY_END),
 	KS_END);
 ;
 

--- a/tests/shell/gen/highlevel/struct.expected.c
+++ b/tests/shell/gen/highlevel/struct.expected.c
@@ -86,8 +86,9 @@ int loadConfiguration (Elektra ** elektra, ElektraError ** error)
 	KeySet * defaults = embeddedSpec ();
 	
 
-	KeySet * contract = ksNew (1,
+	KeySet * contract = ksNew (2,
 	keyNew ("system/elektra/ensure/plugins/global/gopts", KEY_VALUE, "mounted", KEY_END),
+	keyNew ("system/elektra/highlevel/helpmode/ignore/require", KEY_VALUE, "1", KEY_END),
 	KS_END);
 ;
 

--- a/tests/shell/gen/highlevel/struct.expected.c
+++ b/tests/shell/gen/highlevel/struct.expected.c
@@ -60,6 +60,21 @@ static KeySet * embeddedSpec (void)
 ;
 }
 
+static const char * helpFallback = "Usage: tests_script_gen_highlevel_struct\n";
+
+static int isHelpMode (void)
+{
+	ElektraInvokeHandle * gopts = elektraInvokeOpen ("gopts", NULL, NULL);
+
+	typedef int (*func) (void);
+	func goptsIsHelpMode = *(func *) elektraInvokeGetFunction (gopts, "ishelpmode");
+	
+	int ret = goptsIsHelpMode ();
+
+	elektraInvokeClose (gopts, NULL);
+	return ret == 1;
+}
+
 
 /**
  * Initializes an instance of Elektra for the application '/tests/script/gen/highlevel/struct'.
@@ -101,6 +116,13 @@ int loadConfiguration (Elektra ** elektra, ElektraError ** error)
 
 	if (e == NULL)
 	{
+		*elektra = NULL;
+		if (isHelpMode ())
+		{
+			elektraErrorReset (error);
+			return 1;
+		}
+
 		return -1;
 	}
 
@@ -154,6 +176,12 @@ void exitForSpecload (int argc, const char ** argv)
  */// 
 void printHelpMessage (Elektra * elektra, const char * usage, const char * prefix)
 {
+	if (elektra == NULL)
+	{
+		printf ("%s", helpFallback);
+		return;
+	}
+
 	Key * helpKey = elektraHelpKey (elektra);
 	if (helpKey == NULL)
 	{


### PR DESCRIPTION
If the user starts an application that has required keys with `-h`/`--help`, it would result in an error and the help message wouldn't be printed. This changes that.

It also adds the regenerated man page that is missing from #2942 (should've been part of 
b18447e).

## Basics

- [x] Short descriptions should be in the release notes (added as entry in
      `doc/news/_preparation_next_release.md` which contains `_(my name)_`)
      **Please always add something to the the release notes.**
- [x] Longer descriptions should be in documentation or in design decisions.
- [x] Describe details of how you changed the code in commit messages
      (first line should have `module: short statement` syntax)
- [x] References to issues, e.g. `close #X`, should be in the commit messages.

## Checklist

- [x] I added unit tests for my code
- [x] I fixed all affected documentation
- [x] I added code comments, logging, and assertions as appropriate (see [Coding Guidelines](https://master.libelektra.org/doc/CODING.md))
- [x] I updated all meta data (e.g. README.md of plugins and [METADATA.ini](https://master.libelektra.org/doc/METADATA.ini))
- [x] I mentioned every code not directly written by me in [THIRD-PARTY-LICENSES](doc/THIRD-PARTY-LICENSES)

## Review

- [ ] Documentation is introductory, concise and good to read
- [ ] Examples are well chosen and understandable
- [ ] Code is conforming to [our Coding Guidelines](https://master.libelektra.org/doc/CODING.md)
- [ ] APIs are conforming to [our Design Guidelines](https://master.libelektra.org/doc/DESIGN.md)
- [ ] Code is consistent to [our Design Decisions](https://master.libelektra.org/doc/decisions)
