### PR TITLE
Semantic validation message template

### DIFF
--- a/src/include/kdberrors.h
+++ b/src/include/kdberrors.h
@@ -237,19 +237,19 @@ using KeySet = ckdb::KeySet;
 						       ELEKTRA_STRINGIFY (ELEKTRA_MODULE_NAME), reason, __VA_ARGS__);                      \
 	} while (0)
 
-#define ELEKTRA_SET_VALIDATION_SEMANTIC_ERROR(parentKey, wrongKey, reason)                                                                                 \
+#define ELEKTRA_SET_VALIDATION_SEMANTIC_ERROR(parentKey, wrongKey, reason)                                                                 \
 	do                                                                                                                                 \
 	{                                                                                                                                  \
 		ELEKTRA_LOG ("Add Error %s: %s", ELEKTRA_ERROR_VALIDATION_SEMANTIC, reason);                                               \
-		elektraSetErrorVALIDATION_SEMANTIC (parentKey, wrongKey, __FILE__, ELEKTRA_STRINGIFY (__LINE__), ELEKTRA_STRINGIFY (ELEKTRA_MODULE_NAME),  \
-						    reason);                                                                               \
+		elektraSetErrorVALIDATION_SEMANTIC (parentKey, wrongKey, __FILE__, ELEKTRA_STRINGIFY (__LINE__),                           \
+						    ELEKTRA_STRINGIFY (ELEKTRA_MODULE_NAME), reason);                                      \
 	} while (0)
-#define ELEKTRA_SET_VALIDATION_SEMANTIC_ERRORF(key, wrongKey, reason, ...)                                                                           \
+#define ELEKTRA_SET_VALIDATION_SEMANTIC_ERRORF(key, wrongKey, reason, ...)                                                                 \
 	do                                                                                                                                 \
 	{                                                                                                                                  \
 		ELEKTRA_LOG ("Add Error %s: " reason, ELEKTRA_ERROR_VALIDATION_SEMANTIC, __VA_ARGS__);                                     \
-		elektraSetErrorVALIDATION_SEMANTIC (key, wrongKey, __FILE__, ELEKTRA_STRINGIFY (__LINE__), ELEKTRA_STRINGIFY (ELEKTRA_MODULE_NAME),  \
-						    reason, __VA_ARGS__);                                                                  \
+		elektraSetErrorVALIDATION_SEMANTIC (key, wrongKey, __FILE__, ELEKTRA_STRINGIFY (__LINE__),                                 \
+						    ELEKTRA_STRINGIFY (ELEKTRA_MODULE_NAME), reason, __VA_ARGS__);                         \
 	} while (0)
 #define ELEKTRA_ADD_VALIDATION_SEMANTIC_WARNING(key, reason)                                                                               \
 	do                                                                                                                                 \
@@ -291,8 +291,10 @@ extern const char * ELEKTRA_ERROR_VALIDATION_SEMANTIC_NAME;
 extern const char * ELEKTRA_WARNING_VALIDATION_SEMANTIC;
 extern const char * ELEKTRA_WARNING_VALIDATION_SEMANTIC_NAME;
 
-void elektraSetErrorVALIDATION_SEMANTIC (Key * parentKey, Key * wrongKey, const char * file, const char * line, const char * module, const char * reason, ...);
-void elektraAddWarningVALIDATION_SEMANTIC (Key * parentKey, const char * file, const char * line, const char * module, const char * reason, ...);
+void elektraSetErrorVALIDATION_SEMANTIC (Key * parentKey, Key * wrongKey, const char * file, const char * line, const char * module,
+					 const char * reason, ...);
+void elektraAddWarningVALIDATION_SEMANTIC (Key * parentKey, const char * file, const char * line, const char * module, const char * reason,
+					   ...);
 
 #undef DECLARE_ERROR_CODE
 

--- a/src/include/kdberrors.h
+++ b/src/include/kdberrors.h
@@ -237,18 +237,18 @@ using KeySet = ckdb::KeySet;
 						       ELEKTRA_STRINGIFY (ELEKTRA_MODULE_NAME), reason, __VA_ARGS__);                      \
 	} while (0)
 
