### PR TITLE
Plugins: Unify Name of Configuration Check Function

### DIFF
--- a/doc/man/man7/elektra-plugins.7
+++ b/doc/man/man7/elektra-plugins.7
@@ -36,7 +36,7 @@ All plugins implement the same interface:
 \fBkdbClose()\fR makes sure that plugins can finally free their own resources in \fBelektraPluginClose()\fR\.
 .
 .IP "\(bu" 4
-\fBkdbCheckConfig()\fR can be called manually to ensure a plugin is configured properly\.
+\fBkdbCheckConf()\fR can be called manually to ensure a plugin is configured properly\.
 .
 .IP "\(bu" 4
 \fBkdbGenConfig()\fR can be called to produce all valid configurations of a plugin\.

--- a/doc/news/_preparation_next_release.md
+++ b/doc/news/_preparation_next_release.md
@@ -48,7 +48,10 @@ that are generated via `kdb gen`. _(Klemens Böswirth)_
 
 The following section lists news about the [modules](https://www.libelektra.org/plugins/readme) we updated in this release.
 
+### General
+
 - We removed 9 obsolete or unfinished plugins: boolean cachefilter cpptype dini enum regexstore required simplespeclang struct. _(Markus Raab)_
+- We unified the name of the config check function of the plugins to `nameOfPluginCheckConf`. Before this update some plugins used the name `nameOfPluginCheckConfig` instead. _(René Schwaiger)_
 
 ### Camel
 

--- a/doc/tutorials/plugins.md
+++ b/doc/tutorials/plugins.md
@@ -417,7 +417,7 @@ int elektraLineCheckConf (Key * errorKey, KeySet * conf)
 The `elektraPluginCheckConf` function is exported via the plugin's contract. The following example demonstrates how to export the `checkconf` function (see section [Contract](#contract) for further details):
 
 ```c
-keyNew ("system/elektra/modules/" ELEKTRA_PLUGIN_NAME "/exports/checkconf", KEY_FUNC, elektraLineCheckConf, KEY_END),
+keyNew ("system/elektra/modules/" ELEKTRA_PLUGIN_NAME "/exports/checkconf", KEY_FUNC, elektraLineCheckConf, KEY_END);
 ```
 
 Within the `checkconf` function all of the plugin configuration values should be validated.

--- a/src/plugins/README.md
+++ b/src/plugins/README.md
@@ -33,7 +33,7 @@ All plugins implement the same interface:
   their chance for necessary cleanups.
 - `kdbClose()` makes sure that plugins can finally free their
   own resources in `elektraPluginClose()`.
-- `kdbCheckConfig()` can be called manually to ensure a plugin is
+- `kdbCheckConf()` can be called manually to ensure a plugin is
   configured properly.
 - `kdbGenConfig()` can be called to produce all valid configurations
   of a plugin.

--- a/src/plugins/c/c.c
+++ b/src/plugins/c/c.c
@@ -195,7 +195,7 @@ int elektraCGet (Plugin * handle ELEKTRA_UNUSED, KeySet * returned ELEKTRA_UNUSE
 					   keyNew ("system/elektra/modules/c/exports", KEY_END),
 					   keyNew ("system/elektra/modules/c/exports/get", KEY_FUNC, elektraCGet, KEY_END),
 					   keyNew ("system/elektra/modules/c/exports/set", KEY_FUNC, elektraCSet, KEY_END),
-					   keyNew ("system/elektra/modules/c/exports/checkconf", KEY_FUNC, elektraCCheckConfig, KEY_END),
+					   keyNew ("system/elektra/modules/c/exports/checkconf", KEY_FUNC, elektraCCheckConf, KEY_END),
 #include ELEKTRA_README
 					   keyNew ("system/elektra/modules/c/infos/version", KEY_VALUE, PLUGINVERSION, KEY_END), KS_END);
 		ksAppend (returned, contract);
@@ -224,7 +224,7 @@ int elektraCSet (Plugin * handle ELEKTRA_UNUSED, KeySet * returned ELEKTRA_UNUSE
 	return 1; // success
 }
 
-int elektraCCheckConfig (Key * errorKey ELEKTRA_UNUSED, KeySet * conf ELEKTRA_UNUSED)
+int elektraCCheckConf (Key * errorKey ELEKTRA_UNUSED, KeySet * conf ELEKTRA_UNUSED)
 {
 	// validate plugin configuration
 	// this function is optional

--- a/src/plugins/c/c.h
+++ b/src/plugins/c/c.h
@@ -18,7 +18,7 @@ int elektraCClose (Plugin * handle, Key * errorKey);
 int elektraCGet (Plugin * handle, KeySet * ks, Key * parentKey);
 int elektraCSet (Plugin * handle, KeySet * ks, Key * parentKey);
 int elektraCError (Plugin * handle, KeySet * ks, Key * parentKey);
-int elektraCCheckConfig (Key * errorKey, KeySet * conf);
+int elektraCCheckConf (Key * errorKey, KeySet * conf);
 
 Plugin * ELEKTRA_PLUGIN_EXPORT;
 

--- a/src/plugins/cpptemplate/cpptemplate.cpp
+++ b/src/plugins/cpptemplate/cpptemplate.cpp
@@ -38,7 +38,7 @@ CppKeySet getContract ()
 			  keyNew ("system/elektra/modules/cpptemplate/exports/get", KEY_FUNC, elektraCppTemplateGet, KEY_END),
 			  keyNew ("system/elektra/modules/cpptemplate/exports/set", KEY_FUNC, elektraCppTemplateSet, KEY_END),
 			  keyNew ("system/elektra/modules/cpptemplate/exports/error", KEY_FUNC, elektraCppTemplateError, KEY_END),
-			  keyNew ("system/elektra/modules/cpptemplate/exports/checkconf", KEY_FUNC, elektraCppTemplateCheckConfig, KEY_END),
+			  keyNew ("system/elektra/modules/cpptemplate/exports/checkconf", KEY_FUNC, elektraCppTemplateCheckConf, KEY_END),
 #include ELEKTRA_README
 			  keyNew ("system/elektra/modules/cpptemplate/infos/version", KEY_VALUE, PLUGINVERSION, KEY_END),
 			  KS_END };
@@ -110,7 +110,7 @@ int elektraCppTemplateError (Plugin * handle ELEKTRA_UNUSED, KeySet * returned E
 }
 
 /** @see elektraDocCheckConf */
-int elektraCppTemplateCheckConfig (Key * errorKey ELEKTRA_UNUSED, KeySet * conf ELEKTRA_UNUSED)
+int elektraCppTemplateCheckConf (Key * errorKey ELEKTRA_UNUSED, KeySet * conf ELEKTRA_UNUSED)
 {
 	return ELEKTRA_PLUGIN_STATUS_NO_UPDATE;
 }

--- a/src/plugins/cpptemplate/cpptemplate.hpp
+++ b/src/plugins/cpptemplate/cpptemplate.hpp
@@ -22,7 +22,7 @@ int elektraCppTemplateClose (Plugin * handle, Key * errorKey);
 int elektraCppTemplateGet (Plugin * handle, KeySet * returned, Key * parentKey);
 int elektraCppTemplateSet (Plugin * handle, KeySet * returned, Key * parentKey);
 int elektraCppTemplateError (Plugin * handle, KeySet * conf, Key * parentKey);
-int elektraCppTemplateCheckConfig (Key * errorKey, KeySet * conf);
+int elektraCppTemplateCheckConf (Key * errorKey, KeySet * conf);
 
 Plugin * ELEKTRA_PLUGIN_EXPORT;
 } // end extern "C"

