### PR TITLE
CI: improve fedora image

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -215,7 +215,7 @@ mac_task:
 linux_task:
   env:
     INSTALL_DIR: install
-    LUA_CPATH: ${BUILD_DIR}/install/lib/lua/5.2/?.so;
+    LUA_CPATH: ${CIRRUS_WORKING_DIR}/${BUILD_DIR}/${INSTALL_DIR}/lib/lua/5.2/?.so;
 
   matrix:
 
@@ -224,6 +224,7 @@ linux_task:
           dockerfile: scripts/docker/cirrus/fedora/Dockerfile
 
   script:
+    - >
       set --
       -DBUILD_FULL=ON
       -DBUILD_SHARED=ON

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -214,8 +214,8 @@ mac_task:
 
 linux_task:
   env:
-    INSTALL_DIR: install
-    LUA_CPATH: ${CIRRUS_WORKING_DIR}/${BUILD_DIR}/${INSTALL_DIR}/lib/lua/5.2/?.so;
+    INSTALL_DIR: ${CIRRUS_WORKING_DIR}/${BUILD_DIR}/install
+    LUA_CPATH: ${INSTALL_DIR}/lib/lua/5.2/?.so;
 
   matrix:
 
@@ -234,7 +234,7 @@ linux_task:
       -DBINDINGS='ALL'
       -DPLUGINS='ALL'
       -DTOOLS='ALL'
-      -DCMAKE_INSTALL_PREFIX='$INSTALL_DIR'
+      -DCMAKE_INSTALL_PREFIX='${INSTALL_DIR}'
     - *generate
     - *build
     - *install

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -220,10 +220,15 @@ linux_task:
           dockerfile: scripts/docker/cirrus/fedora/Dockerfile
 
   script:
-    - >
       set --
       -DBUILD_FULL=ON
+      -DBUILD_SHARED=ON
+      -DBUILD_STATIC=ON
       -DENABLE_LOGGER=ON
+      -DENABLE_DEBUG=ON
+      -DBINDINGS='ALL'
+      -DPLUGINS='ALL'
+      -DTOOLS='ALL'
     - *generate
     - *build
     - *install

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -239,6 +239,7 @@ linux_task:
     - *install
 
   tests_script:
+    - export PATH=$PATH:"$CIRRUS_WORKING_DIR/install/bin"
     - export LUA_CPATH="${CIRRUS_WORKING_DIR}/install/lib/lua/5.2/?.so;"
     - *run_tests
 

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -215,7 +215,7 @@ mac_task:
 linux_task:
   env:
     INSTALL_DIR: install
-    LUA_CPATH="${BUILD_DIR}/install/lib/lua/5.2/?.so;"
+    LUA_CPATH: ${BUILD_DIR}/install/lib/lua/5.2/?.so;
 
   matrix:
 

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -213,7 +213,6 @@ mac_task:
       fi
 
 linux_task:
-
   matrix:
 
     - name: 🐧 Fedora

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -12,7 +12,7 @@ commands:
   - &generate | # We need to specify the source directory (`.`) explicitly for Alpine linux (`🔗 Check`).
     cmake "$@" -G Ninja -B "$BUILD_DIR" .
   - &build cmake --build "$BUILD_DIR"
-  - &install output="$(cmake --build "$BUILD_DIR" --target "$CIRRUS_WORKING_DIR/$INSTALL_DIR" 2>&1)" || printf '%s' "$output"
+  - &install output="$(cmake --build "$BUILD_DIR" --target "$CIRRUS_WORKING_DIR/install" 2>&1)" || printf '%s' "$output"
   - &run_tests | # Run tests
     if [ "$ENABLE_ASAN" = 'ON' ]; then
       cmake --build "$BUILD_DIR" --target run_nocheckshell
@@ -214,8 +214,7 @@ mac_task:
 
 linux_task:
   env:
-    INSTALL_DIR: install
-    LUA_CPATH: ${CIRRUS_WORKING_DIR}/${INSTALL_DIR}/lib/lua/5.2/?.so;
+    LUA_CPATH: ${CIRRUS_WORKING_DIR}/install/lib/lua/5.2/?.so;
 
   matrix:
 
@@ -234,7 +233,7 @@ linux_task:
       -DBINDINGS='ALL'
       -DPLUGINS='ALL'
       -DTOOLS='ALL'
