### PR TITLE
Kdb plugin list doc

### DIFF
--- a/doc/help/kdb-plugin-list.md
+++ b/doc/help/kdb-plugin-list.md
@@ -9,8 +9,8 @@
 This command will either list all available Elektra plugins
 or all plugins that provide a specific functionality.
 
-The output will be sorted by their status.
-The best plugins will be the last in the list.
+The output will be sorted alphabetically unless option `-v` is passed.
+With option `-v` the output will be sorted by their status, the best plugins will be the last in the list.
 
 ## OPTIONS
 
@@ -23,8 +23,8 @@ The best plugins will be the last in the list.
 - `-C`, `--color <when>`:
   Print never/auto(default)/always colored output.
 - `-v`, `--verbose`:
-  Also output the number calculated by their
-  `infos/status` clause in the contract. Prints additional information in case of errors/warnings.
+  Also output the number calculated by their `infos/status` clause in the contract.
+  Sorts the output ascending by the calculated status. Prints additional information in case of errors/warnings.
 - `-d`, `--debug`:
   Give debug information. Prints additional debug information in case of errors/warnings.
 - `-0`, `--null`:

--- a/doc/news/_preparation_next_release.md
+++ b/doc/news/_preparation_next_release.md
@@ -217,6 +217,7 @@ you up to date with the multi-language support provided by Elektra.
   - `kdb setmeta` is now `kdb meta-set` _(Philipp Gackstatter)_
 - Fix test tool `gen-gpg-testkey` by giving a narrower GPG key description. Fixes mismatches with existing GPG keys that contain "elektra.org" as e-mail address. _(Peter Nirschl)_
 - `kdb list-commands` and `kdb plugins-list` now sort their output in an alphabetical order _(Anton Hößl)_
+- `kdb plugin-list` does now mention in the helptext that with option `-v` the output is sorted by the plugin status _(Anton Hößl)_
 - <<TODO>>
 
 ## Scripts

--- a/src/tools/kdb/pluginlist.cpp
+++ b/src/tools/kdb/pluginlist.cpp
@@ -82,7 +82,11 @@ int PluginListCommand::execute (Cmdline const & cl)
 		sortedPlugins.push_back (elem);
 	}
 
-	std::sort (sortedPlugins.begin (), sortedPlugins.end ());
+	// keep order by status when output verbose is choosen
+	if (!cl.verbose)
+	{
+		std::sort (sortedPlugins.begin (), sortedPlugins.end ());
+	}
 
 	for (auto & elem : sortedPlugins)
 	{

--- a/src/tools/kdb/pluginlist.hpp
+++ b/src/tools/kdb/pluginlist.hpp
@@ -35,7 +35,8 @@ public:
 
 	virtual std::string getLongHelpText () override
 	{
-		return "";
+		return "With -v the output will be sorted by the status of the plugin.\n"
+		       "The number is calculated by their infos/status clause in the contract.\n";
 	}
 
 	virtual int execute (Cmdline const & cmdline) override;


### PR DESCRIPTION
## Basics

These points need to be fulfilled for every PR:

- [x] Short descriptions of your changes are in the release notes
      (added as entry in `doc/news/_preparation_next_release.md` which
      contains `_(my name)_`)
      **Please always add something to the release notes.**
- [x] Details of what you changed are in commit messages
      (first line should have `module: short statement` syntax)
- [ ] References to issues, e.g. `close #X`, are in the commit messages.
- [ ] The buildservers are happy.
- [x] The PR is rebased with current master.

If you have any troubles fulfilling these criteria, please write
about the trouble as comment in the PR. We will help you.
But we cannot accept PRs that do not fulfill the basics.

## Checklist

Check relevant points but **please do not remove entries**.
For docu fixes, spell checking, and similar none of these points below
need to be checked.

- [ ] I added unit tests for my code
- [ ] I fully described what my PR does in the documentation
      (not in the PR description)
- [x] I fixed all affected documentation
- [x] I added code comments, logging, and assertions as appropriate (see [Coding Guidelines](https://master.libelektra.org/doc/CODING.md))
- [ ] I updated all meta data (e.g. README.md of plugins and [METADATA.ini](https://master.libelektra.org/doc/METADATA.ini))
- [ ] I mentioned every code not directly written by me in [THIRD-PARTY-LICENSES](doc/THIRD-PARTY-LICENSES)

## Review

Reviewers will usually check the following:

- [ ] Documentation is introductory, concise, good to read and describes everything what the PR does
- [ ] Examples are well chosen and understandable
- [ ] Code is conforming to [our Coding Guidelines](https://master.libelektra.org/doc/CODING.md)
- [ ] APIs are conforming to [our Design Guidelines](https://master.libelektra.org/doc/DESIGN.md)
- [ ] Code is consistent to [our Design Decisions](https://master.libelektra.org/doc/decisions)

## Labels

If you are already Elektra developer:

- Add the "work in progress" label if you do not want the PR to be reviewed yet.
- Add the "ready to merge" label **if the basics are fulfilled** and you also
  say that everything is ready to be merged.


This pr deals with issue #3109.
The output of the command `kdb plugin-list -v` is now sorted ascending by the status of the plugins. This behavior now documented in the command helptext.

@markus2330 please review my pull request.
