### PR TITLE
SWIG performance

### DIFF
--- a/doc/news/_preparation_next_release.md
+++ b/doc/news/_preparation_next_release.md
@@ -187,6 +187,7 @@ you up to date with the multi-language support provided by Elektra.
 
 - Warnings about cmake policies are avoided. _(Markus Raab)_
 - We removed the Haskell and GI bindings. _(Markus Raab)_
+- Avoid unnecessary copying std::string where possible (setString and setMeta only). _(Manuel Mausz)_
 
 ### Java
 

--- a/src/bindings/cpp/include/key.hpp
+++ b/src/bindings/cpp/include/key.hpp
@@ -175,6 +175,7 @@ public:
 	inline void set (T x);
 
 	inline std::string getString () const;
+	inline void setString (const char * newString);
 	inline void setString (const std::string & newString);
 	inline ssize_t getStringSize () const;
 
@@ -1205,9 +1206,14 @@ inline void Key::setCallback (callback_t fct)
 /**
  * @copydoc keySetString
  */
+inline void Key::setString (const char * newString)
+{
+	ckdb::keySetString (getKey (), newString);
+}
+
 inline void Key::setString (const std::string & newString)
 {
-	ckdb::keySetString (getKey (), newString.c_str ());
+	setString (newString.c_str ());
 }
 
 /**

--- a/src/bindings/cpp/include/key.hpp
+++ b/src/bindings/cpp/include/key.hpp
@@ -175,7 +175,7 @@ public:
 	inline void set (T x);
 
 	inline std::string getString () const;
-	inline void setString (std::string newString);
+	inline void setString (const std::string & newString);
 	inline ssize_t getStringSize () const;
 
 	typedef void (*func_t) ();
@@ -1205,7 +1205,7 @@ inline void Key::setCallback (callback_t fct)
 /**
  * @copydoc keySetString
  */
-inline void Key::setString (std::string newString)
+inline void Key::setString (const std::string & newString)
 {
 	ckdb::keySetString (getKey (), newString.c_str ());
 }

--- a/src/bindings/swig/common.i
+++ b/src/bindings/swig/common.i
@@ -91,6 +91,9 @@
 %ignore kdb::Key::Key (const std::string keyName, ...);
 %ignore kdb::Key::Key (const char *keyName, va_list ap);
 
+// ignore functions we also provide char* signatures
+%ignore kdb::Key::setString(const std::string&);
+
 // reference handling
 %ignore kdb::Key::operator++(int) const;
 %ignore kdb::Key::operator--(int) const;

--- a/src/bindings/swig/lua/kdb.i
+++ b/src/bindings/swig/lua/kdb.i
@@ -347,7 +347,7 @@
 
 // metadata
 %template(_getMeta) kdb::Key::getMeta<const kdb::Key>;
-%template(setMeta) kdb::Key::setMeta<std::string>;
+%template(setMeta) kdb::Key::setMeta<const char *>;
 
 // clear exception handler
 %exception;

--- a/src/bindings/swig/python/kdb.i
+++ b/src/bindings/swig/python/kdb.i
@@ -206,7 +206,7 @@
 
 // metadata
 %template(_getMeta) kdb::Key::getMeta<const kdb::Key>;
-%template(_setMeta) kdb::Key::setMeta<std::string>;
+%template(_setMeta) kdb::Key::setMeta<const char *>;
 
 // clear exception handler
 %exception;


### PR DESCRIPTION
Hi Markus,

as requested I've looked into this in more detail. The first commit fixes one of the extra copies. Fixing the other was only possible by providing a `char *`-alternative (making the first commit actually unnecessary). As all SWIG wrapped languages operate on char pointers wrapping a function with `std::string` always adds an extra copy.

Can you please assign (+ping if already assigned) issues you want me to fix. Thanks