-      -DCMAKE_INSTALL_PREFIX='$CIRRUS_WORKING_DIR/$INSTALL_DIR'
+      -DCMAKE_INSTALL_PREFIX='$CIRRUS_WORKING_DIR/install'
     - *generate
     - *build
     - *install

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -214,8 +214,8 @@ mac_task:
 
 linux_task:
   env:
-    INSTALL_DIR: ${CIRRUS_WORKING_DIR}/${BUILD_DIR}/install
-    LUA_CPATH: ${INSTALL_DIR}/lib/lua/5.2/?.so;
+    INSTALL_DIR: install
+    LUA_CPATH: ${CIRRUS_WORKING_DIR}/${INSTALL_DIR}/lib/lua/5.2/?.so;
 
   matrix:
 
@@ -234,7 +234,7 @@ linux_task:
       -DBINDINGS='ALL'
       -DPLUGINS='ALL'
       -DTOOLS='ALL'
-      -DCMAKE_INSTALL_PREFIX='$INSTALL_DIR'
+      -DCMAKE_INSTALL_PREFIX='$CIRRUS_WORKING_DIR/$INSTALL_DIR'
     - *generate
     - *build
     - *install

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -213,8 +213,6 @@ mac_task:
       fi
 
 linux_task:
-  env:
-    LUA_CPATH: ${CIRRUS_WORKING_DIR}/install/lib/lua/5.2/?.so;
 
   matrix:
 
@@ -231,17 +229,17 @@ linux_task:
       -DENABLE_LOGGER=ON
       -DENABLE_DEBUG=ON
       -DBINDINGS='ALL'
-      -DPLUGINS='ALL'
+      -DPLUGINS='ALL;-fcrypt'
       -DTOOLS='ALL'
-      -DCMAKE_INSTALL_PREFIX='$CIRRUS_WORKING_DIR/install'
+      -DKDB_DB_SYSTEM="$CIRRUS_WORKING_DIR/system"
+      -DCMAKE_INSTALL_PREFIX="$CIRRUS_WORKING_DIR/install"
+    - *print_cmake_options
     - *generate
     - *build
     - *install
 
   tests_script:
-    - |
-      echo $LUA_CPATH
-      echo $CIRRUS_WORKING_DIR
+    - export LUA_CPATH="${CIRRUS_WORKING_DIR}/install/lib/lua/5.2/?.so;"
     - *run_tests
 
 link_task:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -233,7 +233,7 @@ linux_task:
       -DBINDINGS='ALL'
       -DPLUGINS='ALL'
       -DTOOLS='ALL'
-      -DCMAKE_INSTALL_PREFIX='$INSTALL_DIR''
+      -DCMAKE_INSTALL_PREFIX='$INSTALL_DIR'
     - *generate
     - *build
     - *install

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -234,7 +234,7 @@ linux_task:
       -DBINDINGS='ALL'
       -DPLUGINS='ALL'
       -DTOOLS='ALL'
-      -DCMAKE_INSTALL_PREFIX='${INSTALL_DIR}'
+      -DCMAKE_INSTALL_PREFIX='$INSTALL_DIR'
     - *generate
     - *build
     - *install

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -213,6 +213,10 @@ mac_task:
       fi
 
 linux_task:
+  env:
+    INSTALL_DIR: install
+    LUA_CPATH="${BUILD_DIR}/install/lib/lua/5.2/?.so;"
+
   matrix:
 
     - name: 🐧 Fedora
@@ -229,6 +233,7 @@ linux_task:
       -DBINDINGS='ALL'
       -DPLUGINS='ALL'
       -DTOOLS='ALL'
+      -DCMAKE_INSTALL_PREFIX='$INSTALL_DIR''
     - *generate
     - *build
     - *install

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -12,7 +12,7 @@ commands:
   - &generate | # We need to specify the source directory (`.`) explicitly for Alpine linux (`🔗 Check`).
     cmake "$@" -G Ninja -B "$BUILD_DIR" .
   - &build cmake --build "$BUILD_DIR"
-  - &install output="$(cmake --build "$BUILD_DIR" --target install 2>&1)" || printf '%s' "$output"
+  - &install output="$(cmake --build "$BUILD_DIR" --target "$CIRRUS_WORKING_DIR/$INSTALL_DIR" 2>&1)" || printf '%s' "$output"
   - &run_tests | # Run tests
     if [ "$ENABLE_ASAN" = 'ON' ]; then
       cmake --build "$BUILD_DIR" --target run_nocheckshell

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -12,7 +12,7 @@ commands:
   - &generate | # We need to specify the source directory (`.`) explicitly for Alpine linux (`🔗 Check`).
     cmake "$@" -G Ninja -B "$BUILD_DIR" .
   - &build cmake --build "$BUILD_DIR"