-#define ELEKTRA_SET_VALIDATION_SEMANTIC_ERROR(key, reason)                                                                                 \
+#define ELEKTRA_SET_VALIDATION_SEMANTIC_ERROR(parentKey, wrongKey, reason)                                                                                 \
 	do                                                                                                                                 \
 	{                                                                                                                                  \
 		ELEKTRA_LOG ("Add Error %s: %s", ELEKTRA_ERROR_VALIDATION_SEMANTIC, reason);                                               \
-		elektraSetErrorVALIDATION_SEMANTIC (key, __FILE__, ELEKTRA_STRINGIFY (__LINE__), ELEKTRA_STRINGIFY (ELEKTRA_MODULE_NAME),  \
+		elektraSetErrorVALIDATION_SEMANTIC (parentKey, wrongKey, __FILE__, ELEKTRA_STRINGIFY (__LINE__), ELEKTRA_STRINGIFY (ELEKTRA_MODULE_NAME),  \
 						    reason);                                                                               \
 	} while (0)
-#define ELEKTRA_SET_VALIDATION_SEMANTIC_ERRORF(key, reason, ...)                                                                           \
+#define ELEKTRA_SET_VALIDATION_SEMANTIC_ERRORF(key, wrongKey, reason, ...)                                                                           \
 	do                                                                                                                                 \
 	{                                                                                                                                  \
 		ELEKTRA_LOG ("Add Error %s: " reason, ELEKTRA_ERROR_VALIDATION_SEMANTIC, __VA_ARGS__);                                     \
-		elektraSetErrorVALIDATION_SEMANTIC (key, __FILE__, ELEKTRA_STRINGIFY (__LINE__), ELEKTRA_STRINGIFY (ELEKTRA_MODULE_NAME),  \
+		elektraSetErrorVALIDATION_SEMANTIC (key, wrongKey, __FILE__, ELEKTRA_STRINGIFY (__LINE__), ELEKTRA_STRINGIFY (ELEKTRA_MODULE_NAME),  \
 						    reason, __VA_ARGS__);                                                                  \
 	} while (0)
 #define ELEKTRA_ADD_VALIDATION_SEMANTIC_WARNING(key, reason)                                                                               \
@@ -284,7 +284,15 @@ DECLARE_ERROR_CODE (INTERFACE)
 DECLARE_ERROR_CODE (PLUGIN_MISBEHAVIOR)
 DECLARE_ERROR_CODE (CONFLICTING_STATE)
 DECLARE_ERROR_CODE (VALIDATION_SYNTACTIC)
-DECLARE_ERROR_CODE (VALIDATION_SEMANTIC)
+
+extern const char * ELEKTRA_ERROR_VALIDATION_SEMANTIC;
+extern const char * ELEKTRA_ERROR_VALIDATION_SEMANTIC_NAME;
+
+extern const char * ELEKTRA_WARNING_VALIDATION_SEMANTIC;
+extern const char * ELEKTRA_WARNING_VALIDATION_SEMANTIC_NAME;
+
+void elektraSetErrorVALIDATION_SEMANTIC (Key * parentKey, Key * wrongKey, const char * file, const char * line, const char * module, const char * reason, ...);
+void elektraAddWarningVALIDATION_SEMANTIC (Key * parentKey, const char * file, const char * line, const char * module, const char * reason, ...);
 
 #undef DECLARE_ERROR_CODE
 

--- a/src/libs/elektra/errors.c
+++ b/src/libs/elektra/errors.c
@@ -116,8 +116,8 @@ static void setError (Key * key, const char * code, const char * name, const cha
 	}
 }
 
-static void setValidationError (Key * key, Key * wrongKey, const char * code, const char * name, const char * file, const char * line, const char * module,
-		      const char * reasonFmt, va_list va)
+static void setValidationError (Key * key, Key * wrongKey, const char * code, const char * name, const char * file, const char * line,
+				const char * module, const char * reasonFmt, va_list va)
 {
 	if (key == NULL)
 	{
@@ -140,7 +140,7 @@ static void setValidationError (Key * key, Key * wrongKey, const char * code, co
 		keySetMeta (key, "error/configfile", keyString (key));
 		char * keyText = elektraFormat ("Key %s with value %s does not fulfill: ", keyName (wrongKey), keyValue (wrongKey));
 		char * reason = elektraVFormat (reasonFmt, va);
-		keySetMeta (key, "error/reason", strncat(keyText, reason, strlen (reason)));
+		keySetMeta (key, "error/reason", strncat (keyText, reason, strlen (reason)));
 		elektraFree (reason);
 		elektraFree (keyText);
 	}
@@ -176,26 +176,31 @@ DEFINE_ERROR_AND_WARNING (INTERFACE)
 DEFINE_ERROR_AND_WARNING (PLUGIN_MISBEHAVIOR)
 DEFINE_ERROR_AND_WARNING (CONFLICTING_STATE)
 DEFINE_ERROR_AND_WARNING (VALIDATION_SYNTACTIC)
-//DEFINE_ERROR_AND_WARNING (VALIDATION_SEMANTIC)
+// DEFINE_ERROR_AND_WARNING (VALIDATION_SEMANTIC)
 
 const char * ELEKTRA_ERROR_VALIDATION_SEMANTIC = ELEKTRA_ERROR_CODE_VALIDATION_SEMANTIC;
 const char * ELEKTRA_ERROR_VALIDATION_SEMANTIC_NAME = ELEKTRA_ERROR_CODE_VALIDATION_SEMANTIC_NAME;
 const char * ELEKTRA_WARNING_VALIDATION_SEMANTIC = ELEKTRA_ERROR_CODE_VALIDATION_SEMANTIC;
 const char * ELEKTRA_WARNING_VALIDATION_SEMANTIC_NAME = ELEKTRA_ERROR_CODE_VALIDATION_SEMANTIC_NAME;
 
-void elektraSetErrorVALIDATION_SEMANTIC (Key * parentKey, Key * wrongKey, const char * file, const char * line, const char * module, const char * reason, ...)
+void elektraSetErrorVALIDATION_SEMANTIC (Key * parentKey, Key * wrongKey, const char * file, const char * line, const char * module,
+					 const char * reason, ...)
 {
-		va_list va;
-		va_start (va, reason);
-	setValidationError (parentKey, wrongKey, ELEKTRA_ERROR_VALIDATION_SEMANTIC, ELEKTRA_ERROR_VALIDATION_SEMANTIC_NAME, file, line, module, reason, va);
-		va_end (va);
-	}
-
-void elektraAddWarningVALIDATION_SEMANTIC (Key * parentKey, const char * file, const char * line, const char * module, const char * reason, ...) {
 	va_list va;
-		va_start (va, reason);
-		addWarning (parentKey, ELEKTRA_WARNING_VALIDATION_SEMANTIC, ELEKTRA_WARNING_VALIDATION_SEMANTIC_NAME, file, line, module, reason, va);
-		va_end (va);
+	va_start (va, reason);
+	setValidationError (parentKey, wrongKey, ELEKTRA_ERROR_VALIDATION_SEMANTIC, ELEKTRA_ERROR_VALIDATION_SEMANTIC_NAME, file, line,
+			    module, reason, va);
+	va_end (va);
+}
+
+void elektraAddWarningVALIDATION_SEMANTIC (Key * parentKey, const char * file, const char * line, const char * module, const char * reason,
+					   ...)
+{
+	va_list va;
+	va_start (va, reason);
+	addWarning (parentKey, ELEKTRA_WARNING_VALIDATION_SEMANTIC, ELEKTRA_WARNING_VALIDATION_SEMANTIC_NAME, file, line, module, reason,
+		    va);
+	va_end (va);
 }
 
 KeySet * elektraErrorSpecification (void)

--- a/src/libs/elektra/kdb.c
+++ b/src/libs/elektra/kdb.c
@@ -1824,7 +1824,7 @@ static int ensureGlobalPluginMounted (KDB * handle, const char * pluginName, Key
 	if (result == ELEKTRA_PLUGIN_STATUS_ERROR)
 	{
 		ELEKTRA_LOG_WARNING ("could not add plugin %s to list plugin", pluginName);
-		ELEKTRA_SET_VALIDATION_SEMANTIC_ERRORF (errorKey, "The global plugin %s couldn't be mounted (via the list plugin)",
+		ELEKTRA_SET_INSTALLATION_ERRORF (errorKey, "The global plugin %s couldn't be mounted (via the list plugin)",
 							pluginName);
 		return -1;
 	}
@@ -1864,7 +1864,7 @@ static int ensureGlobalPluginUnmounted (KDB * handle, const char * pluginName, K
 	if (result == ELEKTRA_PLUGIN_STATUS_ERROR)
 	{
 		ELEKTRA_LOG_WARNING ("could not remove %s from list plugin", pluginName);
-		ELEKTRA_SET_VALIDATION_SEMANTIC_ERRORF (errorKey, "The global plugin %s couldn't be unmounted (via the list plugin)",
+		ELEKTRA_SET_INSTALLATION_ERRORF (errorKey, "The global plugin %s couldn't be unmounted (via the list plugin)",
 							pluginName);
 		return -1;
 	}
@@ -1902,7 +1902,7 @@ static int ensurePluginUnmounted (KDB * handle, const char * mountpoint, const c
 		{
 			if (elektraPluginClose (setPlugin, errorKey) == ELEKTRA_PLUGIN_STATUS_ERROR)
 			{
-				ELEKTRA_SET_VALIDATION_SEMANTIC_ERRORF (
+				ELEKTRA_SET_PLUGIN_MISBEHAVIOR_ERRORF (
 					errorKey, "The plugin %s couldn't be closed (set, position: %d, mountpoint: %s)", pluginName, i,
 					mountpoint);
 				ret = 0;
@@ -1914,7 +1914,7 @@ static int ensurePluginUnmounted (KDB * handle, const char * mountpoint, const c
 		{
 			if (elektraPluginClose (getPlugin, errorKey) == ELEKTRA_PLUGIN_STATUS_ERROR)
 			{
-				ELEKTRA_SET_VALIDATION_SEMANTIC_ERRORF (
+				ELEKTRA_SET_PLUGIN_MISBEHAVIOR_ERRORF (
 					errorKey, "The plugin %s couldn't be closed (get, position: %d, mountpoint: %s)", pluginName, i,
 					mountpoint);
 				ret = 0;
@@ -1926,7 +1926,7 @@ static int ensurePluginUnmounted (KDB * handle, const char * mountpoint, const c
 		{
 			if (elektraPluginClose (errorPlugin, errorKey) == ELEKTRA_PLUGIN_STATUS_ERROR)
 			{
-				ELEKTRA_SET_VALIDATION_SEMANTIC_ERRORF (
+				ELEKTRA_SET_PLUGIN_MISBEHAVIOR_ERRORF (
 					errorKey, "The plugin %s couldn't be closed (error, position: %d, mountpoint: %s)", pluginName, i,
 					mountpoint);
 				ret = 0;

--- a/src/libs/elektra/kdb.c
+++ b/src/libs/elektra/kdb.c
@@ -1824,8 +1824,7 @@ static int ensureGlobalPluginMounted (KDB * handle, const char * pluginName, Key
 	if (result == ELEKTRA_PLUGIN_STATUS_ERROR)
 	{
 		ELEKTRA_LOG_WARNING ("could not add plugin %s to list plugin", pluginName);
-		ELEKTRA_SET_INSTALLATION_ERRORF (errorKey, "The global plugin %s couldn't be mounted (via the list plugin)",
-							pluginName);
+		ELEKTRA_SET_INSTALLATION_ERRORF (errorKey, "The global plugin %s couldn't be mounted (via the list plugin)", pluginName);
 		return -1;
 	}
 
@@ -1864,8 +1863,7 @@ static int ensureGlobalPluginUnmounted (KDB * handle, const char * pluginName, K
 	if (result == ELEKTRA_PLUGIN_STATUS_ERROR)
 	{
 		ELEKTRA_LOG_WARNING ("could not remove %s from list plugin", pluginName);
-		ELEKTRA_SET_INSTALLATION_ERRORF (errorKey, "The global plugin %s couldn't be unmounted (via the list plugin)",
-							pluginName);
+		ELEKTRA_SET_INSTALLATION_ERRORF (errorKey, "The global plugin %s couldn't be unmounted (via the list plugin)", pluginName);
 		return -1;
 	}
 

--- a/src/libs/opts/opts.c
+++ b/src/libs/opts/opts.c
@@ -315,7 +315,7 @@ bool processSpec (struct Specification * spec, KeySet * ks, Key * parentKey)
 			if (elektraStrCmp (keyBaseName (cur), "#") != 0)
 			{
 				ELEKTRA_SET_VALIDATION_SEMANTIC_ERRORF (
-					parentKey, "'args=remaining' can only be set on array keys (basename = '#'). Offending key: %s",
+					parentKey, cur, "'args=remaining' can only be set on array keys (basename = '#'). Offending key: %s",
 					keyName (cur));
 				keyDel (specParent);
 				ksDel (spec->options);
@@ -487,7 +487,7 @@ bool readOptionData (struct OptionData * optionData, Key * key, const char * met
 	else if (elektraStrCmp (hasArg, "none") != 0 && elektraStrCmp (hasArg, "optional") != 0)
 	{
 		ELEKTRA_SET_VALIDATION_SEMANTIC_ERRORF (
-			errorKey,
+			errorKey, key,
 			"The flagvalue metadata can only be used, if the opt/arg metadata is set to 'none' or "
 			"'optional'. (key: %s)",
 			keyName (key));
@@ -549,7 +549,7 @@ bool processShortOptSpec (struct Specification * spec, struct OptionData * optio
 
 	if (shortOpt == '-')
 	{
-		ELEKTRA_SET_VALIDATION_SEMANTIC_ERRORF (errorKey,
+		ELEKTRA_SET_VALIDATION_SEMANTIC_ERRORF (errorKey, key,
 							"Character '-' cannot be used as a short option. It would collide with the "
 							"special string '--'. Offending key: %s",
 							keyName (key));
@@ -563,7 +563,7 @@ bool processShortOptSpec (struct Specification * spec, struct OptionData * optio
 	Key * existing = ksLookupByName (spec->options, keyName (shortOptSpec), 0);
 	if (existing != NULL)
 	{
-		ELEKTRA_SET_VALIDATION_SEMANTIC_ERRORF (errorKey,
+		ELEKTRA_SET_VALIDATION_SEMANTIC_ERRORF (errorKey, key,
 							"The option '-%c' has already been specified for the key '%s'. Additional key: %s",
 							shortOpt, keyGetMetaString (existing, "key"), keyName (key));
 		keyDel (shortOptSpec);
@@ -633,7 +633,7 @@ bool processLongOptSpec (struct Specification * spec, struct OptionData * option
 
 	if (elektraStrCmp (longOpt, "help") == 0)
 	{
-		ELEKTRA_SET_VALIDATION_SEMANTIC_ERRORF (errorKey,
+		ELEKTRA_SET_VALIDATION_SEMANTIC_ERRORF (errorKey, key,
 							"Option 'help' cannot be used as a long option. It would collide with the "
 							"help option '--help'. Offending key: %s",
 							keyName (key));
@@ -647,7 +647,7 @@ bool processLongOptSpec (struct Specification * spec, struct OptionData * option
 	Key * existing = ksLookupByName (spec->options, keyName (longOptSpec), 0);
 	if (existing != NULL)
 	{
-		ELEKTRA_SET_VALIDATION_SEMANTIC_ERRORF (errorKey,
+		ELEKTRA_SET_VALIDATION_SEMANTIC_ERRORF (errorKey, key,
 							"The option '--%s' has already been specified for the key '%s'. Additional key: %s",
 							longOpt, keyGetMetaString (existing, "key"), keyName (key));
 		keyDel (longOptSpec);
@@ -776,7 +776,7 @@ int writeOptionValues (KeySet * ks, Key * keyWithOpt, KeySet * options, Key * er
 		else if (res < 0)
 		{
 			ELEKTRA_SET_VALIDATION_SEMANTIC_ERRORF (
-				errorKey, "The option '%s%s' cannot be used, because another option has already been used for the key '%s'",
+				errorKey, keyWithOpt, "The option '%s%s' cannot be used, because another option has already been used for the key '%s'",
 				isShort ? "-" : "--", isShort ? (const char[]){ keyBaseName (optKey)[0], '\0' } : keyBaseName (optKey),
 				keyName (keyWithOpt));
 			ksDel (optMetas);
@@ -832,7 +832,7 @@ int writeEnvVarValues (KeySet * ks, Key * keyWithOpt, KeySet * envValues, Key * 
 		if (res < 0)
 		{
 			ELEKTRA_SET_VALIDATION_SEMANTIC_ERRORF (
-				errorKey,
+				errorKey, keyWithOpt,
 				"The environment variable '%s' cannot be used, because another variable has "
 				"already been used for the key '%s'.",
 				keyBaseName (envKey), keyName (keyWithOpt));
@@ -1106,7 +1106,7 @@ bool parseShortOptions (KeySet * optionsSpec, KeySet * options, int argc, const 
 
 		if (optSpec == NULL)
 		{
-			ELEKTRA_SET_VALIDATION_SEMANTIC_ERRORF (errorKey, "Unknown short option: -%c", keyBaseName (shortOpt)[0]);
+			ELEKTRA_SET_VALIDATION_SEMANTIC_ERRORF (errorKey, optSpec, "Unknown short option: -%c", keyBaseName (shortOpt)[0]);
 			keyDel (shortOpt);
 			keyDel (optSpec);
 			return false;
@@ -1126,7 +1126,7 @@ bool parseShortOptions (KeySet * optionsSpec, KeySet * options, int argc, const 
 		}
 		else if (!repeated)
 		{
-			ELEKTRA_SET_VALIDATION_SEMANTIC_ERRORF (errorKey, "This option cannot be repeated: -%c", keyBaseName (shortOpt)[0]);
+			ELEKTRA_SET_VALIDATION_SEMANTIC_ERRORF (errorKey, shortOpt, "This option cannot be repeated: -%c", keyBaseName (shortOpt)[0]);
 			keyDel (shortOpt);
 			keyDel (optSpec);
 			return false;
@@ -1140,7 +1140,7 @@ bool parseShortOptions (KeySet * optionsSpec, KeySet * options, int argc, const 
 			{
 				if (i >= argc - 1)
 				{
-					ELEKTRA_SET_VALIDATION_SEMANTIC_ERRORF (errorKey, "Missing argument for short option: -%c",
+					ELEKTRA_SET_VALIDATION_SEMANTIC_ERRORF (errorKey, shortOpt, "Missing argument for short option: -%c",
 										keyBaseName (shortOpt)[0]);
 					keyDel (shortOpt);
 					keyDel (option);
@@ -1199,7 +1199,7 @@ bool parseLongOption (KeySet * optionsSpec, KeySet * options, int argc, const ch
 
 	if (optSpec == NULL)
 	{
-		ELEKTRA_SET_VALIDATION_SEMANTIC_ERRORF (errorKey, "Unknown long option: --%s", keyBaseName (longOpt));
+		ELEKTRA_SET_VALIDATION_SEMANTIC_ERRORF (errorKey, longOpt, "Unknown long option: --%s", keyBaseName (longOpt));
 		keyDel (longOpt);
 		return false;
 	}
@@ -1218,7 +1218,7 @@ bool parseLongOption (KeySet * optionsSpec, KeySet * options, int argc, const ch
 	}
 	else if (!repeated)
 	{
-		ELEKTRA_SET_VALIDATION_SEMANTIC_ERRORF (errorKey, "This option cannot be repeated: --%s", keyBaseName (longOpt));
+		ELEKTRA_SET_VALIDATION_SEMANTIC_ERRORF (errorKey, longOpt, "This option cannot be repeated: --%s", keyBaseName (longOpt));
 		keyDel (longOpt);
 		keyDel (optSpec);
 		return false;
@@ -1244,7 +1244,7 @@ bool parseLongOption (KeySet * optionsSpec, KeySet * options, int argc, const ch
 		{
 			if (i >= argc - 1)
 			{
-				ELEKTRA_SET_VALIDATION_SEMANTIC_ERRORF (errorKey, "Missing argument for long option: --%s",
+				ELEKTRA_SET_VALIDATION_SEMANTIC_ERRORF (errorKey, longOpt, "Missing argument for long option: --%s",
 									keyBaseName (longOpt));
 				keyDel (longOpt);
 				return false;
@@ -1271,7 +1271,7 @@ bool parseLongOption (KeySet * optionsSpec, KeySet * options, int argc, const ch
 	{
 		if (argStart > 0)
 		{
-			ELEKTRA_SET_VALIDATION_SEMANTIC_ERRORF (errorKey, "This option cannot have an argument: --%s",
+			ELEKTRA_SET_VALIDATION_SEMANTIC_ERRORF (errorKey, longOpt, "This option cannot have an argument: --%s",
 								keyBaseName (longOpt));
 			keyDel (longOpt);
 			return false;

--- a/src/libs/opts/opts.c
+++ b/src/libs/opts/opts.c
@@ -315,7 +315,8 @@ bool processSpec (struct Specification * spec, KeySet * ks, Key * parentKey)
 			if (elektraStrCmp (keyBaseName (cur), "#") != 0)
 			{
 				ELEKTRA_SET_VALIDATION_SEMANTIC_ERRORF (
-					parentKey, cur, "'args=remaining' can only be set on array keys (basename = '#'). Offending key: %s",
+					parentKey, cur,
+					"'args=remaining' can only be set on array keys (basename = '#'). Offending key: %s",
 					keyName (cur));
 				keyDel (specParent);
 				ksDel (spec->options);
@@ -776,7 +777,8 @@ int writeOptionValues (KeySet * ks, Key * keyWithOpt, KeySet * options, Key * er
 		else if (res < 0)
 		{
 			ELEKTRA_SET_VALIDATION_SEMANTIC_ERRORF (
-				errorKey, keyWithOpt, "The option '%s%s' cannot be used, because another option has already been used for the key '%s'",
+				errorKey, keyWithOpt,
+				"The option '%s%s' cannot be used, because another option has already been used for the key '%s'",
 				isShort ? "-" : "--", isShort ? (const char[]){ keyBaseName (optKey)[0], '\0' } : keyBaseName (optKey),
 				keyName (keyWithOpt));
 			ksDel (optMetas);
@@ -1126,7 +1128,8 @@ bool parseShortOptions (KeySet * optionsSpec, KeySet * options, int argc, const 
 		}
 		else if (!repeated)
 		{
-			ELEKTRA_SET_VALIDATION_SEMANTIC_ERRORF (errorKey, shortOpt, "This option cannot be repeated: -%c", keyBaseName (shortOpt)[0]);
+			ELEKTRA_SET_VALIDATION_SEMANTIC_ERRORF (errorKey, shortOpt, "This option cannot be repeated: -%c",
+								keyBaseName (shortOpt)[0]);
 			keyDel (shortOpt);
 			keyDel (optSpec);
 			return false;
@@ -1140,8 +1143,8 @@ bool parseShortOptions (KeySet * optionsSpec, KeySet * options, int argc, const 
 			{
 				if (i >= argc - 1)
 				{
-					ELEKTRA_SET_VALIDATION_SEMANTIC_ERRORF (errorKey, shortOpt, "Missing argument for short option: -%c",
-										keyBaseName (shortOpt)[0]);
+					ELEKTRA_SET_VALIDATION_SEMANTIC_ERRORF (
+						errorKey, shortOpt, "Missing argument for short option: -%c", keyBaseName (shortOpt)[0]);
 					keyDel (shortOpt);
 					keyDel (option);
 					return false;

--- a/src/plugins/conditionals/conditionals.c
+++ b/src/plugins/conditionals/conditionals.c
@@ -242,8 +242,8 @@ static CondResult evalCondition (const Key * curKey, const char * leftSide, Comp
 			{
 				if (!keyGetMeta (parentKey, "error"))
 				{
-					ELEKTRA_SET_VALIDATION_SEMANTIC_ERRORF (parentKey, key,
-										"Key not found but is required for the evaluation of %s", condition);
+					ELEKTRA_SET_VALIDATION_SEMANTIC_ERRORF (
+						parentKey, key, "Key not found but is required for the evaluation of %s", condition);
 				}
 				result = FALSE;
 				goto Cleanup;
@@ -289,7 +289,8 @@ static CondResult evalCondition (const Key * curKey, const char * leftSide, Comp
 	{
 		if (!keyGetMeta (parentKey, "error"))
 		{
-			ELEKTRA_SET_VALIDATION_SEMANTIC_ERRORF (parentKey, key, "Key not found but is required for the evaluation of %s", condition);
+			ELEKTRA_SET_VALIDATION_SEMANTIC_ERRORF (parentKey, key, "Key not found but is required for the evaluation of %s",
+								condition);
 		}
 		result = FALSE;
 		goto Cleanup;
@@ -742,8 +743,7 @@ static CondResult parseConditionString (const Key * meta, const Key * suffixList
 			ret = parseCondition (key, thenexpr, suffixList, ks, parentKey);
 			if (ret == FALSE)
 			{
-				ELEKTRA_SET_VALIDATION_SEMANTIC_ERRORF (parentKey, key, "Validation of Key failed. (%s failed)",
-									thenexpr);
+				ELEKTRA_SET_VALIDATION_SEMANTIC_ERRORF (parentKey, key, "Validation of Key failed. (%s failed)", thenexpr);
 			}
 			else if (ret == ERROR)
 			{

--- a/src/plugins/conditionals/conditionals.c
+++ b/src/plugins/conditionals/conditionals.c
@@ -242,9 +242,8 @@ static CondResult evalCondition (const Key * curKey, const char * leftSide, Comp
 			{
 				if (!keyGetMeta (parentKey, "error"))
 				{
-					ELEKTRA_SET_VALIDATION_SEMANTIC_ERRORF (parentKey,
-										"Key %s not found but is required for the evaluation of %s",
-										lookupName, condition);
+					ELEKTRA_SET_VALIDATION_SEMANTIC_ERRORF (parentKey, key,
+										"Key not found but is required for the evaluation of %s", condition);
 				}
 				result = FALSE;
 				goto Cleanup;
@@ -290,8 +289,7 @@ static CondResult evalCondition (const Key * curKey, const char * leftSide, Comp
 	{
 		if (!keyGetMeta (parentKey, "error"))
 		{
-			ELEKTRA_SET_VALIDATION_SEMANTIC_ERRORF (parentKey, "Key %s not found but is required for the evaluation of %s",
-								lookupName, condition);
+			ELEKTRA_SET_VALIDATION_SEMANTIC_ERRORF (parentKey, key, "Key not found but is required for the evaluation of %s", condition);
 		}
 		result = FALSE;
 		goto Cleanup;
@@ -522,7 +520,7 @@ static const char * isAssign (Key * key, char * expr, Key * parentKey, KeySet * 
 		Key * assign = ksLookup (ks, lookupKey, KDB_O_NONE);
 		if (!assign)
 		{
-			ELEKTRA_SET_VALIDATION_SEMANTIC_ERRORF (parentKey, "Key %s not found", keyName (lookupKey));
+			ELEKTRA_SET_VALIDATION_SEMANTIC_ERROR (parentKey, assign, "Key not found");
 			keyDel (lookupKey);
 			return NULL;
 		}
@@ -744,8 +742,7 @@ static CondResult parseConditionString (const Key * meta, const Key * suffixList
 			ret = parseCondition (key, thenexpr, suffixList, ks, parentKey);
 			if (ret == FALSE)
 			{
-				ELEKTRA_SET_VALIDATION_SEMANTIC_ERRORF (parentKey, "Validation of Key %s: %s failed. (%s failed)",
-									keyName (key) + strlen (keyName (parentKey)) + 1, conditionString,
+				ELEKTRA_SET_VALIDATION_SEMANTIC_ERRORF (parentKey, key, "Validation of Key failed. (%s failed)",
 									thenexpr);
 			}
 			else if (ret == ERROR)
@@ -781,8 +778,7 @@ static CondResult parseConditionString (const Key * meta, const Key * suffixList
 
 				if (ret == FALSE)
 				{
-					ELEKTRA_SET_VALIDATION_SEMANTIC_ERRORF (parentKey, "Validation of Key %s: %s failed. (%s failed)",
-										keyName (key) + strlen (keyName (parentKey)) + 1,
+					ELEKTRA_SET_VALIDATION_SEMANTIC_ERRORF (parentKey, key, "Validation of Key failed. (%s failed)",
 										conditionString, elseexpr);
 				}
 				else if (ret == ERROR)

--- a/src/plugins/crypto/gpg.c
+++ b/src/plugins/crypto/gpg.c
@@ -447,7 +447,7 @@ static int verifyGpgKeysInConf (Key * root, KeySet * conf, Key * errorKey)
 	{
 		if (isValidGpgKey (conf, rootValue) != 1)
 		{
-			ELEKTRA_SET_VALIDATION_SEMANTIC_ERRORF (errorKey, GPG_ERROR_INVALID_KEY, rootValue);
+			ELEKTRA_SET_VALIDATION_SEMANTIC_ERRORF (errorKey, root, GPG_ERROR_INVALID_KEY, rootValue);
 			return -1; // failure
 		}
 	}
@@ -462,7 +462,7 @@ static int verifyGpgKeysInConf (Key * root, KeySet * conf, Key * errorKey)
 			const char * childValue = keyString (k);
 			if (isValidGpgKey (conf, childValue) != 1)
 			{
-				ELEKTRA_SET_VALIDATION_SEMANTIC_ERRORF (errorKey, GPG_ERROR_INVALID_KEY, childValue);
+				ELEKTRA_SET_VALIDATION_SEMANTIC_ERRORF (errorKey, k, GPG_ERROR_INVALID_KEY, childValue);
 				return -1; // failure
 			}
 		}
@@ -750,7 +750,7 @@ int ELEKTRA_PLUGIN_FUNCTION (gpgCall) (KeySet * conf, Key * errorKey, Key * msgK
 
 	case 1:
 		// bad signature
-		ELEKTRA_SET_VALIDATION_SEMANTIC_ERRORF (errorKey, "GPG reported a bad signature. Reason: %s", strerror (errno));
+		ELEKTRA_SET_VALIDATION_SEMANTIC_ERRORF (errorKey, msgKey, "GPG reported a bad signature. Reason: %s", strerror (errno));
 		break;
 
 	case GPG_CALL_DUP_STDIN:

--- a/src/plugins/crypto/helper.c
+++ b/src/plugins/crypto/helper.c
@@ -112,7 +112,7 @@ int ELEKTRA_PLUGIN_FUNCTION (getSaltFromMetakey) (Key * errorKey, Key * k, kdb_o
 	const Key * meta = keyGetMeta (k, ELEKTRA_CRYPTO_META_SALT);
 	if (!meta)
 	{
-		ELEKTRA_SET_VALIDATION_SEMANTIC_ERRORF (errorKey, "Missing salt as metakey %s in key %s", ELEKTRA_CRYPTO_META_SALT,
+		ELEKTRA_SET_VALIDATION_SEMANTIC_ERRORF (errorKey, k, "Missing salt as metakey %s in key %s", ELEKTRA_CRYPTO_META_SALT,
 							keyName (k));
 		return -1;
 	}
@@ -120,7 +120,7 @@ int ELEKTRA_PLUGIN_FUNCTION (getSaltFromMetakey) (Key * errorKey, Key * k, kdb_o
 	int result = ELEKTRA_PLUGIN_FUNCTION (base64Decode) (errorKey, keyString (meta), salt, &saltLenInternal);
 	if (result == -1)
 	{
-		ELEKTRA_SET_VALIDATION_SEMANTIC_ERRORF (errorKey, "Salt was not stored Base64 encoded in key %s", keyName (k));
+		ELEKTRA_SET_VALIDATION_SEMANTIC_ERROR (errorKey, k, "Salt was not stored Base64 encoded");
 		return -1;
 	}
 	else if (result == -2)
@@ -155,7 +155,7 @@ int ELEKTRA_PLUGIN_FUNCTION (getSaltFromPayload) (Key * errorKey, Key * k, kdb_o
 	// validate payload length
 	if ((size_t) payloadLen < sizeof (size_t) || payloadLen < 0)
 	{
-		ELEKTRA_SET_VALIDATION_SEMANTIC_ERRORF (errorKey, "Payload is too small to contain a salt (payload length is: %zu)",
+		ELEKTRA_SET_VALIDATION_SEMANTIC_ERRORF (errorKey, k, "Payload is too small to contain a salt (payload length is: %zu)",
 							payloadLen);
 		if (salt) *salt = NULL;
 		return -1;
@@ -172,7 +172,7 @@ int ELEKTRA_PLUGIN_FUNCTION (getSaltFromPayload) (Key * errorKey, Key * k, kdb_o
 	// validate restored salt length
 	if (restoredSaltLen < 1 || restoredSaltLen > (payloadLen - headerLen))
 	{
-		ELEKTRA_SET_VALIDATION_SEMANTIC_ERRORF (errorKey, "Restored salt has invalid length of %u (payload length is: %zu)",
+		ELEKTRA_SET_VALIDATION_SEMANTIC_ERRORF (errorKey, k, "Restored salt has invalid length of %u (payload length is: %zu)",
 							restoredSaltLen, payloadLen);
 		if (salt) *salt = NULL;
 		return -1;
@@ -272,7 +272,7 @@ int ELEKTRA_PLUGIN_FUNCTION (gpgEncryptMasterPassword) (KeySet * conf, Key * err
 	if (recipientCount == 0)
 	{
 		char * errorDescription = ELEKTRA_PLUGIN_FUNCTION (getMissingGpgKeyErrorText) (conf);
-		ELEKTRA_SET_VALIDATION_SEMANTIC_ERROR (errorKey, errorDescription);
+		ELEKTRA_SET_VALIDATION_SEMANTIC_ERROR (errorKey, msgKey, errorDescription);
 		elektraFree (errorDescription);
 		return -1;
 	}

--- a/src/plugins/crypto/openssl_operations.c
+++ b/src/plugins/crypto/openssl_operations.c
@@ -199,7 +199,7 @@ int elektraCryptoOpenSSLHandleCreate (elektraCryptoHandle ** handle, KeySet * co
 	{
 		keyDel (key);
 		keyDel (iv);
-		ELEKTRA_SET_VALIDATION_SEMANTIC_ERROR (errorKey, "Invalid key length was provided by the configuration");
+		ELEKTRA_SET_VALIDATION_SEMANTIC_ERROR (errorKey, key, "Invalid key length was provided by the configuration");
 		return -1;
 	}
 
@@ -208,7 +208,7 @@ int elektraCryptoOpenSSLHandleCreate (elektraCryptoHandle ** handle, KeySet * co
 		keyDel (key);
 		keyDel (iv);
 
-		ELEKTRA_SET_VALIDATION_SEMANTIC_ERROR (errorKey, "Invalid IV length was prodived by the configuration");
+		ELEKTRA_SET_VALIDATION_SEMANTIC_ERROR (errorKey, iv, "Invalid IV length was prodived by the configuration");
 		return -1;
 	}
 

--- a/src/plugins/curlget/curlget.c
+++ b/src/plugins/curlget/curlget.c
@@ -428,7 +428,7 @@ int elektraCurlgetOpen (Plugin * handle, Key * errorKey ELEKTRA_UNUSED)
 		if (!data->password)
 		{
 			ELEKTRA_SET_VALIDATION_SEMANTIC_ERROR (
-				errorKey, "No password specified for SSH password authentication in plugin configuration");
+				errorKey, key, "No password specified for SSH password authentication in plugin configuration");
 			if (data->uploadFileName) elektraFree (data->__uploadFileName);
 			elektraFree (data);
 			data = NULL;

--- a/src/plugins/fcrypt/fcrypt.c
+++ b/src/plugins/fcrypt/fcrypt.c
@@ -285,7 +285,7 @@ static int fcryptEncrypt (KeySet * pluginConfig, Key * parentKey)
 	if (recipientCount == 0 && signatureCount == 0)
 	{
 		ELEKTRA_SET_VALIDATION_SEMANTIC_ERRORF (
-			parentKey,
+			parentKey, k,
 			"Missing GPG recipient key (specified as %s) or GPG signature key (specified as %s) in plugin configuration",
 			ELEKTRA_RECIPIENT_KEY, ELEKTRA_SIGNATURE_KEY);
 		return -1;
@@ -674,7 +674,7 @@ int ELEKTRA_PLUGIN_FUNCTION (checkconf) (Key * errorKey, KeySet * conf)
 	if (recipientCount == 0 && signatureCount == 0)
 	{
 		char * errorDescription = ELEKTRA_PLUGIN_FUNCTION (getMissingGpgKeyErrorText) (conf);
-		ELEKTRA_SET_VALIDATION_SEMANTIC_ERROR (errorKey, errorDescription);
+		ELEKTRA_SET_VALIDATION_SEMANTIC_ERROR (errorKey, errorKey, errorDescription);
 		elektraFree (errorDescription);
 		return -1;
 	}

--- a/src/plugins/gpgme/gpgme.c
+++ b/src/plugins/gpgme/gpgme.c
@@ -153,8 +153,8 @@ static gpgme_key_t * extractRecipientFromPluginConfig (KeySet * config, Key * er
 		err = gpgme_get_key (ctx, keyString (gpgRecipientRoot), &key, 0);
 		if (err)
 		{
-			ELEKTRA_SET_VALIDATION_SEMANTIC_ERRORF (errorKey, gpgRecipientRoot, "Failed to read the specified GPG key. Reason: %s",
-								gpgme_strerror (err));
+			ELEKTRA_SET_VALIDATION_SEMANTIC_ERRORF (errorKey, gpgRecipientRoot,
+								"Failed to read the specified GPG key. Reason: %s", gpgme_strerror (err));
 			elektraGpgmeKeylistFree (&list);
 			return NULL;
 		}

--- a/src/plugins/gpgme/gpgme.c
+++ b/src/plugins/gpgme/gpgme.c
@@ -153,7 +153,7 @@ static gpgme_key_t * extractRecipientFromPluginConfig (KeySet * config, Key * er
 		err = gpgme_get_key (ctx, keyString (gpgRecipientRoot), &key, 0);
 		if (err)
 		{
-			ELEKTRA_SET_VALIDATION_SEMANTIC_ERRORF (errorKey, "Failed to read the specified GPG key. Reason: %s",
+			ELEKTRA_SET_VALIDATION_SEMANTIC_ERRORF (errorKey, gpgRecipientRoot, "Failed to read the specified GPG key. Reason: %s",
 								gpgme_strerror (err));
 			elektraGpgmeKeylistFree (&list);
 			return NULL;
@@ -184,7 +184,7 @@ static gpgme_key_t * extractRecipientFromPluginConfig (KeySet * config, Key * er
 				if (err)
 				{
 					ELEKTRA_SET_VALIDATION_SEMANTIC_ERRORF (
-						errorKey, "Failed to read the specified GPG key. Reason: %s", gpgme_strerror (err));
+						errorKey, k, "Failed to read the specified GPG key. Reason: %s", gpgme_strerror (err));
 					elektraGpgmeKeylistFree (&list);
 					return NULL;
 				}
@@ -365,7 +365,7 @@ static int gpgEncrypt (Plugin * handle, KeySet * data, Key * errorKey)
 	recipients = extractRecipientFromPluginConfig (pluginConfig, errorKey, ctx);
 	if (!recipients)
 	{
-		ELEKTRA_SET_VALIDATION_SEMANTIC_ERROR (errorKey, "No valid recipients were specified");
+		ELEKTRA_SET_VALIDATION_SEMANTIC_ERROR (errorKey, errorKey, "No valid recipients were specified");
 		returnValue = -1;
 		goto cleanup;
 	}
@@ -433,7 +433,7 @@ static int gpgEncrypt (Plugin * handle, KeySet * data, Key * errorKey)
 			generateInvalidKeyErrorMsg (&errorMsg, invalidKey);
 			if (errorMsg)
 			{
-				ELEKTRA_SET_VALIDATION_SEMANTIC_ERRORF (errorKey, "Invalid key ID(s): %s", errorMsg);
+				ELEKTRA_SET_VALIDATION_SEMANTIC_ERRORF (errorKey, invalidKey, "Invalid key ID(s): %s", errorMsg);
 				elektraFree (errorMsg);
 			}
 			else
@@ -614,7 +614,7 @@ int elektraGpgmeCheckconf (Key * errorKey, KeySet * conf)
 	}
 	else
 	{
-		ELEKTRA_SET_VALIDATION_SEMANTIC_ERROR (errorKey, "No valid recipients were specified");
+		ELEKTRA_SET_VALIDATION_SEMANTIC_ERROR (errorKey, errorKey, "No valid recipients were specified");
 		return -1; // failure
 	}
 	return 1; // success

--- a/src/plugins/hexnumber/hexnumber.c
+++ b/src/plugins/hexnumber/hexnumber.c
@@ -68,7 +68,7 @@ static int convertHexToDec (Key * key, Key * parentKey)
 	if (errno == ERANGE && value == ULLONG_MAX)
 	{
 		errno = errnoSaved;
-		ELEKTRA_SET_VALIDATION_SEMANTIC_ERRORF (parentKey, "Hexadecimal number %s out of range 0 to %llu", hexValue, ULLONG_MAX);
+		ELEKTRA_SET_VALIDATION_SEMANTIC_ERRORF (parentKey, key, "Hexadecimal number %s out of range 0 to %llu", hexValue, ULLONG_MAX);
 		return ELEKTRA_PLUGIN_STATUS_ERROR;
 	}
 	else if ((errno != 0 && value == 0) || endPtr == hexValue || *endPtr != '\0')
@@ -137,7 +137,7 @@ static int convertDecToHex (Key * key, Key * parentKey)
 	if (errno == ERANGE && value == ULLONG_MAX)
 	{
 		errno = errnoSaved;
-		ELEKTRA_SET_VALIDATION_SEMANTIC_ERRORF (parentKey, "Decimal number %s out of range 0 to %llu", decValue, ULLONG_MAX);
+		ELEKTRA_SET_VALIDATION_SEMANTIC_ERRORF (parentKey, key, "Decimal number %s out of range 0 to %llu", decValue, ULLONG_MAX);
 		return ELEKTRA_PLUGIN_STATUS_ERROR;
 	}
 	else if ((errno != 0 && value == 0) || endPtr == decValue)

--- a/src/plugins/hexnumber/hexnumber.c
+++ b/src/plugins/hexnumber/hexnumber.c
@@ -68,7 +68,8 @@ static int convertHexToDec (Key * key, Key * parentKey)
 	if (errno == ERANGE && value == ULLONG_MAX)
 	{
 		errno = errnoSaved;
-		ELEKTRA_SET_VALIDATION_SEMANTIC_ERRORF (parentKey, key, "Hexadecimal number %s out of range 0 to %llu", hexValue, ULLONG_MAX);
+		ELEKTRA_SET_VALIDATION_SEMANTIC_ERRORF (parentKey, key, "Hexadecimal number %s out of range 0 to %llu", hexValue,
+							ULLONG_MAX);
 		return ELEKTRA_PLUGIN_STATUS_ERROR;
 	}
 	else if ((errno != 0 && value == 0) || endPtr == hexValue || *endPtr != '\0')

--- a/src/plugins/ipaddr/ipaddr.c
+++ b/src/plugins/ipaddr/ipaddr.c
@@ -102,7 +102,7 @@ static int validateKey (Key * key, Key * parentKey)
 
 	if (!rc)
 	{
-		ELEKTRA_SET_VALIDATION_SEMANTIC_ERRORF (parentKey, "Validation of key %s with value %s failed", keyName (key),
+		ELEKTRA_SET_VALIDATION_SEMANTIC_ERRORF (parentKey, key, "Validation of key %s with value %s failed", keyName (key),
 							keyString (key));
 	}
 	else if (rc == -1)

--- a/src/plugins/lua/lua.cpp
+++ b/src/plugins/lua/lua.cpp
@@ -75,11 +75,11 @@ static int Lua_CallFunction_Int (lua_State * L, int nargs, ckdb::Key * errorKey)
 {
 	int ret = -1;
 	if (lua_pcall (L, nargs, 1, 0) != LUA_OK)
-		ELEKTRA_SET_VALIDATION_SEMANTIC_ERROR (errorKey, lua_tostring (L, -1));
+		ELEKTRA_SET_VALIDATION_SEMANTIC_ERROR (errorKey, errorKey, lua_tostring (L, -1));
 	else
 	{
 		if (!lua_isnumber (L, -1))
-			ELEKTRA_SET_VALIDATION_SEMANTIC_ERROR (errorKey, "Return value is no integer");
+			ELEKTRA_SET_VALIDATION_SEMANTIC_ERROR (errorKey, errorKey, "Return value is no integer");
 		else
 			ret = lua_tonumber (L, -1);
 	}

--- a/src/plugins/mathcheck/mathcheck.c
+++ b/src/plugins/mathcheck/mathcheck.c
@@ -397,7 +397,7 @@ int elektraMathcheckSet (Plugin * handle ELEKTRA_UNUSED, KeySet * returned, Key 
 		{
 			if (fabs (elektraEFtoF (keyString (cur)) - result.value) > EPSILON)
 			{
-				ELEKTRA_SET_VALIDATION_SEMANTIC_ERRORF (parentKey, "Mathcheck failed: %s != %s", val1, val2);
+				ELEKTRA_SET_VALIDATION_SEMANTIC_ERRORF (parentKey, cur, "Mathcheck failed: %s != %s", val1, val2);
 				return -1;
 			}
 		}
@@ -405,7 +405,7 @@ int elektraMathcheckSet (Plugin * handle ELEKTRA_UNUSED, KeySet * returned, Key 
 		{
 			if (fabs (elektraEFtoF (keyString (cur)) - result.value) < EPSILON)
 			{
-				ELEKTRA_SET_VALIDATION_SEMANTIC_ERRORF (parentKey,
+				ELEKTRA_SET_VALIDATION_SEMANTIC_ERRORF (parentKey, cur,
 									"Mathcheck failed: %s == %s but requirement was !=", val1, val2);
 				return -1;
 			}
@@ -414,7 +414,7 @@ int elektraMathcheckSet (Plugin * handle ELEKTRA_UNUSED, KeySet * returned, Key 
 		{
 			if (elektraEFtoF (keyString (cur)) >= result.value)
 			{
-				ELEKTRA_SET_VALIDATION_SEMANTIC_ERRORF (parentKey, "Mathcheck failed: %s not < %s", val1, val2);
+				ELEKTRA_SET_VALIDATION_SEMANTIC_ERRORF (parentKey, cur, "Mathcheck failed: %s not < %s", val1, val2);
 				return -1;
 			}
 		}
@@ -422,7 +422,7 @@ int elektraMathcheckSet (Plugin * handle ELEKTRA_UNUSED, KeySet * returned, Key 
 		{
 			if (elektraEFtoF (keyString (cur)) <= result.value)
 			{
-				ELEKTRA_SET_VALIDATION_SEMANTIC_ERRORF (parentKey, "Mathcheck failed: %s not > %s", val1, val2);
+				ELEKTRA_SET_VALIDATION_SEMANTIC_ERRORF (parentKey, cur, "Mathcheck failed: %s not > %s", val1, val2);
 				return -1;
 			}
 		}
@@ -430,7 +430,7 @@ int elektraMathcheckSet (Plugin * handle ELEKTRA_UNUSED, KeySet * returned, Key 
 		{
 			if (elektraEFtoF (keyString (cur)) > result.value)
 			{
-				ELEKTRA_SET_VALIDATION_SEMANTIC_ERRORF (parentKey, "Mathcheck failed: %s not <=	%s", val1, val2);
+				ELEKTRA_SET_VALIDATION_SEMANTIC_ERRORF (parentKey, cur, "Mathcheck failed: %s not <=	%s", val1, val2);
 				return -1;
 			}
 		}
@@ -438,7 +438,7 @@ int elektraMathcheckSet (Plugin * handle ELEKTRA_UNUSED, KeySet * returned, Key 
 		{
 			if (elektraEFtoF (keyString (cur)) < result.value)
 			{
-				ELEKTRA_SET_VALIDATION_SEMANTIC_ERRORF (parentKey, "Mathcheck failed: %s not >= %s", val1, val2);
+				ELEKTRA_SET_VALIDATION_SEMANTIC_ERRORF (parentKey, cur, "Mathcheck failed: %s not >= %s", val1, val2);
 				return -1;
 			}
 		}

--- a/src/plugins/network/network.c
+++ b/src/plugins/network/network.c
@@ -63,7 +63,7 @@ int elektraPortInfo (Key * toCheck, Key * parentKey)
 	{
 		if (portNumber < 0 || portNumber > 65535)
 		{
-			ELEKTRA_SET_VALIDATION_SEMANTIC_ERRORF (parentKey, "Port %ld on key %s was not within 0 - 65535", portNumber,
+			ELEKTRA_SET_VALIDATION_SEMANTIC_ERRORF (parentKey, toCheck, "Port %ld on key %s was not within 0 - 65535", portNumber,
 								keyName (toCheck));
 			return -1;
 		}
@@ -76,8 +76,7 @@ int elektraPortInfo (Key * toCheck, Key * parentKey)
 		if (service == NULL)
 		{
 			// `getservbyname` does not set any errno
-			ELEKTRA_SET_VALIDATION_SEMANTIC_ERRORF (parentKey, "Could not find service with name %s on key %s",
-								keyString (toCheck), keyName (toCheck));
+			ELEKTRA_SET_VALIDATION_SEMANTIC_ERROR (parentKey, toCheck, "Could not find service");
 			return -1;
 		}
 		portNumberNetworkByteOrder = service->s_port;
@@ -102,12 +101,12 @@ int elektraPortInfo (Key * toCheck, Key * parentKey)
 	{
 		if (errno == HOST_NOT_FOUND)
 		{
-			ELEKTRA_SET_VALIDATION_SEMANTIC_ERRORF (parentKey, "Could not connect to %s: No such host", hostname);
+			ELEKTRA_SET_VALIDATION_SEMANTIC_ERRORF (parentKey, toCheck, "Could not connect to %s: No such host", hostname);
 			return -1;
 		}
 		else
 		{
-			ELEKTRA_SET_VALIDATION_SEMANTIC_ERRORF (parentKey, "There was an error trying to connect to host '%s'. Reason: %s",
+			ELEKTRA_SET_VALIDATION_SEMANTIC_ERRORF (parentKey, toCheck, "There was an error trying to connect to host '%s'. Reason: %s",
 								hostname, strerror (errno));
 			return -1;
 		}
@@ -125,12 +124,12 @@ int elektraPortInfo (Key * toCheck, Key * parentKey)
 		close (sockfd);
 		if (errno == EADDRINUSE)
 		{
-			ELEKTRA_SET_VALIDATION_SEMANTIC_ERRORF (parentKey, "Port %s is already in use which was specified on key %s",
+			ELEKTRA_SET_VALIDATION_SEMANTIC_ERRORF (parentKey, toCheck, "Port %s is already in use which was specified on key %s",
 								keyString (toCheck), keyName (toCheck));
 		}
 		else
 		{
-			ELEKTRA_SET_VALIDATION_SEMANTIC_ERRORF (parentKey,
+			ELEKTRA_SET_VALIDATION_SEMANTIC_ERRORF (parentKey, toCheck, 
 								"Could not bind to port %s which was specified on key %s. Reason: %s",
 								keyString (toCheck), keyName (toCheck), strerror (errno));
 		}
@@ -181,7 +180,7 @@ int elektraNetworkSet (Plugin * handle ELEKTRA_UNUSED, KeySet * returned, Key * 
 			strcat (errmsg, keyValue (cur));
 			strcat (errmsg, " message: ");
 			strcat (errmsg, gaimsg);
-			ELEKTRA_SET_VALIDATION_SEMANTIC_ERROR (parentKey, errmsg);
+			ELEKTRA_SET_VALIDATION_SEMANTIC_ERROR (parentKey, cur, errmsg);
 			elektraFree (errmsg);
 			return -1;
 		}

--- a/src/plugins/network/network.c
+++ b/src/plugins/network/network.c
@@ -63,8 +63,8 @@ int elektraPortInfo (Key * toCheck, Key * parentKey)
 	{
 		if (portNumber < 0 || portNumber > 65535)
 		{
-			ELEKTRA_SET_VALIDATION_SEMANTIC_ERRORF (parentKey, toCheck, "Port %ld on key %s was not within 0 - 65535", portNumber,
-								keyName (toCheck));
+			ELEKTRA_SET_VALIDATION_SEMANTIC_ERRORF (parentKey, toCheck, "Port %ld on key %s was not within 0 - 65535",
+								portNumber, keyName (toCheck));
 			return -1;
 		}
 		portNumberNetworkByteOrder = htons (portNumber);
@@ -106,8 +106,9 @@ int elektraPortInfo (Key * toCheck, Key * parentKey)
 		}
 		else
 		{
-			ELEKTRA_SET_VALIDATION_SEMANTIC_ERRORF (parentKey, toCheck, "There was an error trying to connect to host '%s'. Reason: %s",
-								hostname, strerror (errno));
+			ELEKTRA_SET_VALIDATION_SEMANTIC_ERRORF (parentKey, toCheck,
+								"There was an error trying to connect to host '%s'. Reason: %s", hostname,
+								strerror (errno));
 			return -1;
 		}
 		// TODO: Maybe consider errno == TRY_AGAIN separately and try to reconnect
@@ -124,12 +125,13 @@ int elektraPortInfo (Key * toCheck, Key * parentKey)
 		close (sockfd);
 		if (errno == EADDRINUSE)
 		{
-			ELEKTRA_SET_VALIDATION_SEMANTIC_ERRORF (parentKey, toCheck, "Port %s is already in use which was specified on key %s",
+			ELEKTRA_SET_VALIDATION_SEMANTIC_ERRORF (parentKey, toCheck,
+								"Port %s is already in use which was specified on key %s",
 								keyString (toCheck), keyName (toCheck));
 		}
 		else
 		{
-			ELEKTRA_SET_VALIDATION_SEMANTIC_ERRORF (parentKey, toCheck, 
+			ELEKTRA_SET_VALIDATION_SEMANTIC_ERRORF (parentKey, toCheck,
 								"Could not bind to port %s which was specified on key %s. Reason: %s",
 								keyString (toCheck), keyName (toCheck), strerror (errno));
 		}

--- a/src/plugins/path/path.c
+++ b/src/plugins/path/path.c
@@ -130,7 +130,7 @@ static int validatePermission (Key * key, Key * parentKey)
 		// Check if user exists
 		if (p == NULL)
 		{
-			ELEKTRA_SET_VALIDATION_SEMANTIC_ERRORF (parentKey,
+			ELEKTRA_SET_VALIDATION_SEMANTIC_ERRORF (parentKey, key,
 								"Could not find user '%s' for key '%s'. "
 								"Does the user exist?",
 								name, keyName (key));
@@ -213,7 +213,7 @@ static int validatePermission (Key * key, Key * parentKey)
 	if (canAccess != 0)
 	{
 		// No Resource error per se because related to the specification check!
-		ELEKTRA_SET_VALIDATION_SEMANTIC_ERRORF (parentKey, "User %s does not have required permission (%s) on '%s'. Key: %s", name,
+		ELEKTRA_SET_VALIDATION_SEMANTIC_ERRORF (parentKey, key, "User %s does not have required permission (%s) on '%s'. Key: %s", name,
 							modes, validPath, keyName (key));
 		return -1;
 	}
@@ -314,7 +314,7 @@ static int handleNoUserCase (Key * parentKey, const char * validPath, const char
 	int result = access (validPath, modeMask);
 	if (result != 0)
 	{
-		ELEKTRA_SET_VALIDATION_SEMANTIC_ERRORF (parentKey, "User '%s' does not have required permission (%s) on '%s'. Key: %s",
+		ELEKTRA_SET_VALIDATION_SEMANTIC_ERRORF (parentKey, key, "User '%s' does not have required permission (%s) on '%s'. Key: %s",
 							p->pw_name, modes, validPath, keyName (key));
 		return -1;
 	}

--- a/src/plugins/path/path.c
+++ b/src/plugins/path/path.c
@@ -213,8 +213,8 @@ static int validatePermission (Key * key, Key * parentKey)
 	if (canAccess != 0)
 	{
 		// No Resource error per se because related to the specification check!
-		ELEKTRA_SET_VALIDATION_SEMANTIC_ERRORF (parentKey, key, "User %s does not have required permission (%s) on '%s'. Key: %s", name,
-							modes, validPath, keyName (key));
+		ELEKTRA_SET_VALIDATION_SEMANTIC_ERRORF (parentKey, key, "User %s does not have required permission (%s) on '%s'. Key: %s",
+							name, modes, validPath, keyName (key));
 		return -1;
 	}
 

--- a/src/plugins/quickdump/quickdump.c
+++ b/src/plugins/quickdump/quickdump.c
@@ -255,7 +255,7 @@ int elektraQuickdumpGet (Plugin * handle ELEKTRA_UNUSED, KeySet * returned, Key 
 			elektraFree (metaNameBuffer.string);
 			elektraFree (valueBuffer.string);
 			fclose (file);
-			ELEKTRA_SET_VALIDATION_SEMANTIC_ERROR (parentKey, "Missing key type");
+			ELEKTRA_SET_VALIDATION_SEMANTIC_ERROR (parentKey, parentKey, "Missing key type");
 			return ELEKTRA_PLUGIN_STATUS_ERROR;
 		}
 
@@ -316,7 +316,7 @@ int elektraQuickdumpGet (Plugin * handle ELEKTRA_UNUSED, KeySet * returned, Key 
 			elektraFree (metaNameBuffer.string);
 			elektraFree (valueBuffer.string);
 			fclose (file);
-			ELEKTRA_SET_VALIDATION_SEMANTIC_ERRORF (parentKey, "Unknown key type %c", type);
+			ELEKTRA_SET_VALIDATION_SEMANTIC_ERRORF (parentKey, parentKey, "Unknown key type %c", type);
 			return ELEKTRA_PLUGIN_STATUS_ERROR;
 		}
 

--- a/src/plugins/range/range.c
+++ b/src/plugins/range/range.c
@@ -444,7 +444,7 @@ static int validateKey (Key * key, Key * parentKey)
 		}
 		else if (rc == 0)
 		{
-			ELEKTRA_SET_VALIDATION_SEMANTIC_ERRORF (parentKey, RANGE_ERROR_MESSAGE, keyString (key), keyName (key),
+			ELEKTRA_SET_VALIDATION_SEMANTIC_ERRORF (parentKey, key, RANGE_ERROR_MESSAGE, keyString (key), keyName (key),
 								rangeString);
 			return 0;
 		}
@@ -458,7 +458,7 @@ static int validateKey (Key * key, Key * parentKey)
 		int rc = validateMultipleRanges (keyString (key), rangeString, parentKey, type);
 		if (rc == 0)
 		{
-			ELEKTRA_SET_VALIDATION_SEMANTIC_ERRORF (parentKey, RANGE_ERROR_MESSAGE, keyString (key), keyName (key),
+			ELEKTRA_SET_VALIDATION_SEMANTIC_ERRORF (parentKey, key, RANGE_ERROR_MESSAGE, keyString (key), keyName (key),
 								rangeString);
 		}
 		return rc;

--- a/src/plugins/reference/reference.c
+++ b/src/plugins/reference/reference.c
@@ -135,8 +135,9 @@ static int checkSingleReference (const Key * key, KeySet * allKeys, Key * parent
 		bool error = false;
 		if (refKey == NULL)
 		{
-			ELEKTRA_SET_VALIDATION_SEMANTIC_ERRORF (
-				parentKey, arrayElement, "Reference '%s', set in key '%s', does not reference an existing key", ref, elementName);
+			ELEKTRA_SET_VALIDATION_SEMANTIC_ERRORF (parentKey, arrayElement,
+								"Reference '%s', set in key '%s', does not reference an existing key", ref,
+								elementName);
 			error = true;
 		}
 
@@ -339,8 +340,8 @@ static int checkRecursiveReference (const Key * rootKey, KeySet * allKeys, Key *
 				if (refKey == NULL)
 				{
 					ELEKTRA_SET_VALIDATION_SEMANTIC_ERRORF (
-						parentKey, refKey, "Reference '%s', set in key '%s', does not reference an existing key", ref,
-						elementName);
+						parentKey, refKey, "Reference '%s', set in key '%s', does not reference an existing key",
+						ref, elementName);
 					error = true;
 				}
 

--- a/src/plugins/reference/reference.c
+++ b/src/plugins/reference/reference.c
@@ -136,7 +136,7 @@ static int checkSingleReference (const Key * key, KeySet * allKeys, Key * parent
 		if (refKey == NULL)
 		{
 			ELEKTRA_SET_VALIDATION_SEMANTIC_ERRORF (
-				parentKey, "Reference '%s', set in key '%s', does not reference an existing key", ref, elementName);
+				parentKey, arrayElement, "Reference '%s', set in key '%s', does not reference an existing key", ref, elementName);
 			error = true;
 		}
 
@@ -158,7 +158,7 @@ static int checkSingleReference (const Key * key, KeySet * allKeys, Key * parent
 			if (!anyMatch)
 			{
 				ELEKTRA_SET_VALIDATION_SEMANTIC_ERRORF (
-					parentKey, "Reference '%s', set in key '%s', does not any of the given restrictions", ref,
+					parentKey, refKey, "Reference '%s', set in key '%s', does not any of the given restrictions", ref,
 					elementName);
 				error = true;
 			}
@@ -339,7 +339,7 @@ static int checkRecursiveReference (const Key * rootKey, KeySet * allKeys, Key *
 				if (refKey == NULL)
 				{
 					ELEKTRA_SET_VALIDATION_SEMANTIC_ERRORF (
-						parentKey, "Reference '%s', set in key '%s', does not reference an existing key", ref,
+						parentKey, refKey, "Reference '%s', set in key '%s', does not reference an existing key", ref,
 						elementName);
 					error = true;
 				}
@@ -364,7 +364,7 @@ static int checkRecursiveReference (const Key * rootKey, KeySet * allKeys, Key *
 					if (!anyMatch)
 					{
 						ELEKTRA_SET_VALIDATION_SEMANTIC_ERRORF (
-							parentKey,
+							parentKey, refKey,
 							"Reference '%s', set in key '%s', does not any of the given restrictions", ref,
 							elementName);
 						error = true;
@@ -407,7 +407,7 @@ static int checkRecursiveReference (const Key * rootKey, KeySet * allKeys, Key *
 	*strrchr (rootName, '/') = '\0';
 	if (!checkReferenceGraphAcyclic (referenceGraph, rootName))
 	{
-		ELEKTRA_SET_VALIDATION_SEMANTIC_ERROR (parentKey, "The configuration contains a cyclic reference");
+		ELEKTRA_SET_VALIDATION_SEMANTIC_ERROR (parentKey, parentKey, "The configuration contains a cyclic reference");
 
 		elektraFree (rootName);
 		rgDel (referenceGraph);

--- a/src/plugins/type/type.c
+++ b/src/plugins/type/type.c
@@ -127,7 +127,7 @@ bool elektraTypeValidateKey (Plugin * handle, Key * key, Key * errorKey)
 
 	if (type->restore != NULL && !type->restore (handle, key))
 	{
-		ELEKTRA_SET_VALIDATION_SEMANTIC_ERRORF (errorKey, key, 
+		ELEKTRA_SET_VALIDATION_SEMANTIC_ERRORF (errorKey, key,
 							"The normalized value '%s' of key '%s' could not be restored (type is '%s')",
 							keyString (key), keyName (key), typeName);
 		return false;
@@ -172,7 +172,7 @@ static kdb_long_long_t readBooleans (KeySet * config, struct boolean_pair ** res
 		if ((trueKey == NULL) != (falseKey == NULL))
 		{
 			ELEKTRA_SET_VALIDATION_SEMANTIC_ERRORF (
-				errorKey,parent,  "You must set both true and false for a boolean pair (config key: '%s')", buffer);
+				errorKey, parent, "You must set both true and false for a boolean pair (config key: '%s')", buffer);
 			elektraFree (*result);
 			*result = NULL;
 			return -2;
@@ -267,8 +267,9 @@ int elektraTypeOpen (Plugin * handle, Key * errorKey)
 	data->booleanRestore = readBooleanRestore (conf);
 	if (data->booleanRestore < -2 || data->booleanRestore >= data->booleanCount)
 	{
-		//TODO: Add value which was invalid
-		ELEKTRA_SET_VALIDATION_SEMANTIC_ERROR (errorKey, keyNew ("/boolean/restoreas"), "The value of the config key /boolean/restoreas was invalid");
+		// TODO: Add value which was invalid
+		ELEKTRA_SET_VALIDATION_SEMANTIC_ERROR (errorKey, keyNew ("/boolean/restoreas"),
+						       "The value of the config key /boolean/restoreas was invalid");
 		elektraFree (data);
 		return ELEKTRA_PLUGIN_STATUS_ERROR;
 	}
@@ -404,8 +405,8 @@ int elektraTypeSet (Plugin * handle ELEKTRA_UNUSED, KeySet * returned, Key * par
 		if (type->restore != NULL && !type->restore (handle, cur))
 		{
 			ELEKTRA_SET_VALIDATION_SEMANTIC_ERRORF (
-				parentKey, cur, "The normalized value '%s' of key '%s' could not be restored (type is '%s')", keyString (cur),
-				keyName (cur), typeName);
+				parentKey, cur, "The normalized value '%s' of key '%s' could not be restored (type is '%s')",
+				keyString (cur), keyName (cur), typeName);
 			ksSetCursor (returned, cursor);
 			return ELEKTRA_PLUGIN_STATUS_ERROR;
 		}

--- a/src/plugins/type/type.c
+++ b/src/plugins/type/type.c
@@ -93,7 +93,7 @@ bool elektraTypeCheckType (const Key * key)
 
 static void elektraTypeSetDefaultError (Plugin * handle ELEKTRA_UNUSED, Key * errorKey, const Key * key)
 {
-	ELEKTRA_SET_VALIDATION_SEMANTIC_ERRORF (errorKey, "The type '%s' failed to match for '%s' with string '%s'", getTypeName (key),
+	ELEKTRA_SET_VALIDATION_SEMANTIC_ERRORF (errorKey, key, "The type '%s' failed to match for '%s' with string '%s'", getTypeName (key),
 						keyName (key), keyString (key));
 }
 
@@ -108,7 +108,7 @@ bool elektraTypeValidateKey (Plugin * handle, Key * key, Key * errorKey)
 	const Type * type = findType (typeName);
 	if (type == NULL)
 	{
-		ELEKTRA_SET_VALIDATION_SEMANTIC_ERRORF (errorKey, "Unknown type '%s' for key '%s'", typeName, keyName (key));
+		ELEKTRA_SET_VALIDATION_SEMANTIC_ERRORF (errorKey, key, "Unknown type '%s' for key '%s'", typeName, keyName (key));
 		return false;
 	}
 
@@ -127,7 +127,7 @@ bool elektraTypeValidateKey (Plugin * handle, Key * key, Key * errorKey)
 
 	if (type->restore != NULL && !type->restore (handle, key))
 	{
-		ELEKTRA_SET_VALIDATION_SEMANTIC_ERRORF (errorKey,
+		ELEKTRA_SET_VALIDATION_SEMANTIC_ERRORF (errorKey, key, 
 							"The normalized value '%s' of key '%s' could not be restored (type is '%s')",
 							keyString (key), keyName (key), typeName);
 		return false;
@@ -172,7 +172,7 @@ static kdb_long_long_t readBooleans (KeySet * config, struct boolean_pair ** res
 		if ((trueKey == NULL) != (falseKey == NULL))
 		{
 			ELEKTRA_SET_VALIDATION_SEMANTIC_ERRORF (
-				errorKey, "You must set both true and false for a boolean pair (config key: '%s')", buffer);
+				errorKey,parent,  "You must set both true and false for a boolean pair (config key: '%s')", buffer);
 			elektraFree (*result);
 			*result = NULL;
 			return -2;
@@ -267,7 +267,8 @@ int elektraTypeOpen (Plugin * handle, Key * errorKey)
 	data->booleanRestore = readBooleanRestore (conf);
 	if (data->booleanRestore < -2 || data->booleanRestore >= data->booleanCount)
 	{
-		ELEKTRA_SET_VALIDATION_SEMANTIC_ERROR (errorKey, "The value of the config key /boolean/restoreas was invalid");
+		//TODO: Add value which was invalid
+		ELEKTRA_SET_VALIDATION_SEMANTIC_ERROR (errorKey, keyNew ("/boolean/restoreas"), "The value of the config key /boolean/restoreas was invalid");
 		elektraFree (data);
 		return ELEKTRA_PLUGIN_STATUS_ERROR;
 	}
@@ -314,7 +315,7 @@ int elektraTypeGet (Plugin * handle ELEKTRA_UNUSED, KeySet * returned, Key * par
 		const Type * type = findType (typeName);
 		if (type == NULL)
 		{
-			ELEKTRA_SET_VALIDATION_SEMANTIC_ERRORF (parentKey, "Unknown type '%s' for key '%s'", typeName, keyName (cur));
+			ELEKTRA_SET_VALIDATION_SEMANTIC_ERRORF (parentKey, cur, "Unknown type '%s' for key '%s'", typeName, keyName (cur));
 			ksSetCursor (returned, cursor);
 			return ELEKTRA_PLUGIN_STATUS_ERROR;
 		}
@@ -335,7 +336,7 @@ int elektraTypeGet (Plugin * handle ELEKTRA_UNUSED, KeySet * returned, Key * par
 
 			if (!type->normalize (handle, cur))
 			{
-				ELEKTRA_SET_VALIDATION_SEMANTIC_ERRORF (parentKey,
+				ELEKTRA_SET_VALIDATION_SEMANTIC_ERRORF (parentKey, cur,
 									"The value '%s' of key '%s' could not be converted into a %s",
 									keyString (cur), keyName (cur), typeName);
 				ksSetCursor (returned, cursor);
@@ -374,7 +375,7 @@ int elektraTypeSet (Plugin * handle ELEKTRA_UNUSED, KeySet * returned, Key * par
 		const Type * type = findType (typeName);
 		if (type == NULL)
 		{
-			ELEKTRA_SET_VALIDATION_SEMANTIC_ERRORF (parentKey, "Unknown type '%s' for key '%s'", typeName, keyName (cur));
+			ELEKTRA_SET_VALIDATION_SEMANTIC_ERRORF (parentKey, cur, "Unknown type '%s' for key '%s'", typeName, keyName (cur));
 			ksSetCursor (returned, cursor);
 			return ELEKTRA_PLUGIN_STATUS_ERROR;
 		}
@@ -385,7 +386,7 @@ int elektraTypeSet (Plugin * handle ELEKTRA_UNUSED, KeySet * returned, Key * par
 			// skip normalization origvalue already set
 			if (orig == NULL && !type->normalize (handle, cur))
 			{
-				ELEKTRA_SET_VALIDATION_SEMANTIC_ERRORF (parentKey,
+				ELEKTRA_SET_VALIDATION_SEMANTIC_ERRORF (parentKey, cur,
 									"The value '%s' of key '%s' could not be converted into a %s",
 									keyString (cur), keyName (cur), typeName);
 				ksSetCursor (returned, cursor);
@@ -403,7 +404,7 @@ int elektraTypeSet (Plugin * handle ELEKTRA_UNUSED, KeySet * returned, Key * par
 		if (type->restore != NULL && !type->restore (handle, cur))
 		{
 			ELEKTRA_SET_VALIDATION_SEMANTIC_ERRORF (
-				parentKey, "The normalized value '%s' of key '%s' could not be restored (type is '%s')", keyString (cur),
+				parentKey, cur, "The normalized value '%s' of key '%s' could not be restored (type is '%s')", keyString (cur),
 				keyName (cur), typeName);
 			ksSetCursor (returned, cursor);
 			return ELEKTRA_PLUGIN_STATUS_ERROR;

--- a/src/plugins/type/types.c
+++ b/src/plugins/type/types.c
@@ -492,7 +492,7 @@ void elektraTypeSetErrorEnum (Plugin * handle ELEKTRA_UNUSED, Key * errorKey, co
 	if (max == NULL)
 	{
 		ELEKTRA_SET_VALIDATION_SEMANTIC_ERRORF (
-			errorKey,
+			errorKey, key,
 			"The type 'enum' failed to match for '%s' with string: '%s'\n"
 			"No values are allowed (check/enum is an empty array, or parent isn't set to last element)",
 			keyName (key), keyString (key));
@@ -525,6 +525,6 @@ void elektraTypeSetErrorEnum (Plugin * handle ELEKTRA_UNUSED, Key * errorKey, co
 		elektraWriteArrayNumber (indexStart, index);
 	}
 
-	ELEKTRA_SET_VALIDATION_SEMANTIC_ERROR (errorKey, errorMessage);
+	ELEKTRA_SET_VALIDATION_SEMANTIC_ERROR (errorKey, key, errorMessage);
 	elektraFree (errorMessage);
 }


### PR DESCRIPTION
## Proof of concept for semantic validation errors

This PR is a proof of concept and not intended to be merged as it is a basis for discussion. It compiles on my system (with minor warnings), tests are not fixed.

## What I have done

I introduced a different error signature for semantic validation errors that force the developer to provide the faulty key. This key then will get printed out along with its value.

An error message for a non-existing error not looks like this:

```sh
Using name user/tests/abc
Sorry, module network issued the error C03200:
Validation Semantic: Key user/tests/abc with value sshaa does not fulfill: Could not find service
```

instead of 

```sh
Using name user/tests/abc
Sorry, module network issued the error C03200:
Validation Semantic: Could not find service with name sshaa on key user/tests/abc
```

## What does it solve?

In the majority of the error messages either the key or the value was missing. 
Any new error message will easily forget one of these two essential parts. This signature enforces a correct error message which helps the user/admin find the erroneous configuration setting.

## Problems with this approach 

1.  https://github.com/ElektraInitiative/libelektra/blob/master/src/plugins/fcrypt/fcrypt.c#L677
    Erroneous keyset, not concrete Key.
2. opts.c
    Value usually not needed, just keyName (or keyBaseName)
3. lua.cpp https://github.com/ElektraInitiative/libelektra/blob/master/src/plugins/lua/lua.cpp#L78
    Probably no validation semantic errors
4. reference.c https://github.com/Piankero/libelektra/blob/master/src/plugins/reference/reference.c#L410
    Giving parentKey here is ok as other error message should yield concrete key

## Remedies

1. With current approach a Key has to be generated that holds the key + value if for example a keyset is erroneous. Furthermore to remedy the opts.c problem I would suggest that
        if value == null then do not show the value in the error message:
        Eg. Key "user/tests" failed to validate because of ....
        instead of
        Eg. Key "user/tests" with value "wrong" failed to validate because of ....
2. Rewrite signature to accept keyName + value instead of Key
	This solves the problem when a keyset is faulty and not a single key
3. Provide an extra macro that is primarily used for specification errors that expect the Key with a value
        The problematic cases could then be ignored
        The knowledge of this extra macro though might not be obvious to new developers

## Implications

Some methods have to be rewritten to provide the needed information