--- a/src/plugins/multifile/multifile.c
+++ b/src/plugins/multifile/multifile.c
@@ -617,7 +617,7 @@ int elektraMultifileGet (Plugin * handle, KeySet * returned, Key * parentKey ELE
 			keyNew ("system/elektra/modules/multifile/exports/set", KEY_FUNC, elektraMultifileSet, KEY_END),
 			keyNew ("system/elektra/modules/multifile/exports/commit", KEY_FUNC, elektraMultifileCommit, KEY_END),
 			keyNew ("system/elektra/modules/multifile/exports/error", KEY_FUNC, elektraMultifileError, KEY_END),
-			keyNew ("system/elektra/modules/multifile/exports/checkconf", KEY_FUNC, elektraMultifileCheckConfig, KEY_END),
+			keyNew ("system/elektra/modules/multifile/exports/checkconf", KEY_FUNC, elektraMultifileCheckConf, KEY_END),
 			keyNew ("system/elektra/modules/multifile/exports/checkfile", KEY_FUNC, elektraMultifileCheckFile, KEY_END),
 
 #include ELEKTRA_README
@@ -924,7 +924,7 @@ int elektraMultifileCommit (Plugin * handle ELEKTRA_UNUSED, KeySet * returned EL
 	return elektraMultifileSet (handle, returned, parentKey);
 }
 
-int elektraMultifileCheckConfig (Key * errorKey ELEKTRA_UNUSED, KeySet * conf ELEKTRA_UNUSED)
+int elektraMultifileCheckConf (Key * errorKey ELEKTRA_UNUSED, KeySet * conf ELEKTRA_UNUSED)
 {
 	// validate plugin configuration
 	// this function is optional

--- a/src/plugins/multifile/multifile.h
+++ b/src/plugins/multifile/multifile.h
@@ -19,7 +19,7 @@ int elektraMultifileGet (Plugin * handle, KeySet * ks, Key * parentKey);
 int elektraMultifileSet (Plugin * handle, KeySet * ks, Key * parentKey);
 int elektraMultifileError (Plugin * handle, KeySet * ks, Key * parentKey);
 int elektraMultifileCommit (Plugin * handle, KeySet * ks, Key * parentKey);
-int elektraMultifileCheckConfig (Key * errorKey, KeySet * conf);
+int elektraMultifileCheckConf (Key * errorKey, KeySet * conf);
 
 Plugin * ELEKTRA_PLUGIN_EXPORT;
 

--- a/src/plugins/process/process.c
+++ b/src/plugins/process/process.c
@@ -188,7 +188,7 @@ int elektraProcessGet (Plugin * handle, KeySet * returned, Key * parentKey)
 			       keyNew ("system/elektra/modules/process/exports/get", KEY_FUNC, elektraProcessGet, KEY_END),
 			       keyNew ("system/elektra/modules/process/exports/set", KEY_FUNC, elektraProcessSet, KEY_END),
 			       keyNew ("system/elektra/modules/process/exports/error", KEY_FUNC, elektraProcessError, KEY_END),
-			       keyNew ("system/elektra/modules/process/exports/checkconf", KEY_FUNC, elektraProcessCheckConfig, KEY_END),
+			       keyNew ("system/elektra/modules/process/exports/checkconf", KEY_FUNC, elektraProcessCheckConf, KEY_END),
 #include ELEKTRA_README
 			       keyNew ("system/elektra/modules/process/infos/version", KEY_VALUE, PLUGINVERSION, KEY_END), KS_END);
 		ksAppend (returned, contract);
@@ -250,7 +250,7 @@ int elektraProcessError (Plugin * handle, KeySet * returned, Key * parentKey)
 	return ret;
 }
 