-  - &install output="$(cmake --build "$BUILD_DIR" --target "$CIRRUS_WORKING_DIR/install" 2>&1)" || printf '%s' "$output"
+  - &install output="$(cmake --build "$BUILD_DIR" --target install 2>&1)" || printf '%s' "$output"
   - &run_tests | # Run tests
     if [ "$ENABLE_ASAN" = 'ON' ]; then
       cmake --build "$BUILD_DIR" --target run_nocheckshell
@@ -239,6 +239,9 @@ linux_task:
     - *install
 
   tests_script:
+    - |
+      echo $LUA_CPATH
+      echo $CIRRUS_WORKING_DIR
     - *run_tests
 
 link_task:

--- a/doc/news/_preparation_next_release.md
+++ b/doc/news/_preparation_next_release.md
@@ -242,6 +242,7 @@ you up to date with the multi-language support provided by Elektra.
 - Use newer FreeBSD images and use image family instead of concrete image names. _(Mihael Pranjić)_
 - Disable tcl on FreeBSD images because of test failures (see #3353). _(Mihael Pranjić)_
 - Disable curlget plugin for macOS jobs (see #3382). _(Mihael Pranjić)_
+- Add more dependencies to Fedora image. _(Mihael Pranjić)_
 
 ### Jenkins
 

--- a/scripts/docker/cirrus/fedora/Dockerfile
+++ b/scripts/docker/cirrus/fedora/Dockerfile
@@ -1,34 +1,37 @@
 FROM fedora:31
 
 RUN dnf upgrade -y && dnf install -y \
-    augeas-devel \
-    boost-devel \
-    botan-devel \
-    cmake \
-    curl \
-    diffutils \
-    file \
-    findutils \
-    gcc-c++ \
-    git \
-    glib2 \
-    gpgme-devel \
-    java-1.8.0-openjdk-devel \
-    jna \
-    libcurl-devel \
-    libgit2-devel \
-    libxml2-devel \
-    lua-devel \
-    make \
-    maven \
-    ninja-build \
-    openssl-devel \
-    python3-devel \
-    qt5-devel \
-    ruby-devel \
-    swig \
-    xerces-c-devel \
-    yajl-devel \
-    yaml-cpp-devel \
-    zlib-devel
+        augeas-devel \
+        boost-devel \
+        botan-devel \
+        cmake \
+        curl \
+        diffutils \
+        file \
+        findutils \
+        gcc-c++ \
+        gcrypt-devel \
+        git \
+        glib2 \
+        gpgme-devel \
+        java-1.8.0-openjdk-devel \
+        jna \
+        libcurl-devel \
+        libgit2-devel \
+        libxml2-devel \
+        lua-devel \
+        make \
+        maven \
+        ninja-build \
+        openssl-devel \
+        python3-devel \
+        qt5-devel \
+        ruby-devel \
+        rubygem-test-unit \
+        swig \
+        xerces-c-devel \
+        yajl-devel \
+        yaml-cpp-devel \
+        zlib-devel \
+    && dnf clean all -y
 

--- a/scripts/docker/cirrus/fedora/Dockerfile
+++ b/scripts/docker/cirrus/fedora/Dockerfile
@@ -16,7 +16,7 @@ RUN dnf upgrade -y && dnf install -y \
     libcurl-devel \
     libgit2-devel \
     libxml2-devel \
-    lua-devel
+    lua-devel \
     make \
     ninja-build \
     openssl-devel \

--- a/scripts/docker/cirrus/fedora/Dockerfile
+++ b/scripts/docker/cirrus/fedora/Dockerfile
@@ -1,9 +1,9 @@
 FROM fedora:31
 
 RUN dnf upgrade -y && dnf install -y \
-    antlr4 \
     augeas-devel \
     boost-devel \
+    botan-devel \
     cmake \
     curl \
     diffutils \
@@ -11,6 +11,8 @@ RUN dnf upgrade -y && dnf install -y \
     findutils \
     gcc-c++ \
     git \
+    glib2 \
+    gpgme-devel \
     java-1.8.0-openjdk-devel \
     jna \
     libcurl-devel \
@@ -18,9 +20,11 @@ RUN dnf upgrade -y && dnf install -y \
     libxml2-devel \
     lua-devel \
     make \
+    maven \
     ninja-build \
     openssl-devel \
     python3-devel \
+    qt5-devel \
     ruby-devel \
     swig \
     xerces-c-devel \

--- a/scripts/docker/cirrus/fedora/Dockerfile
+++ b/scripts/docker/cirrus/fedora/Dockerfile
@@ -10,13 +10,13 @@ RUN dnf upgrade -y && dnf install -y \
         file \
         findutils \
         gcc-c++ \
-        gcrypt-devel \
         git \
         glib2 \
         gpgme-devel \
         java-1.8.0-openjdk-devel \
         jna \
         libcurl-devel \
+        libgcrypt-devel \
         libgit2-devel \
         libxml2-devel \
         lua-devel \

--- a/scripts/docker/cirrus/fedora/Dockerfile
+++ b/scripts/docker/cirrus/fedora/Dockerfile
@@ -1,12 +1,30 @@
 FROM fedora:31
 
-RUN dnf install -y \
+RUN dnf upgrade -y && dnf install -y \
+    antlr4 \
+    augeas-devel \
+    boost-devel \
     cmake \
+    curl \
     diffutils \
     file \
     findutils \
     gcc-c++ \
     git \
+    java-1.8.0-openjdk-devel \
+    jna \
+    libcurl-devel \
+    libgit2-devel \
+    libxml2-devel \
+    lua-devel
     make \
     ninja-build \
-    yaml-cpp-devel
+    openssl-devel \
+    python3-devel \
+    ruby-devel \
+    swig \
+    xerces-c-devel \
+    yajl-devel \
+    yaml-cpp-devel \
+    zlib-devel
+

--- a/scripts/docker/cirrus/fedora/Dockerfile
+++ b/scripts/docker/cirrus/fedora/Dockerfile
@@ -6,6 +6,7 @@ RUN dnf upgrade -y && dnf install -y \
         botan-devel \
         cmake \
         curl \
+        dbus-devel \
         diffutils \
         file \
         findutils \
@@ -16,22 +17,37 @@ RUN dnf upgrade -y && dnf install -y \
         java-1.8.0-openjdk-devel \
         jna \
         libcurl-devel \
+        libev-devel \
         libgcrypt-devel \
         libgit2-devel \
+        libmarkdown-devel \
+        libuv-devel \
         libxml2-devel \
         lua-devel \
         make \
         maven \
         ninja-build \
         openssl-devel \
+        procps-ng \
         python3-devel \
         qt5-devel \
         ruby-devel \
         rubygem-test-unit \
         swig \
+        valgrind \
         xerces-c-devel \
         yajl-devel \
         yaml-cpp-devel \
         zlib-devel \
     && dnf clean all -y
+
+# Google Test
+ENV GTEST_ROOT=/opt/gtest
+ARG GTEST_VER=release-1.10.0
+RUN mkdir -p ${GTEST_ROOT} \
+    && cd /tmp \
+    && curl -o gtest.tar.gz \
+      -L https://github.com/google/googletest/archive/${GTEST_VER}.tar.gz \
+    && tar -zxvf gtest.tar.gz --strip-components=1 -C ${GTEST_ROOT} \
+    && rm gtest.tar.gz
 

--- a/scripts/docker/debian/buster/Dockerfile
+++ b/scripts/docker/debian/buster/Dockerfile
@@ -69,7 +69,7 @@ RUN apt-get update \
         reprepro \
         ruby \
         ruby-dev \
-        swig3.0 \
+        swig4.0 \
         systemd \
         tclcl-dev \
         uuid-dev \

--- a/scripts/docker/debian/buster/Dockerfile
+++ b/scripts/docker/debian/buster/Dockerfile
@@ -69,7 +69,7 @@ RUN apt-get update \
         reprepro \
         ruby \
         ruby-dev \
-        swig4.0 \
+        swig3.0 \
         systemd \
         tclcl-dev \
         uuid-dev \

--- a/scripts/docker/fedora/31/Dockerfile
+++ b/scripts/docker/fedora/31/Dockerfile
@@ -6,6 +6,7 @@ RUN dnf upgrade -y && dnf install -y \
         botan-devel \
         cmake \
         curl \
+        dbus-devel \
         diffutils \
         file \
         findutils \
@@ -16,8 +17,11 @@ RUN dnf upgrade -y && dnf install -y \
         java-1.8.0-openjdk-devel \
         jna \
         libcurl-devel \
+        libev-devel \
         libgcrypt-devel \
         libgit2-devel \
+        libmarkdown-devel \
+        libuv-devel \
         libxml2-devel \
         lua-devel \
         make \

--- a/scripts/docker/fedora/31/Dockerfile
+++ b/scripts/docker/fedora/31/Dockerfile
@@ -37,6 +37,16 @@ RUN dnf upgrade -y && dnf install -y \
         zlib-devel \
     && dnf clean all -y
 
+# Google Test
+ENV GTEST_ROOT=/opt/gtest
+ARG GTEST_VER=release-1.10.0
+RUN mkdir -p ${GTEST_ROOT} \
+    && cd /tmp \
+    && curl -o gtest.tar.gz \
+      -L https://github.com/google/googletest/archive/${GTEST_VER}.tar.gz \
+    && tar -zxvf gtest.tar.gz --strip-components=1 -C ${GTEST_ROOT} \
+    && rm gtest.tar.gz
+
 # Create User:Group
 # The id is important as jenkins docker agents use the same id that is running
 # on the slaves to execute containers

--- a/scripts/docker/fedora/31/Dockerfile
+++ b/scripts/docker/fedora/31/Dockerfile
@@ -1,0 +1,59 @@
+FROM fedora:31
+
+RUN dnf upgrade -y && dnf install -y \
+        augeas-devel \
+        boost-devel \
+        botan-devel \
+        cmake \
+        curl \
+        diffutils \
+        file \
+        findutils \
+        gcc-c++ \
+        git \
+        glib2 \
+        gpgme-devel \
+        java-1.8.0-openjdk-devel \
+        jna \
+        libcurl-devel \
+        libgcrypt-devel \
+        libgit2-devel \
+        libxml2-devel \
+        lua-devel \
+        make \
+        maven \
+        ninja-build \
+        openssl-devel \
+        python3-devel \
+        qt5-devel \
+        ruby-devel \
+        rubygem-test-unit \
+        swig \
+        valgrind \
+        xerces-c-devel \
+        yajl-devel \
+        yaml-cpp-devel \
+        zlib-devel \
+    && dnf clean all -y
+
+# Create User:Group
+# The id is important as jenkins docker agents use the same id that is running
+# on the slaves to execute containers
+ARG JENKINS_GROUPID
+RUN groupadd \
+    -g ${JENKINS_GROUPID} \
+    -f \
+    jenkins
+
+ARG JENKINS_USERID
+RUN useradd \
+    --create-home \
+    --uid ${JENKINS_USERID} \
+    --gid ${JENKINS_GROUPID} \
+    --shell "/bin/bash" \
+    jenkins
+USER ${JENKINS_USERID}
+
+RUN git config --global user.email 'Jenkins <autobuilder@libelektra.org>' \
+    && git config --global user.name 'Jenkins'
+

--- a/scripts/docker/fedora/31/Dockerfile
+++ b/scripts/docker/fedora/31/Dockerfile
@@ -24,6 +24,7 @@ RUN dnf upgrade -y && dnf install -y \
         maven \
         ninja-build \
         openssl-devel \
+        procps-ng \
         python3-devel \
         qt5-devel \
         ruby-devel \

--- a/scripts/jenkins/Jenkinsfile
+++ b/scripts/jenkins/Jenkinsfile
@@ -971,7 +971,11 @@ export LUA_CPATH="${WORKSPACE}/system/lib/lua/5.2/?.so;"
 env
 
 kdb run_all
-kill `pidof dbus-daemon`
+
+dbus_pid=`pidof dbus-daemon`
+if [ -z "$dbus_pid" ]; then
+    kill $dbus_pid
+fi
 '''
           }
         } catch(e) {

--- a/scripts/jenkins/Jenkinsfile
+++ b/scripts/jenkins/Jenkinsfile
@@ -971,11 +971,7 @@ export LUA_CPATH="${WORKSPACE}/system/lib/lua/5.2/?.so;"
 env
 
 kdb run_all
-
-dbus_pid=`pidof dbus-daemon`
-if [ -z "$dbus_pid" ]; then
-    kill $dbus_pid
-fi
+kill `pidof dbus-daemon` || echo "No dbus-daemon to kill."
 '''
           }
         } catch(e) {

--- a/scripts/jenkins/Jenkinsfile
+++ b/scripts/jenkins/Jenkinsfile
@@ -330,6 +330,13 @@ def dockerInit() {
       "./scripts/docker/ubuntu/bionic/Dockerfile"
     )
 
+    /* Fedora 31 image*/
+    DOCKER_IMAGES.fedora_31 = createDockerImageDesc(
+      "fedora-31", this.&idTesting,
+      "./scripts/docker/fedora/31",
+      "./scripts/docker/fedora/31/Dockerfile"
+    )
+
     /* Image building the libelektra.org frontend */
     DOCKER_IMAGES.website_frontend = createDockerImageDesc(
       "website-frontend", this.&idWebsite,
@@ -462,6 +469,17 @@ def generateMainBuildStages() {
   def tasks = [:]
   // We want fo fail fast (i.e. abort parallel stages if one fails
   tasks.failFast = true
+
+  tasks << buildAndTest(
+    "fedora-31-full",
+    DOCKER_IMAGES.fedora_31,
+    CMAKE_FLAGS_BUILD_ALL +
+      CMAKE_FLAGS_DEBUG +
+      CMAKE_FLAGS_BUILD_FULL +
+      CMAKE_FLAGS_BUILD_STATIC
+    ,
+    [TEST.ALL, TEST.MEM, TEST.NOKDB, TEST.INSTALL]
+  )
 
   // Add a task that should build the whole project to catch all test errors
   // in a standard environment
@@ -633,10 +651,10 @@ def generateFullBuildStages() {
     [TEST.ALL, TEST.MEM]
   )
 
-  // Build Elektra with the mmap backend instead of the default
+  // Build Elektra without the cache plugin
   tasks << buildAndTest(
-    "debian-stretch-full-mmap",
-    DOCKER_IMAGES.stretch,
+    "debian-buster-full-nocache",
+    DOCKER_IMAGES.buster,
     CMAKE_FLAGS_BUILD_ALL +
       CMAKE_FLAGS_DEBUG +
       CMAKE_FLAGS_COVERAGE + [
@@ -646,8 +664,8 @@ def generateFullBuildStages() {
   )
 
   tasks << buildAndTestAsan(
-    "debian-stretch-full-mmap-asan",
-    DOCKER_IMAGES.stretch,
+    "debian-buster-full-mmap-asan",
+    DOCKER_IMAGES.buster,
     CMAKE_FLAGS_BUILD_ALL +
       CMAKE_FLAGS_DEBUG +
       CMAKE_FLAGS_MMAP

--- a/scripts/jenkins/Jenkinsfile
+++ b/scripts/jenkins/Jenkinsfile
@@ -484,20 +484,6 @@ def generateMainBuildStages() {
   // Add a task that should build the whole project to catch all test errors
   // in a standard environment
   tasks << buildAndTest(
-    "debian-stretch-full",
-    DOCKER_IMAGES.stretch,
-    CMAKE_FLAGS_BUILD_ALL +
-      CMAKE_FLAGS_DEBUG +
-      CMAKE_FLAGS_BUILD_FULL +
-      CMAKE_FLAGS_BUILD_STATIC +
-      CMAKE_FLAGS_COVERAGE
-    ,
-    [TEST.ALL, TEST.MEM, TEST.NOKDB, TEST.INSTALL]
-  )
-
-  // Add a task that should build the whole project to catch all test errors
-  // in a standard environment
-  tasks << buildAndTest(
     "debian-buster-full",
     DOCKER_IMAGES.buster,
     CMAKE_FLAGS_BUILD_ALL +
@@ -531,6 +517,20 @@ def generateFullBuildStages() {
 
   // Build doc and upload
   tasks << buildDoc()
+
+  // Add a task that should build the whole project to catch all test errors
+  // in a standard environment
+  tasks << buildAndTest(
+    "debian-stretch-full",
+    DOCKER_IMAGES.stretch,
+    CMAKE_FLAGS_BUILD_ALL +
+      CMAKE_FLAGS_DEBUG +
+      CMAKE_FLAGS_BUILD_FULL +
+      CMAKE_FLAGS_BUILD_STATIC +
+      CMAKE_FLAGS_COVERAGE
+    ,
+    [TEST.ALL, TEST.MEM, TEST.NOKDB, TEST.INSTALL]
+  )
 
   // Build Elektra with ASAN enabled
   // Detects memory leaks via ASAN


### PR DESCRIPTION
Jenkins: main build stage with debian and fedora stable. Move oldstable to second build stage.

Improve cirrus fedora image and add fedora docker image for jenkins to cover many tests.

Closes #3227.