### PR TITLE
Whitelist antlr4 website

### DIFF
--- a/tests/linkchecker.whitelist
+++ b/tests/linkchecker.whitelist
@@ -17,3 +17,4 @@ http://standards.freedesktop.org/basedir-spec/basedir-spec-0.8.html
 http://standards.freedesktop.org/basedir-spec/basedir-spec-latest.html
 https://freedesktop.org
 https://www.freedesktop.org/wiki/Software/pkg-config
+https://repology.org/metapackage/antlr4


### PR DESCRIPTION
The website responds with 404 on this link (at least there is some 404 in my network traffic when clicking it).