-int elektraProcessCheckConfig (Key * errorKey, KeySet * conf)
+int elektraProcessCheckConf (Key * errorKey, KeySet * conf)
 {
 	// We need the plugin key to know which plugin we should proxy
 	Key * pluginNameKey = ksLookupByName (conf, "/plugin", KDB_O_NONE);

--- a/src/plugins/process/process.h
+++ b/src/plugins/process/process.h
@@ -17,7 +17,7 @@ int elektraProcessClose (Plugin * handle, Key * errorKey);
 int elektraProcessGet (Plugin * handle, KeySet * ks, Key * parentKey);
 int elektraProcessSet (Plugin * handle, KeySet * ks, Key * parentKey);
 int elektraProcessError (Plugin * handle, KeySet * ks, Key * parentKey);
-int elektraProcessCheckConfig (Key * errorKey, KeySet * conf);
+int elektraProcessCheckConf (Key * errorKey, KeySet * conf);
 
 Plugin * ELEKTRA_PLUGIN_EXPORT;
 

--- a/src/plugins/reference/reference.h
+++ b/src/plugins/reference/reference.h
@@ -24,7 +24,7 @@ int elektraReferenceClose (Plugin * handle, Key * errorKey);
 int elektraReferenceGet (Plugin * handle, KeySet * ks, Key * parentKey);
 int elektraReferenceSet (Plugin * handle, KeySet * ks, Key * parentKey);
 int elektraReferenceError (Plugin * handle, KeySet * ks, Key * parentKey);
-int elektraReferenceCheckConfig (Key * errorKey, KeySet * conf);
+int elektraReferenceCheckConf (Key * errorKey, KeySet * conf);
 
 Plugin * ELEKTRA_PLUGIN_EXPORT;
 

--- a/src/plugins/specload/specload.c
+++ b/src/plugins/specload/specload.c
@@ -188,7 +188,7 @@ int elektraSpecloadGet (Plugin * handle, KeySet * returned, Key * parentKey)
 			       keyNew ("system/elektra/modules/specload/exports/close", KEY_FUNC, elektraSpecloadClose, KEY_END),
 			       keyNew ("system/elektra/modules/specload/exports/get", KEY_FUNC, elektraSpecloadGet, KEY_END),
 			       keyNew ("system/elektra/modules/specload/exports/set", KEY_FUNC, elektraSpecloadSet, KEY_END),
-			       keyNew ("system/elektra/modules/specload/exports/checkconf", KEY_FUNC, elektraSpecloadCheckConfig, KEY_END),
+			       keyNew ("system/elektra/modules/specload/exports/checkconf", KEY_FUNC, elektraSpecloadCheckConf, KEY_END),
 			       keyNew ("system/elektra/modules/specload/exports/sendspec", KEY_FUNC, elektraSpecloadSendSpec, KEY_END),
 #include ELEKTRA_README
 			       keyNew ("system/elektra/modules/specload/infos/version", KEY_VALUE, PLUGINVERSION, KEY_END), KS_END);
