### PR TITLE
Generate kconfig plugin and implement the get method

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Elektra
 
 [![Release](https://img.shields.io/github/release/ElektraInitiative/libelektra.svg)](https://github.com/ElektraInitiative/libelektra/releases/latest)
-[![Jenkins Build Status](https://img.shields.io/jenkins/t/https/build.libelektra.org/jenkins/job/libelektra/job/master.svg)](https://build.libelektra.org/jenkins/job/libelektra/job/master/lastBuild)
+[![Jenkins Build Status](https://img.shields.io/jenkins/t/https/build.libelektra.org/job/libelektra/job/master.svg)](https://build.libelektra.org/job/libelektra/job/master/lastBuild)
 [![Travis Build Status](https://travis-ci.org/ElektraInitiative/libelektra.svg?branch=master)](https://travis-ci.org/ElektraInitiative/libelektra)
 [![Cirrus Build Status](https://api.cirrus-ci.com/github/ElektraInitiative/libelektra.svg)](https://cirrus-ci.com/github/ElektraInitiative/libelektra)
 [![Coverage Status](https://img.shields.io/coveralls/github/ElektraInitiative/libelektra.svg)](https://coveralls.io/github/ElektraInitiative/libelektra)

--- a/doc/AUTHORS.md
+++ b/doc/AUTHORS.md
@@ -203,3 +203,11 @@ development of the highlevel API and code-generation; various other things
 - email: k.boeswirth+git@gmail.com
 - github user: [kodebach](https://github.com/kodebach)
 - devel/test on: Fedora
+
+## Dardan Haxhimustafa
+
+development of KConfig plugin and changes on qt-gui
+
+- email: mail@dardan.im
+- github user: [darddan](https://github.com/darddan)
+- devel/test on: Arch Linux

--- a/doc/BUILDSERVER.md
+++ b/doc/BUILDSERVER.md
@@ -48,14 +48,14 @@ Currently Elektra uses two different files.
 #### Jenkinsfile.daily
 
 - [Jenkinsfile.daily](/scripts/jenkins/Jenkinsfile.daily) contains daily maintenance tasks, like cleaning up build servers.
-- [Buildjob: libelektra-daily](https://build.libelektra.org/jenkins/job/libelektra-daily/)
+- [Buildjob: libelektra-daily](https://build.libelektra.org/job/libelektra-daily/)
 - [Jenkinsfile.daily](https://master.libelektra.org/scripts/jenkins/Jenkinsfile.daily)
 
 #### Jenkinsfile
 
 - Triggered on code changes and is for testing changes to the codebase.
 - [Jenkinsfile](/scripts/jenkins/Jenkinsfile) contains descriptions how to build, test and deploy Elektra.
-- [Buildjob: libelektra](https://build.libelektra.org/jenkins/job/libelektra/)
+- [Buildjob: libelektra](https://build.libelektra.org/job/libelektra/)
 - [Jenkinsfile](https://master.libelektra.org/scripts/jenkins/Jenkinsfile)
 
 #### DSL
@@ -68,7 +68,7 @@ is executed in a sandbox which might block certain calls.
 Since plugins might extend the pool of available commands or variables a full
 list of currently available syntax can be seen in
 [pipeline
-syntax](https://build.libelektra.org/jenkins/job/libelektra/pipeline-syntax/)
+syntax](https://build.libelektra.org/job/libelektra/pipeline-syntax/)
 after a login to the build server.
 Some functionality is not covered by this page when the responsible plugin is
 not implementing it.
@@ -185,7 +185,7 @@ verified or added to build Elektra correctly:
 - `Advanced clone behaviors` should be added and the path to the git mirror
   needs to be specified: `/home/jenkins/git_mirrors/libelektra`.
   This reference repository is created and maintained by our
-  [daily buildjob](https://build.libelektra.org/jenkins/job/libelektra-daily/).
+  [daily buildjob](https://build.libelektra.org/job/libelektra-daily/).
 - Under Property strategy you can add `Trigger build on pull request comment`.
   `jenkins build (libelektra|all) please` is a good starting point.
   This functionality is provided by the
@@ -223,8 +223,8 @@ To reliable determine which stages failed it is best to look over the build
 results in the Jenkins Blue Ocean view.
 It is the default View opened when accessing the build results from GitHub.
 For libelektra the URLs are
-https://build.libelektra.org/jenkins/job/libelektra/ and
-https://build.libelektra.org/jenkins/blue/organizations/jenkins/libelektra/branches/
+https://build.libelektra.org/job/libelektra/ and
+https://build.libelektra.org/blue/organizations/jenkins/libelektra/branches/
 .
 
 Failed stages are marked in red.
@@ -280,7 +280,7 @@ sure to test any modifications locally first.
 
 All Triggers are described in the configuration of the respective build jobs.
 
-The [libelektra](https://build.libelektra.org/jenkins/job/libelektra/)
+The [libelektra](https://build.libelektra.org/job/libelektra/)
 build is triggered for all branches of the libelektra repository except for
 `debian`.
 Additionally all open branches in forks targeting libelektra's repository via
@@ -288,16 +288,15 @@ PRs are going to be build.
 Pushes to any of those branches will trigger a new build automatically.
 
 The
-[daily build](https://build.libelektra.org/jenkins/job/libelektra-daily/)
+[daily build](https://build.libelektra.org/job/libelektra-daily/)
 is executed according to a cron schedule.
 
 The following phrases can be used as comments to manually trigger a specific
 build:
 
-- jenkins build [libelektra](https://build.libelektra.org/jenkins/job/libelektra/) please
-- jenkins build [website](https://build.libelektra.org/job/elektra-website/) please
-- jenkins build [daily](https://build.libelektra.org/jenkins/job/libelektra-daily/) please
-- jenkins build [monthly](https://build.libelektra.org/jenkins/job/libelektra-monthly/) please
+- jenkins build [libelektra](https://build.libelektra.org/job/libelektra/) please
+- jenkins build [daily](https://build.libelektra.org/job/libelektra-daily/) please
+- jenkins build [monthly](https://build.libelektra.org/job/libelektra-monthly/) please
 
 Additionally `jenkins build all please` can be used to trigger all build jobs
 relevant for PR's.

--- a/doc/man/man7/elektra-plugins.7
+++ b/doc/man/man7/elektra-plugins.7
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "ELEKTRA\-PLUGINS" "7" "October 2019" "" ""
+.TH "ELEKTRA\-PLUGINS" "7" "November 2019" "" ""
 .
 .SH "NAME"
 \fBelektra\-plugins\fR \- plugins overview
@@ -123,6 +123,9 @@ augeas \fIaugeas/\fR reads/writes many different configuration files using the a
 .
 .IP "\(bu" 4
 hosts \fIhosts/\fR reads/writes hosts files
+.
+.IP "\(bu" 4
+kconfig \fIkconfig/\fR reads/writes KConfig ini files
 .
 .IP "\(bu" 4
 line \fIline/\fR reads/writes any file line by line

--- a/doc/news/2014-07-28_0.8.7.md
+++ b/doc/news/2014-07-28_0.8.7.md
@@ -16,8 +16,7 @@ The GSoC efforts have their first large contribution to Elektra, the 3
 way merge finally arrives with this release. It is still a long way to
 go, however, because augeas plugins can only be mounted with a
 workaround and the package integration of the 3-way merge is still in
-its infancy. More information about GSoC and its progress can be found
-[here](http://community.libelektra.org/wp).
+its infancy.
 
 A special thanks to Felix Berlakovich for his contributions to the
 3-way merge, including meta merging, conflict resolving strategies and

--- a/doc/news/2016-06-14_0.8.17.md
+++ b/doc/news/2016-06-14_0.8.17.md
@@ -115,10 +115,7 @@ issues and setting up travis:
 Now (nearly) every build job can be triggered from Pull Requests.
 For example:
 
-- jenkins build [git-buildpackage-jessie](https://build.libelektra.org/job/elektra-git-buildpackage-jessie/) please
-- jenkins build [git-buildpackage-wheezy](https://build.libelektra.org/job/elektra-git-buildpackage-wheezy/) please
-- jenkins build [icc](https://build.libelektra.org/job/elektra-icc/) please
-- jenkins build [local-installation](https://build.libelektra.org/job/elektra-local-installation/) please
+- jenkins build [libelektra](https://build.libelektra.org/job/libelektra/) please
 
 For a full list see [here](https://github.com/elektrainitiative/libelektra/tree/master/doc/GIT.md).
 

--- a/doc/news/_preparation_next_release.md
+++ b/doc/news/_preparation_next_release.md
@@ -91,6 +91,7 @@ plugins. _(René Schwaiger)_
 - We now store the OPMPHM inside of the mmap format. _(Mihael Pranjić)_
 - The storage format was changed and many sanity checks were improved or added. _(Mihael Pranjić)_
 - Enforce consistency by writing the magic file footer last. _(Mihael Pranjić)_
+- Filter empty meta KeySets to save space. _(Mihael Pranjić)_
 
 ### Noresolver
 

--- a/doc/news/_preparation_next_release.md
+++ b/doc/news/_preparation_next_release.md
@@ -86,6 +86,10 @@ plugins. _(René Schwaiger)_
   of the string in `argv`. _(Klemens Böswirth)_
 - Increase test timeout from 120s to 240s. _(Mihael Pranjić)_
 
+### KConfig
+
+- We added a plugin which can be used to parse kconfig ini files into a keyset and save keysets to such files. _(Dardan Haxhimustafa)_
+
 ### Mmapstorage
 
 - We now store the OPMPHM inside of the mmap format. _(Mihael Pranjić)_

--- a/doc/todo/API
+++ b/doc/todo/API
@@ -1,5 +1,5 @@
 On potential changes of the API/ABI as detected by
-[`elektra-icheck`](https://build.libelektra.org/jenkins/job/elektra-icheck),
+[`elektra-icheck`](https://build.libelektra.org/job/elektra-icheck),
 please check following list:
 
 - API is reviewed

--- a/scripts/jenkins/Jenkinsfile
+++ b/scripts/jenkins/Jenkinsfile
@@ -1,5 +1,5 @@
 // vim: ts=2:sw=2:expandtab:syntax=groovy
-/* https://build.libelektra.org/jenkins/job/elektra-jenkinsfile/
+/* https://build.libelektra.org/job/elektra-jenkinsfile/
  * This file describes how the elektra-jenkinsfile buildjob should be
  * executed.
  *
@@ -14,7 +14,7 @@
  * A Snippet generator is available to the public at
  * https://qa.nuxeo.org/jenkins/pipeline-syntax/.
  * A list of available commands on the build server can be found after a login at
- * https://build.libelektra.org/jenkins/job/elektra-jenkinsfile/pipeline-syntax/.
+ * https://build.libelektra.org/job/elektra-jenkinsfile/pipeline-syntax/.
  */
 
 // TODO have a per plugin/binding deps in Dockerfile for easier maintenance

--- a/scripts/jenkins/Jenkinsfile.daily
+++ b/scripts/jenkins/Jenkinsfile.daily
@@ -1,5 +1,5 @@
 // vim: ts=2:sw=2:expandtab:syntax=groovy
-/* https://build.libelektra.org/jenkins/job/elektra-jenkinsfile-daily/ */
+/* https://build.libelektra.org/job/elektra-jenkinsfile-daily/ */
 
 // Set properties for buildjob
 properties([

--- a/src/plugins/README.md
+++ b/src/plugins/README.md
@@ -87,6 +87,7 @@ Read (and write) standard config files:
 - [augeas](augeas/) reads/writes many different configuration
   files using the augeas library
 - [hosts](hosts/) reads/writes hosts files
+- [kconfig](kconfig/) reads/writes KConfig ini files
 - [line](line/) reads/writes any file line by line
 - [yajl](yajl/) reads/writes JSON.
 

--- a/src/plugins/cpptemplate/cpptemplate_delegate.cpp
+++ b/src/plugins/cpptemplate/cpptemplate_delegate.cpp
@@ -37,7 +37,7 @@ CppTemplateDelegate::CppTemplateDelegate (KeySet config)
  */
 kdb::KeySet CppTemplateDelegate::getConfig (Key const & parent)
 {
-	KeySet keys{ 0, KS_END };
+	KeySet keys;
 
 	for (auto configKey : configuration)
 	{

--- a/src/plugins/kconfig/CMakeLists.txt
+++ b/src/plugins/kconfig/CMakeLists.txt
@@ -1,9 +1,10 @@
 include (LibAddMacros)
 
+set (TEST_ARGUMENTS ADD_TEST CPP_TEST INSTALL_TEST_DATA)
+
 add_plugin (kconfig
 	    CPP
-	    ADD_TEST
-	    CPP_TEST
+	    ${TEST_ARGUMENTS}
 	    TEST_README
 	    SOURCES kconfig.hpp
 		    kconfig.cpp

--- a/src/plugins/kconfig/CMakeLists.txt
+++ b/src/plugins/kconfig/CMakeLists.txt
@@ -1,15 +1,14 @@
 include (LibAddMacros)
 
-add_plugin (
-	kconfig
-	CPP
-	ADD_TEST
-	CPP_TEST
-	TEST_README
-	SOURCES kconfig.hpp
-		kconfig.cpp
-		kconfig_delegate.hpp
-		kconfig_delegate.cpp
-		kconfig_parser.cpp
-		kconfig_parser_exception.cpp
-		file_utility.cpp)
+add_plugin (kconfig
+	    CPP
+	    ADD_TEST
+	    CPP_TEST
+	    TEST_README
+	    SOURCES kconfig.hpp
+		    kconfig.cpp
+		    kconfig_delegate.hpp
+		    kconfig_delegate.cpp
+		    kconfig_parser.cpp
+		    kconfig_parser_exception.cpp
+		    file_utility.cpp)

--- a/src/plugins/kconfig/CMakeLists.txt
+++ b/src/plugins/kconfig/CMakeLists.txt
@@ -1,0 +1,15 @@
+include (LibAddMacros)
+
+add_plugin (
+	kconfig
+	CPP
+	ADD_TEST
+	CPP_TEST
+	TEST_README
+	SOURCES kconfig.hpp
+		kconfig.cpp
+		kconfig_delegate.hpp
+		kconfig_delegate.cpp
+		kconfig_parser.cpp
+		kconfig_parser_exception.cpp
+		file_utility.cpp)

--- a/src/plugins/kconfig/CMakeLists.txt
+++ b/src/plugins/kconfig/CMakeLists.txt
@@ -1,10 +1,8 @@
-include (LibAddMacros)
-
-set (TEST_ARGUMENTS ADD_TEST CPP_TEST INSTALL_TEST_DATA)
-
 add_plugin (kconfig
 	    CPP
-	    ${TEST_ARGUMENTS}
+	    ADD_TEST
+	    CPP_TEST
+	    INSTALL_TEST_DATA
 	    TEST_README
 	    SOURCES kconfig.hpp
 		    kconfig.cpp

--- a/src/plugins/kconfig/README.md
+++ b/src/plugins/kconfig/README.md
@@ -21,7 +21,8 @@ Information about the syntax:
 - Can contain multiple keys with different locales (`keyName[en]` and `keyName[de]`)
 - Cannot contain multiple keys with different metadata (either `keyname[$a]` or `keyname[$b]`).
 - If a key `keyname[$metavalue]` is parsed, it will be represented as a Key with name `parent/keyname` and meta `kconfig` as `metavalue`
-- Group names begin have a `[` symbol at the beginning of a line and every key that follows them is part of this group (until the next group is declared)
+- Group names begin have a `[` symbol at the beginning of a line and every key that follows them is part of this group (until the next
+  group is declared)
 
 ## Usage
 

--- a/src/plugins/kconfig/README.md
+++ b/src/plugins/kconfig/README.md
@@ -1,0 +1,48 @@
+- infos = Information about the kconfig plugin is in keys below
+- infos/author = Dardan Haxhimustafa <mail@dardan.im>
+- infos/licence = BSD
+- infos/needs =
+- infos/provides = storage/kconfig
+- infos/recommends =
+- infos/placements = getstorage setstorage
+- infos/status = recommended maintained compatible specific experimental unfinished nodoc concept
+- infos/metadata =
+- infos/description = Reads and writes the KConfig ini format
+
+## Introduction
+
+This plugin can be used to parse a KConfig ini file into a KeySet and save a given KeySet to such a file.
+
+Information about the syntax:
+
+- Comments start with character `#`
+- Keys can contain spaces and special characters except from the main special characters (`[`, `]`, `=`, `#`and `$`)
+- If a key has values, then it will be followed with an `=` symbol and then the value will be read to the end of the line
+- Can contain multiple keys with different locales (`keyName[en]` and `keyName[de]`)
+- Cannot contain multiple keys with different metadata (either `keyname[$a]` or `keyname[$b]`).
+- If a key `keyname[$metavalue]` is parsed, it will be represented as a Key with name `parent/keyname` and meta `kconfig` as `metavalue`
+- Group names begin have a `[` symbol at the beginning of a line and every key that follows them is part of this group (until the next group is declared)
+
+## Usage
+
+The following example shows you how you can read and write data using this plugin.
+
+```sh
+# Mount the plugin to the cascading namespace `/tests/kconfig`
+sudo kdb mount configrc /tests/kconfig kconfig
+
+# Manually add a key-value pair to the database
+printf 'key=Value' > `kdb file /tests/kconfig`
+
+# Retrieve the new value
+kdb get /tests/kconfig/key
+#> Value
+
+# Undo modifications to the database
+sudo kdb umount /tests/kconfig
+```
+
+## Limitations
+
+- Comments from file are discarded on save (same as the default KConfig functionality)
+- No validation for meta values or locale codes

--- a/src/plugins/kconfig/README.md
+++ b/src/plugins/kconfig/README.md
@@ -7,37 +7,86 @@
 - infos/placements = getstorage setstorage
 - infos/status = recommended maintained compatible specific experimental unfinished nodoc concept
 - infos/metadata =
-- infos/description = Reads and writes the KConfig ini format
+- infos/description = Reads the KConfig INI format
 
 ## Introduction
 
-This plugin can be used to parse a KConfig ini file into a KeySet and save a given KeySet to such a file.
+This plugin can be used to parse a [KConfig](https://cgit.kde.org/kconfig.git) INI file into a KeySet.
 
 Information about the syntax:
 
-- Comments start with character `#`
-- Keys can contain spaces and special characters except from the main special characters (`[`, `]`, `=`, `#`and `$`)
-- If a key has values, then it will be followed with an `=` symbol and then the value will be read to the end of the line
-- Can contain multiple keys with different locales (`keyName[en]` and `keyName[de]`)
-- Cannot contain multiple keys with different metadata (either `keyname[$a]` or `keyname[$b]`).
+- Files are expected to be encoded in `UTF-8`.
+- Empty lines are ignored.
+- Lines that start with a `#` character are considered comments. Comments are ignored too.
+- Configurations consist of groups and keys. Only keys can have values.
+- Key names can't start with a `[` character
+- Keys can contain spaces and any special characters as long except `=`.
+- If a key has a value, then it will be followed with an `=` symbol and then the value will be read until the end of the line.
+  The white space characters around the `=` symbol are ignored.
+- In values, the following escape sequences can be used:
+  - `\n` and `r` are mapped to newline
+  - `\t` is mapped to tab
+  - `\\` is mapped to `\`
+- Values can contain any character from the `UTF-8` set except for newline and `\` followed by an invalid excape sequence.
+- Keys can be localized. The locale is surrounded with `[` and `]` and cannot contain start with `$`.
+- Same key name can be used multiple times if it has different locales. The following example is valid:
+  ```
+  greeting[en] = Hello
+  greeting[de] = Hallo
+  ```
+- Keys can have meta data. Those are one character (1 byte only) long, start with `$` and are surrounded with `[` and `]`.
+- Same key name can't be used multiple times with different metadata as in locales. The following example is invalid:
+  ```
+  key.name[$a] = Something
+  key.name[$i] = Something else
+  ```
 - If a key `keyname[$metavalue]` is parsed, it will be represented as a Key with name `parent/keyname` and meta `kconfig` as `metavalue`
 - Group names begin have a `[` symbol at the beginning of a line and every key that follows them is part of this group (until the next
   group is declared)
 
+An example of how a valid config file might look like:
+
+```
+[group][subgroup]
+key.name[en][$i][$e]=Key Value
+key.name[de]=Key Wert
+```
+
+And how it will be represented in kdb:
+
+```
+keyNew (PREFIX "group/subgroup/key.name[en]", KEY_VALUE, "Key Value", KEY_META, "kconfig", "ie", KEY_END)
+keyNew (PREFIX "group/subgroup/key.name[de]", KEY_VALUE, "Key Wert", KEY_END)
+```
+
 ## Usage
 
-The following example shows you how you can read and write data using this plugin.
+The following example shows you how you can read data using this plugin.
 
 ```sh
 # Mount the plugin to the cascading namespace `/tests/kconfig`
 sudo kdb mount configrc /tests/kconfig kconfig
 
 # Manually add a key-value pair to the database
-printf 'key=Value' > `kdb file /tests/kconfig`
+echo 'key=Value' > `kdb file /tests/kconfig`
 
 # Retrieve the new value
 kdb get /tests/kconfig/key
 #> Value
+
+# Manually add a gorup to the database
+echo '[group][subgroup]' >> `kdb file /tests/kconfig`
+
+# Manually add a key that contains metas to that group
+echo 'key.name[$a][$i]=New Value' >> `kdb file /tests/kconfig`
+
+# Retrieve the new value
+kdb get /tests/kconfig/group/subgroup/key.name
+#> New Value
+
+# Retrieve the meta values
+kdb meta-get /tests/kconfig/group/subgroup/key.name kconfig
+#> ai
 
 # Undo modifications to the database
 sudo kdb umount /tests/kconfig

--- a/src/plugins/kconfig/base.hpp
+++ b/src/plugins/kconfig/base.hpp
@@ -5,6 +5,7 @@
 
 static const char character_newline = '\n';
 static const char character_carriage_return = '\r';
+static const char character_escape = '\\';
 static const char character_equals_sign = '=';
 static const char character_dollar_sign = '$';
 static const char character_hash_sign = '#';

--- a/src/plugins/kconfig/base.hpp
+++ b/src/plugins/kconfig/base.hpp
@@ -1,0 +1,14 @@
+#ifndef ELEKTRA_BASE_HPP
+#define ELEKTRA_BASE_HPP
+
+#define KCONFIG_METADATA_KEY "kconfig"
+
+static const char character_newline = '\n';
+static const char character_carriage_return = '\r';
+static const char character_equals_sign = '=';
+static const char character_dollar_sign = '$';
+static const char character_hash_sign = '#';
+static const char character_open_bracket = '[';
+static const char character_close_bracket = ']';
+
+#endif // ELEKTRA_BASE_HPP

--- a/src/plugins/kconfig/file_utility.cpp
+++ b/src/plugins/kconfig/file_utility.cpp
@@ -125,13 +125,13 @@ void FileUtility::readUntilChar (std::ostream & str, const char & delimiter)
 	char c;
 	while (true)
 	{
-		if (isNextCharEOF ())
+		c = this->file->get ();
+
+		if (c == EOF && isNextCharEOF ())
 		{
 			break;
 		}
-
-		c = this->file->get ();
-		if (c == character_newline || c == character_carriage_return || c == delimiter)
+		else if (c == character_newline || c == character_carriage_return || c == delimiter)
 		{
 			this->file->putback (c);
 			break;
@@ -152,13 +152,12 @@ void FileUtility::readUntilChar (std::ostream & str, const char & delimiterA, co
 	char c;
 	while (true)
 	{
-		if (isNextCharEOF ())
+		c = this->file->get ();
+		if (c == EOF && isNextCharEOF ())
 		{
 			break;
 		}
-
-		c = this->file->get ();
-		if (c == character_newline || c == character_carriage_return || c == delimiterA || c == delimiterB)
+		else if (c == character_newline || c == character_carriage_return || c == delimiterA || c == delimiterB)
 		{
 			this->file->putback (c);
 			break;

--- a/src/plugins/kconfig/file_utility.cpp
+++ b/src/plugins/kconfig/file_utility.cpp
@@ -1,0 +1,157 @@
+#include "file_utility.hpp"
+#include "base.hpp"
+#include "kconfig_parser_exception.hpp"
+
+FileUtility::FileUtility (const std::string & filenameParam)
+: file{ filenameParam }, stringBuffer{}, currentLine{ 1 }, filename{ filenameParam }
+{
+	if (!(this->file).is_open ())
+	{
+		throw KConfigParserException (*this, "Could not open the file.");
+	}
+}
+
+char FileUtility::peekNextChar ()
+{
+	return (this->file).peek ();
+}
+
+bool FileUtility::isNextCharEOF ()
+{
+	return peekNextChar () == EOF;
+}
+
+bool FileUtility::isNextCharNewline ()
+{
+	char nextChar = peekNextChar ();
+	return nextChar == character_newline || nextChar == character_carriage_return;
+}
+
+bool FileUtility::isNextCharNewlineOrEOF ()
+{
+	return isNextCharNewline () || isNextCharEOF ();
+}
+
+bool FileUtility::isNextCharToken ()
+{
+	switch (peekNextChar ())
+	{
+	case character_dollar_sign:
+	case character_open_bracket:
+	case character_newline:
+	case character_carriage_return:
+	case character_equals_sign:
+	case character_hash_sign:
+	case character_close_bracket:
+	case EOF:
+		return true;
+	default:
+		return false;
+	}
+}
+
+void FileUtility::skipChar ()
+{
+	(this->file).get ();
+}
+
+void FileUtility::skipCharsIfBlank ()
+{
+	while (isblank (peekNextChar ()))
+	{
+		skipChar ();
+	}
+}
+
+void FileUtility::skipLine ()
+{
+	++currentLine;
+	while (true)
+	{
+		switch ((this->file).get ())
+		{
+		case character_newline:
+			return;
+		case character_carriage_return:
+			if (peekNextChar () == character_newline) skipChar ();
+			return;
+		case EOF:
+			// Not sure if the following line is needed
+			// (this->file).putback (EOF);
+			return;
+		}
+	}
+}
+
+void FileUtility::skipLineIfEmptyOrComment ()
+{
+	while (true)
+	{
+		switch ((this->file).peek ())
+		{
+		case character_newline:
+		case character_carriage_return:
+		case character_hash_sign:
+			skipLine ();
+			break;
+		default:
+			return;
+		}
+	}
+}
+
+void FileUtility::readUntilChar (std::ostream & str, const char & delimiter)
+{
+	char c;
+	while (true)
+	{
+		c = this->file.get ();
+		if (c == EOF || c == character_newline || c == character_carriage_return || c == delimiter)
+		{
+			this->file.putback (c);
+			break;
+		}
+		str << c;
+	}
+}
+
+void FileUtility::readUntilChar (std::ostream & str, const char & delimiterA, const char & delimiterB)
+{
+	char c;
+	while (true)
+	{
+		c = this->file.get ();
+		if (c == EOF || c == character_newline || c == character_carriage_return || c == delimiterA || c == delimiterB)
+		{
+			this->file.putback (c);
+			break;
+		}
+		str << c;
+	}
+}
+
+std::string FileUtility::getUntilChar (const char & delimiter)
+{
+	// Empty the stringBuffer before re-using it
+	(this->stringBuffer).str (std::string ());
+	readUntilChar (this->stringBuffer, delimiter);
+	return (this->stringBuffer).str ();
+}
+
+std::string FileUtility::getUntilChar (const char & delimiterA, const char & delimiterB)
+{
+	// Empty the stringBuffer before re-using it
+	(this->stringBuffer).str (std::string ());
+	readUntilChar (this->stringBuffer, delimiterA, delimiterB);
+	return (this->stringBuffer).str ();
+}
+
+int FileUtility::getCurrentLineNumber () const
+{
+	return currentLine;
+}
+
+std::string FileUtility::getFilename () const
+{
+	return filename;
+}

--- a/src/plugins/kconfig/file_utility.hpp
+++ b/src/plugins/kconfig/file_utility.hpp
@@ -35,28 +35,32 @@ public:
 	/**
 	 * @brief This method is used to check if the next character in the buffer is end of file
 	 *
-	 * @return true if the next character is end of file, false otherwise
+	 * @retval true if the next character is end of file
+	 * @retval false otherwise
 	 */
 	bool isNextCharEOF ();
 
 	/**
 	 * @brief This method is used to check if the next character in the buffer is a new line
 	 *
-	 * @return true if the next character is new line, false otherwise
+	 * @retval true if the next character is new line
+	 * @retval false otherwise
 	 */
 	bool isNextCharNewline ();
 
 	/**
 	 * @brief This method is used to check if the next character in the buffer is a new line or end of file
 	 *
-	 * @return true if the next character is new line or end of file, false otherwise
+	 * @retval true if the next character is new line or end of file
+	 * @retval false otherwise
 	 */
 	bool isNextCharNewlineOrEOF ();
 
 	/**
 	 * @brief This method is used to check if the next character in the buffer is any of special characters used to specify a token
 	 *
-	 * @return true if the next character is used to specify a token, false otherwise
+	 * @retval true if the next character is used to specify a token
+	 * @retval false otherwise
 	 */
 	bool isNextCharToken ();
 

--- a/src/plugins/kconfig/file_utility.hpp
+++ b/src/plugins/kconfig/file_utility.hpp
@@ -2,7 +2,6 @@
 #define ELEKTRA_FILEUTILITY_HPP
 
 #include "kconfig_parser_exception.hpp"
-#include <fstream>
 #include <ostream>
 #include <sstream>
 #include <string>
@@ -11,7 +10,7 @@ class FileUtility
 {
 private:
 	/* This file is the file stream that we want to parse  */
-	std::ifstream file;
+	std::istream& file;
 	/* This stringBuffer is used when reading strings from file so that we don't initialize a stringstream each time */
 	std::stringstream stringBuffer;
 	/* This int is used to save the current line number for the purpose of better error messages */
@@ -25,10 +24,10 @@ public:
 	 * file
 	 * @param filename This string contains the absolute/relative path to the file
 	 */
-	explicit FileUtility (const std::string & filenameParam);
+	explicit FileUtility (const std::string & filenameParam, std::istream &fileParam);
 
 	/**
-	 * \copydoc std::ifstream::peek()
+	 * \copydoc std::istream::peek()
 	 */
 	char peekNextChar ();
 
@@ -79,6 +78,8 @@ public:
 	 * @brief This method is used to skip empty lines or lines that start with a `#` character
 	 */
 	void skipLineIfEmptyOrComment ();
+
+	inline void readEscapedChar(std::ostream & str);
 
 	/**
 	 * @brief This method is used to read characters into a buffer until (exclusive) a given delimiter, new line or end of file

--- a/src/plugins/kconfig/file_utility.hpp
+++ b/src/plugins/kconfig/file_utility.hpp
@@ -1,0 +1,126 @@
+#ifndef ELEKTRA_FILEUTILITY_HPP
+#define ELEKTRA_FILEUTILITY_HPP
+
+#include "kconfig_parser_exception.hpp"
+#include <fstream>
+#include <ostream>
+#include <sstream>
+#include <string>
+
+class FileUtility
+{
+private:
+	/* This file is the file stream that we want to parse  */
+	std::ifstream file;
+	/* This stringBuffer is used when reading strings from file so that we don't initialize a stringstream each time */
+	std::stringstream stringBuffer;
+	/* This int is used to save the current line number for the purpose of better error messages */
+	int currentLine;
+	/* This string is used to save the filename for the purpose of better error messages */
+	std::string filename;
+
+public:
+	/**
+	 * @brief This constructor is used to abstract the file stream into the methods that are specific to parsing a kconfig configuration
+	 * file
+	 * @param filename This string contains the absolute/relative path to the file
+	 */
+	explicit FileUtility (const std::string & filenameParam);
+
+	/**
+	 * \copydoc std::ifstream::peek()
+	 */
+	char peekNextChar ();
+
+	/**
+	 * @brief This method is used to check if the next character in the buffer is end of file
+	 *
+	 * @return true if the next character is end of file, false otherwise
+	 */
+	bool isNextCharEOF ();
+
+	/**
+	 * @brief This method is used to check if the next character in the buffer is a new line
+	 *
+	 * @return true if the next character is new line, false otherwise
+	 */
+	bool isNextCharNewline ();
+
+	/**
+	 * @brief This method is used to check if the next character in the buffer is a new line or end of file
+	 *
+	 * @return true if the next character is new line or end of file, false otherwise
+	 */
+	bool isNextCharNewlineOrEOF ();
+
+	/**
+	 * @brief This method is used to check if the next character in the buffer is any of special characters used to specify a token
+	 *
+	 * @return true if the next character is used to specify a token, false otherwise
+	 */
+	bool isNextCharToken ();
+
+	/**
+	 * @brief This method is used to consume a character from the buffer
+	 */
+	void skipChar ();
+
+	/**
+	 * @brief This method is used to consume a character from the buffer only if it is a blank character
+	 */
+	void skipCharsIfBlank ();
+
+	/**
+	 * @brief This method is used to skip all characters until (inclusive) the new line character
+	 */
+	void skipLine ();
+
+	/**
+	 * @brief This method is used to skip empty lines or lines that start with a `#` character
+	 */
+	void skipLineIfEmptyOrComment ();
+
+	/**
+	 * @brief This method is used to read characters into a buffer until (exclusive) a given delimiter, new line or end of file
+	 * @param str This output stream is used to read the characters into it
+	 * @param delimiter This character is used to determine when to stop reading
+	 */
+	void readUntilChar (std::ostream & str, const char & delimiter);
+
+	/**
+	 * @brief This method is used to read characters into a buffer until (exclusive) any given delimiter, new line or end of file
+	 * @param str This output stream is used to read the characters into it
+	 * @param delimiterA This character is used to determine when to stop reading
+	 * @param delimiterB This character is used to determine when to stop reading
+	 */
+	void readUntilChar (std::ostream & str, const char & delimiterA, const char & delimiterB);
+
+	/**
+	 * @brief This method is used to read characters into a string until (exclusive) a given delimiter, new line or end of file
+	 * @param delimiter This character is used to determine when to stop reading
+	 * @return A string containing the characters that are read
+	 */
+	std::string getUntilChar (const char & delimiter);
+
+	/**
+	 * @brief This method is used to read characters into a string until (exclusive) any given delimiter, new line or end of file
+	 * @param delimiterA This character is used to determine when to stop reading
+	 * @param delimiterB This character is used to determine when to stop reading
+	 * @return A string containing the characters that are read
+	 */
+	std::string getUntilChar (const char & delimiterA, const char & delimiterB);
+
+	/**
+	 * @brief This method is used to get the current line number
+	 * @return An int containing the current line number
+	 */
+	int getCurrentLineNumber () const;
+
+	/**
+	 * @brief This method is used to get the file name
+	 * @return A string containing the file name
+	 */
+	std::string getFilename () const;
+};
+
+#endif // ELEKTRA_FILEUTILITY_HPP

--- a/src/plugins/kconfig/file_utility.hpp
+++ b/src/plugins/kconfig/file_utility.hpp
@@ -2,15 +2,16 @@
 #define ELEKTRA_FILEUTILITY_HPP
 
 #include "kconfig_parser_exception.hpp"
-#include <ostream>
+#include <memory>
 #include <sstream>
-#include <string>
 
+namespace kconfig
+{
 class FileUtility
 {
 private:
 	/* This file is the file stream that we want to parse  */
-	std::istream& file;
+	std::unique_ptr<std::istream> file;
 	/* This stringBuffer is used when reading strings from file so that we don't initialize a stringstream each time */
 	std::stringstream stringBuffer;
 	/* This int is used to save the current line number for the purpose of better error messages */
@@ -24,7 +25,7 @@ public:
 	 * file
 	 * @param filename This string contains the absolute/relative path to the file
 	 */
-	explicit FileUtility (const std::string & filenameParam, std::istream &fileParam);
+	explicit FileUtility (std::string filenameParam, std::unique_ptr<std::istream> fileParam);
 
 	/**
 	 * \copydoc std::istream::peek()
@@ -79,7 +80,7 @@ public:
 	 */
 	void skipLineIfEmptyOrComment ();
 
-	inline void readEscapedChar(std::ostream & str);
+	inline void readEscapedChar (std::ostream & str);
 
 	/**
 	 * @brief This method is used to read characters into a buffer until (exclusive) a given delimiter, new line or end of file
@@ -123,5 +124,6 @@ public:
 	 */
 	std::string getFilename () const;
 };
+}
 
 #endif // ELEKTRA_FILEUTILITY_HPP

--- a/src/plugins/kconfig/kconfig.cpp
+++ b/src/plugins/kconfig/kconfig.cpp
@@ -1,0 +1,131 @@
+/**
+ * @file
+ *
+ * @brief Source for kconfig plugin
+ *
+ * @copyright BSD License (see LICENSE.md or https://www.libelektra.org)
+ *
+ */
+
+#include "kconfig.hpp"
+#include "kconfig_delegate.hpp"
+
+#include <kdberrors.h>
+#include <kdbhelper.h>
+
+using ckdb::keyNew;
+using std::exception;
+
+using elektra::KconfigDelegate;
+
+using CppKey = kdb::Key;
+using CppKeySet = kdb::KeySet;
+
+namespace
+{
+
+/**
+ * @brief This function returns a key set containing the plugin contract.
+ *
+ * @return A key set specifying the capabilities of the plugin
+ */
+CppKeySet getContract ()
+{
+	return CppKeySet{ 30,
+			  keyNew ("system/elektra/modules/kconfig", KEY_VALUE, "kconfig plugin waits for your orders", KEY_END),
+			  keyNew ("system/elektra/modules/kconfig/exports", KEY_END),
+			  keyNew ("system/elektra/modules/kconfig/exports/open", KEY_FUNC, elektraKconfigOpen, KEY_END),
+			  keyNew ("system/elektra/modules/kconfig/exports/close", KEY_FUNC, elektraKconfigClose, KEY_END),
+			  keyNew ("system/elektra/modules/kconfig/exports/get", KEY_FUNC, elektraKconfigGet, KEY_END),
+			  keyNew ("system/elektra/modules/kconfig/exports/set", KEY_FUNC, elektraKconfigSet, KEY_END),
+			  keyNew ("system/elektra/modules/kconfig/exports/error", KEY_FUNC, elektraKconfigError, KEY_END),
+			  keyNew ("system/elektra/modules/kconfig/exports/checkconf", KEY_FUNC, elektraKconfigCheckConf, KEY_END),
+#include ELEKTRA_README
+			  keyNew ("system/elektra/modules/kconfig/infos/version", KEY_VALUE, PLUGINVERSION, KEY_END),
+			  KS_END };
+}
+
+} // end namespace
+
+extern "C" {
+
+typedef Delegator<KconfigDelegate> delegator;
+
+/** @see elektraDocOpen */
+int elektraKconfigOpen (Plugin * handle, Key * key)
+{
+	int status = ELEKTRA_PLUGIN_STATUS_ERROR;
+
+	try
+	{
+		// - The function below calls the constructor `KconfigDelegate(config)`.
+		// - After the call to `delegator::open` you can retrieve a pointer to the delegate via `delegator::get (handle)`.
+		status = delegator::open (handle, key);
+	}
+	catch (exception const & error)
+	{
+		ELEKTRA_SET_PLUGIN_MISBEHAVIOR_ERRORF (key, "Uncaught Exception: %s", error.what ());
+	}
+
+	return status;
+}
+
+/** @see elektraDocClose */
+int elektraKconfigClose (Plugin * handle, Key * key)
+{
+	// The function `delegator::close` calls the destructor of `KconfigDelegate`.
+	return delegator::close (handle, key);
+}
+
+/** @see elektraDocGet */
+int elektraKconfigGet (Plugin * handle, KeySet * returned, Key * parentKey)
+{
+	CppKeySet keys{ returned };
+	CppKey parent{ parentKey };
+
+	if (parent.getName () == "system/elektra/modules/kconfig")
+	{
+		keys.append (getContract ());
+	}
+	else
+	{
+		// This is only an example, to show you how to call a method of the delegate
+		keys.append (delegator::get (handle)->getConfig (parent));
+	}
+
+	parent.release ();
+	keys.release ();
+	return ELEKTRA_PLUGIN_STATUS_SUCCESS;
+}
+
+/** @see elektraDocSet */
+int elektraKconfigSet (Plugin * handle ELEKTRA_UNUSED, KeySet * returned ELEKTRA_UNUSED, Key * parentKey ELEKTRA_UNUSED)
+{
+	return ELEKTRA_PLUGIN_STATUS_NO_UPDATE;
+}
+
+/** @see elektraDocError */
+int elektraKconfigError (Plugin * handle ELEKTRA_UNUSED, KeySet * returned ELEKTRA_UNUSED, Key * parentKey ELEKTRA_UNUSED)
+{
+	return ELEKTRA_PLUGIN_STATUS_SUCCESS;
+}
+
+/** @see elektraDocCheckConf */
+int elektraKconfigCheckConf (Key * errorKey ELEKTRA_UNUSED, KeySet * conf ELEKTRA_UNUSED)
+{
+	return ELEKTRA_PLUGIN_STATUS_NO_UPDATE;
+}
+
+Plugin * ELEKTRA_PLUGIN_EXPORT
+{
+	// clang-format off
+	return elektraPluginExport ("kconfig",
+		ELEKTRA_PLUGIN_OPEN,	&elektraKconfigOpen,
+		ELEKTRA_PLUGIN_CLOSE,	&elektraKconfigClose,
+		ELEKTRA_PLUGIN_GET,	&elektraKconfigGet,
+		ELEKTRA_PLUGIN_SET,	&elektraKconfigSet,
+		ELEKTRA_PLUGIN_ERROR,	&elektraKconfigError,
+		ELEKTRA_PLUGIN_END);
+}
+
+} // end extern "C"

--- a/src/plugins/kconfig/kconfig.cpp
+++ b/src/plugins/kconfig/kconfig.cpp
@@ -86,16 +86,34 @@ int elektraKconfigGet (Plugin * handle, KeySet * returned, Key * parentKey)
 	if (parent.getName () == "system/elektra/modules/kconfig")
 	{
 		keys.append (getContract ());
+		parent.release ();
+		keys.release ();
+		return ELEKTRA_PLUGIN_STATUS_SUCCESS;
 	}
-	else
+
+
+	int status = ELEKTRA_PLUGIN_STATUS_ERROR;
+
+	try
 	{
-		// This is only an example, to show you how to call a method of the delegate
 		keys.append (delegator::get (handle)->getConfig (parent));
+		status = ELEKTRA_PLUGIN_STATUS_SUCCESS;
+	}
+	catch (std::overflow_error const & exception)
+	{
+		ELEKTRA_SET_RESOURCE_ERRORF (parent.getKey (), "Unable to read data from file '%s'. Reason: %s",
+					     parent.getString ().c_str (), exception.what ());
+	}
+	catch (std::runtime_error const & exception)
+	{
+		ELEKTRA_SET_VALIDATION_SYNTACTIC_ERRORF (parent.getKey (), "Unable to parse file '%s'. Reason: %s",
+							 parent.getString ().c_str (), exception.what ());
 	}
 
 	parent.release ();
 	keys.release ();
-	return ELEKTRA_PLUGIN_STATUS_SUCCESS;
+
+	return status;
 }
 
 /** @see elektraDocSet */

--- a/src/plugins/kconfig/kconfig.hpp
+++ b/src/plugins/kconfig/kconfig.hpp
@@ -1,0 +1,30 @@
+/**
+ * @file
+ *
+ * @brief Header for kconfig plugin
+ *
+ * @copyright BSD License (see LICENSE.md or https://www.libelektra.org)
+ *
+ */
+
+#ifndef ELEKTRA_PLUGIN_KCONFIG_HPP
+#define ELEKTRA_PLUGIN_KCONFIG_HPP
+
+#include <kdbplugin.h>
+
+using ckdb::Key;
+using ckdb::KeySet;
+using ckdb::Plugin;
+
+extern "C" {
+int elektraKconfigOpen (Plugin * handle, Key * errorKey);
+int elektraKconfigClose (Plugin * handle, Key * errorKey);
+int elektraKconfigGet (Plugin * handle, KeySet * returned, Key * parentKey);
+int elektraKconfigSet (Plugin * handle, KeySet * returned, Key * parentKey);
+int elektraKconfigError (Plugin * handle, KeySet * conf, Key * parentKey);
+int elektraKconfigCheckConf (Key * errorKey, KeySet * conf);
+
+Plugin * ELEKTRA_PLUGIN_EXPORT;
+} // end extern "C"
+
+#endif

--- a/src/plugins/kconfig/kconfig/meta_example.h
+++ b/src/plugins/kconfig/kconfig/meta_example.h
@@ -1,0 +1,7 @@
+// clang-format off
+ksNew (10,
+       keyNew (PREFIX "meta_key", KEY_VALUE, "Some meta", KEY_META, "kconfig", "i", KEY_END),
+       keyNew (PREFIX "empty_group/with_meta", KEY_META, "kconfig", "a", KEY_END),
+       keyNew (PREFIX "group_with/localizations/localized[en]", KEY_VALUE, "Hello", KEY_END),
+       keyNew (PREFIX "group_with/localizations/localized[de]", KEY_VALUE, "Hallo", KEY_END),
+       KS_END)

--- a/src/plugins/kconfig/kconfig/meta_examplerc
+++ b/src/plugins/kconfig/kconfig/meta_examplerc
@@ -1,0 +1,6 @@
+meta_key[$i]=Some meta
+
+[empty_group][with_meta][$a]
+[group_with][localizations]
+localized[en]=Hello
+localized[de]=Hallo

--- a/src/plugins/kconfig/kconfig/simple_example.h
+++ b/src/plugins/kconfig/kconfig/simple_example.h
@@ -1,0 +1,5 @@
+// clang-format off
+ksNew (10,
+       keyNew (PREFIX "groupless.key", KEY_VALUE, "Simple Value With Spaces", KEY_END),
+       keyNew (PREFIX "example/group/example.key", KEY_VALUE, "Key\nWith\tEscaped\\Characters", KEY_END),
+       KS_END)

--- a/src/plugins/kconfig/kconfig/simple_examplerc
+++ b/src/plugins/kconfig/kconfig/simple_examplerc
@@ -1,0 +1,9 @@
+# Ignore comment
+# Ignore other comment with escape character\
+groupless.key=Simple Value With Spaces
+[empty][group]
+[example][group]
+#Ignore comment before empty space
+
+#Ignore comment after empty space
+example.key=Key\nWith\tEscaped\\Characters

--- a/src/plugins/kconfig/kconfig_delegate.cpp
+++ b/src/plugins/kconfig/kconfig_delegate.cpp
@@ -1,0 +1,61 @@
+/**
+ * @file
+ *
+ * @brief Delegate implementation for the `kconfig` plugin
+ *
+ * @copyright BSD License (see LICENSE.md or https://www.libelektra.org)
+ *
+ */
+
+#include "kconfig_delegate.hpp"
+#include "file_utility.hpp"
+#include "kconfig_parser.hpp"
+
+using kdb::Key;
+using kdb::KeySet;
+
+namespace elektra
+{
+
+/**
+ * @brief This constructor creates a new delegate object used by the `kconfig` plugin
+ *
+ * @param config This key set contains configuration values provided by the `kconfig` plugin
+ */
+KconfigDelegate::KconfigDelegate (KeySet config)
+{
+	configuration = config;
+}
+
+/**
+ * @brief This method returns the configuration of the plugin, prefixing key names with the name of `parent`.
+ *
+ * @param parent This key specifies the name this function adds to the stored configuration values.
+ *
+ * @return A key set storing the configuration values of the plugin
+ */
+kdb::KeySet KconfigDelegate::getConfig (Key const & parent)
+{
+	KeySet keys{ 0, KS_END };
+
+	try
+	{
+		ELEKTRA_LOG_DEBUG ("Parse `%s` using the kconfig plugin", parent.getString ().c_str ());
+		FileUtility fileUtility{ parent.getString () };
+
+		ELEKTRA_LOG_DEBUG ("The file opened successfully. Start parsing");
+		KConfigParser parser{ fileUtility, keys };
+		parser.parse (parent);
+
+		ELEKTRA_LOG_DEBUG ("Parsing finished successfully");
+	}
+	catch (KConfigParserException & e)
+	{
+		// TODO: Handle the error properly
+		throw std::runtime_error (e.getMessage ());
+	}
+
+	return keys;
+}
+
+} // end namespace elektra

--- a/src/plugins/kconfig/kconfig_delegate.cpp
+++ b/src/plugins/kconfig/kconfig_delegate.cpp
@@ -38,8 +38,7 @@ KconfigDelegate::KconfigDelegate (KeySet config)
  */
 kdb::KeySet KconfigDelegate::getConfig (Key const & parent)
 {
-	KeySet keys{ 0, KS_END };
-
+	KeySet keys;
 
 	ELEKTRA_LOG_DEBUG ("Parse `%s` using the kconfig plugin", parent.getString ().c_str ());
 	auto filePtr = new std::ifstream{ parent.getString () };

--- a/src/plugins/kconfig/kconfig_delegate.hpp
+++ b/src/plugins/kconfig/kconfig_delegate.hpp
@@ -1,0 +1,45 @@
+/**
+ * @file
+ *
+ * @brief Delegate definitions for the `kconfig` plugin
+ *
+ * @copyright BSD License (see LICENSE.md or https://www.libelektra.org)
+ *
+ */
+
+#ifndef ELEKTRA_CPP_KCONFIG_DELEGATE_HPP
+#define ELEKTRA_CPP_KCONFIG_DELEGATE_HPP
+
+#include <kdberrors.h>
+#include <kdbplugin.hpp>
+
+namespace elektra
+{
+
+class KconfigDelegate
+{
+	using KeySet = kdb::KeySet;
+	using Key = kdb::Key;
+
+	/** This key set stores the plugin configuration. */
+	KeySet configuration; // For your own plugin you can remove this value and also add any other member you like here.
+
+public:
+	explicit KconfigDelegate (KeySet config);
+
+	/**
+	 * @brief This method returns the configuration of the plugin, prefixing key names with the name of `parent`.
+	 *
+	 *  This is only an example to show you how to use the delegate. You can add any method you want here and then call it in
+	 *  `kconfig.cpp` via `delegator::get (handle)->functionName(parameter1, parameter2, …)`.
+	 *
+	 * @param parent This key specifies the name this function adds to the stored configuration values.
+	 *
+	 * @return A key set storing the configuration values of the plugin
+	 */
+	KeySet getConfig (Key const & prefix);
+};
+
+} // end namespace elektra
+
+#endif

--- a/src/plugins/kconfig/kconfig_parser.cpp
+++ b/src/plugins/kconfig/kconfig_parser.cpp
@@ -1,0 +1,198 @@
+#include "kconfig_parser.hpp"
+#include "base.hpp"
+#include "kconfig_parser_exception.hpp"
+
+KConfigParser::KConfigParser (FileUtility & fileUtilityParam, CppKeySet & keySetParam)
+: fileUtility{ fileUtilityParam }, keySet{ keySetParam }
+{
+}
+
+
+void KConfigParser::parse (CppKey const & parent)
+{
+	CppKey current_group{ parent.getName (), KEY_END };
+	CppKey current_key{ parent.getName (), KEY_END };
+
+	while (true)
+	{
+		fileUtility.skipLineIfEmptyOrComment ();
+
+		if (fileUtility.isNextCharEOF ())
+		{
+			break;
+		}
+
+		if (fileUtility.peekNextChar () == character_open_bracket)
+		{
+			current_group = loadGroupNameFromFile (parent);
+			appendIfContainsMeta (current_group);
+		}
+		else
+		{
+			current_key = loadKeyFromFile (current_group);
+			appendIfNotGroup (current_key, current_group);
+		}
+	}
+}
+
+kdb::Key KConfigParser::loadGroupNameFromFile (CppKey const & parent)
+{
+	CppKey key{ parent.getName (), KEY_END };
+
+	while (fileUtility.peekNextChar () == character_open_bracket)
+	{
+		// Skip open bracket
+		fileUtility.skipChar ();
+
+		// If a name starts with `$`, it should be saved as a meta value instead of a key name
+		if (fileUtility.peekNextChar () == character_dollar_sign)
+		{
+			// Skip the dollar sign
+			fileUtility.skipChar ();
+
+			std::string meta_candidate{ fileUtility.getUntilChar (character_close_bracket) };
+
+			if (fileUtility.peekNextChar () == character_close_bracket)
+			{
+				fileUtility.skipChar ();
+			}
+			else
+			{
+				throw KConfigParserException::expect (fileUtility, character_close_bracket);
+			}
+
+			// A meta value can only be placed at the last value. E.g.
+			// 	[keyName1][$pseudoMeta][keyName2][$realMeta]
+			//	In the previous example `realMeta` is a meta value, `pseudoMeta` is not
+			if (fileUtility.isNextCharNewlineOrEOF ())
+			{
+				key.setMeta (KCONFIG_METADATA_KEY, meta_candidate);
+			}
+			else
+			{
+				// Add the dollar sign that we skipped earlier
+				key.addBaseName (character_dollar_sign + meta_candidate);
+			}
+		}
+		else
+		{
+			key.addBaseName (fileUtility.getUntilChar (character_close_bracket));
+
+			if (fileUtility.peekNextChar () == character_close_bracket)
+			{
+				fileUtility.skipChar ();
+			}
+			else
+			{
+				throw KConfigParserException::expect (fileUtility, character_close_bracket);
+			}
+		}
+	}
+
+	if (!fileUtility.isNextCharNewlineOrEOF ())
+	{
+		throw KConfigParserException::expect (fileUtility, "new line or end of file");
+	}
+
+	return key;
+}
+
+CppKey KConfigParser::loadKeyFromFile (CppKey const & parent)
+{
+	fileUtility.skipCharsIfBlank ();
+	if (fileUtility.isNextCharToken ())
+	{
+		throw KConfigParserException::expect (fileUtility, "key name, not a spacial character");
+	}
+
+	std::string keyName{ fileUtility.getUntilChar (character_equals_sign, character_open_bracket) };
+
+	// If the following line introduces problems, use `parent.dup();`
+	CppKey key{ parent.getName (), KEY_END };
+
+	if (fileUtility.isNextCharNewlineOrEOF ())
+	{
+		// This key doesn't contain any value
+		key.addBaseName (keyName);
+		return key;
+	}
+
+	std::string meta;
+	bool has_locale = false;
+	// Load the meta values and/or locales
+	while (fileUtility.peekNextChar () == character_open_bracket)
+	{
+		// Skip the open bracket
+		fileUtility.skipChar ();
+
+		if (fileUtility.peekNextChar () == character_dollar_sign)
+		{
+			// Load meta value
+			// Skip dollar sign
+			fileUtility.skipChar ();
+			meta += fileUtility.getUntilChar (character_close_bracket);
+		}
+		else
+		{
+			// Load locale
+			if (has_locale)
+			{
+				throw KConfigParserException{ fileUtility, "Only one locale is allowed in a single key definition." };
+			}
+			else
+			{
+				has_locale = true;
+			}
+			keyName += character_open_bracket + fileUtility.getUntilChar (character_close_bracket) + character_close_bracket;
+		}
+
+
+		if (fileUtility.peekNextChar () == character_close_bracket)
+		{
+			fileUtility.skipChar ();
+		}
+		else
+		{
+			throw KConfigParserException::expect (fileUtility, character_close_bracket);
+		}
+	}
+
+
+	key.addBaseName (keyName);
+	// Skip empty spaces if any
+	fileUtility.skipCharsIfBlank ();
+	// Load the value
+	if (fileUtility.peekNextChar () == character_equals_sign)
+	{
+		// Skip the equals sign
+		fileUtility.skipChar ();
+		fileUtility.skipCharsIfBlank ();
+		key.setString (fileUtility.getUntilChar (character_newline));
+	}
+	else if (!fileUtility.isNextCharNewlineOrEOF ())
+	{
+		throw KConfigParserException::expect (fileUtility, "new line or end of file");
+	}
+
+	if (!meta.empty ())
+	{
+		key.setMeta (KCONFIG_METADATA_KEY, meta);
+	}
+
+	return key;
+}
+
+void KConfigParser::appendIfContainsMeta (CppKey const & key)
+{
+	if (key.hasMeta (KCONFIG_METADATA_KEY))
+	{
+		keySet.append (key);
+	}
+}
+void KConfigParser::appendIfNotGroup (CppKey const & key, CppKey const & group)
+{
+	if (key != group)
+	{
+		keySet.append (key);
+	}
+}

--- a/src/plugins/kconfig/kconfig_parser.cpp
+++ b/src/plugins/kconfig/kconfig_parser.cpp
@@ -2,6 +2,8 @@
 #include "base.hpp"
 #include "kconfig_parser_exception.hpp"
 
+namespace kconfig
+{
 KConfigParser::KConfigParser (FileUtility & fileUtilityParam, CppKeySet & keySetParam)
 : fileUtility{ fileUtilityParam }, keySet{ keySetParam }
 {
@@ -195,4 +197,5 @@ void KConfigParser::appendIfNotGroup (CppKey const & key, CppKey const & group)
 	{
 		keySet.append (key);
 	}
+}
 }

--- a/src/plugins/kconfig/kconfig_parser.hpp
+++ b/src/plugins/kconfig/kconfig_parser.hpp
@@ -8,6 +8,8 @@
 using CppKeySet = kdb::KeySet;
 using CppKey = kdb::Key;
 
+namespace kconfig
+{
 class KConfigParser
 {
 private:
@@ -60,6 +62,6 @@ public:
 	 */
 	void parse (CppKey const & parent);
 };
-
+}
 
 #endif // ELEKTRA_KCONFIGPARSER_HPP

--- a/src/plugins/kconfig/kconfig_parser.hpp
+++ b/src/plugins/kconfig/kconfig_parser.hpp
@@ -1,0 +1,65 @@
+#ifndef ELEKTRA_KCONFIGPARSER_HPP
+#define ELEKTRA_KCONFIGPARSER_HPP
+
+#include "file_utility.hpp"
+#include <kdberrors.h>
+#include <kdbplugin.hpp>
+
+using CppKeySet = kdb::KeySet;
+using CppKey = kdb::Key;
+
+class KConfigParser
+{
+private:
+	/* This FileUtility is used to read from the file */
+	FileUtility & fileUtility;
+	/* This KeySet is used to store the parsed values */
+	CppKeySet & keySet;
+
+	/**
+	 * @brief This method parses a group from the file into an Elektra key
+	 * 	Format: (\[keyname\])+[\[$meta\]]
+	 * @param parent
+	 * @return
+	 */
+	kdb::Key loadGroupNameFromFile (CppKey const & parent);
+
+	/**
+	 * @brief This method parses a key from the file into an Elektra key.
+	 * 	Format: keyname[\[locale\]](\[$meta\])*[=value]
+	 * @param parent
+	 * @return
+	 */
+	kdb::Key loadKeyFromFile (CppKey const & parent);
+
+	/**
+	 * @brief This method is used to add a key to the KeySet only if it contains KConfig metadata
+	 * @param key This is the key that we want to add
+	 */
+	void appendIfContainsMeta (CppKey const & key);
+
+	/**
+	 * @brief This method is used to add a key to the KeySet if it isn't the same as the group
+	 * @param key This is the key that we want to add
+	 * @param group This is the key that we don't want to add
+	 */
+	void appendIfNotGroup (CppKey const & key, CppKey const & group);
+
+public:
+	/**
+	 * @brief This constructor is used to abstract the File and KeySet that we're working on as well as the parsing methods
+	 * @param fileUtilityParam This FileUtility is where we read the file from
+	 * @param keySetParam This KeySet is where we store the parsed keys
+	 */
+	KConfigParser (FileUtility & fileUtilityParam, CppKeySet & keySetParam);
+
+	/**
+	 * @brief This method is used to parses a KConfig file into an Elektra KeySet similarly to the KConfigIniBackend from the KConfig
+	 * project
+	 * @param parent the prefix to all the created keys
+	 */
+	void parse (CppKey const & parent);
+};
+
+
+#endif // ELEKTRA_KCONFIGPARSER_HPP

--- a/src/plugins/kconfig/kconfig_parser_exception.cpp
+++ b/src/plugins/kconfig/kconfig_parser_exception.cpp
@@ -1,0 +1,54 @@
+#include "kconfig_parser_exception.hpp"
+#include "base.hpp"
+#include "file_utility.hpp"
+
+#include <sstream>
+
+KConfigParserException::KConfigParserException (FileUtility const & fileUtility, std::string const & errorMessage)
+{
+	message = generateErrorMessage (fileUtility.getFilename (), fileUtility.getCurrentLineNumber (), errorMessage);
+}
+
+KConfigParserException KConfigParserException::expect (FileUtility & fileUtility, char expected)
+{
+	return expect (fileUtility, describeCharacter (expected));
+}
+
+KConfigParserException KConfigParserException::expect (FileUtility & fileUtility, std::string const & expectedValue)
+{
+	std::string foundValue{ describeCharacter (fileUtility.peekNextChar ()) };
+	return { fileUtility, "Expected " + expectedValue + " character, found " + foundValue };
+}
+
+std::string KConfigParserException::generateErrorMessage (std::string filename, int lineNumber, std::string message)
+{
+	std::stringstream errorMessage;
+	errorMessage << "Error while parsing " << filename;
+	if (lineNumber != 0)
+	{
+		errorMessage << " at line " << lineNumber;
+	}
+	errorMessage << ": ";
+	errorMessage << message;
+	return errorMessage.str ();
+}
+
+std::string KConfigParserException::describeCharacter (char c)
+{
+	if (c == character_newline || c == character_carriage_return)
+	{
+		return "new line";
+	}
+	else
+	{
+		std::string ret{ "`" };
+		ret.push_back (c);
+		ret.push_back ('`');
+		return ret;
+	}
+}
+
+std::string KConfigParserException::getMessage () const
+{
+	return message;
+}

--- a/src/plugins/kconfig/kconfig_parser_exception.cpp
+++ b/src/plugins/kconfig/kconfig_parser_exception.cpp
@@ -3,7 +3,8 @@
 #include "file_utility.hpp"
 
 #include <sstream>
-
+namespace kconfig
+{
 KConfigParserException::KConfigParserException (FileUtility const & fileUtility, std::string const & errorMessage)
 {
 	message = generateErrorMessage (fileUtility.getFilename (), fileUtility.getCurrentLineNumber (), errorMessage);
@@ -20,7 +21,7 @@ KConfigParserException KConfigParserException::expect (FileUtility & fileUtility
 	return { fileUtility, "Expected " + expectedValue + " character, found " + foundValue };
 }
 
-std::string KConfigParserException::generateErrorMessage (std::string filename, int lineNumber, std::string message)
+std::string KConfigParserException::generateErrorMessage (std::string const & filename, int lineNumber, std::string const & message)
 {
 	std::stringstream errorMessage;
 	errorMessage << "Error while parsing " << filename;
@@ -51,4 +52,5 @@ std::string KConfigParserException::describeCharacter (char c)
 std::string KConfigParserException::getMessage () const
 {
 	return message;
+}
 }

--- a/src/plugins/kconfig/kconfig_parser_exception.hpp
+++ b/src/plugins/kconfig/kconfig_parser_exception.hpp
@@ -1,0 +1,61 @@
+#ifndef ELEKTRA_KCONFIG_PARSER_EXCEPTION_HPP
+#define ELEKTRA_KCONFIG_PARSER_EXCEPTION_HPP
+
+#include <exception>
+#include <string>
+
+class FileUtility;
+
+class KConfigParserException : std::exception
+{
+private:
+	/* This string contains the error message */
+	std::string message;
+
+	/**
+	 * @brief This function describes characters via a visible string. Is needed for cases such as new lines and end of file.
+	 * @param c This character is the value we want do describe
+	 * @return A string
+	 */
+	static std::string describeCharacter (char c);
+
+	/**
+	 * @brief This function generates an error message for the given values
+	 * @param filename This string contains the name of the file that is being parsed
+	 * @param lineNumber This int contains the current line number
+	 * @param message This string contains a specific error message
+	 * @return
+	 */
+	static std::string generateErrorMessage (std::string filename, int lineNumber, std::string message);
+
+public:
+	/**
+	 * @brief This constructor is used to create an exception with an error message that contains the filename and a message
+	 * @param fileUtility This FileUtility contains the file name and the line number
+	 * @param errorMessage This string contains a specific error message
+	 */
+	KConfigParserException (FileUtility const & fileUtility, std::string const & errorMessage);
+	/**
+	 * @brief This function is used to create an exception when a char was expected but not found
+	 * @param fileUtility This FileUtility contains the file name and the line number
+	 * @param value This string is a description of the expected character
+	 * @return
+	 */
+	static KConfigParserException expect (FileUtility & fileUtility, std::string const & value);
+
+	/**
+	 * @brief This function is used to create an exception when a char was expected but not found
+	 * @param fileUtility This FileUtility contains the file name and the line number
+	 * @param value This character is the expected character
+	 * @return
+	 */
+	static KConfigParserException expect (FileUtility & fileUtility, char value);
+
+	/**
+	 * @brief This is a getter method
+	 * @return the error message
+	 */
+	std::string getMessage () const;
+};
+
+#endif // ELEKTRA_KCONFIG_PARSER_EXCEPTION_HPP

--- a/src/plugins/kconfig/kconfig_parser_exception.hpp
+++ b/src/plugins/kconfig/kconfig_parser_exception.hpp
@@ -4,8 +4,9 @@
 #include <exception>
 #include <string>
 
+namespace kconfig
+{
 class FileUtility;
-
 class KConfigParserException : std::exception
 {
 private:
@@ -26,7 +27,7 @@ private:
 	 * @param message This string contains a specific error message
 	 * @return
 	 */
-	static std::string generateErrorMessage (std::string filename, int lineNumber, std::string message);
+	static std::string generateErrorMessage (std::string const & filename, int lineNumber, std::string const & message);
 
 public:
 	/**
@@ -57,5 +58,6 @@ public:
 	 */
 	std::string getMessage () const;
 };
+}
 
 #endif // ELEKTRA_KCONFIG_PARSER_EXCEPTION_HPP

--- a/src/plugins/kconfig/testmod_kconfig.cpp
+++ b/src/plugins/kconfig/testmod_kconfig.cpp
@@ -12,10 +12,61 @@
 #include <kdbmodule.h>
 #include <kdbprivate.h>
 
+#include <tests.h>
 #include <tests.hpp>
+
+using ckdb::keyNew;
+using ckdb::ksNew;
 
 using CppKeySet = kdb::KeySet;
 using CppKey = kdb::Key;
+
+
+// BEGIN: COPY UTIL FUNCTIONS FROM testmod_yamlcpp.cpp
+#define PREFIX "user/unit_tests/kconfig/"
+#define OPEN_PLUGIN(parentName, filepath)                                                                                                  \
+	CppKeySet modules{ 0, KS_END };                                                                                                    \
+	CppKeySet config{ 0, KS_END };                                                                                                     \
+	elektraModulesInit (modules.getKeySet (), 0);                                                                                      \
+	CppKey parent{ parentName, KEY_VALUE, filepath, KEY_END };                                                                         \
+	Plugin * plugin = elektraPluginOpen ("kconfig", modules.getKeySet (), config.getKeySet (), *parent);                               \
+	exit_if_fail (plugin != NULL, "Could not open kconfig plugin")
+#define CLOSE_PLUGIN()                                                                                                                     \
+	elektraPluginClose (plugin, 0);                                                                                                    \
+	elektraModulesClose (modules.getKeySet (), 0);                                                                                     \
+	ksDel (modules.release ());                                                                                                        \
+	config.release ()
+
+void update_parent (CppKeySet expected, string const filepath)
+{
+	// We replace the value of the parent key of expected keyset, if the header file specifies the value @CONFIG_FILEPATH@.
+	// We could also do that via CMake, but the current solution should be easier for now.
+	CppKey root = expected.lookup (PREFIX, KDB_O_POP);
+	if (root)
+	{
+		if (root.getString () == "@CONFIG_FILEPATH@") root.setString (filepath);
+		expected.append (root);
+	}
+}
+
+static void test_read (string const & filename, CppKeySet expected, int const status = ELEKTRA_PLUGIN_STATUS_SUCCESS)
+#ifdef __llvm__
+	__attribute__ ((annotate ("oclint:suppress")))
+#endif
+{
+	string filepath = srcdir_file (filename.c_str ());
+	update_parent (expected, filepath);
+
+	OPEN_PLUGIN (PREFIX, filepath.c_str ());
+
+	CppKeySet keys;
+	succeed_if_same (plugin->kdbGet (plugin, keys.getKeySet (), *parent), status, "Call of `kdbGet` failed");
+
+	compare_keyset (keys, expected);
+
+	CLOSE_PLUGIN ();
+}
+// END: COPY UTIL FUNCTIONS FROM testmod_yamlcpp.cpp
 
 TEST (kconfig, basics)
 {
@@ -39,4 +90,28 @@ TEST (kconfig, basics)
 
 	ksDel (modules.release ());
 	config.release ();
+}
+
+TEST (kconfig, simple_file_get)
+{
+	test_read ("kconfig/simple_examplerc",
+#include "kconfig/simple_example.h"
+	);
+}
+
+TEST (kconfig, meta_file_get)
+{
+	test_read ("kconfig/meta_examplerc",
+#include "kconfig/meta_example.h"
+	);
+}
+
+
+// -- Main ---------------------------------------------------------------------------------------------------------------------------------
+
+int main (int argc, char * argv[])
+{
+	init (argc, argv); // Required for `srcdir_file` to work properly
+	::testing::InitGoogleTest (&argc, argv);
+	return RUN_ALL_TESTS ();
 }

--- a/src/plugins/kconfig/testmod_kconfig.cpp
+++ b/src/plugins/kconfig/testmod_kconfig.cpp
@@ -1,0 +1,42 @@
+/**
+ * @file
+ *
+ * @brief Tests for kconfig plugin
+ *
+ * @copyright BSD License (see LICENSE.md or https://www.libelektra.org)
+ *
+ */
+
+#include "kconfig.hpp"
+
+#include <kdbmodule.h>
+#include <kdbprivate.h>
+
+#include <tests.hpp>
+
+using CppKeySet = kdb::KeySet;
+using CppKey = kdb::Key;
+
+TEST (kconfig, basics)
+{
+	CppKeySet modules{ 0, KS_END };
+	CppKeySet config{ 0, KS_END };
+	CppKeySet keys{ 0, KS_END };
+	elektraModulesInit (modules.getKeySet (), 0);
+
+	CppKey parent{ "system/elektra/modules/kconfig", KEY_END };
+	Plugin * plugin = elektraPluginOpen ("kconfig", modules.getKeySet (), config.getKeySet (), *parent);
+	exit_if_fail (plugin != NULL, "Could not open kconfig plugin"); //! OCLint (empty if, too few branches switch)
+
+	succeed_if_same (plugin->kdbGet (plugin, keys.getKeySet (), *parent), ELEKTRA_PLUGIN_STATUS_SUCCESS, "Call of `kdbGet` failed");
+
+	succeed_if_same (plugin->kdbSet (plugin, keys.getKeySet (), *parent), ELEKTRA_PLUGIN_STATUS_NO_UPDATE, "Call of `kdbSet` failed");
+
+	succeed_if_same (plugin->kdbError (plugin, keys.getKeySet (), *parent), ELEKTRA_PLUGIN_STATUS_SUCCESS, "Call of `kdbError` failed");
+
+	elektraPluginClose (plugin, 0);
+	elektraModulesClose (modules.getKeySet (), 0);
+
+	ksDel (modules.release ());
+	config.release ();
+}

--- a/src/plugins/mmapstorage/mmapstorage.c
+++ b/src/plugins/mmapstorage/mmapstorage.c
@@ -638,7 +638,7 @@ static void calculateMmapDataSize (MmapHeader * mmapHeader, MmapMetaData * mmapM
 	{
 		dataBlocksSize += (cur->keySize + cur->keyUSize + cur->dataSize);
 
-		if (cur->meta)
+		if (cur->meta && cur->meta->size > 0)
 		{
 			++mmapMetaData->numKeySets;
 
@@ -668,7 +668,7 @@ static void calculateMmapDataSize (MmapHeader * mmapHeader, MmapMetaData * mmapM
 		{
 			dataBlocksSize += (globalKey->keySize + globalKey->keyUSize + globalKey->dataSize);
 
-			if (globalKey->meta)
+			if (globalKey->meta && globalKey->meta->size > 0)
 			{
 				++mmapMetaData->numKeySets;
 
@@ -786,7 +786,7 @@ static void writeMetaKeys (MmapAddr * mmapAddr, DynArray * dynArray)
 static KeySet * writeMetaKeySet (Key * key, MmapAddr * mmapAddr, DynArray * dynArray)
 {
 	// write the meta KeySet
-	if (!key->meta) return 0;
+	if (!key->meta || !(key->meta->size > 0)) return 0;
 
 	KeySet * newMeta = (KeySet *) mmapAddr->metaKsPtr;
 	mmapAddr->metaKsPtr += SIZEOF_KEYSET;

--- a/src/plugins/ruby/CMakeLists.txt
+++ b/src/plugins/ruby/CMakeLists.txt
@@ -22,8 +22,8 @@ if (DEPENDENCY_PHASE)
 
 	# ~~~
 	# Disable on GCC 4 and earlier:
-	# - https://build.libelektra.org/jenkins/job/elektra-gcc47-all
-	# - https://build.libelektra.org/jenkins/job/elektra-gcc-configure-debian-wheezy
+	# - https://build.libelektra.org/job/elektra-gcc47-all
+	# - https://build.libelektra.org/job/elektra-gcc-configure-debian-wheezy
 	# ~~~
 	set (SUPPORTED_COMPILER (NOT ("${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU" AND ${CMAKE_CXX_COMPILER_VERSION} VERSION_LESS 5)))
 

--- a/src/tools/website-frontend/public/pages/main/website/home.html
+++ b/src/tools/website-frontend/public/pages/main/website/home.html
@@ -137,7 +137,7 @@
                     </a>
                 </div>
                 <p><a href="https://github.com/ElektraInitiative/libelektra/releases/latest"><img src="https://img.shields.io/github/release/ElektraInitiative/libelektra.svg" alt="Release" /></a>
-                <a href="https://build.libelektra.org/jenkins/job/libelektra/job/master/lastBuild"><img src="https://img.shields.io/jenkins/t/https/build.libelektra.org/jenkins/job/libelektra/job/master.svg" alt="Jenkins Build Status" /></a>
+                <a href="https://build.libelektra.org/job/libelektra/job/master/lastBuild"><img src="https://img.shields.io/jenkins/t/https/build.libelektra.org/job/libelektra/job/master.svg" alt="Jenkins Build Status" /></a>
                 <a href="https://travis-ci.org/ElektraInitiative/libelektra"><img src="https://travis-ci.org/ElektraInitiative/libelektra.svg?branch=master" alt="Travis Build Status" /></a>
                 <a href="https://cirrus-ci.com/github/ElektraInitiative/libelektra"><img src="https://api.cirrus-ci.com/github/ElektraInitiative/libelektra.svg" alt="Cirrus Build Status" /></a>
                 <a href="https://coveralls.io/github/ElektraInitiative/libelektra"><img src="https://img.shields.io/coveralls/github/ElektraInitiative/libelektra.svg" alt="Coverage Status" /></a>

--- a/tests/linkchecker.whitelist
+++ b/tests/linkchecker.whitelist
@@ -5,7 +5,7 @@
 #
 # The following link only works if you are logged into the build server
 # See also: https://github.com/ElektraInitiative/libelektra/issues/2674
-https://build.libelektra.org/jenkins/job/libelektra/pipeline-syntax
+https://build.libelektra.org/job/libelektra/pipeline-syntax
 # Webdemo doesn't work right now
 # see https://github.com/ElektraInitiative/libelektra/issues/2913
 http://webdemo.libelektra.org

--- a/tests/linkchecker.whitelist
+++ b/tests/linkchecker.whitelist
@@ -15,3 +15,5 @@ https://crates.io/crates/elektra
 https://crates.io/crates/elektra-sys
 https://wiki.jenkins-ci.org/display/JENKINS/GitHub%2BPR+Comment+Build+Plugin
 https://wiki.jenkins.io/display/JENKINS/Pipeline%2BMultibranch+Plugin
+https://build.libelektra.org/job/libelektra-monthly
+http://www.snmp.com/protocol


### PR DESCRIPTION
This has the same changes `https://github.com/ElektraInitiative/libelektra/pull/3239` but without the reverted commits and rebase problems.
I also changed the documentation mentions in the comments from the other PR.
## Basics

- [x] Short descriptions of your changes are in the release notes
      (added as entry in `doc/news/_preparation_next_release.md` which
      contains `_(my name)_`)
      **Please always add something to the release notes.**
- [x] Details of what you changed are in commit messages
      (first line should have `module: short statement` syntax)
- [x] References to issues, e.g. `close #X`, are in the commit messages.
- [x] The buildservers are happy.
- [ ] The PR is rebased with current master.

## Checklist

- [x] I added unit tests for my code
- [x] I fully described what my PR does in the documentation
      (not in the PR description)
- [x] I fixed all affected documentation
- [x] I added code comments, logging, and assertions as appropriate (see [Coding Guidelines](https://master.libelektra.org/doc/CODING.md))
- [x] I updated all meta data (e.g. README.md of plugins and [METADATA.ini](https://master.libelektra.org/doc/METADATA.ini))
- [x] I mentioned every code not directly written by me in [THIRD-PARTY-LICENSES](doc/THIRD-PARTY-LICENSES)

## Review

- [ ] Documentation is introductory, concise, good to read and describes everything what the PR does
- [ ] Examples are well chosen and understandable
- [ ] Code is conforming to [our Coding Guidelines](https://master.libelektra.org/doc/CODING.md)
- [ ] APIs are conforming to [our Design Guidelines](https://master.libelektra.org/doc/DESIGN.md)
- [ ] Code is consistent to [our Design Decisions](https://master.libelektra.org/doc/decisions)
