### PR TITLE
docker: fix debian sid packages

### DIFF
--- a/doc/news/_preparation_next_release.md
+++ b/doc/news/_preparation_next_release.md
@@ -239,6 +239,7 @@ you up to date with the multi-language support provided by Elektra.
 - Fixed [coveralls](https://coveralls.io/github/ElektraInitiative/libelektra) coverage report. _(Mihael Pranjić)_
 - The build jobs `debian-unstable-clang-asan` and `debian-unstable-full-clang` now use Clang 9 to compile Elektra. _(René Schwaiger)_
 - Added the Jenkins.monthly in the jenkins' scripts file. _(Djordje Bulatovic)_
+- Test CI after jenkins upgrade. _(Mihael Pranjić)_
 - <<TODO>>
 
 ### Travis

--- a/doc/news/_preparation_next_release.md
+++ b/doc/news/_preparation_next_release.md
@@ -222,6 +222,7 @@ you up to date with the multi-language support provided by Elektra.
 - We updated some of the software in the [Dockerfile for Debian sid](../../scripts/docker/debian/sid/Dockerfile). _(René Schwaiger)_
 - Building the [documentation Dockerfile for Debian Stretch](../../scripts/docker/debian/stretch/doc.Dockerfile) works again. _(René Schwaiger)_
 - Use python 3, SWIG 4.0 and ruby 2.5 in the [Dockerfile for Debian sid](../../scripts/docker/debian/sid/Dockerfile). _(Mihael Pranjić)_
+- Disable python binding on `debian-unstable-full-clang` due to upstream [issue](https://github.com/ElektraInitiative/libelektra/issues/3379). _(Mihael Pranjić)_
 - <<TODO>>
 
 ## Infrastructure

--- a/doc/news/_preparation_next_release.md
+++ b/doc/news/_preparation_next_release.md
@@ -221,7 +221,7 @@ you up to date with the multi-language support provided by Elektra.
 
 - We updated some of the software in the [Dockerfile for Debian sid](../../scripts/docker/debian/sid/Dockerfile). _(René Schwaiger)_
 - Building the [documentation Dockerfile for Debian Stretch](../../scripts/docker/debian/stretch/doc.Dockerfile) works again. _(René Schwaiger)_
-- Use python 3.7 and ruby 2.5 in the [Dockerfile for Debian sid](../../scripts/docker/debian/sid/Dockerfile). _(Mihael Pranjić)_
+- Use python 3, SWIG 4.0 and ruby 2.5 in the [Dockerfile for Debian sid](../../scripts/docker/debian/sid/Dockerfile). _(Mihael Pranjić)_
 - <<TODO>>
 
 ## Infrastructure

--- a/doc/news/_preparation_next_release.md
+++ b/doc/news/_preparation_next_release.md
@@ -221,6 +221,7 @@ you up to date with the multi-language support provided by Elektra.
 
 - We updated some of the software in the [Dockerfile for Debian sid](../../scripts/docker/debian/sid/Dockerfile). _(René Schwaiger)_
 - Building the [documentation Dockerfile for Debian Stretch](../../scripts/docker/debian/stretch/doc.Dockerfile) works again. _(René Schwaiger)_
+- Use python3-pip in the [Dockerfile for Debian sid](../../scripts/docker/debian/sid/Dockerfile). _(Mihael Pranjić)_
 - <<TODO>>
 
 ## Infrastructure
@@ -239,7 +240,6 @@ you up to date with the multi-language support provided by Elektra.
 - Fixed [coveralls](https://coveralls.io/github/ElektraInitiative/libelektra) coverage report. _(Mihael Pranjić)_
 - The build jobs `debian-unstable-clang-asan` and `debian-unstable-full-clang` now use Clang 9 to compile Elektra. _(René Schwaiger)_
 - Added the Jenkins.monthly in the jenkins' scripts file. _(Djordje Bulatovic)_
-- Test CI after jenkins upgrade. _(Mihael Pranjić)_
 - <<TODO>>
 
 ### Travis

--- a/doc/news/_preparation_next_release.md
+++ b/doc/news/_preparation_next_release.md
@@ -221,7 +221,7 @@ you up to date with the multi-language support provided by Elektra.
 
 - We updated some of the software in the [Dockerfile for Debian sid](../../scripts/docker/debian/sid/Dockerfile). _(René Schwaiger)_
 - Building the [documentation Dockerfile for Debian Stretch](../../scripts/docker/debian/stretch/doc.Dockerfile) works again. _(René Schwaiger)_
-- Use python3-pip and ruby 2.5 in the [Dockerfile for Debian sid](../../scripts/docker/debian/sid/Dockerfile). _(Mihael Pranjić)_
+- Use python 3.7 and ruby 2.5 in the [Dockerfile for Debian sid](../../scripts/docker/debian/sid/Dockerfile). _(Mihael Pranjić)_
 - <<TODO>>
 
 ## Infrastructure

--- a/doc/news/_preparation_next_release.md
+++ b/doc/news/_preparation_next_release.md
@@ -221,7 +221,7 @@ you up to date with the multi-language support provided by Elektra.
 
 - We updated some of the software in the [Dockerfile for Debian sid](../../scripts/docker/debian/sid/Dockerfile). _(René Schwaiger)_
 - Building the [documentation Dockerfile for Debian Stretch](../../scripts/docker/debian/stretch/doc.Dockerfile) works again. _(René Schwaiger)_
-- Use python3-pip in the [Dockerfile for Debian sid](../../scripts/docker/debian/sid/Dockerfile). _(Mihael Pranjić)_
+- Use python3-pip and ruby 2.5 in the [Dockerfile for Debian sid](../../scripts/docker/debian/sid/Dockerfile). _(Mihael Pranjić)_
 - <<TODO>>
 
 ## Infrastructure

--- a/scripts/docker/debian/sid/Dockerfile
+++ b/scripts/docker/debian/sid/Dockerfile
@@ -50,8 +50,7 @@ RUN apt-get update && apt-get -y install \
         npm \
         pkg-config \
         python3.7-dev \
-        python3.7-pip \
-        python3.7-dev \
+        python3-pip \
         ronn \
         ruby2.5-dev \
         sloccount \

--- a/scripts/docker/debian/sid/Dockerfile
+++ b/scripts/docker/debian/sid/Dockerfile
@@ -49,12 +49,12 @@ RUN apt-get update && apt-get -y install \
         ninja-build \
         npm \
         pkg-config \
-        python3.7-dev \
+        python3-dev \
         python3-pip \
         ronn \
         ruby2.5-dev \
         sloccount \
-        swig3.0 \
+        swig4.0 \
         systemd \
         tclcl-dev \
         valgrind \

--- a/scripts/docker/debian/sid/Dockerfile
+++ b/scripts/docker/debian/sid/Dockerfile
@@ -64,7 +64,7 @@ RUN apt-get update && apt-get -y install \
 # Update cache for shared libraries
 RUN ldconfig
 
-RUN pip install cmake-format[yaml]==0.6.3
+RUN pip3 install cmake-format[yaml]==0.6.3
 
 # Google Test
 ENV GTEST_ROOT=/opt/gtest

--- a/scripts/docker/debian/sid/Dockerfile
+++ b/scripts/docker/debian/sid/Dockerfile
@@ -53,7 +53,7 @@ RUN apt-get update && apt-get -y install \
         python3-pip \
         python3-dev \
         ronn \
-        ruby-dev \
+        ruby2.5-dev \
         sloccount \
         swig3.0 \
         systemd \

--- a/scripts/docker/debian/sid/Dockerfile
+++ b/scripts/docker/debian/sid/Dockerfile
@@ -49,9 +49,9 @@ RUN apt-get update && apt-get -y install \
         ninja-build \
         npm \
         pkg-config \
-        python3-dev \
-        python3-pip \
-        python3-dev \
+        python3.7-dev \
+        python3.7-pip \
+        python3.7-dev \
         ronn \
         ruby2.5-dev \
         sloccount \

--- a/scripts/docker/debian/sid/Dockerfile
+++ b/scripts/docker/debian/sid/Dockerfile
@@ -49,8 +49,8 @@ RUN apt-get update && apt-get -y install \
         ninja-build \
         npm \
         pkg-config \
-        python-dev \
-        python-pip \
+        python3-dev \
+        python3-pip \
         python3-dev \
         ronn \
         ruby-dev \

--- a/scripts/jenkins/Jenkinsfile
+++ b/scripts/jenkins/Jenkinsfile
@@ -558,15 +558,17 @@ def generateFullBuildStages() {
     [TEST.ALL]
   )
 
-  // Build Elektra with clang. We use unstable for easy access to clang-6.0
+  // Build Elektra with clang. We use unstable for easy access to clang-9.0
   // Detects problems when using an alternative compiler (clang)
+  // SWIG 4.0.1 has issues with Python 3.8 (https://github.com/ElektraInitiative/libelektra/issues/3379)
   tasks << buildAndTest(
     "debian-unstable-full-clang",
     DOCKER_IMAGES.sid,
     CMAKE_FLAGS_BUILD_ALL +
       CMAKE_FLAGS_DEBUG +
-      CMAKE_FLAGS_CLANG
-    ,
+      CMAKE_FLAGS_CLANG + [
+      'BINDINGS': 'ALL;-python',
+      ],
     [TEST.ALL, TEST.MEM, TEST.INSTALL]
   )
 


### PR DESCRIPTION
Debian sid bumped some package versions so some packages we used are no longer available. Notably python 2 was dropped and ruby was bumped to 2.7.