@@ -332,7 +332,7 @@ int elektraSpecloadSet (Plugin * handle, KeySet * returned, Key * parentKey)
 	return result;
 }
 
-int elektraSpecloadCheckConfig (Key * errorKey, KeySet * conf)
+int elektraSpecloadCheckConf (Key * errorKey, KeySet * conf)
 {
 	char * directFile;
 	char * app;

--- a/src/plugins/specload/specload.h
+++ b/src/plugins/specload/specload.h
@@ -26,7 +26,7 @@ int elektraSpecloadOpen (Plugin * handle, Key * errorKey);
 int elektraSpecloadClose (Plugin * handle, Key * errorKey);
 int elektraSpecloadGet (Plugin * handle, KeySet * ks, Key * parentKey);
 int elektraSpecloadSet (Plugin * handle, KeySet * ks, Key * parentKey);
-int elektraSpecloadCheckConfig (Key * errorKey, KeySet * conf);
+int elektraSpecloadCheckConf (Key * errorKey, KeySet * conf);
 
 int elektraSpecloadSendSpec (Plugin * handle, KeySet * spec, Key * parentKey);
 

--- a/src/plugins/specload/testmod_specload.c
+++ b/src/plugins/specload/testmod_specload.c
@@ -67,7 +67,7 @@ static void test_basics (bool directFile)
 		conf = ksNew (2, keyNew ("/app", KEY_VALUE, TESTAPP_PATH, KEY_END), KS_END);
 	}
 
-	succeed_if (elektraSpecloadCheckConfig (parentKey, conf) == ELEKTRA_PLUGIN_STATUS_NO_UPDATE,
+	succeed_if (elektraSpecloadCheckConf (parentKey, conf) == ELEKTRA_PLUGIN_STATUS_NO_UPDATE,
 		    "call to checkConfig was not successful");
 
 	PLUGIN_OPEN ("specload");
@@ -105,7 +105,7 @@ static void test_newfile (bool directFile)
 		conf = ksNew (2, keyNew ("/app", KEY_VALUE, TESTAPP_PATH, KEY_END), KS_END);
 	}
 
-	succeed_if (elektraSpecloadCheckConfig (parentKey, conf) == ELEKTRA_PLUGIN_STATUS_NO_UPDATE,
+	succeed_if (elektraSpecloadCheckConf (parentKey, conf) == ELEKTRA_PLUGIN_STATUS_NO_UPDATE,
 		    "call to checkConfig was not successful");
 
 	PLUGIN_OPEN ("specload");
@@ -143,7 +143,7 @@ static void test_add (bool directFile)
 		conf = ksNew (2, keyNew ("/app", KEY_VALUE, TESTAPP_PATH, KEY_END), KS_END);
 	}
 
