### PR TITLE
CI: Fix macOS Build Jobs

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -153,7 +153,6 @@ mac_task:
       brew update # Work around for [Homebrew Services issue 206](https://github.com/Homebrew/homebrew-services/issues/206)
       brew services start dbus
     - | # Install Python
-      brew install python@2; brew link --overwrite python@2
       brew install python || brew upgrade python
     - | # Install Python packages
       pip install cmake-format[yaml]==0.6.3

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -155,7 +155,7 @@ mac_task:
     - | # Install Python
       brew install python || brew upgrade python
     - | # Install Python packages
-      pip install cmake-format[yaml]==0.6.3
+      pip3 install cmake-format[yaml]==0.6.3
     - | # Install Ruby (We use the Homebrew version of Ruby to install gems, since compiling `ronn` fails with the macOs version of Ruby.)
       brew install ruby@2.6
       export PATH="/usr/local/opt/ruby@2.6/bin:/usr/local/lib/ruby/gems/2.6.0/bin:$PATH"

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -157,8 +157,8 @@ mac_task:
     - | # Install Python packages
       pip3 install cmake-format[yaml]==0.6.3
     - | # Install Ruby (We use the Homebrew version of Ruby to install gems, since compiling `ronn` fails with the macOs version of Ruby.)
-      brew install ruby@2.6
-      export PATH="/usr/local/opt/ruby@2.6/bin:/usr/local/lib/ruby/gems/2.6.0/bin:$PATH"
+      brew install ruby@2.7
+      export PATH="/usr/local/opt/ruby@2.7/bin:/usr/local/lib/ruby/gems/2.7.0/bin:$PATH"
     - | # Install Ruby gems
       sudo gem install ronn test-unit --no-document
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -177,6 +177,7 @@ matrix:
             - swig
             - yajl
             - zeromq
+          update: true
       env:
         # Unfortunately the tests for the Xerces plugin fail: https://travis-ci.org/ElektraInitiative/libelektra/jobs/483331657#L3740
         - PLUGINS='ALL;-xerces'

--- a/doc/news/_preparation_next_release.md
+++ b/doc/news/_preparation_next_release.md
@@ -183,7 +183,7 @@ you up to date with the multi-language support provided by Elektra.
 
 - We fixed a minor problem with the package install procedure on macOS build jobs. _(René Schwaiger)_
 - We updated the startup command for D-Bus on macOS. _(René Schwaiger)_
-- <<TODO>>
+- We removed python2 (EOL and removed from homebrew). _(Mihael Pranjić)_
 
 ### Jenkins
 


### PR DESCRIPTION
This pull request is partially based on PR #3350. As far as I know, it should fix the current build problems on both Cirrus and Travis. It is a little bit less intrusive than PR #3350, since afterwards `ronn` should still build the man pages in the Cirrus macOS build jobs. This has the advantage that the uninstall check:

https://github.com/ElektraInitiative/libelektra/blob/5f742352a5bc1a6a25d8e153cf5c30203fbcc89a/.cirrus.yml#L197-L205

makes sure that uninstalling also removes all man pages. Please feel free to close this PR in favor of pull request #3350 if you like.