### PR TITLE
Various documentation improvements

### DIFF
--- a/doc/CODING.md
+++ b/doc/CODING.md
@@ -113,8 +113,10 @@ Thus please use following techniques (in order of preference):
   - Use space after `,` of every function argument.
 
 The [reformat script](/scripts/dev/reformat-source) can ensure most code style rules,
-but it is obviously not capable of ensuring everything (e.g. naming conventions).
-So do not give this responsibility out of hands entirely.
+but it is obviously not capable of ensuring everything (e.g. naming
+conventions). So do not give this responsibility out of hands entirely. You
+can [use docker](/doc/tutorials/run_reformatting_script_with_docker.md) to
+ensure that you have the correct version of all our reformatting tools at hand.
 
 ### C Guidelines
 

--- a/doc/TESTING.md
+++ b/doc/TESTING.md
@@ -117,6 +117,11 @@ cd build
 After sourcing `run_dev_env`, you can directly execute `kdb` and other
 binaries built with Elektra (such as the examples).
 
+Pay attention that sourcing depends on the operating system or rather the
+shell. For example on standard FreeBSD 11.3 you have to execute `sh` in the
+root of the repository first. Then do _not_ use the `source` command but the
+point `.` as explained above.
+
 ## Recommended Environment
 
 The tests are designed to disable themselves if some necessary tools are

--- a/doc/TESTING.md
+++ b/doc/TESTING.md
@@ -321,7 +321,7 @@ To enable sanitize checks use `ENABLE_ASAN` via cmake.
 Then, to use ASAN, run `run_asan` in the build directory, which simply does:
 
 ```sh
-ASAN_OPTIONS=symbolize=1 ASAN_SYMBOLIZER_PATH=$(shell which llvm-symbolizer) make run_all
+ASAN_OPTIONS=symbolize=1 ASAN_SYMBOLIZER_PATH=$(which llvm-symbolizer) make run_all
 ```
 
 It could also happen that you need to preload ASAN library, e.g.:

--- a/doc/news/_preparation_next_release.md
+++ b/doc/news/_preparation_next_release.md
@@ -255,6 +255,8 @@ you up to date with the multi-language support provided by Elektra.
 - We updated links for the INI parsing library Nickel. _(René Schwaiger)_
 - We removed links to old and disabled Jenkins build jobs. _(René Schwaiger)_
 - The [compile instructions](../COMPILE.md) do not assume that you use `make` to build Elektra anymore. _(René Schwaiger)_
+- Add hints about reformatting with docker. _(Dominic Jäger)_
+- Add instructions about sourcing on FreeBSD. _(Dominic Jäger)_
 
 ## Tests
 

--- a/doc/tutorials/run_reformatting_script_with_docker.md
+++ b/doc/tutorials/run_reformatting_script_with_docker.md
@@ -35,6 +35,7 @@ The build process depends on your Internet connection speed and the overall perf
 5 minutes. Please be patient. Once you have built the image, you can reuse it multiple times.
 
 The image tag `buildelektra-sid` we suggested can be replaced by a name of your own choosing.
+Note that currently our `sid` image is the only one with all the necessary tools installed.
 
 ### 2. Run the Docker Container
 


### PR DESCRIPTION
FreeBSD has `csh` as default shell. The syntax of `run_dev_env` is invalid in `csh`. 

```csh
source ../scripts/run_dev_env
# if: Expression Syntax.
echo $?
#1
```

@d3nwp I added you as reviewer as you were mentioned in #3067.