-	succeed_if (elektraSpecloadCheckConfig (parentKey, conf) == ELEKTRA_PLUGIN_STATUS_NO_UPDATE,
+	succeed_if (elektraSpecloadCheckConf (parentKey, conf) == ELEKTRA_PLUGIN_STATUS_NO_UPDATE,
 		    "call to checkConfig was not successful");
 
 
@@ -218,7 +218,7 @@ static void test_edit (bool directFile)
 		conf = ksNew (2, keyNew ("/app", KEY_VALUE, TESTAPP_PATH, KEY_END), KS_END);
 	}
 
-	succeed_if (elektraSpecloadCheckConfig (parentKey, conf) == ELEKTRA_PLUGIN_STATUS_NO_UPDATE,
+	succeed_if (elektraSpecloadCheckConf (parentKey, conf) == ELEKTRA_PLUGIN_STATUS_NO_UPDATE,
 		    "call to checkConfig was not successful");
 
 
@@ -287,7 +287,7 @@ static void test_remove (bool directFile)
 		conf = ksNew (2, keyNew ("/app", KEY_VALUE, TESTAPP_PATH, KEY_END), KS_END);
 	}
 
-	succeed_if (elektraSpecloadCheckConfig (parentKey, conf) == ELEKTRA_PLUGIN_STATUS_NO_UPDATE,
+	succeed_if (elektraSpecloadCheckConf (parentKey, conf) == ELEKTRA_PLUGIN_STATUS_NO_UPDATE,
 		    "call to checkConfig was not successful");
 
 

--- a/src/plugins/template/template.c
+++ b/src/plugins/template/template.c
@@ -41,7 +41,7 @@ int elektraTemplateGet (Plugin * handle ELEKTRA_UNUSED, KeySet * returned, Key *
 			       keyNew ("system/elektra/modules/template/exports/set", KEY_FUNC, elektraTemplateSet, KEY_END),
 			       keyNew ("system/elektra/modules/template/exports/commit", KEY_FUNC, elektraTemplateCommit, KEY_END),
 			       keyNew ("system/elektra/modules/template/exports/error", KEY_FUNC, elektraTemplateError, KEY_END),
-			       keyNew ("system/elektra/modules/template/exports/checkconf", KEY_FUNC, elektraTemplateCheckConfig, KEY_END),
+			       keyNew ("system/elektra/modules/template/exports/checkconf", KEY_FUNC, elektraTemplateCheckConf, KEY_END),
 #include ELEKTRA_README
 			       keyNew ("system/elektra/modules/template/infos/version", KEY_VALUE, PLUGINVERSION, KEY_END), KS_END);
 		ksAppend (returned, contract);
@@ -78,7 +78,7 @@ int elektraTemplateCommit (Plugin * handle ELEKTRA_UNUSED, KeySet * returned ELE
 	return ELEKTRA_PLUGIN_STATUS_SUCCESS;
 }
 
-int elektraTemplateCheckConfig (Key * errorKey ELEKTRA_UNUSED, KeySet * conf ELEKTRA_UNUSED)
+int elektraTemplateCheckConf (Key * errorKey ELEKTRA_UNUSED, KeySet * conf ELEKTRA_UNUSED)
 {
 	// validate plugin configuration
 	// this function is optional

--- a/src/plugins/template/template.h
+++ b/src/plugins/template/template.h
@@ -19,7 +19,7 @@ int elektraTemplateGet (Plugin * handle, KeySet * ks, Key * parentKey);
 int elektraTemplateSet (Plugin * handle, KeySet * ks, Key * parentKey);
 int elektraTemplateError (Plugin * handle, KeySet * ks, Key * parentKey);
 int elektraTemplateCommit (Plugin * handle, KeySet * ks, Key * parentKey);
-int elektraTemplateCheckConfig (Key * errorKey, KeySet * conf);
+int elektraTemplateCheckConf (Key * errorKey, KeySet * conf);
 
 Plugin * ELEKTRA_PLUGIN_EXPORT;
 


### PR DESCRIPTION
May I ask why we now [use the name `checkConf`](https://github.com/ElektraInitiative/libelektra/commit/3478694d) instead of `checkConfig`? I liked the old name better, since I am usually not a fan of abbreviated names. It also looks like we still use the similar name `kdbGenConfig` in the [ReadMe of all plugins](https://github.com/ElektraInitiative/libelektra/blob/master/src/plugins/README.md#c-interface). Do we use this function anywhere? At least searching the code base for `GenConfig` did only show two occurrences of the string, one in the ReadMe of all plugins, and one in the man page generated from said ReadMe file.