### PR TITLE
gopts: increase test timeout

### DIFF
--- a/doc/news/_preparation_next_release.md
+++ b/doc/news/_preparation_next_release.md
@@ -81,6 +81,7 @@ plugins. _(René Schwaiger)_
 - A better error, if the plugin fails to load `argv` from the system, was added. _(Klemens Böswirth)_
 - A function to detect help mode, without invoking `elektraGetOpts` was added. It simply checks, whether `--help` is one
   of the string in `argv`. _(Klemens Böswirth)_
+- Increase test timeout from 120s to 240s. _(Mihael Pranjić)_
 
 ### Path
 

--- a/src/plugins/gopts/CMakeLists.txt
+++ b/src/plugins/gopts/CMakeLists.txt
@@ -46,7 +46,7 @@ if (gopts_source)
 		set (TESTAPP_PATH "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/elektra-gopts-testapp")
 		configure_file ("${CMAKE_CURRENT_SOURCE_DIR}/config.c.in" "${CMAKE_CURRENT_BINARY_DIR}/config.c" @ONLY)
 
-		add_plugintest (gopts INCLUDE_DIRECTORIES ${CMAKE_CURRENT_BINARY_DIR} TIMEOUT 120)
+		add_plugintest (gopts INCLUDE_DIRECTORIES ${CMAKE_CURRENT_BINARY_DIR} TIMEOUT 240)
 
 		if (BUILD_SHARED)
 			add_dependencies (elektra-gopts-testapp elektra-gopts)


### PR DESCRIPTION
Closes #3148.

Try to increase gopts timeout due to slow valgrind tests (#3148).