### PR TITLE
Close 2925: Add merge driver for release notes

### DIFF
--- a/doc/news/.gitattributes
+++ b/doc/news/.gitattributes
@@ -1,0 +1,1 @@
+_preparation_next_release.md merge=union

--- a/doc/news/_preparation_next_release.md
+++ b/doc/news/_preparation_next_release.md
@@ -320,6 +320,7 @@ you up to date with the multi-language support provided by Elektra.
 - Improved various error messages and synchronized documentations. _(Michael Zronek)_
 - Improved `range` plugin error message. _(Michael Zronek)_
 - Improved error codes documentation to clarify the hierarchy for developers. _(Michael Zronek)_
+- Release notes now use git's union merge driver. _(Dominic Jäger)_
 
 ## Infrastructure
 


### PR DESCRIPTION
This solves #2925.

The following code snippets are from my test. The first one still produced a merge conflict while the second one (which is based on this branch) did not.

```zsh
10086* gco -b anton
10087* echo "anton" > _preparation_next_release_test.md
10088* git add _preparation_next_release_test.md
10089* git commit -m "test"
10090* gcm
10091* gco -b berta
10092* echo "berta" > _preparation_next_release_test.md
10093* git add _preparation_next_release_test.md
10094* git commit -m "test"
10095* git merge anton
```

```zsh
10119* gco mergeDriver
10120* gco -b anton2
10121* echo "anton" > _preparation_next_release_test.md
10122* git add _preparation_next_release_test.md
10123* git commit -m "test"
10124* gco mergeDriver
10125* gco -b berta2
10126* echo "berta" > _preparation_next_release_test.md
10127* git add _preparation_next_release_test.md
10128* git commit -m "test"
10129* git merge anton
10130* cat _preparation_next_release_test.md
```