### PR TITLE
Fix website dependency injection issue created by minification

### DIFF
--- a/doc/news/_preparation_next_release.md
+++ b/doc/news/_preparation_next_release.md
@@ -205,7 +205,8 @@ The website is generated from the repository, so all information about
 plugins, bindings and tools are always up to date. Furthermore, we changed:
 
 - Renamed [website](/src/tools/website) and removed its backend. _(Markus Raab)_
-- <<TODO>>
+- Use strict dependency injection for website modules. _(Marvin Mall)_
+- Added `package-lock.json` to ensure repeatable builds. _(Marvin Mall)_
 - <<TODO>>
 - <<TODO>>
 

--- a/src/tools/website/package-lock.json
+++ b/src/tools/website/package-lock.json
@@ -1,0 +1,5468 @@
+{
+    "name": "website",
+    "version": "1.0.0",
+    "lockfileVersion": 1,
+    "requires": true,
+    "dependencies": {
+        "@iamadamjowett/angular-logger-max": {
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/@iamadamjowett/angular-logger-max/-/angular-logger-max-1.2.3.tgz",
+            "integrity": "sha1-k/LT1+qcmKs2UGTgZTNL5cpy8x4=",
+            "dev": true
+        },
+        "JSONStream": {
+            "version": "1.3.5",
+            "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.5.tgz",
+            "integrity": "sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==",
+            "dev": true,
+            "requires": {
+                "jsonparse": "^1.2.0",
+                "through": ">=2.2.7 <3"
+            }
+        },
+        "abbrev": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+            "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
+            "dev": true
+        },
+        "accepts": {
+            "version": "1.3.7",
+            "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.7.tgz",
+            "integrity": "sha512-Il80Qs2WjYlJIBNzNkK6KYqlVMTbZLXgHx2oT0pU/fjRHyEp+PEfEPY0R3WCwAGVOtauxh1hOxNgIf5bv7dQpA==",
+            "dev": true,
+            "requires": {
+                "mime-types": "~2.1.24",
+                "negotiator": "0.6.2"
+            }
+        },
+        "acorn": {
+            "version": "7.4.1",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
+            "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
+            "dev": true
+        },
+        "acorn-node": {
+            "version": "1.8.2",
+            "resolved": "https://registry.npmjs.org/acorn-node/-/acorn-node-1.8.2.tgz",
+            "integrity": "sha512-8mt+fslDufLYntIoPAaIMUe/lrbrehIiwmR3t2k9LljIzoigEPF27eLk2hy8zSGzmR/ogr7zbRKINMo1u0yh5A==",
+            "dev": true,
+            "requires": {
+                "acorn": "^7.0.0",
+                "acorn-walk": "^7.0.0",
+                "xtend": "^4.0.2"
+            }
+        },
+        "acorn-walk": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-7.2.0.tgz",
+            "integrity": "sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA==",
+            "dev": true
+        },
+        "agentkeepalive": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-2.2.0.tgz",
+            "integrity": "sha1-xdG9SxKQCPEWPyNvhuX66iAm4u8=",
+            "dev": true
+        },
+        "ajv": {
+            "version": "6.12.6",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+            "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+            "dev": true,
+            "requires": {
+                "fast-deep-equal": "^3.1.1",
+                "fast-json-stable-stringify": "^2.0.0",
+                "json-schema-traverse": "^0.4.1",
+                "uri-js": "^4.2.2"
+            }
+        },
+        "algoliasearch": {
+            "version": "3.35.1",
+            "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-3.35.1.tgz",
+            "integrity": "sha512-K4yKVhaHkXfJ/xcUnil04xiSrB8B8yHZoFEhWNpXg23eiCnqvTZw1tn/SqvdsANlYHLJlKl0qi3I/Q2Sqo7LwQ==",
+            "dev": true,
+            "requires": {
+                "agentkeepalive": "^2.2.0",
+                "debug": "^2.6.9",
+                "envify": "^4.0.0",
+                "es6-promise": "^4.1.0",
+                "events": "^1.1.0",
+                "foreach": "^2.0.5",
+                "global": "^4.3.2",
+                "inherits": "^2.0.1",
+                "isarray": "^2.0.1",
+                "load-script": "^1.0.0",
+                "object-keys": "^1.0.11",
+                "querystring-es3": "^0.2.1",
+                "reduce": "^1.0.1",
+                "semver": "^5.1.0",
+                "tunnel-agent": "^0.6.0"
+            }
+        },
+        "angular": {
+            "version": "1.8.1",
+            "resolved": "https://registry.npmjs.org/angular/-/angular-1.8.1.tgz",
+            "integrity": "sha512-eiasF4uFXsmKD8qYpkKEi9rKVxMv0nIDZXsYrwzSbPIbjmTV05bx+18VDbRmMx7p+gL84T9Qw2NCpVe8w1QKHQ==",
+            "dev": true
+        },
+        "angular-animate": {
+            "version": "1.8.1",
+            "resolved": "https://registry.npmjs.org/angular-animate/-/angular-animate-1.8.1.tgz",
+            "integrity": "sha512-v5J02y47Du7k42wNZK+q4GWclP4Acw0sS6fZu/TI1rE8i/3MRvI/umAvfpm+WBB5+mAg4c35iBfw0qgyIVZl7A==",
+            "dev": true
+        },
+        "angular-breadcrumb": {
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/angular-breadcrumb/-/angular-breadcrumb-0.4.1.tgz",
+            "integrity": "sha1-W/9XgMeZzMYIglioQlbTR/6WkaU=",
+            "dev": true
+        },
+        "angular-clipboard": {
+            "version": "1.7.0",
+            "resolved": "https://registry.npmjs.org/angular-clipboard/-/angular-clipboard-1.7.0.tgz",
+            "integrity": "sha512-4/eg3zZw1MJpIsMc+mWzeVNyWBu8YWpXPTdmbgyPRp/6f0xB6I3XR2iC6Mb4mg/5E9q6exCd0sX2yiIsw+ZLJw==",
+            "dev": true
+        },
+        "angular-file-saver": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/angular-file-saver/-/angular-file-saver-1.1.3.tgz",
+            "integrity": "sha1-3K7AaVIU8iakyq/IwW0hqaYffRs=",
+            "dev": true,
+            "requires": {
+                "blob-tmp": "^1.0.0",
+                "file-saver": "^1.3.3"
+            }
+        },
+        "angular-marked": {
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/angular-marked/-/angular-marked-1.2.2.tgz",
+            "integrity": "sha1-Ax+BAV2tX7Aa341IkixS/rNYjeU=",
+            "dev": true,
+            "requires": {
+                "marked": "^0.3.3"
+            }
+        },
+        "angular-messages": {
+            "version": "1.8.1",
+            "resolved": "https://registry.npmjs.org/angular-messages/-/angular-messages-1.8.1.tgz",
+            "integrity": "sha512-09+sV4b51/y6oE9DRVcc6+zs2jN5a1Hf0LWO18tv9dgjit2qVR99eYlzLM5HQAaCBUN5gfzJEk2cgVrXWzkijA==",
+            "dev": true
+        },
+        "angular-sanitize": {
+            "version": "1.8.1",
+            "resolved": "https://registry.npmjs.org/angular-sanitize/-/angular-sanitize-1.8.1.tgz",
+            "integrity": "sha512-kDtbAQkN+biyvBMJ8mgFIDZureng5yl6qegFCQ+bUw50n3KOx4FCsZ9S5tNAQ/rjYYTC5tP4hREv7+2ha+8M2w==",
+            "dev": true
+        },
+        "angular-slugify": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/angular-slugify/-/angular-slugify-1.0.3.tgz",
+            "integrity": "sha1-P34HNN6rfzNzcUVGDwy+EvLeDRs=",
+            "dev": true
+        },
+        "angular-translate": {
+            "version": "2.18.3",
+            "resolved": "https://registry.npmjs.org/angular-translate/-/angular-translate-2.18.3.tgz",
+            "integrity": "sha512-ziEi1nTaNIsdn3iKpcALaSFjM9CjwvoIWE/EKepajB/6qT5oB3K1IU5VcaH7Bd0scNRfaJpW+qUD6nsHWDEZ6A==",
+            "dev": true,
+            "requires": {
+                "angular": "^1.8.0"
+            }
+        },
+        "angular-translate-loader-static-files": {
+            "version": "2.18.3",
+            "resolved": "https://registry.npmjs.org/angular-translate-loader-static-files/-/angular-translate-loader-static-files-2.18.3.tgz",
+            "integrity": "sha512-B5hD7aWjFr2TZ6YTnmoTFSscI+eDOXSi3GksyTvtqs4cPZI2lgnO38/Pm1gfN1wpUQcs2Rm/V+z8n58TERZyBQ==",
+            "dev": true,
+            "requires": {
+                "angular-translate": "~2.18.3"
+            }
+        },
+        "angular-typewriter": {
+            "version": "0.0.15",
+            "resolved": "https://registry.npmjs.org/angular-typewriter/-/angular-typewriter-0.0.15.tgz",
+            "integrity": "sha1-xt8fwyorTkH+cvOmTlWar+bQpDU=",
+            "dev": true,
+            "requires": {
+                "angular": "^1.2.0"
+            }
+        },
+        "angular-ui-bootstrap": {
+            "version": "2.5.6",
+            "resolved": "https://registry.npmjs.org/angular-ui-bootstrap/-/angular-ui-bootstrap-2.5.6.tgz",
+            "integrity": "sha512-yzcHpPMLQl0232nDzm5P4iAFTFQ9dMw0QgFLuKYbDj9M0xJ62z0oudYD/Lvh1pWfRsukiytP4Xj6BHOSrSXP8A==",
+            "dev": true
+        },
+        "angular-ui-notification": {
+            "version": "0.3.6",
+            "resolved": "https://registry.npmjs.org/angular-ui-notification/-/angular-ui-notification-0.3.6.tgz",
+            "integrity": "sha1-MzvL6ComUUgrOcNZWzy/qI4wvPc=",
+            "dev": true
+        },
+        "angular-ui-router": {
+            "version": "0.4.3",
+            "resolved": "https://registry.npmjs.org/angular-ui-router/-/angular-ui-router-0.4.3.tgz",
+            "integrity": "sha512-EGBG7G7ArFVkJPM+ZIgPKuMYuT16UQrr3zj3BEiXHKwxss867bGt3u7QD9g4BxR+K2qQOSWok6JGvgTWXAko3A==",
+            "dev": true,
+            "requires": {
+                "angular": "^1.0.8"
+            }
+        },
+        "ansi-regex": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+            "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+            "dev": true
+        },
+        "ansi-styles": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+            "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+            "dev": true,
+            "requires": {
+                "color-convert": "^2.0.1"
+            }
+        },
+        "anymatch": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
+            "integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
+            "dev": true,
+            "requires": {
+                "micromatch": "^3.1.4",
+                "normalize-path": "^2.1.1"
+            }
+        },
+        "argparse": {
+            "version": "1.0.10",
+            "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+            "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+            "dev": true,
+            "requires": {
+                "sprintf-js": "~1.0.2"
+            },
+            "dependencies": {
+                "sprintf-js": {
+                    "version": "1.0.3",
+                    "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+                    "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+                    "dev": true
+                }
+            }
+        },
+        "arr-diff": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+            "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
+            "dev": true
+        },
+        "arr-flatten": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
+            "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
+            "dev": true
+        },
+        "arr-union": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
+            "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
+            "dev": true
+        },
+        "array-each": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/array-each/-/array-each-1.0.1.tgz",
+            "integrity": "sha1-p5SvDAWrF1KEbudTofIRoFugxE8=",
+            "dev": true
+        },
+        "array-slice": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/array-slice/-/array-slice-1.1.0.tgz",
+            "integrity": "sha512-B1qMD3RBP7O8o0H2KbrXDyB0IccejMF15+87Lvlor12ONPRHP6gTjXMNkt/d3ZuOGbAe66hFmaCfECI24Ufp6w==",
+            "dev": true
+        },
+        "array-unique": {
+            "version": "0.3.2",
+            "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+            "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
+            "dev": true
+        },
+        "asap": {
+            "version": "2.0.6",
+            "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+            "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=",
+            "dev": true
+        },
+        "asn1": {
+            "version": "0.2.4",
+            "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
+            "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
+            "dev": true,
+            "requires": {
+                "safer-buffer": "~2.1.0"
+            }
+        },
+        "asn1.js": {
+            "version": "5.4.1",
+            "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.4.1.tgz",
+            "integrity": "sha512-+I//4cYPccV8LdmBLiX8CYvf9Sp3vQsrqu2QNXRcrbiWvcx/UdlFiqUJJzxRQxgsZmvhXhn4cSKeSmoFjVdupA==",
+            "dev": true,
+            "requires": {
+                "bn.js": "^4.0.0",
+                "inherits": "^2.0.1",
+                "minimalistic-assert": "^1.0.0",
+                "safer-buffer": "^2.1.0"
+            },
+            "dependencies": {
+                "bn.js": {
+                    "version": "4.11.9",
+                    "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.9.tgz",
+                    "integrity": "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw==",
+                    "dev": true
+                }
+            }
+        },
+        "assert": {
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/assert/-/assert-1.5.0.tgz",
+            "integrity": "sha512-EDsgawzwoun2CZkCgtxJbv392v4nbk9XDD06zI+kQYoBM/3RBWLlEyJARDOmhAAosBjWACEkKL6S+lIZtcAubA==",
+            "dev": true,
+            "requires": {
+                "object-assign": "^4.1.1",
+                "util": "0.10.3"
+            },
+            "dependencies": {
+                "inherits": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                    "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=",
+                    "dev": true
+                },
+                "util": {
+                    "version": "0.10.3",
+                    "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
+                    "integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
+                    "dev": true,
+                    "requires": {
+                        "inherits": "2.0.1"
+                    }
+                }
+            }
+        },
+        "assert-plus": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+            "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+            "dev": true
+        },
+        "assign-symbols": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
+            "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
+            "dev": true
+        },
+        "async": {
+            "version": "1.5.2",
+            "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+            "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
+            "dev": true
+        },
+        "async-each": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.3.tgz",
+            "integrity": "sha512-z/WhQ5FPySLdvREByI2vZiTWwCnF0moMJ1hK9YQwDTHKh6I7/uSckMetoRGb5UBZPC1z0jlw+n/XCgjeH7y1AQ==",
+            "dev": true
+        },
+        "asynckit": {
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+            "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+            "dev": true
+        },
+        "atob": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
+            "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
+            "dev": true
+        },
+        "autocomplete.js": {
+            "version": "0.36.0",
+            "resolved": "https://registry.npmjs.org/autocomplete.js/-/autocomplete.js-0.36.0.tgz",
+            "integrity": "sha512-jEwUXnVMeCHHutUt10i/8ZiRaCb0Wo+ZyKxeGsYwBDtw6EJHqEeDrq4UwZRD8YBSvp3g6klP678il2eeiVXN2Q==",
+            "dev": true,
+            "requires": {
+                "immediate": "^3.2.3"
+            }
+        },
+        "aws-sign2": {
+            "version": "0.7.0",
+            "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+            "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
+            "dev": true
+        },
+        "aws4": {
+            "version": "1.10.1",
+            "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.10.1.tgz",
+            "integrity": "sha512-zg7Hz2k5lI8kb7U32998pRRFin7zJlkfezGJjUc2heaD4Pw2wObakCDVzkKztTm/Ln7eiVvYsjqak0Ed4LkMDA==",
+            "dev": true
+        },
+        "balanced-match": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+            "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+            "dev": true
+        },
+        "base": {
+            "version": "0.11.2",
+            "resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
+            "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
+            "dev": true,
+            "requires": {
+                "cache-base": "^1.0.1",
+                "class-utils": "^0.3.5",
+                "component-emitter": "^1.2.1",
+                "define-property": "^1.0.0",
+                "isobject": "^3.0.1",
+                "mixin-deep": "^1.2.0",
+                "pascalcase": "^0.1.1"
+            },
+            "dependencies": {
+                "define-property": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+                    "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+                    "dev": true,
+                    "requires": {
+                        "is-descriptor": "^1.0.0"
+                    }
+                },
+                "is-accessor-descriptor": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+                    "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+                    "dev": true,
+                    "requires": {
+                        "kind-of": "^6.0.0"
+                    }
+                },
+                "is-data-descriptor": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+                    "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+                    "dev": true,
+                    "requires": {
+                        "kind-of": "^6.0.0"
+                    }
+                },
+                "is-descriptor": {
+                    "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+                    "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+                    "dev": true,
+                    "requires": {
+                        "is-accessor-descriptor": "^1.0.0",
+                        "is-data-descriptor": "^1.0.0",
+                        "kind-of": "^6.0.2"
+                    }
+                }
+            }
+        },
+        "base64-js": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
+            "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g==",
+            "dev": true
+        },
+        "basic-auth": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-2.0.1.tgz",
+            "integrity": "sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==",
+            "dev": true,
+            "requires": {
+                "safe-buffer": "5.1.2"
+            },
+            "dependencies": {
+                "safe-buffer": {
+                    "version": "5.1.2",
+                    "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+                    "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+                    "dev": true
+                }
+            }
+        },
+        "batch": {
+            "version": "0.6.1",
+            "resolved": "https://registry.npmjs.org/batch/-/batch-0.6.1.tgz",
+            "integrity": "sha1-3DQxT05nkxgJP8dgJyUl+UvyXBY=",
+            "dev": true
+        },
+        "bcrypt-pbkdf": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+            "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
+            "dev": true,
+            "requires": {
+                "tweetnacl": "^0.14.3"
+            }
+        },
+        "beeper": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/beeper/-/beeper-1.1.1.tgz",
+            "integrity": "sha1-5tXqjF2tABMEpwsiY4RH9pyy+Ak=",
+            "dev": true
+        },
+        "binary-extensions": {
+            "version": "1.13.1",
+            "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.13.1.tgz",
+            "integrity": "sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw==",
+            "dev": true
+        },
+        "bindings": {
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+            "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+            "dev": true,
+            "optional": true,
+            "requires": {
+                "file-uri-to-path": "1.0.0"
+            }
+        },
+        "blob-tmp": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/blob-tmp/-/blob-tmp-1.0.0.tgz",
+            "integrity": "sha1-3oJJHiIv8TVMd6k+6OTqLIlUQnM=",
+            "dev": true
+        },
+        "bn.js": {
+            "version": "5.1.3",
+            "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.1.3.tgz",
+            "integrity": "sha512-GkTiFpjFtUzU9CbMeJ5iazkCzGL3jrhzerzZIuqLABjbwRaFt33I9tUdSNryIptM+RxDet6OKm2WnLXzW51KsQ==",
+            "dev": true
+        },
+        "body": {
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/body/-/body-5.1.0.tgz",
+            "integrity": "sha1-5LoM5BCkaTYyM2dgnstOZVMSUGk=",
+            "dev": true,
+            "requires": {
+                "continuable-cache": "^0.3.1",
+                "error": "^7.0.0",
+                "raw-body": "~1.1.0",
+                "safe-json-parse": "~1.0.1"
+            }
+        },
+        "bootstrap": {
+            "version": "3.4.1",
+            "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-3.4.1.tgz",
+            "integrity": "sha512-yN5oZVmRCwe5aKwzRj6736nSmKDX7pLYwsXiCj/EYmo16hODaBiT4En5btW/jhBF/seV+XMx3aYwukYC3A49DA==",
+            "dev": true
+        },
+        "brace-expansion": {
+            "version": "1.1.11",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+            "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+            "dev": true,
+            "requires": {
+                "balanced-match": "^1.0.0",
+                "concat-map": "0.0.1"
+            }
+        },
+        "braces": {
+            "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+            "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+            "dev": true,
+            "requires": {
+                "arr-flatten": "^1.1.0",
+                "array-unique": "^0.3.2",
+                "extend-shallow": "^2.0.1",
+                "fill-range": "^4.0.0",
+                "isobject": "^3.0.1",
+                "repeat-element": "^1.1.2",
+                "snapdragon": "^0.8.1",
+                "snapdragon-node": "^2.0.1",
+                "split-string": "^3.0.2",
+                "to-regex": "^3.0.1"
+            },
+            "dependencies": {
+                "extend-shallow": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                    "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                    "dev": true,
+                    "requires": {
+                        "is-extendable": "^0.1.0"
+                    }
+                }
+            }
+        },
+        "brorand": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
+            "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8=",
+            "dev": true
+        },
+        "browser-pack": {
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/browser-pack/-/browser-pack-6.1.0.tgz",
+            "integrity": "sha512-erYug8XoqzU3IfcU8fUgyHqyOXqIE4tUTTQ+7mqUjQlvnXkOO6OlT9c/ZoJVHYoAaqGxr09CN53G7XIsO4KtWA==",
+            "dev": true,
+            "requires": {
+                "JSONStream": "^1.0.3",
+                "combine-source-map": "~0.8.0",
+                "defined": "^1.0.0",
+                "safe-buffer": "^5.1.1",
+                "through2": "^2.0.0",
+                "umd": "^3.0.0"
+            }
+        },
+        "browser-resolve": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-2.0.0.tgz",
+            "integrity": "sha512-7sWsQlYL2rGLy2IWm8WL8DCTJvYLc/qlOnsakDac87SOoCd16WLsaAMdCiAqsTNHIe+SXfaqyxyo6THoWqs8WQ==",
+            "dev": true,
+            "requires": {
+                "resolve": "^1.17.0"
+            }
+        },
+        "browserify": {
+            "version": "16.5.2",
+            "resolved": "https://registry.npmjs.org/browserify/-/browserify-16.5.2.tgz",
+            "integrity": "sha512-TkOR1cQGdmXU9zW4YukWzWVSJwrxmNdADFbqbE3HFgQWe5wqZmOawqZ7J/8MPCwk/W8yY7Y0h+7mOtcZxLP23g==",
+            "dev": true,
+            "requires": {
+                "JSONStream": "^1.0.3",
+                "assert": "^1.4.0",
+                "browser-pack": "^6.0.1",
+                "browser-resolve": "^2.0.0",
+                "browserify-zlib": "~0.2.0",
+                "buffer": "~5.2.1",
+                "cached-path-relative": "^1.0.0",
+                "concat-stream": "^1.6.0",
+                "console-browserify": "^1.1.0",
+                "constants-browserify": "~1.0.0",
+                "crypto-browserify": "^3.0.0",
+                "defined": "^1.0.0",
+                "deps-sort": "^2.0.0",
+                "domain-browser": "^1.2.0",
+                "duplexer2": "~0.1.2",
+                "events": "^2.0.0",
+                "glob": "^7.1.0",
+                "has": "^1.0.0",
+                "htmlescape": "^1.1.0",
+                "https-browserify": "^1.0.0",
+                "inherits": "~2.0.1",
+                "insert-module-globals": "^7.0.0",
+                "labeled-stream-splicer": "^2.0.0",
+                "mkdirp-classic": "^0.5.2",
+                "module-deps": "^6.2.3",
+                "os-browserify": "~0.3.0",
+                "parents": "^1.0.1",
+                "path-browserify": "~0.0.0",
+                "process": "~0.11.0",
+                "punycode": "^1.3.2",
+                "querystring-es3": "~0.2.0",
+                "read-only-stream": "^2.0.0",
+                "readable-stream": "^2.0.2",
+                "resolve": "^1.1.4",
+                "shasum": "^1.0.0",
+                "shell-quote": "^1.6.1",
+                "stream-browserify": "^2.0.0",
+                "stream-http": "^3.0.0",
+                "string_decoder": "^1.1.1",
+                "subarg": "^1.0.0",
+                "syntax-error": "^1.1.1",
+                "through2": "^2.0.0",
+                "timers-browserify": "^1.0.1",
+                "tty-browserify": "0.0.1",
+                "url": "~0.11.0",
+                "util": "~0.10.1",
+                "vm-browserify": "^1.0.0",
+                "xtend": "^4.0.0"
+            },
+            "dependencies": {
+                "events": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/events/-/events-2.1.0.tgz",
+                    "integrity": "sha512-3Zmiobend8P9DjmKAty0Era4jV8oJ0yGYe2nJJAxgymF9+N8F2m0hhZiMoWtcfepExzNKZumFU3ksdQbInGWCg==",
+                    "dev": true
+                },
+                "punycode": {
+                    "version": "1.4.1",
+                    "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+                    "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+                    "dev": true
+                }
+            }
+        },
+        "browserify-aes": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
+            "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
+            "dev": true,
+            "requires": {
+                "buffer-xor": "^1.0.3",
+                "cipher-base": "^1.0.0",
+                "create-hash": "^1.1.0",
+                "evp_bytestokey": "^1.0.3",
+                "inherits": "^2.0.1",
+                "safe-buffer": "^5.0.1"
+            }
+        },
+        "browserify-cache-api": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/browserify-cache-api/-/browserify-cache-api-3.0.1.tgz",
+            "integrity": "sha1-liR+hT8Gj9bg1FzHPwuyzZd47wI=",
+            "dev": true,
+            "requires": {
+                "async": "^1.5.2",
+                "through2": "^2.0.0",
+                "xtend": "^4.0.0"
+            }
+        },
+        "browserify-cipher": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/browserify-cipher/-/browserify-cipher-1.0.1.tgz",
+            "integrity": "sha512-sPhkz0ARKbf4rRQt2hTpAHqn47X3llLkUGn+xEJzLjwY8LRs2p0v7ljvI5EyoRO/mexrNunNECisZs+gw2zz1w==",
+            "dev": true,
+            "requires": {
+                "browserify-aes": "^1.0.4",
+                "browserify-des": "^1.0.0",
+                "evp_bytestokey": "^1.0.0"
+            }
+        },
+        "browserify-des": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.2.tgz",
+            "integrity": "sha512-BioO1xf3hFwz4kc6iBhI3ieDFompMhrMlnDFC4/0/vd5MokpuAc3R+LYbwTA9A5Yc9pq9UYPqffKpW2ObuwX5A==",
+            "dev": true,
+            "requires": {
+                "cipher-base": "^1.0.1",
+                "des.js": "^1.0.0",
+                "inherits": "^2.0.1",
+                "safe-buffer": "^5.1.2"
+            }
+        },
+        "browserify-incremental": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/browserify-incremental/-/browserify-incremental-3.1.1.tgz",
+            "integrity": "sha1-BxPLdYckemMqnwjPG9FpuHi2Koo=",
+            "dev": true,
+            "requires": {
+                "JSONStream": "^0.10.0",
+                "browserify-cache-api": "^3.0.0",
+                "through2": "^2.0.0",
+                "xtend": "^4.0.0"
+            },
+            "dependencies": {
+                "JSONStream": {
+                    "version": "0.10.0",
+                    "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.10.0.tgz",
+                    "integrity": "sha1-dDSdDYlSK3HzDwoD/5vSDKbxKsA=",
+                    "dev": true,
+                    "requires": {
+                        "jsonparse": "0.0.5",
+                        "through": ">=2.2.7 <3"
+                    }
+                },
+                "jsonparse": {
+                    "version": "0.0.5",
+                    "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-0.0.5.tgz",
+                    "integrity": "sha1-MwVCrT8KZUZlt3jz6y2an6UHrGQ=",
+                    "dev": true
+                }
+            }
+        },
+        "browserify-rsa": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
+            "integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
+            "dev": true,
+            "requires": {
+                "bn.js": "^4.1.0",
+                "randombytes": "^2.0.1"
+            },
+            "dependencies": {
+                "bn.js": {
+                    "version": "4.11.9",
+                    "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.9.tgz",
+                    "integrity": "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw==",
+                    "dev": true
+                }
+            }
+        },
+        "browserify-sign": {
+            "version": "4.2.1",
+            "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.2.1.tgz",
+            "integrity": "sha512-/vrA5fguVAKKAVTNJjgSm1tRQDHUU6DbwO9IROu/0WAzC8PKhucDSh18J0RMvVeHAn5puMd+QHC2erPRNf8lmg==",
+            "dev": true,
+            "requires": {
+                "bn.js": "^5.1.1",
+                "browserify-rsa": "^4.0.1",
+                "create-hash": "^1.2.0",
+                "create-hmac": "^1.1.7",
+                "elliptic": "^6.5.3",
+                "inherits": "^2.0.4",
+                "parse-asn1": "^5.1.5",
+                "readable-stream": "^3.6.0",
+                "safe-buffer": "^5.2.0"
+            },
+            "dependencies": {
+                "readable-stream": {
+                    "version": "3.6.0",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+                    "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+                    "dev": true,
+                    "requires": {
+                        "inherits": "^2.0.3",
+                        "string_decoder": "^1.1.1",
+                        "util-deprecate": "^1.0.1"
+                    }
+                }
+            }
+        },
+        "browserify-zlib": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.2.0.tgz",
+            "integrity": "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==",
+            "dev": true,
+            "requires": {
+                "pako": "~1.0.5"
+            }
+        },
+        "buffer": {
+            "version": "5.2.1",
+            "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.2.1.tgz",
+            "integrity": "sha512-c+Ko0loDaFfuPWiL02ls9Xd3GO3cPVmUobQ6t3rXNUk304u6hGq+8N/kFi+QEIKhzK3uwolVhLzszmfLmMLnqg==",
+            "dev": true,
+            "requires": {
+                "base64-js": "^1.0.2",
+                "ieee754": "^1.1.4"
+            }
+        },
+        "buffer-from": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
+            "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
+            "dev": true
+        },
+        "buffer-xor": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
+            "integrity": "sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk=",
+            "dev": true
+        },
+        "builtin-status-codes": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz",
+            "integrity": "sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug=",
+            "dev": true
+        },
+        "bytes": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/bytes/-/bytes-1.0.0.tgz",
+            "integrity": "sha1-NWnt6Lo0MV+rmcPpLLBMciDeH6g=",
+            "dev": true
+        },
+        "cache-base": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
+            "integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
+            "dev": true,
+            "requires": {
+                "collection-visit": "^1.0.0",
+                "component-emitter": "^1.2.1",
+                "get-value": "^2.0.6",
+                "has-value": "^1.0.0",
+                "isobject": "^3.0.1",
+                "set-value": "^2.0.0",
+                "to-object-path": "^0.3.0",
+                "union-value": "^1.0.0",
+                "unset-value": "^1.0.0"
+            }
+        },
+        "cached-path-relative": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/cached-path-relative/-/cached-path-relative-1.0.2.tgz",
+            "integrity": "sha512-5r2GqsoEb4qMTTN9J+WzXfjov+hjxT+j3u5K+kIVNIwAd99DLCJE9pBIMP1qVeybV6JiijL385Oz0DcYxfbOIg==",
+            "dev": true
+        },
+        "caseless": {
+            "version": "0.12.0",
+            "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+            "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
+            "dev": true
+        },
+        "chalk": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+            "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+            "dev": true,
+            "requires": {
+                "ansi-styles": "^4.1.0",
+                "supports-color": "^7.1.0"
+            }
+        },
+        "chokidar": {
+            "version": "2.1.8",
+            "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.8.tgz",
+            "integrity": "sha512-ZmZUazfOzf0Nve7duiCKD23PFSCs4JPoYyccjUFF3aQkQadqBhfzhjkwBH2mNOG9cTBwhamM37EIsIkZw3nRgg==",
+            "dev": true,
+            "requires": {
+                "anymatch": "^2.0.0",
+                "async-each": "^1.0.1",
+                "braces": "^2.3.2",
+                "fsevents": "^1.2.7",
+                "glob-parent": "^3.1.0",
+                "inherits": "^2.0.3",
+                "is-binary-path": "^1.0.0",
+                "is-glob": "^4.0.0",
+                "normalize-path": "^3.0.0",
+                "path-is-absolute": "^1.0.0",
+                "readdirp": "^2.2.1",
+                "upath": "^1.1.1"
+            },
+            "dependencies": {
+                "is-glob": {
+                    "version": "4.0.1",
+                    "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
+                    "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
+                    "dev": true,
+                    "requires": {
+                        "is-extglob": "^2.1.1"
+                    }
+                },
+                "normalize-path": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+                    "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+                    "dev": true
+                }
+            }
+        },
+        "cipher-base": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
+            "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
+            "dev": true,
+            "requires": {
+                "inherits": "^2.0.1",
+                "safe-buffer": "^5.0.1"
+            }
+        },
+        "class-utils": {
+            "version": "0.3.6",
+            "resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
+            "integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
+            "dev": true,
+            "requires": {
+                "arr-union": "^3.1.0",
+                "define-property": "^0.2.5",
+                "isobject": "^3.0.0",
+                "static-extend": "^0.1.1"
+            },
+            "dependencies": {
+                "define-property": {
+                    "version": "0.2.5",
+                    "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+                    "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+                    "dev": true,
+                    "requires": {
+                        "is-descriptor": "^0.1.0"
+                    }
+                }
+            }
+        },
+        "clean-css": {
+            "version": "4.2.3",
+            "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-4.2.3.tgz",
+            "integrity": "sha512-VcMWDN54ZN/DS+g58HYL5/n4Zrqe8vHJpGA8KdgUXFU4fuP/aHNw8eld9SyEIyabIMJX/0RaY/fplOo5hYLSFA==",
+            "dev": true,
+            "requires": {
+                "source-map": "~0.6.0"
+            },
+            "dependencies": {
+                "source-map": {
+                    "version": "0.6.1",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+                    "dev": true
+                }
+            }
+        },
+        "cli": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/cli/-/cli-1.0.1.tgz",
+            "integrity": "sha1-IoF1NPJL+klQw01TLUjsvGIbjBQ=",
+            "dev": true,
+            "requires": {
+                "exit": "0.1.2",
+                "glob": "^7.1.1"
+            }
+        },
+        "collection-visit": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
+            "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
+            "dev": true,
+            "requires": {
+                "map-visit": "^1.0.0",
+                "object-visit": "^1.0.0"
+            }
+        },
+        "color-convert": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+            "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+            "dev": true,
+            "requires": {
+                "color-name": "~1.1.4"
+            }
+        },
+        "color-name": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+            "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+            "dev": true
+        },
+        "colors": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
+            "integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM=",
+            "dev": true
+        },
+        "combine-source-map": {
+            "version": "0.8.0",
+            "resolved": "https://registry.npmjs.org/combine-source-map/-/combine-source-map-0.8.0.tgz",
+            "integrity": "sha1-pY0N8ELBhvz4IqjoAV9UUNLXmos=",
+            "dev": true,
+            "requires": {
+                "convert-source-map": "~1.1.0",
+                "inline-source-map": "~0.6.0",
+                "lodash.memoize": "~3.0.3",
+                "source-map": "~0.5.3"
+            }
+        },
+        "combined-stream": {
+            "version": "1.0.8",
+            "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+            "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+            "dev": true,
+            "requires": {
+                "delayed-stream": "~1.0.0"
+            }
+        },
+        "component-emitter": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
+            "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==",
+            "dev": true
+        },
+        "concat-map": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+            "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+            "dev": true
+        },
+        "concat-stream": {
+            "version": "1.6.2",
+            "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+            "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+            "dev": true,
+            "requires": {
+                "buffer-from": "^1.0.0",
+                "inherits": "^2.0.3",
+                "readable-stream": "^2.2.2",
+                "typedarray": "^0.0.6"
+            }
+        },
+        "connect": {
+            "version": "3.7.0",
+            "resolved": "https://registry.npmjs.org/connect/-/connect-3.7.0.tgz",
+            "integrity": "sha512-ZqRXc+tZukToSNmh5C2iWMSoV3X1YUcPbqEM4DkEG5tNQXrQUZCNVGGv3IuicnkMtPfGf3Xtp8WCXs295iQ1pQ==",
+            "dev": true,
+            "requires": {
+                "debug": "2.6.9",
+                "finalhandler": "1.1.2",
+                "parseurl": "~1.3.3",
+                "utils-merge": "1.0.1"
+            }
+        },
+        "connect-livereload": {
+            "version": "0.5.4",
+            "resolved": "https://registry.npmjs.org/connect-livereload/-/connect-livereload-0.5.4.tgz",
+            "integrity": "sha1-gBV9E3HJ83zBQDmrGJWXDRGdw7w=",
+            "dev": true
+        },
+        "connect-modrewrite": {
+            "version": "0.10.2",
+            "resolved": "https://registry.npmjs.org/connect-modrewrite/-/connect-modrewrite-0.10.2.tgz",
+            "integrity": "sha512-37+kS9t26vxjW5ErNrr8d04F7Us1EH7XhHtxSm8yE8kO2uDF2DsPI+qI2wCeBSaoakXKit0/88sg4vL2Wl8tDw==",
+            "dev": true,
+            "requires": {
+                "qs": "^6.3.1"
+            }
+        },
+        "console-browserify": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.2.0.tgz",
+            "integrity": "sha512-ZMkYO/LkF17QvCPqM0gxw8yUzigAOZOSWSHg91FH6orS7vcEj5dVZTidN2fQ14yBSdg97RqhSNwLUXInd52OTA==",
+            "dev": true
+        },
+        "constants-browserify": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-1.0.0.tgz",
+            "integrity": "sha1-wguW2MYXdIqvHBYCF2DNJ/y4y3U=",
+            "dev": true
+        },
+        "continuable-cache": {
+            "version": "0.3.1",
+            "resolved": "https://registry.npmjs.org/continuable-cache/-/continuable-cache-0.3.1.tgz",
+            "integrity": "sha1-vXJ6f67XfnH/OYWskzUakSczrQ8=",
+            "dev": true
+        },
+        "convert-source-map": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.1.3.tgz",
+            "integrity": "sha1-SCnId+n+SbMWHzvzZziI4gRpmGA=",
+            "dev": true
+        },
+        "copy-descriptor": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
+            "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
+            "dev": true
+        },
+        "core-util-is": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+            "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+            "dev": true
+        },
+        "create-ecdh": {
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.4.tgz",
+            "integrity": "sha512-mf+TCx8wWc9VpuxfP2ht0iSISLZnt0JgWlrOKZiNqyUZWnjIaCIVNQArMHnCZKfEYRg6IM7A+NeJoN8gf/Ws0A==",
+            "dev": true,
+            "requires": {
+                "bn.js": "^4.1.0",
+                "elliptic": "^6.5.3"
+            },
+            "dependencies": {
+                "bn.js": {
+                    "version": "4.11.9",
+                    "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.9.tgz",
+                    "integrity": "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw==",
+                    "dev": true
+                }
+            }
+        },
+        "create-hash": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
+            "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
+            "dev": true,
+            "requires": {
+                "cipher-base": "^1.0.1",
+                "inherits": "^2.0.1",
+                "md5.js": "^1.3.4",
+                "ripemd160": "^2.0.1",
+                "sha.js": "^2.4.0"
+            }
+        },
+        "create-hmac": {
+            "version": "1.1.7",
+            "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
+            "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
+            "dev": true,
+            "requires": {
+                "cipher-base": "^1.0.3",
+                "create-hash": "^1.1.0",
+                "inherits": "^2.0.1",
+                "ripemd160": "^2.0.0",
+                "safe-buffer": "^5.0.1",
+                "sha.js": "^2.4.8"
+            }
+        },
+        "crypto-browserify": {
+            "version": "3.12.0",
+            "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.12.0.tgz",
+            "integrity": "sha512-fz4spIh+znjO2VjL+IdhEpRJ3YN6sMzITSBijk6FK2UvTqruSQW+/cCZTSNsMiZNvUeq0CqurF+dAbyiGOY6Wg==",
+            "dev": true,
+            "requires": {
+                "browserify-cipher": "^1.0.0",
+                "browserify-sign": "^4.0.0",
+                "create-ecdh": "^4.0.0",
+                "create-hash": "^1.1.0",
+                "create-hmac": "^1.1.0",
+                "diffie-hellman": "^5.0.0",
+                "inherits": "^2.0.1",
+                "pbkdf2": "^3.0.3",
+                "public-encrypt": "^4.0.0",
+                "randombytes": "^2.0.0",
+                "randomfill": "^1.0.3"
+            }
+        },
+        "dash-ast": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/dash-ast/-/dash-ast-1.0.0.tgz",
+            "integrity": "sha512-Vy4dx7gquTeMcQR/hDkYLGUnwVil6vk4FOOct+djUnHOUWt+zJPJAaRIXaAFkPXtJjvlY7o3rfRu0/3hpnwoUA==",
+            "dev": true
+        },
+        "dashdash": {
+            "version": "1.14.1",
+            "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+            "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+            "dev": true,
+            "requires": {
+                "assert-plus": "^1.0.0"
+            }
+        },
+        "date-now": {
+            "version": "0.1.4",
+            "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz",
+            "integrity": "sha1-6vQ5/U1ISK105cx9vvIAZyueNFs=",
+            "dev": true
+        },
+        "dateformat": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-3.0.3.tgz",
+            "integrity": "sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q==",
+            "dev": true
+        },
+        "debug": {
+            "version": "2.6.9",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+            "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+            "dev": true,
+            "requires": {
+                "ms": "2.0.0"
+            }
+        },
+        "decode-uri-component": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
+            "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
+            "dev": true
+        },
+        "define-property": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
+            "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
+            "dev": true,
+            "requires": {
+                "is-descriptor": "^1.0.2",
+                "isobject": "^3.0.1"
+            },
+            "dependencies": {
+                "is-accessor-descriptor": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+                    "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+                    "dev": true,
+                    "requires": {
+                        "kind-of": "^6.0.0"
+                    }
+                },
+                "is-data-descriptor": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+                    "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+                    "dev": true,
+                    "requires": {
+                        "kind-of": "^6.0.0"
+                    }
+                },
+                "is-descriptor": {
+                    "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+                    "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+                    "dev": true,
+                    "requires": {
+                        "is-accessor-descriptor": "^1.0.0",
+                        "is-data-descriptor": "^1.0.0",
+                        "kind-of": "^6.0.2"
+                    }
+                }
+            }
+        },
+        "defined": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
+            "integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM=",
+            "dev": true
+        },
+        "delayed-stream": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+            "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+            "dev": true
+        },
+        "depd": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+            "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+            "dev": true
+        },
+        "deps-sort": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/deps-sort/-/deps-sort-2.0.1.tgz",
+            "integrity": "sha512-1orqXQr5po+3KI6kQb9A4jnXT1PBwggGl2d7Sq2xsnOeI9GPcE/tGcF9UiSZtZBM7MukY4cAh7MemS6tZYipfw==",
+            "dev": true,
+            "requires": {
+                "JSONStream": "^1.0.3",
+                "shasum-object": "^1.0.0",
+                "subarg": "^1.0.0",
+                "through2": "^2.0.0"
+            }
+        },
+        "des.js": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.0.1.tgz",
+            "integrity": "sha512-Q0I4pfFrv2VPd34/vfLrFOoRmlYj3OV50i7fskps1jZWK1kApMWWT9G6RRUeYedLcBDIhnSDaUvJMb3AhUlaEA==",
+            "dev": true,
+            "requires": {
+                "inherits": "^2.0.1",
+                "minimalistic-assert": "^1.0.0"
+            }
+        },
+        "destroy": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
+            "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=",
+            "dev": true
+        },
+        "detect-file": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/detect-file/-/detect-file-1.0.0.tgz",
+            "integrity": "sha1-8NZtA2cqglyxtzvbP+YjEMjlUrc=",
+            "dev": true
+        },
+        "detective": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/detective/-/detective-5.2.0.tgz",
+            "integrity": "sha512-6SsIx+nUUbuK0EthKjv0zrdnajCCXVYGmbYYiYjFVpzcjwEs/JMDZ8tPRG29J/HhN56t3GJp2cGSWDRjjot8Pg==",
+            "dev": true,
+            "requires": {
+                "acorn-node": "^1.6.1",
+                "defined": "^1.0.0",
+                "minimist": "^1.1.1"
+            }
+        },
+        "diffie-hellman": {
+            "version": "5.0.3",
+            "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
+            "integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
+            "dev": true,
+            "requires": {
+                "bn.js": "^4.1.0",
+                "miller-rabin": "^4.0.0",
+                "randombytes": "^2.0.0"
+            },
+            "dependencies": {
+                "bn.js": {
+                    "version": "4.11.9",
+                    "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.9.tgz",
+                    "integrity": "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw==",
+                    "dev": true
+                }
+            }
+        },
+        "docsearch.js": {
+            "version": "2.6.3",
+            "resolved": "https://registry.npmjs.org/docsearch.js/-/docsearch.js-2.6.3.tgz",
+            "integrity": "sha512-GN+MBozuyz664ycpZY0ecdQE0ND/LSgJKhTLA0/v3arIS3S1Rpf2OJz6A35ReMsm91V5apcmzr5/kM84cvUg+A==",
+            "dev": true,
+            "requires": {
+                "algoliasearch": "^3.24.5",
+                "autocomplete.js": "0.36.0",
+                "hogan.js": "^3.0.2",
+                "request": "^2.87.0",
+                "stack-utils": "^1.0.1",
+                "to-factory": "^1.0.0",
+                "zepto": "^1.2.0"
+            }
+        },
+        "dom-serializer": {
+            "version": "0.2.2",
+            "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.2.2.tgz",
+            "integrity": "sha512-2/xPb3ORsQ42nHYiSunXkDjPLBaEj/xTwUO4B7XCZQTRk7EBtTOPaygh10YAAh2OI1Qrp6NWfpAhzswj0ydt9g==",
+            "dev": true,
+            "requires": {
+                "domelementtype": "^2.0.1",
+                "entities": "^2.0.0"
+            },
+            "dependencies": {
+                "domelementtype": {
+                    "version": "2.0.2",
+                    "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.0.2.tgz",
+                    "integrity": "sha512-wFwTwCVebUrMgGeAwRL/NhZtHAUyT9n9yg4IMDwf10+6iCMxSkVq9MGCVEH+QZWo1nNidy8kNvwmv4zWHDTqvA==",
+                    "dev": true
+                },
+                "entities": {
+                    "version": "2.0.3",
+                    "resolved": "https://registry.npmjs.org/entities/-/entities-2.0.3.tgz",
+                    "integrity": "sha512-MyoZ0jgnLvB2X3Lg5HqpFmn1kybDiIfEQmKzTb5apr51Rb+T3KdmMiqa70T+bhGnyv7bQ6WMj2QMHpGMmlrUYQ==",
+                    "dev": true
+                }
+            }
+        },
+        "dom-walk": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.2.tgz",
+            "integrity": "sha512-6QvTW9mrGeIegrFXdtQi9pk7O/nSK6lSdXW2eqUspN5LWD7UTji2Fqw5V2YLjBpHEoU9Xl/eUWNpDeZvoyOv2w==",
+            "dev": true
+        },
+        "domain-browser": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.2.0.tgz",
+            "integrity": "sha512-jnjyiM6eRyZl2H+W8Q/zLMA481hzi0eszAaBUzIVnmYVDBbnLxVNnfu1HgEBvCbL+71FrxMl3E6lpKH7Ge3OXA==",
+            "dev": true
+        },
+        "domelementtype": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.1.tgz",
+            "integrity": "sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w==",
+            "dev": true
+        },
+        "domhandler": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.3.0.tgz",
+            "integrity": "sha1-LeWaCCLVAn+r/28DLCsloqir5zg=",
+            "dev": true,
+            "requires": {
+                "domelementtype": "1"
+            }
+        },
+        "domutils": {
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
+            "integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
+            "dev": true,
+            "requires": {
+                "dom-serializer": "0",
+                "domelementtype": "1"
+            }
+        },
+        "duplexer": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
+            "integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==",
+            "dev": true
+        },
+        "duplexer2": {
+            "version": "0.1.4",
+            "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
+            "integrity": "sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=",
+            "dev": true,
+            "requires": {
+                "readable-stream": "^2.0.2"
+            }
+        },
+        "ecc-jsbn": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
+            "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
+            "dev": true,
+            "requires": {
+                "jsbn": "~0.1.0",
+                "safer-buffer": "^2.1.0"
+            }
+        },
+        "ee-first": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+            "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=",
+            "dev": true
+        },
+        "elliptic": {
+            "version": "6.5.3",
+            "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.3.tgz",
+            "integrity": "sha512-IMqzv5wNQf+E6aHeIqATs0tOLeOTwj1QKbRcS3jBbYkl5oLAserA8yJTT7/VyHUYG91PRmPyeQDObKLPpeS4dw==",
+            "dev": true,
+            "requires": {
+                "bn.js": "^4.4.0",
+                "brorand": "^1.0.1",
+                "hash.js": "^1.0.0",
+                "hmac-drbg": "^1.0.0",
+                "inherits": "^2.0.1",
+                "minimalistic-assert": "^1.0.0",
+                "minimalistic-crypto-utils": "^1.0.0"
+            },
+            "dependencies": {
+                "bn.js": {
+                    "version": "4.11.9",
+                    "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.9.tgz",
+                    "integrity": "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw==",
+                    "dev": true
+                }
+            }
+        },
+        "encodeurl": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
+            "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=",
+            "dev": true
+        },
+        "entities": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/entities/-/entities-1.0.0.tgz",
+            "integrity": "sha1-sph6o4ITR/zeZCsk/fyeT7cSvyY=",
+            "dev": true
+        },
+        "envify": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/envify/-/envify-4.1.0.tgz",
+            "integrity": "sha512-IKRVVoAYr4pIx4yIWNsz9mOsboxlNXiu7TNBnem/K/uTHdkyzXWDzHCK7UTolqBbgaBz0tQHsD3YNls0uIIjiw==",
+            "dev": true,
+            "requires": {
+                "esprima": "^4.0.0",
+                "through": "~2.3.4"
+            }
+        },
+        "errno": {
+            "version": "0.1.7",
+            "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.7.tgz",
+            "integrity": "sha512-MfrRBDWzIWifgq6tJj60gkAwtLNb6sQPlcFrSOflcP1aFmmruKQ2wRnze/8V6kgyz7H3FF8Npzv78mZ7XLLflg==",
+            "dev": true,
+            "optional": true,
+            "requires": {
+                "prr": "~1.0.1"
+            }
+        },
+        "error": {
+            "version": "7.2.1",
+            "resolved": "https://registry.npmjs.org/error/-/error-7.2.1.tgz",
+            "integrity": "sha512-fo9HBvWnx3NGUKMvMwB/CBCMMrfEJgbDTVDEkPygA3Bdd3lM1OyCd+rbQ8BwnpF6GdVeOLDNmyL4N5Bg80ZvdA==",
+            "dev": true,
+            "requires": {
+                "string-template": "~0.2.1"
+            }
+        },
+        "es6-promise": {
+            "version": "4.2.8",
+            "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
+            "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==",
+            "dev": true
+        },
+        "escape-html": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+            "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=",
+            "dev": true
+        },
+        "escape-string-regexp": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+            "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+            "dev": true
+        },
+        "esprima": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+            "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+            "dev": true
+        },
+        "etag": {
+            "version": "1.8.1",
+            "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+            "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
+            "dev": true
+        },
+        "eventemitter2": {
+            "version": "0.4.14",
+            "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-0.4.14.tgz",
+            "integrity": "sha1-j2G3XN4BKy6esoTUVFWDtWQ7Yas=",
+            "dev": true
+        },
+        "events": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
+            "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ=",
+            "dev": true
+        },
+        "evp_bytestokey": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
+            "integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
+            "dev": true,
+            "requires": {
+                "md5.js": "^1.3.4",
+                "safe-buffer": "^5.1.1"
+            }
+        },
+        "exit": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
+            "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=",
+            "dev": true
+        },
+        "expand-brackets": {
+            "version": "2.1.4",
+            "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
+            "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
+            "dev": true,
+            "requires": {
+                "debug": "^2.3.3",
+                "define-property": "^0.2.5",
+                "extend-shallow": "^2.0.1",
+                "posix-character-classes": "^0.1.0",
+                "regex-not": "^1.0.0",
+                "snapdragon": "^0.8.1",
+                "to-regex": "^3.0.1"
+            },
+            "dependencies": {
+                "define-property": {
+                    "version": "0.2.5",
+                    "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+                    "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+                    "dev": true,
+                    "requires": {
+                        "is-descriptor": "^0.1.0"
+                    }
+                },
+                "extend-shallow": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                    "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                    "dev": true,
+                    "requires": {
+                        "is-extendable": "^0.1.0"
+                    }
+                }
+            }
+        },
+        "expand-tilde": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-2.0.2.tgz",
+            "integrity": "sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=",
+            "dev": true,
+            "requires": {
+                "homedir-polyfill": "^1.0.1"
+            }
+        },
+        "extend": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+            "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+            "dev": true
+        },
+        "extend-shallow": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
+            "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
+            "dev": true,
+            "requires": {
+                "assign-symbols": "^1.0.0",
+                "is-extendable": "^1.0.1"
+            },
+            "dependencies": {
+                "is-extendable": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+                    "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+                    "dev": true,
+                    "requires": {
+                        "is-plain-object": "^2.0.4"
+                    }
+                }
+            }
+        },
+        "extglob": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
+            "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
+            "dev": true,
+            "requires": {
+                "array-unique": "^0.3.2",
+                "define-property": "^1.0.0",
+                "expand-brackets": "^2.1.4",
+                "extend-shallow": "^2.0.1",
+                "fragment-cache": "^0.2.1",
+                "regex-not": "^1.0.0",
+                "snapdragon": "^0.8.1",
+                "to-regex": "^3.0.1"
+            },
+            "dependencies": {
+                "define-property": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+                    "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+                    "dev": true,
+                    "requires": {
+                        "is-descriptor": "^1.0.0"
+                    }
+                },
+                "extend-shallow": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                    "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                    "dev": true,
+                    "requires": {
+                        "is-extendable": "^0.1.0"
+                    }
+                },
+                "is-accessor-descriptor": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+                    "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+                    "dev": true,
+                    "requires": {
+                        "kind-of": "^6.0.0"
+                    }
+                },
+                "is-data-descriptor": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+                    "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+                    "dev": true,
+                    "requires": {
+                        "kind-of": "^6.0.0"
+                    }
+                },
+                "is-descriptor": {
+                    "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+                    "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+                    "dev": true,
+                    "requires": {
+                        "is-accessor-descriptor": "^1.0.0",
+                        "is-data-descriptor": "^1.0.0",
+                        "kind-of": "^6.0.2"
+                    }
+                }
+            }
+        },
+        "extsprintf": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+            "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
+            "dev": true
+        },
+        "fast-deep-equal": {
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+            "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+            "dev": true
+        },
+        "fast-json-stable-stringify": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+            "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+            "dev": true
+        },
+        "fast-safe-stringify": {
+            "version": "2.0.7",
+            "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.0.7.tgz",
+            "integrity": "sha512-Utm6CdzT+6xsDk2m8S6uL8VHxNwI6Jub+e9NYTcAms28T84pTa25GJQV9j0CY0N1rM8hK4x6grpF2BQf+2qwVA==",
+            "dev": true
+        },
+        "faye-websocket": {
+            "version": "0.10.0",
+            "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.10.0.tgz",
+            "integrity": "sha1-TkkvjQTftviQA1B/btvy1QHnxvQ=",
+            "dev": true,
+            "requires": {
+                "websocket-driver": ">=0.5.1"
+            }
+        },
+        "figures": {
+            "version": "1.7.0",
+            "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
+            "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
+            "dev": true,
+            "requires": {
+                "escape-string-regexp": "^1.0.5",
+                "object-assign": "^4.1.0"
+            }
+        },
+        "file-saver": {
+            "version": "1.3.8",
+            "resolved": "https://registry.npmjs.org/file-saver/-/file-saver-1.3.8.tgz",
+            "integrity": "sha512-spKHSBQIxxS81N/O21WmuXA2F6wppUCsutpzenOeZzOCCJ5gEfcbqJP983IrpLXzYmXnMUa6J03SubcNPdKrlg==",
+            "dev": true
+        },
+        "file-sync-cmp": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/file-sync-cmp/-/file-sync-cmp-0.1.1.tgz",
+            "integrity": "sha1-peeo/7+kk7Q7kju9TKiaU7Y7YSs=",
+            "dev": true
+        },
+        "file-uri-to-path": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+            "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+            "dev": true,
+            "optional": true
+        },
+        "fill-range": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+            "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+            "dev": true,
+            "requires": {
+                "extend-shallow": "^2.0.1",
+                "is-number": "^3.0.0",
+                "repeat-string": "^1.6.1",
+                "to-regex-range": "^2.1.0"
+            },
+            "dependencies": {
+                "extend-shallow": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                    "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                    "dev": true,
+                    "requires": {
+                        "is-extendable": "^0.1.0"
+                    }
+                }
+            }
+        },
+        "finalhandler": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.2.tgz",
+            "integrity": "sha512-aAWcW57uxVNrQZqFXjITpW3sIUQmHGG3qSb9mUah9MgMC4NeWhNOlNjXEYq3HjRAvL6arUviZGGJsBg6z0zsWA==",
+            "dev": true,
+            "requires": {
+                "debug": "2.6.9",
+                "encodeurl": "~1.0.2",
+                "escape-html": "~1.0.3",
+                "on-finished": "~2.3.0",
+                "parseurl": "~1.3.3",
+                "statuses": "~1.5.0",
+                "unpipe": "~1.0.0"
+            }
+        },
+        "findup-sync": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.3.0.tgz",
+            "integrity": "sha1-N5MKpdgWt3fANEXhlmzGeQpMCxY=",
+            "dev": true,
+            "requires": {
+                "glob": "~5.0.0"
+            },
+            "dependencies": {
+                "glob": {
+                    "version": "5.0.15",
+                    "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+                    "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
+                    "dev": true,
+                    "requires": {
+                        "inflight": "^1.0.4",
+                        "inherits": "2",
+                        "minimatch": "2 || 3",
+                        "once": "^1.3.0",
+                        "path-is-absolute": "^1.0.0"
+                    }
+                }
+            }
+        },
+        "fined": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/fined/-/fined-1.2.0.tgz",
+            "integrity": "sha512-ZYDqPLGxDkDhDZBjZBb+oD1+j0rA4E0pXY50eplAAOPg2N/gUBSSk5IM1/QhPfyVo19lJ+CvXpqfvk+b2p/8Ng==",
+            "dev": true,
+            "requires": {
+                "expand-tilde": "^2.0.2",
+                "is-plain-object": "^2.0.3",
+                "object.defaults": "^1.1.0",
+                "object.pick": "^1.2.0",
+                "parse-filepath": "^1.0.1"
+            }
+        },
+        "flagged-respawn": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/flagged-respawn/-/flagged-respawn-1.0.1.tgz",
+            "integrity": "sha512-lNaHNVymajmk0OJMBn8fVUAU1BtDeKIqKoVhk4xAALB57aALg6b4W0MfJ/cUE0g9YBXy5XhSlPIpYIJ7HaY/3Q==",
+            "dev": true
+        },
+        "for-in": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
+            "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
+            "dev": true
+        },
+        "for-own": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/for-own/-/for-own-1.0.0.tgz",
+            "integrity": "sha1-xjMy9BXO3EsE2/5wz4NklMU8tEs=",
+            "dev": true,
+            "requires": {
+                "for-in": "^1.0.1"
+            }
+        },
+        "foreach": {
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
+            "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k=",
+            "dev": true
+        },
+        "forever-agent": {
+            "version": "0.6.1",
+            "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+            "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+            "dev": true
+        },
+        "form-data": {
+            "version": "2.3.3",
+            "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
+            "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+            "dev": true,
+            "requires": {
+                "asynckit": "^0.4.0",
+                "combined-stream": "^1.0.6",
+                "mime-types": "^2.1.12"
+            }
+        },
+        "fragment-cache": {
+            "version": "0.2.1",
+            "resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
+            "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
+            "dev": true,
+            "requires": {
+                "map-cache": "^0.2.2"
+            }
+        },
+        "fresh": {
+            "version": "0.5.2",
+            "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+            "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=",
+            "dev": true
+        },
+        "fs-extra": {
+            "version": "0.30.0",
+            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.30.0.tgz",
+            "integrity": "sha1-8jP/zAjU2n1DLapEl3aYnbHfk/A=",
+            "dev": true,
+            "requires": {
+                "graceful-fs": "^4.1.2",
+                "jsonfile": "^2.1.0",
+                "klaw": "^1.0.0",
+                "path-is-absolute": "^1.0.0",
+                "rimraf": "^2.2.8"
+            }
+        },
+        "fs.realpath": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+            "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+            "dev": true
+        },
+        "fsevents": {
+            "version": "1.2.13",
+            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
+            "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
+            "dev": true,
+            "optional": true,
+            "requires": {
+                "bindings": "^1.5.0",
+                "nan": "^2.12.1"
+            }
+        },
+        "function-bind": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+            "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+            "dev": true
+        },
+        "gaze": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/gaze/-/gaze-1.1.3.tgz",
+            "integrity": "sha512-BRdNm8hbWzFzWHERTrejLqwHDfS4GibPoq5wjTPIoJHoBtKGPg3xAFfxmM+9ztbXelxcf2hwQcaz1PtmFeue8g==",
+            "dev": true,
+            "requires": {
+                "globule": "^1.0.0"
+            }
+        },
+        "get-assigned-identifiers": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/get-assigned-identifiers/-/get-assigned-identifiers-1.2.0.tgz",
+            "integrity": "sha512-mBBwmeGTrxEMO4pMaaf/uUEFHnYtwr8FTe8Y/mer4rcV/bye0qGm6pw1bGZFGStxC5O76c5ZAVBGnqHmOaJpdQ==",
+            "dev": true
+        },
+        "get-value": {
+            "version": "2.0.6",
+            "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
+            "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=",
+            "dev": true
+        },
+        "getobject": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/getobject/-/getobject-0.1.0.tgz",
+            "integrity": "sha1-BHpEl4n6Fg0Bj1SG7ZEyC27HiFw=",
+            "dev": true
+        },
+        "getpass": {
+            "version": "0.1.7",
+            "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+            "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+            "dev": true,
+            "requires": {
+                "assert-plus": "^1.0.0"
+            }
+        },
+        "glob": {
+            "version": "7.1.6",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+            "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+            "dev": true,
+            "requires": {
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.0.4",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
+            }
+        },
+        "glob-parent": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
+            "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
+            "dev": true,
+            "requires": {
+                "is-glob": "^3.1.0",
+                "path-dirname": "^1.0.0"
+            }
+        },
+        "global": {
+            "version": "4.4.0",
+            "resolved": "https://registry.npmjs.org/global/-/global-4.4.0.tgz",
+            "integrity": "sha512-wv/LAoHdRE3BeTGz53FAamhGlPLhlssK45usmGFThIi4XqnBmjKQ16u+RNbP7WvigRZDxUsM0J3gcQ5yicaL0w==",
+            "dev": true,
+            "requires": {
+                "min-document": "^2.19.0",
+                "process": "^0.11.10"
+            }
+        },
+        "global-modules": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-1.0.0.tgz",
+            "integrity": "sha512-sKzpEkf11GpOFuw0Zzjzmt4B4UZwjOcG757PPvrfhxcLFbq0wpsgpOqxpxtxFiCG4DtG93M6XRVbF2oGdev7bg==",
+            "dev": true,
+            "requires": {
+                "global-prefix": "^1.0.1",
+                "is-windows": "^1.0.1",
+                "resolve-dir": "^1.0.0"
+            }
+        },
+        "global-prefix": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-1.0.2.tgz",
+            "integrity": "sha1-2/dDxsFJklk8ZVVoy2btMsASLr4=",
+            "dev": true,
+            "requires": {
+                "expand-tilde": "^2.0.2",
+                "homedir-polyfill": "^1.0.1",
+                "ini": "^1.3.4",
+                "is-windows": "^1.0.1",
+                "which": "^1.2.14"
+            }
+        },
+        "globule": {
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/globule/-/globule-1.3.2.tgz",
+            "integrity": "sha512-7IDTQTIu2xzXkT+6mlluidnWo+BypnbSoEVVQCGfzqnl5Ik8d3e1d4wycb8Rj9tWW+Z39uPWsdlquqiqPCd/pA==",
+            "dev": true,
+            "requires": {
+                "glob": "~7.1.1",
+                "lodash": "~4.17.10",
+                "minimatch": "~3.0.2"
+            }
+        },
+        "graceful-fs": {
+            "version": "4.2.4",
+            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
+            "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
+            "dev": true
+        },
+        "grunt": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/grunt/-/grunt-1.3.0.tgz",
+            "integrity": "sha512-6ILlMXv11/4cxuhSMfSU+SfvbxrPuqZrAtLN64+tZpQ3DAKfSQPQHRbTjSbdtxfyQhGZPtN0bDZJ/LdCM5WXXA==",
+            "dev": true,
+            "requires": {
+                "dateformat": "~3.0.3",
+                "eventemitter2": "~0.4.13",
+                "exit": "~0.1.2",
+                "findup-sync": "~0.3.0",
+                "glob": "~7.1.6",
+                "grunt-cli": "~1.3.2",
+                "grunt-known-options": "~1.1.0",
+                "grunt-legacy-log": "~3.0.0",
+                "grunt-legacy-util": "~2.0.0",
+                "iconv-lite": "~0.4.13",
+                "js-yaml": "~3.14.0",
+                "minimatch": "~3.0.4",
+                "mkdirp": "~1.0.4",
+                "nopt": "~3.0.6",
+                "rimraf": "~3.0.2"
+            },
+            "dependencies": {
+                "mkdirp": {
+                    "version": "1.0.4",
+                    "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+                    "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+                    "dev": true
+                },
+                "nopt": {
+                    "version": "3.0.6",
+                    "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
+                    "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
+                    "dev": true,
+                    "requires": {
+                        "abbrev": "1"
+                    }
+                },
+                "rimraf": {
+                    "version": "3.0.2",
+                    "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+                    "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+                    "dev": true,
+                    "requires": {
+                        "glob": "^7.1.3"
+                    }
+                }
+            }
+        },
+        "grunt-browserify": {
+            "version": "5.3.0",
+            "resolved": "https://registry.npmjs.org/grunt-browserify/-/grunt-browserify-5.3.0.tgz",
+            "integrity": "sha1-R/2M+LrFj+LeaDr9xX9/OoDKeS0=",
+            "dev": true,
+            "requires": {
+                "async": "^2.5.0",
+                "browserify": "^16.0.0",
+                "browserify-incremental": "^3.1.1",
+                "glob": "^7.1.2",
+                "lodash": "^4.17.4",
+                "resolve": "^1.1.6",
+                "watchify": "^3.6.1"
+            },
+            "dependencies": {
+                "async": {
+                    "version": "2.6.3",
+                    "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
+                    "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
+                    "dev": true,
+                    "requires": {
+                        "lodash": "^4.17.14"
+                    }
+                }
+            }
+        },
+        "grunt-cli": {
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/grunt-cli/-/grunt-cli-1.3.2.tgz",
+            "integrity": "sha512-8OHDiZZkcptxVXtMfDxJvmN7MVJNE8L/yIcPb4HB7TlyFD1kDvjHrb62uhySsU14wJx9ORMnTuhRMQ40lH/orQ==",
+            "dev": true,
+            "requires": {
+                "grunt-known-options": "~1.1.0",
+                "interpret": "~1.1.0",
+                "liftoff": "~2.5.0",
+                "nopt": "~4.0.1",
+                "v8flags": "~3.1.1"
+            },
+            "dependencies": {
+                "nopt": {
+                    "version": "4.0.3",
+                    "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.3.tgz",
+                    "integrity": "sha512-CvaGwVMztSMJLOeXPrez7fyfObdZqNUK1cPAEzLHrTybIua9pMdmmPR5YwtfNftIOMv3DPUhFaxsZMNTQO20Kg==",
+                    "dev": true,
+                    "requires": {
+                        "abbrev": "1",
+                        "osenv": "^0.1.4"
+                    }
+                }
+            }
+        },
+        "grunt-contrib-concat": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/grunt-contrib-concat/-/grunt-contrib-concat-1.0.1.tgz",
+            "integrity": "sha1-YVCYYwhOhx1+ht5IwBUlntl3Rb0=",
+            "dev": true,
+            "requires": {
+                "chalk": "^1.0.0",
+                "source-map": "^0.5.3"
+            },
+            "dependencies": {
+                "ansi-styles": {
+                    "version": "2.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+                    "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+                    "dev": true
+                },
+                "chalk": {
+                    "version": "1.1.3",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+                    "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^2.2.1",
+                        "escape-string-regexp": "^1.0.2",
+                        "has-ansi": "^2.0.0",
+                        "strip-ansi": "^3.0.0",
+                        "supports-color": "^2.0.0"
+                    }
+                },
+                "supports-color": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+                    "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+                    "dev": true
+                }
+            }
+        },
+        "grunt-contrib-connect": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/grunt-contrib-connect/-/grunt-contrib-connect-1.0.2.tgz",
+            "integrity": "sha1-XPkzuRpnOGBEJzwLJERgPNmIebo=",
+            "dev": true,
+            "requires": {
+                "async": "^1.5.2",
+                "connect": "^3.4.0",
+                "connect-livereload": "^0.5.0",
+                "http2": "^3.3.4",
+                "morgan": "^1.6.1",
+                "opn": "^4.0.0",
+                "portscanner": "^1.0.0",
+                "serve-index": "^1.7.1",
+                "serve-static": "^1.10.0"
+            }
+        },
+        "grunt-contrib-copy": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/grunt-contrib-copy/-/grunt-contrib-copy-1.0.0.tgz",
+            "integrity": "sha1-cGDGWB6QS4qw0A8HbgqPbj58NXM=",
+            "dev": true,
+            "requires": {
+                "chalk": "^1.1.1",
+                "file-sync-cmp": "^0.1.0"
+            },
+            "dependencies": {
+                "ansi-styles": {
+                    "version": "2.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+                    "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+                    "dev": true
+                },
+                "chalk": {
+                    "version": "1.1.3",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+                    "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^2.2.1",
+                        "escape-string-regexp": "^1.0.2",
+                        "has-ansi": "^2.0.0",
+                        "strip-ansi": "^3.0.0",
+                        "supports-color": "^2.0.0"
+                    }
+                },
+                "supports-color": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+                    "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+                    "dev": true
+                }
+            }
+        },
+        "grunt-contrib-cssmin": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/grunt-contrib-cssmin/-/grunt-contrib-cssmin-3.0.0.tgz",
+            "integrity": "sha512-eXpooYmVGKMs/xV7DzTLgJFPVOfMuawPD3x0JwhlH0mumq2NtH3xsxaHxp1Y3NKxp0j0tRhFS6kSBRsz6TuTGg==",
+            "dev": true,
+            "requires": {
+                "chalk": "^2.4.1",
+                "clean-css": "~4.2.1",
+                "maxmin": "^2.1.0"
+            },
+            "dependencies": {
+                "ansi-styles": {
+                    "version": "3.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+                    "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+                    "dev": true,
+                    "requires": {
+                        "color-convert": "^1.9.0"
+                    }
+                },
+                "chalk": {
+                    "version": "2.4.2",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+                    "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^3.2.1",
+                        "escape-string-regexp": "^1.0.5",
+                        "supports-color": "^5.3.0"
+                    }
+                },
+                "color-convert": {
+                    "version": "1.9.3",
+                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+                    "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+                    "dev": true,
+                    "requires": {
+                        "color-name": "1.1.3"
+                    }
+                },
+                "color-name": {
+                    "version": "1.1.3",
+                    "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+                    "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+                    "dev": true
+                },
+                "has-flag": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+                    "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+                    "dev": true
+                },
+                "supports-color": {
+                    "version": "5.5.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+                    "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^3.0.0"
+                    }
+                }
+            }
+        },
+        "grunt-contrib-jshint": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/grunt-contrib-jshint/-/grunt-contrib-jshint-2.1.0.tgz",
+            "integrity": "sha512-65S2/C/6RfjY/umTxfwXXn+wVvaYmykHkHSsW6Q6rhkbv3oudTEgqnFFZvWzWCoHUb+3GMZLbP3oSrNyvshmIQ==",
+            "dev": true,
+            "requires": {
+                "chalk": "^2.4.2",
+                "hooker": "^0.2.3",
+                "jshint": "~2.10.2"
+            },
+            "dependencies": {
+                "ansi-styles": {
+                    "version": "3.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+                    "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+                    "dev": true,
+                    "requires": {
+                        "color-convert": "^1.9.0"
+                    }
+                },
+                "chalk": {
+                    "version": "2.4.2",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+                    "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^3.2.1",
+                        "escape-string-regexp": "^1.0.5",
+                        "supports-color": "^5.3.0"
+                    }
+                },
+                "color-convert": {
+                    "version": "1.9.3",
+                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+                    "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+                    "dev": true,
+                    "requires": {
+                        "color-name": "1.1.3"
+                    }
+                },
+                "color-name": {
+                    "version": "1.1.3",
+                    "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+                    "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+                    "dev": true
+                },
+                "has-flag": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+                    "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+                    "dev": true
+                },
+                "supports-color": {
+                    "version": "5.5.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+                    "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^3.0.0"
+                    }
+                }
+            }
+        },
+        "grunt-contrib-less": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/grunt-contrib-less/-/grunt-contrib-less-2.0.0.tgz",
+            "integrity": "sha512-nsaODoEMjVn61OuqPaFeFQpb4Qd/EbfxQDeYnh2oONXm8L5Gnuchtv59kl0V3hjiFdOkZlPILDc3ZrkoZI0PNw==",
+            "dev": true,
+            "requires": {
+                "async": "^2.0.0",
+                "chalk": "^1.0.0",
+                "less": "^3.0.4",
+                "lodash": "^4.17.10"
+            },
+            "dependencies": {
+                "ansi-styles": {
+                    "version": "2.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+                    "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+                    "dev": true
+                },
+                "async": {
+                    "version": "2.6.3",
+                    "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
+                    "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
+                    "dev": true,
+                    "requires": {
+                        "lodash": "^4.17.14"
+                    }
+                },
+                "chalk": {
+                    "version": "1.1.3",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+                    "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^2.2.1",
+                        "escape-string-regexp": "^1.0.2",
+                        "has-ansi": "^2.0.0",
+                        "strip-ansi": "^3.0.0",
+                        "supports-color": "^2.0.0"
+                    }
+                },
+                "supports-color": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+                    "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+                    "dev": true
+                }
+            }
+        },
+        "grunt-contrib-uglify": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/grunt-contrib-uglify/-/grunt-contrib-uglify-5.0.0.tgz",
+            "integrity": "sha512-rIFFPJMWKnh6oxDe2b810Ysg5SKoiI0u/FvuvAVpvJ7VHILkKtGqA4jgJ1JWruWQ+1m5FtB1lVSK81YyzIgDUw==",
+            "dev": true,
+            "requires": {
+                "chalk": "^2.4.1",
+                "maxmin": "^2.1.0",
+                "uglify-js": "^3.5.0",
+                "uri-path": "^1.0.0"
+            },
+            "dependencies": {
+                "ansi-styles": {
+                    "version": "3.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+                    "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+                    "dev": true,
+                    "requires": {
+                        "color-convert": "^1.9.0"
+                    }
+                },
+                "chalk": {
+                    "version": "2.4.2",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+                    "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^3.2.1",
+                        "escape-string-regexp": "^1.0.5",
+                        "supports-color": "^5.3.0"
+                    }
+                },
+                "color-convert": {
+                    "version": "1.9.3",
+                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+                    "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+                    "dev": true,
+                    "requires": {
+                        "color-name": "1.1.3"
+                    }
+                },
+                "color-name": {
+                    "version": "1.1.3",
+                    "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+                    "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+                    "dev": true
+                },
+                "has-flag": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+                    "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+                    "dev": true
+                },
+                "supports-color": {
+                    "version": "5.5.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+                    "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^3.0.0"
+                    }
+                }
+            }
+        },
+        "grunt-contrib-watch": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/grunt-contrib-watch/-/grunt-contrib-watch-1.1.0.tgz",
+            "integrity": "sha512-yGweN+0DW5yM+oo58fRu/XIRrPcn3r4tQx+nL7eMRwjpvk+rQY6R8o94BPK0i2UhTg9FN21hS+m8vR8v9vXfeg==",
+            "dev": true,
+            "requires": {
+                "async": "^2.6.0",
+                "gaze": "^1.1.0",
+                "lodash": "^4.17.10",
+                "tiny-lr": "^1.1.1"
+            },
+            "dependencies": {
+                "async": {
+                    "version": "2.6.3",
+                    "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
+                    "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
+                    "dev": true,
+                    "requires": {
+                        "lodash": "^4.17.14"
+                    }
+                }
+            }
+        },
+        "grunt-known-options": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/grunt-known-options/-/grunt-known-options-1.1.1.tgz",
+            "integrity": "sha512-cHwsLqoighpu7TuYj5RonnEuxGVFnztcUqTqp5rXFGYL4OuPFofwC4Ycg7n9fYwvK6F5WbYgeVOwph9Crs2fsQ==",
+            "dev": true
+        },
+        "grunt-legacy-log": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/grunt-legacy-log/-/grunt-legacy-log-3.0.0.tgz",
+            "integrity": "sha512-GHZQzZmhyq0u3hr7aHW4qUH0xDzwp2YXldLPZTCjlOeGscAOWWPftZG3XioW8MasGp+OBRIu39LFx14SLjXRcA==",
+            "dev": true,
+            "requires": {
+                "colors": "~1.1.2",
+                "grunt-legacy-log-utils": "~2.1.0",
+                "hooker": "~0.2.3",
+                "lodash": "~4.17.19"
+            }
+        },
+        "grunt-legacy-log-utils": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/grunt-legacy-log-utils/-/grunt-legacy-log-utils-2.1.0.tgz",
+            "integrity": "sha512-lwquaPXJtKQk0rUM1IQAop5noEpwFqOXasVoedLeNzaibf/OPWjKYvvdqnEHNmU+0T0CaReAXIbGo747ZD+Aaw==",
+            "dev": true,
+            "requires": {
+                "chalk": "~4.1.0",
+                "lodash": "~4.17.19"
+            }
+        },
+        "grunt-legacy-util": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/grunt-legacy-util/-/grunt-legacy-util-2.0.0.tgz",
+            "integrity": "sha512-ZEmYFB44bblwPE2oz3q3ygfF6hseQja9tx8I3UZIwbUik32FMWewA+d1qSFicMFB+8dNXDkh35HcDCWlpRsGlA==",
+            "dev": true,
+            "requires": {
+                "async": "~1.5.2",
+                "exit": "~0.1.1",
+                "getobject": "~0.1.0",
+                "hooker": "~0.2.3",
+                "lodash": "~4.17.20",
+                "underscore.string": "~3.3.5",
+                "which": "~1.3.0"
+            }
+        },
+        "grunt-preprocess": {
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/grunt-preprocess/-/grunt-preprocess-5.1.0.tgz",
+            "integrity": "sha1-XJUpN14wQxsMSyYEenk+OCFyII8=",
+            "dev": true,
+            "requires": {
+                "lodash": "^4.5.0",
+                "preprocess": "^3.0.2"
+            }
+        },
+        "gzip-size": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-3.0.0.tgz",
+            "integrity": "sha1-VGGI6b3DN/Zzdy+BZgRks4nc5SA=",
+            "dev": true,
+            "requires": {
+                "duplexer": "^0.1.1"
+            }
+        },
+        "har-schema": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+            "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
+            "dev": true
+        },
+        "har-validator": {
+            "version": "5.1.5",
+            "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
+            "integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
+            "dev": true,
+            "requires": {
+                "ajv": "^6.12.3",
+                "har-schema": "^2.0.0"
+            }
+        },
+        "has": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+            "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+            "dev": true,
+            "requires": {
+                "function-bind": "^1.1.1"
+            }
+        },
+        "has-ansi": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+            "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+            "dev": true,
+            "requires": {
+                "ansi-regex": "^2.0.0"
+            }
+        },
+        "has-flag": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+            "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+            "dev": true
+        },
+        "has-value": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
+            "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
+            "dev": true,
+            "requires": {
+                "get-value": "^2.0.6",
+                "has-values": "^1.0.0",
+                "isobject": "^3.0.0"
+            }
+        },
+        "has-values": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
+            "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
+            "dev": true,
+            "requires": {
+                "is-number": "^3.0.0",
+                "kind-of": "^4.0.0"
+            },
+            "dependencies": {
+                "kind-of": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
+                    "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
+                    "dev": true,
+                    "requires": {
+                        "is-buffer": "^1.1.5"
+                    }
+                }
+            }
+        },
+        "hash-base": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.1.0.tgz",
+            "integrity": "sha512-1nmYp/rhMDiE7AYkDw+lLwlAzz0AntGIe51F3RfFfEqyQ3feY2eI/NcwC6umIQVOASPMsWJLJScWKSSvzL9IVA==",
+            "dev": true,
+            "requires": {
+                "inherits": "^2.0.4",
+                "readable-stream": "^3.6.0",
+                "safe-buffer": "^5.2.0"
+            },
+            "dependencies": {
+                "readable-stream": {
+                    "version": "3.6.0",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+                    "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+                    "dev": true,
+                    "requires": {
+                        "inherits": "^2.0.3",
+                        "string_decoder": "^1.1.1",
+                        "util-deprecate": "^1.0.1"
+                    }
+                }
+            }
+        },
+        "hash.js": {
+            "version": "1.1.7",
+            "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
+            "integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
+            "dev": true,
+            "requires": {
+                "inherits": "^2.0.3",
+                "minimalistic-assert": "^1.0.1"
+            }
+        },
+        "highlight.js": {
+            "version": "9.18.3",
+            "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.18.3.tgz",
+            "integrity": "sha512-zBZAmhSupHIl5sITeMqIJnYCDfAEc3Gdkqj65wC1lpI468MMQeeQkhcIAvk+RylAkxrCcI9xy9piHiXeQ1BdzQ==",
+            "dev": true
+        },
+        "hmac-drbg": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
+            "integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
+            "dev": true,
+            "requires": {
+                "hash.js": "^1.0.3",
+                "minimalistic-assert": "^1.0.0",
+                "minimalistic-crypto-utils": "^1.0.1"
+            }
+        },
+        "hogan.js": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/hogan.js/-/hogan.js-3.0.2.tgz",
+            "integrity": "sha1-TNnhq9QpQUbnZ55B14mHMrAse/0=",
+            "dev": true,
+            "requires": {
+                "mkdirp": "0.3.0",
+                "nopt": "1.0.10"
+            }
+        },
+        "homedir-polyfill": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.3.tgz",
+            "integrity": "sha512-eSmmWE5bZTK2Nou4g0AI3zZ9rswp7GRKoKXS1BLUkvPviOqs4YTN1djQIqrXy9k5gEtdLPy86JjRwsNM9tnDcA==",
+            "dev": true,
+            "requires": {
+                "parse-passwd": "^1.0.0"
+            }
+        },
+        "hooker": {
+            "version": "0.2.3",
+            "resolved": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz",
+            "integrity": "sha1-uDT3I8xKJCqmWWNFnfbZhMXT2Vk=",
+            "dev": true
+        },
+        "htmlescape": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/htmlescape/-/htmlescape-1.1.1.tgz",
+            "integrity": "sha1-OgPtwiFLyjtmQko+eVk0lQnLA1E=",
+            "dev": true
+        },
+        "htmlparser2": {
+            "version": "3.8.3",
+            "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.8.3.tgz",
+            "integrity": "sha1-mWwosZFRaovoZQGn15dX5ccMEGg=",
+            "dev": true,
+            "requires": {
+                "domelementtype": "1",
+                "domhandler": "2.3",
+                "domutils": "1.5",
+                "entities": "1.0",
+                "readable-stream": "1.1"
+            },
+            "dependencies": {
+                "isarray": {
+                    "version": "0.0.1",
+                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                    "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+                    "dev": true
+                },
+                "readable-stream": {
+                    "version": "1.1.14",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+                    "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+                    "dev": true,
+                    "requires": {
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.1",
+                        "isarray": "0.0.1",
+                        "string_decoder": "~0.10.x"
+                    }
+                },
+                "string_decoder": {
+                    "version": "0.10.31",
+                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                    "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+                    "dev": true
+                }
+            }
+        },
+        "http-basic": {
+            "version": "2.5.1",
+            "resolved": "https://registry.npmjs.org/http-basic/-/http-basic-2.5.1.tgz",
+            "integrity": "sha1-jORHvbW2xXf4pj4/p4BW7Eu02/s=",
+            "dev": true,
+            "requires": {
+                "caseless": "~0.11.0",
+                "concat-stream": "^1.4.6",
+                "http-response-object": "^1.0.0"
+            },
+            "dependencies": {
+                "caseless": {
+                    "version": "0.11.0",
+                    "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
+                    "integrity": "sha1-cVuW6phBWTzDMGeSP17GDr2k99c=",
+                    "dev": true
+                }
+            }
+        },
+        "http-errors": {
+            "version": "1.6.3",
+            "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
+            "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
+            "dev": true,
+            "requires": {
+                "depd": "~1.1.2",
+                "inherits": "2.0.3",
+                "setprototypeof": "1.1.0",
+                "statuses": ">= 1.4.0 < 2"
+            },
+            "dependencies": {
+                "depd": {
+                    "version": "1.1.2",
+                    "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+                    "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
+                    "dev": true
+                },
+                "inherits": {
+                    "version": "2.0.3",
+                    "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+                    "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+                    "dev": true
+                }
+            }
+        },
+        "http-parser-js": {
+            "version": "0.5.2",
+            "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.5.2.tgz",
+            "integrity": "sha512-opCO9ASqg5Wy2FNo7A0sxy71yGbbkJJXLdgMK04Tcypw9jr2MgWbyubb0+WdmDmGnFflO7fRbqbaihh/ENDlRQ==",
+            "dev": true
+        },
+        "http-response-object": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/http-response-object/-/http-response-object-1.1.0.tgz",
+            "integrity": "sha1-p8TnWq6C87tJBOT0P2FWc7TVGMM=",
+            "dev": true
+        },
+        "http-signature": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+            "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+            "dev": true,
+            "requires": {
+                "assert-plus": "^1.0.0",
+                "jsprim": "^1.2.2",
+                "sshpk": "^1.7.0"
+            }
+        },
+        "http2": {
+            "version": "3.3.7",
+            "resolved": "https://registry.npmjs.org/http2/-/http2-3.3.7.tgz",
+            "integrity": "sha512-puSi8M8WNlFJm9Pk4c/Mbz9Gwparuj3gO9/RRO5zv6piQ0FY+9Qywp0PdWshYgsMJSalixFY7eC6oPu0zRxLAQ==",
+            "dev": true
+        },
+        "https-browserify": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz",
+            "integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=",
+            "dev": true
+        },
+        "iconv-lite": {
+            "version": "0.4.24",
+            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+            "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+            "dev": true,
+            "requires": {
+                "safer-buffer": ">= 2.1.2 < 3"
+            }
+        },
+        "ieee754": {
+            "version": "1.1.13",
+            "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
+            "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==",
+            "dev": true
+        },
+        "image-size": {
+            "version": "0.5.5",
+            "resolved": "https://registry.npmjs.org/image-size/-/image-size-0.5.5.tgz",
+            "integrity": "sha1-Cd/Uq50g4p6xw+gLiZA3jfnjy5w=",
+            "dev": true,
+            "optional": true
+        },
+        "immediate": {
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.3.0.tgz",
+            "integrity": "sha512-HR7EVodfFUdQCTIeySw+WDRFJlPcLOJbXfwwZ7Oom6tjsvZ3bOkCDJHehQC3nxJrv7+f9XecwazynjU8e4Vw3Q==",
+            "dev": true
+        },
+        "inflight": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+            "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+            "dev": true,
+            "requires": {
+                "once": "^1.3.0",
+                "wrappy": "1"
+            }
+        },
+        "inherits": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+            "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+            "dev": true
+        },
+        "ini": {
+            "version": "1.3.5",
+            "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+            "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
+            "dev": true
+        },
+        "inline-source-map": {
+            "version": "0.6.2",
+            "resolved": "https://registry.npmjs.org/inline-source-map/-/inline-source-map-0.6.2.tgz",
+            "integrity": "sha1-+Tk0ccGKedFyT4Y/o4tYY3Ct4qU=",
+            "dev": true,
+            "requires": {
+                "source-map": "~0.5.3"
+            }
+        },
+        "insert-module-globals": {
+            "version": "7.2.1",
+            "resolved": "https://registry.npmjs.org/insert-module-globals/-/insert-module-globals-7.2.1.tgz",
+            "integrity": "sha512-ufS5Qq9RZN+Bu899eA9QCAYThY+gGW7oRkmb0vC93Vlyu/CFGcH0OYPEjVkDXA5FEbTt1+VWzdoOD3Ny9N+8tg==",
+            "dev": true,
+            "requires": {
+                "JSONStream": "^1.0.3",
+                "acorn-node": "^1.5.2",
+                "combine-source-map": "^0.8.0",
+                "concat-stream": "^1.6.1",
+                "is-buffer": "^1.1.0",
+                "path-is-absolute": "^1.0.1",
+                "process": "~0.11.0",
+                "through2": "^2.0.0",
+                "undeclared-identifiers": "^1.1.2",
+                "xtend": "^4.0.0"
+            }
+        },
+        "interpret": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.1.0.tgz",
+            "integrity": "sha1-ftGxQQxqDg94z5XTuEQMY/eLhhQ=",
+            "dev": true
+        },
+        "irregular-plurals": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/irregular-plurals/-/irregular-plurals-1.4.0.tgz",
+            "integrity": "sha1-LKmwM2UREYVUEvFr5dd8YqRYp2Y=",
+            "dev": true
+        },
+        "is-absolute": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-1.0.0.tgz",
+            "integrity": "sha512-dOWoqflvcydARa360Gvv18DZ/gRuHKi2NU/wU5X1ZFzdYfH29nkiNZsF3mp4OJ3H4yo9Mx8A/uAGNzpzPN3yBA==",
+            "dev": true,
+            "requires": {
+                "is-relative": "^1.0.0",
+                "is-windows": "^1.0.1"
+            }
+        },
+        "is-accessor-descriptor": {
+            "version": "0.1.6",
+            "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+            "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+            "dev": true,
+            "requires": {
+                "kind-of": "^3.0.2"
+            },
+            "dependencies": {
+                "kind-of": {
+                    "version": "3.2.2",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                    "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                    "dev": true,
+                    "requires": {
+                        "is-buffer": "^1.1.5"
+                    }
+                }
+            }
+        },
+        "is-binary-path": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
+            "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
+            "dev": true,
+            "requires": {
+                "binary-extensions": "^1.0.0"
+            }
+        },
+        "is-buffer": {
+            "version": "1.1.6",
+            "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+            "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+            "dev": true
+        },
+        "is-data-descriptor": {
+            "version": "0.1.4",
+            "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+            "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+            "dev": true,
+            "requires": {
+                "kind-of": "^3.0.2"
+            },
+            "dependencies": {
+                "kind-of": {
+                    "version": "3.2.2",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                    "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                    "dev": true,
+                    "requires": {
+                        "is-buffer": "^1.1.5"
+                    }
+                }
+            }
+        },
+        "is-descriptor": {
+            "version": "0.1.6",
+            "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+            "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+            "dev": true,
+            "requires": {
+                "is-accessor-descriptor": "^0.1.6",
+                "is-data-descriptor": "^0.1.4",
+                "kind-of": "^5.0.0"
+            },
+            "dependencies": {
+                "kind-of": {
+                    "version": "5.1.0",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+                    "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+                    "dev": true
+                }
+            }
+        },
+        "is-extendable": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+            "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
+            "dev": true
+        },
+        "is-extglob": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+            "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+            "dev": true
+        },
+        "is-glob": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+            "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+            "dev": true,
+            "requires": {
+                "is-extglob": "^2.1.0"
+            }
+        },
+        "is-number": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+            "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+            "dev": true,
+            "requires": {
+                "kind-of": "^3.0.2"
+            },
+            "dependencies": {
+                "kind-of": {
+                    "version": "3.2.2",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                    "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                    "dev": true,
+                    "requires": {
+                        "is-buffer": "^1.1.5"
+                    }
+                }
+            }
+        },
+        "is-plain-object": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+            "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+            "dev": true,
+            "requires": {
+                "isobject": "^3.0.1"
+            }
+        },
+        "is-relative": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-1.0.0.tgz",
+            "integrity": "sha512-Kw/ReK0iqwKeu0MITLFuj0jbPAmEiOsIwyIXvvbfa6QfmN9pkD1M+8pdk7Rl/dTKbH34/XBFMbgD4iMJhLQbGA==",
+            "dev": true,
+            "requires": {
+                "is-unc-path": "^1.0.0"
+            }
+        },
+        "is-typedarray": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+            "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+            "dev": true
+        },
+        "is-unc-path": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-unc-path/-/is-unc-path-1.0.0.tgz",
+            "integrity": "sha512-mrGpVd0fs7WWLfVsStvgF6iEJnbjDFZh9/emhRDcGWTduTfNHd9CHeUwH3gYIjdbwo4On6hunkztwOaAw0yllQ==",
+            "dev": true,
+            "requires": {
+                "unc-path-regex": "^0.1.2"
+            }
+        },
+        "is-windows": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
+            "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
+            "dev": true
+        },
+        "isarray": {
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+            "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+            "dev": true
+        },
+        "isexe": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+            "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+            "dev": true
+        },
+        "isobject": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+            "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+            "dev": true
+        },
+        "isstream": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+            "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+            "dev": true
+        },
+        "jquery": {
+            "version": "3.5.1",
+            "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.5.1.tgz",
+            "integrity": "sha512-XwIBPqcMn57FxfT+Go5pzySnm4KWkT1Tv7gjrpT1srtf8Weynl6R273VJ5GjkRb51IzMp5nbaPjJXMWeju2MKg==",
+            "dev": true
+        },
+        "js-yaml": {
+            "version": "3.14.0",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.0.tgz",
+            "integrity": "sha512-/4IbIeHcD9VMHFqDR/gQ7EdZdLimOvW2DdcxFjdyyZ9NsbS+ccrXqVWDtab/lRl5AlUqmpBx8EhPaWR+OtY17A==",
+            "dev": true,
+            "requires": {
+                "argparse": "^1.0.7",
+                "esprima": "^4.0.0"
+            }
+        },
+        "jsbn": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+            "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+            "dev": true
+        },
+        "jshint": {
+            "version": "2.10.3",
+            "resolved": "https://registry.npmjs.org/jshint/-/jshint-2.10.3.tgz",
+            "integrity": "sha512-d8AoXcNNYzmm7cdmulQ3dQApbrPYArtVBO6n4xOICe4QsXGNHCAKDcFORzqP52LhK61KX0VhY39yYzCsNq+bxQ==",
+            "dev": true,
+            "requires": {
+                "cli": "~1.0.0",
+                "console-browserify": "1.1.x",
+                "exit": "0.1.x",
+                "htmlparser2": "3.8.x",
+                "lodash": "~4.17.11",
+                "minimatch": "~3.0.2",
+                "shelljs": "0.3.x",
+                "strip-json-comments": "1.0.x"
+            },
+            "dependencies": {
+                "console-browserify": {
+                    "version": "1.1.0",
+                    "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
+                    "integrity": "sha1-8CQcRXMKn8YyOyBtvzjtx0HQuxA=",
+                    "dev": true,
+                    "requires": {
+                        "date-now": "^0.1.4"
+                    }
+                }
+            }
+        },
+        "jshint-stylish": {
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/jshint-stylish/-/jshint-stylish-2.2.1.tgz",
+            "integrity": "sha1-JCCCosA1rgP9gQROBXDMQgjPbmE=",
+            "dev": true,
+            "requires": {
+                "beeper": "^1.1.0",
+                "chalk": "^1.0.0",
+                "log-symbols": "^1.0.0",
+                "plur": "^2.1.0",
+                "string-length": "^1.0.0",
+                "text-table": "^0.2.0"
+            },
+            "dependencies": {
+                "ansi-styles": {
+                    "version": "2.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+                    "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+                    "dev": true
+                },
+                "chalk": {
+                    "version": "1.1.3",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+                    "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^2.2.1",
+                        "escape-string-regexp": "^1.0.2",
+                        "has-ansi": "^2.0.0",
+                        "strip-ansi": "^3.0.0",
+                        "supports-color": "^2.0.0"
+                    }
+                },
+                "supports-color": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+                    "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+                    "dev": true
+                }
+            }
+        },
+        "json-schema": {
+            "version": "0.2.3",
+            "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+            "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
+            "dev": true
+        },
+        "json-schema-traverse": {
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+            "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+            "dev": true
+        },
+        "json-stable-stringify": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-0.0.1.tgz",
+            "integrity": "sha1-YRwj6BTbN1Un34URk9tZ3Sryf0U=",
+            "dev": true,
+            "requires": {
+                "jsonify": "~0.0.0"
+            }
+        },
+        "json-stringify-safe": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+            "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+            "dev": true
+        },
+        "jsonfile": {
+            "version": "2.4.0",
+            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
+            "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
+            "dev": true,
+            "requires": {
+                "graceful-fs": "^4.1.6"
+            }
+        },
+        "jsonify": {
+            "version": "0.0.0",
+            "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+            "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
+            "dev": true
+        },
+        "jsonparse": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
+            "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=",
+            "dev": true
+        },
+        "jsprim": {
+            "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
+            "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+            "dev": true,
+            "requires": {
+                "assert-plus": "1.0.0",
+                "extsprintf": "1.3.0",
+                "json-schema": "0.2.3",
+                "verror": "1.10.0"
+            }
+        },
+        "kind-of": {
+            "version": "6.0.3",
+            "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+            "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+            "dev": true
+        },
+        "klaw": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/klaw/-/klaw-1.3.1.tgz",
+            "integrity": "sha1-QIhDO0azsbolnXh4XY6W9zugJDk=",
+            "dev": true,
+            "requires": {
+                "graceful-fs": "^4.1.9"
+            }
+        },
+        "labeled-stream-splicer": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/labeled-stream-splicer/-/labeled-stream-splicer-2.0.2.tgz",
+            "integrity": "sha512-Ca4LSXFFZUjPScRaqOcFxneA0VpKZr4MMYCljyQr4LIewTLb3Y0IUTIsnBBsVubIeEfxeSZpSjSsRM8APEQaAw==",
+            "dev": true,
+            "requires": {
+                "inherits": "^2.0.1",
+                "stream-splicer": "^2.0.0"
+            }
+        },
+        "less": {
+            "version": "3.12.2",
+            "resolved": "https://registry.npmjs.org/less/-/less-3.12.2.tgz",
+            "integrity": "sha512-+1V2PCMFkL+OIj2/HrtrvZw0BC0sYLMICJfbQjuj/K8CEnlrFX6R5cKKgzzttsZDHyxQNL1jqMREjKN3ja/E3Q==",
+            "dev": true,
+            "requires": {
+                "errno": "^0.1.1",
+                "graceful-fs": "^4.1.2",
+                "image-size": "~0.5.0",
+                "make-dir": "^2.1.0",
+                "mime": "^1.4.1",
+                "native-request": "^1.0.5",
+                "source-map": "~0.6.0",
+                "tslib": "^1.10.0"
+            },
+            "dependencies": {
+                "source-map": {
+                    "version": "0.6.1",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+                    "dev": true,
+                    "optional": true
+                }
+            }
+        },
+        "liftoff": {
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/liftoff/-/liftoff-2.5.0.tgz",
+            "integrity": "sha1-IAkpG7Mc6oYbvxCnwVooyvdcMew=",
+            "dev": true,
+            "requires": {
+                "extend": "^3.0.0",
+                "findup-sync": "^2.0.0",
+                "fined": "^1.0.1",
+                "flagged-respawn": "^1.0.0",
+                "is-plain-object": "^2.0.4",
+                "object.map": "^1.0.0",
+                "rechoir": "^0.6.2",
+                "resolve": "^1.1.7"
+            },
+            "dependencies": {
+                "findup-sync": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-2.0.0.tgz",
+                    "integrity": "sha1-kyaxSIwi0aYIhlCoaQGy2akKLLw=",
+                    "dev": true,
+                    "requires": {
+                        "detect-file": "^1.0.0",
+                        "is-glob": "^3.1.0",
+                        "micromatch": "^3.0.4",
+                        "resolve-dir": "^1.0.1"
+                    }
+                }
+            }
+        },
+        "livereload-js": {
+            "version": "2.4.0",
+            "resolved": "https://registry.npmjs.org/livereload-js/-/livereload-js-2.4.0.tgz",
+            "integrity": "sha512-XPQH8Z2GDP/Hwz2PCDrh2mth4yFejwA1OZ/81Ti3LgKyhDcEjsSsqFWZojHG0va/duGd+WyosY7eXLDoOyqcPw==",
+            "dev": true
+        },
+        "load-script": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/load-script/-/load-script-1.0.0.tgz",
+            "integrity": "sha1-BJGTngvuVkPuSUp+PaPSuscMbKQ=",
+            "dev": true
+        },
+        "lodash": {
+            "version": "4.17.20",
+            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+            "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+            "dev": true
+        },
+        "lodash.memoize": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-3.0.4.tgz",
+            "integrity": "sha1-LcvSwofLwKVcxCMovQxzYVDVPj8=",
+            "dev": true
+        },
+        "log-symbols": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz",
+            "integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
+            "dev": true,
+            "requires": {
+                "chalk": "^1.0.0"
+            },
+            "dependencies": {
+                "ansi-styles": {
+                    "version": "2.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+                    "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+                    "dev": true
+                },
+                "chalk": {
+                    "version": "1.1.3",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+                    "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^2.2.1",
+                        "escape-string-regexp": "^1.0.2",
+                        "has-ansi": "^2.0.0",
+                        "strip-ansi": "^3.0.0",
+                        "supports-color": "^2.0.0"
+                    }
+                },
+                "supports-color": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+                    "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+                    "dev": true
+                }
+            }
+        },
+        "make-dir": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
+            "integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
+            "dev": true,
+            "optional": true,
+            "requires": {
+                "pify": "^4.0.1",
+                "semver": "^5.6.0"
+            }
+        },
+        "make-iterator": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/make-iterator/-/make-iterator-1.0.1.tgz",
+            "integrity": "sha512-pxiuXh0iVEq7VM7KMIhs5gxsfxCux2URptUQaXo4iZZJxBAzTPOLE2BumO5dbfVYq/hBJFBR/a1mFDmOx5AGmw==",
+            "dev": true,
+            "requires": {
+                "kind-of": "^6.0.2"
+            }
+        },
+        "map-cache": {
+            "version": "0.2.2",
+            "resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
+            "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=",
+            "dev": true
+        },
+        "map-visit": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
+            "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
+            "dev": true,
+            "requires": {
+                "object-visit": "^1.0.0"
+            }
+        },
+        "marked": {
+            "version": "0.3.19",
+            "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.19.tgz",
+            "integrity": "sha512-ea2eGWOqNxPcXv8dyERdSr/6FmzvWwzjMxpfGB/sbMccXoct+xY+YukPD+QTUZwyvK7BZwcr4m21WBOW41pAkg==",
+            "dev": true
+        },
+        "maxmin": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/maxmin/-/maxmin-2.1.0.tgz",
+            "integrity": "sha1-TTsiCQPZXu5+t6x/qGTnLcCaMWY=",
+            "dev": true,
+            "requires": {
+                "chalk": "^1.0.0",
+                "figures": "^1.0.1",
+                "gzip-size": "^3.0.0",
+                "pretty-bytes": "^3.0.0"
+            },
+            "dependencies": {
+                "ansi-styles": {
+                    "version": "2.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+                    "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+                    "dev": true
+                },
+                "chalk": {
+                    "version": "1.1.3",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+                    "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^2.2.1",
+                        "escape-string-regexp": "^1.0.2",
+                        "has-ansi": "^2.0.0",
+                        "strip-ansi": "^3.0.0",
+                        "supports-color": "^2.0.0"
+                    }
+                },
+                "supports-color": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+                    "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+                    "dev": true
+                }
+            }
+        },
+        "md5.js": {
+            "version": "1.3.5",
+            "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
+            "integrity": "sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==",
+            "dev": true,
+            "requires": {
+                "hash-base": "^3.0.0",
+                "inherits": "^2.0.1",
+                "safe-buffer": "^5.1.2"
+            }
+        },
+        "micromatch": {
+            "version": "3.1.10",
+            "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+            "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+            "dev": true,
+            "requires": {
+                "arr-diff": "^4.0.0",
+                "array-unique": "^0.3.2",
+                "braces": "^2.3.1",
+                "define-property": "^2.0.2",
+                "extend-shallow": "^3.0.2",
+                "extglob": "^2.0.4",
+                "fragment-cache": "^0.2.1",
+                "kind-of": "^6.0.2",
+                "nanomatch": "^1.2.9",
+                "object.pick": "^1.3.0",
+                "regex-not": "^1.0.0",
+                "snapdragon": "^0.8.1",
+                "to-regex": "^3.0.2"
+            }
+        },
+        "miller-rabin": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.1.tgz",
+            "integrity": "sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==",
+            "dev": true,
+            "requires": {
+                "bn.js": "^4.0.0",
+                "brorand": "^1.0.1"
+            },
+            "dependencies": {
+                "bn.js": {
+                    "version": "4.11.9",
+                    "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.9.tgz",
+                    "integrity": "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw==",
+                    "dev": true
+                }
+            }
+        },
+        "mime": {
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+            "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+            "dev": true
+        },
+        "mime-db": {
+            "version": "1.44.0",
+            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.44.0.tgz",
+            "integrity": "sha512-/NOTfLrsPBVeH7YtFPgsVWveuL+4SjjYxaQ1xtM1KMFj7HdxlBlxeyNLzhyJVx7r4rZGJAZ/6lkKCitSc/Nmpg==",
+            "dev": true
+        },
+        "mime-types": {
+            "version": "2.1.27",
+            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.27.tgz",
+            "integrity": "sha512-JIhqnCasI9yD+SsmkquHBxTSEuZdQX5BuQnS2Vc7puQQQ+8yiP5AY5uWhpdv4YL4VM5c6iliiYWPgJ/nJQLp7w==",
+            "dev": true,
+            "requires": {
+                "mime-db": "1.44.0"
+            }
+        },
+        "min-document": {
+            "version": "2.19.0",
+            "resolved": "https://registry.npmjs.org/min-document/-/min-document-2.19.0.tgz",
+            "integrity": "sha1-e9KC4/WELtKVu3SM3Z8f+iyCRoU=",
+            "dev": true,
+            "requires": {
+                "dom-walk": "^0.1.0"
+            }
+        },
+        "minimalistic-assert": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+            "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
+            "dev": true
+        },
+        "minimalistic-crypto-utils": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
+            "integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo=",
+            "dev": true
+        },
+        "minimatch": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+            "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+            "dev": true,
+            "requires": {
+                "brace-expansion": "^1.1.7"
+            }
+        },
+        "minimist": {
+            "version": "1.2.5",
+            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+            "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+            "dev": true
+        },
+        "mixin-deep": {
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.2.tgz",
+            "integrity": "sha512-WRoDn//mXBiJ1H40rqa3vH0toePwSsGb45iInWlTySa+Uu4k3tYUSxa2v1KqAiLtvlrSzaExqS1gtk96A9zvEA==",
+            "dev": true,
+            "requires": {
+                "for-in": "^1.0.2",
+                "is-extendable": "^1.0.1"
+            },
+            "dependencies": {
+                "is-extendable": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+                    "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+                    "dev": true,
+                    "requires": {
+                        "is-plain-object": "^2.0.4"
+                    }
+                }
+            }
+        },
+        "mkdirp": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz",
+            "integrity": "sha1-G79asbqCevI1dRQ0kEJkVfSB/h4=",
+            "dev": true
+        },
+        "mkdirp-classic": {
+            "version": "0.5.3",
+            "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+            "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+            "dev": true
+        },
+        "module-deps": {
+            "version": "6.2.3",
+            "resolved": "https://registry.npmjs.org/module-deps/-/module-deps-6.2.3.tgz",
+            "integrity": "sha512-fg7OZaQBcL4/L+AK5f4iVqf9OMbCclXfy/znXRxTVhJSeW5AIlS9AwheYwDaXM3lVW7OBeaeUEY3gbaC6cLlSA==",
+            "dev": true,
+            "requires": {
+                "JSONStream": "^1.0.3",
+                "browser-resolve": "^2.0.0",
+                "cached-path-relative": "^1.0.2",
+                "concat-stream": "~1.6.0",
+                "defined": "^1.0.0",
+                "detective": "^5.2.0",
+                "duplexer2": "^0.1.2",
+                "inherits": "^2.0.1",
+                "parents": "^1.0.0",
+                "readable-stream": "^2.0.2",
+                "resolve": "^1.4.0",
+                "stream-combiner2": "^1.1.1",
+                "subarg": "^1.0.0",
+                "through2": "^2.0.0",
+                "xtend": "^4.0.0"
+            }
+        },
+        "morgan": {
+            "version": "1.10.0",
+            "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.10.0.tgz",
+            "integrity": "sha512-AbegBVI4sh6El+1gNwvD5YIck7nSA36weD7xvIxG4in80j/UoK8AEGaWnnz8v1GxonMCltmlNs5ZKbGvl9b1XQ==",
+            "dev": true,
+            "requires": {
+                "basic-auth": "~2.0.1",
+                "debug": "2.6.9",
+                "depd": "~2.0.0",
+                "on-finished": "~2.3.0",
+                "on-headers": "~1.0.2"
+            }
+        },
+        "ms": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+            "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+            "dev": true
+        },
+        "nan": {
+            "version": "2.14.1",
+            "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.1.tgz",
+            "integrity": "sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw==",
+            "dev": true,
+            "optional": true
+        },
+        "nanomatch": {
+            "version": "1.2.13",
+            "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
+            "integrity": "sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==",
+            "dev": true,
+            "requires": {
+                "arr-diff": "^4.0.0",
+                "array-unique": "^0.3.2",
+                "define-property": "^2.0.2",
+                "extend-shallow": "^3.0.2",
+                "fragment-cache": "^0.2.1",
+                "is-windows": "^1.0.2",
+                "kind-of": "^6.0.2",
+                "object.pick": "^1.3.0",
+                "regex-not": "^1.0.0",
+                "snapdragon": "^0.8.1",
+                "to-regex": "^3.0.1"
+            }
+        },
+        "native-request": {
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/native-request/-/native-request-1.0.7.tgz",
+            "integrity": "sha512-9nRjinI9bmz+S7dgNtf4A70+/vPhnd+2krGpy4SUlADuOuSa24IDkNaZ+R/QT1wQ6S8jBdi6wE7fLekFZNfUpQ==",
+            "dev": true,
+            "optional": true
+        },
+        "negotiator": {
+            "version": "0.6.2",
+            "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz",
+            "integrity": "sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw==",
+            "dev": true
+        },
+        "ng-tags-input": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/ng-tags-input/-/ng-tags-input-3.2.0.tgz",
+            "integrity": "sha1-kSgt5XUTDIq3lHl/6/CXKw87uj4=",
+            "dev": true
+        },
+        "nopt": {
+            "version": "1.0.10",
+            "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
+            "integrity": "sha1-bd0hvSoxQXuScn3Vhfim83YI6+4=",
+            "dev": true,
+            "requires": {
+                "abbrev": "1"
+            }
+        },
+        "normalize-path": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+            "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+            "dev": true,
+            "requires": {
+                "remove-trailing-separator": "^1.0.1"
+            }
+        },
+        "number-is-nan": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+            "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+            "dev": true
+        },
+        "oauth-sign": {
+            "version": "0.9.0",
+            "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
+            "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
+            "dev": true
+        },
+        "object-assign": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+            "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+            "dev": true
+        },
+        "object-copy": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
+            "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
+            "dev": true,
+            "requires": {
+                "copy-descriptor": "^0.1.0",
+                "define-property": "^0.2.5",
+                "kind-of": "^3.0.3"
+            },
+            "dependencies": {
+                "define-property": {
+                    "version": "0.2.5",
+                    "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+                    "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+                    "dev": true,
+                    "requires": {
+                        "is-descriptor": "^0.1.0"
+                    }
+                },
+                "kind-of": {
+                    "version": "3.2.2",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                    "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                    "dev": true,
+                    "requires": {
+                        "is-buffer": "^1.1.5"
+                    }
+                }
+            }
+        },
+        "object-keys": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+            "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+            "dev": true
+        },
+        "object-visit": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
+            "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
+            "dev": true,
+            "requires": {
+                "isobject": "^3.0.0"
+            }
+        },
+        "object.defaults": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/object.defaults/-/object.defaults-1.1.0.tgz",
+            "integrity": "sha1-On+GgzS0B96gbaFtiNXNKeQ1/s8=",
+            "dev": true,
+            "requires": {
+                "array-each": "^1.0.1",
+                "array-slice": "^1.0.0",
+                "for-own": "^1.0.0",
+                "isobject": "^3.0.0"
+            }
+        },
+        "object.map": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/object.map/-/object.map-1.0.1.tgz",
+            "integrity": "sha1-z4Plncj8wK1fQlDh94s7gb2AHTc=",
+            "dev": true,
+            "requires": {
+                "for-own": "^1.0.0",
+                "make-iterator": "^1.0.0"
+            }
+        },
+        "object.pick": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
+            "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
+            "dev": true,
+            "requires": {
+                "isobject": "^3.0.1"
+            }
+        },
+        "on-finished": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+            "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
+            "dev": true,
+            "requires": {
+                "ee-first": "1.1.1"
+            }
+        },
+        "on-headers": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.2.tgz",
+            "integrity": "sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA==",
+            "dev": true
+        },
+        "once": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+            "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+            "dev": true,
+            "requires": {
+                "wrappy": "1"
+            }
+        },
+        "opn": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/opn/-/opn-4.0.2.tgz",
+            "integrity": "sha1-erwi5kTf9jsKltWrfyeQwPAavJU=",
+            "dev": true,
+            "requires": {
+                "object-assign": "^4.0.1",
+                "pinkie-promise": "^2.0.0"
+            }
+        },
+        "os-browserify": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.3.0.tgz",
+            "integrity": "sha1-hUNzx/XCMVkU/Jv8a9gjj92h7Cc=",
+            "dev": true
+        },
+        "os-homedir": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+            "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+            "dev": true
+        },
+        "os-tmpdir": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+            "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+            "dev": true
+        },
+        "osenv": {
+            "version": "0.1.5",
+            "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
+            "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
+            "dev": true,
+            "requires": {
+                "os-homedir": "^1.0.0",
+                "os-tmpdir": "^1.0.0"
+            }
+        },
+        "outpipe": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/outpipe/-/outpipe-1.1.1.tgz",
+            "integrity": "sha1-UM+GFjZeh+Ax4ppeyTOaPaRyX6I=",
+            "dev": true,
+            "requires": {
+                "shell-quote": "^1.4.2"
+            }
+        },
+        "pace-progress": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/pace-progress/-/pace-progress-1.0.2.tgz",
+            "integrity": "sha1-/cVlxX3ZFyWjFns2C/JXjTw7VI0=",
+            "dev": true
+        },
+        "pako": {
+            "version": "1.0.11",
+            "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+            "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+            "dev": true
+        },
+        "parents": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/parents/-/parents-1.0.1.tgz",
+            "integrity": "sha1-/t1NK/GTp3dF/nHjcdc8MwfZx1E=",
+            "dev": true,
+            "requires": {
+                "path-platform": "~0.11.15"
+            }
+        },
+        "parse-asn1": {
+            "version": "5.1.6",
+            "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.6.tgz",
+            "integrity": "sha512-RnZRo1EPU6JBnra2vGHj0yhp6ebyjBZpmUCLHWiFhxlzvBCCpAuZ7elsBp1PVAbQN0/04VD/19rfzlBSwLstMw==",
+            "dev": true,
+            "requires": {
+                "asn1.js": "^5.2.0",
+                "browserify-aes": "^1.0.0",
+                "evp_bytestokey": "^1.0.0",
+                "pbkdf2": "^3.0.3",
+                "safe-buffer": "^5.1.1"
+            }
+        },
+        "parse-filepath": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/parse-filepath/-/parse-filepath-1.0.2.tgz",
+            "integrity": "sha1-pjISf1Oq89FYdvWHLz/6x2PWyJE=",
+            "dev": true,
+            "requires": {
+                "is-absolute": "^1.0.0",
+                "map-cache": "^0.2.0",
+                "path-root": "^0.1.1"
+            }
+        },
+        "parse-passwd": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz",
+            "integrity": "sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY=",
+            "dev": true
+        },
+        "parseurl": {
+            "version": "1.3.3",
+            "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+            "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+            "dev": true
+        },
+        "pascalcase": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
+            "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=",
+            "dev": true
+        },
+        "path-browserify": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.1.tgz",
+            "integrity": "sha512-BapA40NHICOS+USX9SN4tyhq+A2RrN/Ws5F0Z5aMHDp98Fl86lX8Oti8B7uN93L4Ifv4fHOEA+pQw87gmMO/lQ==",
+            "dev": true
+        },
+        "path-dirname": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz",
+            "integrity": "sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA=",
+            "dev": true
+        },
+        "path-is-absolute": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+            "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+            "dev": true
+        },
+        "path-parse": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+            "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+            "dev": true
+        },
+        "path-platform": {
+            "version": "0.11.15",
+            "resolved": "https://registry.npmjs.org/path-platform/-/path-platform-0.11.15.tgz",
+            "integrity": "sha1-6GQhf3TDaFDwhSt43Hv31KVyG/I=",
+            "dev": true
+        },
+        "path-root": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/path-root/-/path-root-0.1.1.tgz",
+            "integrity": "sha1-mkpoFMrBwM1zNgqV8yCDyOpHRbc=",
+            "dev": true,
+            "requires": {
+                "path-root-regex": "^0.1.0"
+            }
+        },
+        "path-root-regex": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/path-root-regex/-/path-root-regex-0.1.2.tgz",
+            "integrity": "sha1-v8zcjfWxLcUsi0PsONGNcsBLqW0=",
+            "dev": true
+        },
+        "pbkdf2": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.1.1.tgz",
+            "integrity": "sha512-4Ejy1OPxi9f2tt1rRV7Go7zmfDQ+ZectEQz3VGUQhgq62HtIRPDyG/JtnwIxs6x3uNMwo2V7q1fMvKjb+Tnpqg==",
+            "dev": true,
+            "requires": {
+                "create-hash": "^1.1.2",
+                "create-hmac": "^1.1.4",
+                "ripemd160": "^2.0.1",
+                "safe-buffer": "^5.0.1",
+                "sha.js": "^2.4.8"
+            }
+        },
+        "performance-now": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+            "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
+            "dev": true
+        },
+        "pify": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+            "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+            "dev": true,
+            "optional": true
+        },
+        "pinkie": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+            "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+            "dev": true
+        },
+        "pinkie-promise": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+            "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+            "dev": true,
+            "requires": {
+                "pinkie": "^2.0.0"
+            }
+        },
+        "plur": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/plur/-/plur-2.1.2.tgz",
+            "integrity": "sha1-dIJFLBoPUI4+NE6uwxLJHCncZVo=",
+            "dev": true,
+            "requires": {
+                "irregular-plurals": "^1.0.0"
+            }
+        },
+        "portscanner": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/portscanner/-/portscanner-1.2.0.tgz",
+            "integrity": "sha1-sUu9olfRTDEPqcwJaCrwLUCWGAI=",
+            "dev": true,
+            "requires": {
+                "async": "1.5.2"
+            }
+        },
+        "posix-character-classes": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
+            "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
+            "dev": true
+        },
+        "preprocess": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/preprocess/-/preprocess-3.2.0.tgz",
+            "integrity": "sha512-cO+Rf+Ose/eD+ze8Hxd9p9nS1xT8thYqv8owG/V8+IS/Remd7Z17SvaRK/oJxp08yaM8zb+QTckDKJUul2pk7g==",
+            "dev": true,
+            "requires": {
+                "xregexp": "3.1.0"
+            }
+        },
+        "pretty-bytes": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-3.0.1.tgz",
+            "integrity": "sha1-J9AAjXeAY6C0gRuzXHnxvV1fvM8=",
+            "dev": true,
+            "requires": {
+                "number-is-nan": "^1.0.0"
+            }
+        },
+        "process": {
+            "version": "0.11.10",
+            "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+            "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI=",
+            "dev": true
+        },
+        "process-nextick-args": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+            "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+            "dev": true
+        },
+        "promise": {
+            "version": "7.3.1",
+            "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
+            "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
+            "dev": true,
+            "requires": {
+                "asap": "~2.0.3"
+            }
+        },
+        "prr": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
+            "integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY=",
+            "dev": true,
+            "optional": true
+        },
+        "psl": {
+            "version": "1.8.0",
+            "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
+            "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ==",
+            "dev": true
+        },
+        "public-encrypt": {
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.3.tgz",
+            "integrity": "sha512-zVpa8oKZSz5bTMTFClc1fQOnyyEzpl5ozpi1B5YcvBrdohMjH2rfsBtyXcuNuwjsDIXmBYlF2N5FlJYhR29t8Q==",
+            "dev": true,
+            "requires": {
+                "bn.js": "^4.1.0",
+                "browserify-rsa": "^4.0.0",
+                "create-hash": "^1.1.0",
+                "parse-asn1": "^5.0.0",
+                "randombytes": "^2.0.1",
+                "safe-buffer": "^5.1.2"
+            },
+            "dependencies": {
+                "bn.js": {
+                    "version": "4.11.9",
+                    "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.9.tgz",
+                    "integrity": "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw==",
+                    "dev": true
+                }
+            }
+        },
+        "punycode": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+            "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+            "dev": true
+        },
+        "qs": {
+            "version": "6.9.4",
+            "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.4.tgz",
+            "integrity": "sha512-A1kFqHekCTM7cz0udomYUoYNWjBebHm/5wzU/XqrBRBNWectVH0QIiN+NEcZ0Dte5hvzHwbr8+XQmguPhJ6WdQ==",
+            "dev": true
+        },
+        "querystring": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
+            "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=",
+            "dev": true
+        },
+        "querystring-es3": {
+            "version": "0.2.1",
+            "resolved": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz",
+            "integrity": "sha1-nsYfeQSYdXB9aUFFlv2Qek1xHnM=",
+            "dev": true
+        },
+        "randombytes": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+            "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+            "dev": true,
+            "requires": {
+                "safe-buffer": "^5.1.0"
+            }
+        },
+        "randomfill": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/randomfill/-/randomfill-1.0.4.tgz",
+            "integrity": "sha512-87lcbR8+MhcWcUiQ+9e+Rwx8MyR2P7qnt15ynUlbm3TU/fjbgz4GsvfSUDTemtCCtVCqb4ZcEFlyPNTh9bBTLw==",
+            "dev": true,
+            "requires": {
+                "randombytes": "^2.0.5",
+                "safe-buffer": "^5.1.0"
+            }
+        },
+        "range-parser": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+            "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+            "dev": true
+        },
+        "raw-body": {
+            "version": "1.1.7",
+            "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-1.1.7.tgz",
+            "integrity": "sha1-HQJ8K/oRasxmI7yo8AAWVyqH1CU=",
+            "dev": true,
+            "requires": {
+                "bytes": "1",
+                "string_decoder": "0.10"
+            },
+            "dependencies": {
+                "string_decoder": {
+                    "version": "0.10.31",
+                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                    "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+                    "dev": true
+                }
+            }
+        },
+        "read-only-stream": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/read-only-stream/-/read-only-stream-2.0.0.tgz",
+            "integrity": "sha1-JyT9aoET1zdkrCiNQ4YnDB2/F/A=",
+            "dev": true,
+            "requires": {
+                "readable-stream": "^2.0.2"
+            }
+        },
+        "readable-stream": {
+            "version": "2.3.7",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+            "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+            "dev": true,
+            "requires": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
+            },
+            "dependencies": {
+                "isarray": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+                    "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+                    "dev": true
+                },
+                "safe-buffer": {
+                    "version": "5.1.2",
+                    "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+                    "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+                    "dev": true
+                },
+                "string_decoder": {
+                    "version": "1.1.1",
+                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+                    "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+                    "dev": true,
+                    "requires": {
+                        "safe-buffer": "~5.1.0"
+                    }
+                }
+            }
+        },
+        "readdirp": {
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.2.1.tgz",
+            "integrity": "sha512-1JU/8q+VgFZyxwrJ+SVIOsh+KywWGpds3NTqikiKpDMZWScmAYyKIgqkO+ARvNWJfXeXR1zxz7aHF4u4CyH6vQ==",
+            "dev": true,
+            "requires": {
+                "graceful-fs": "^4.1.11",
+                "micromatch": "^3.1.10",
+                "readable-stream": "^2.0.2"
+            }
+        },
+        "rechoir": {
+            "version": "0.6.2",
+            "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
+            "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
+            "dev": true,
+            "requires": {
+                "resolve": "^1.1.6"
+            }
+        },
+        "reduce": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/reduce/-/reduce-1.0.2.tgz",
+            "integrity": "sha512-xX7Fxke/oHO5IfZSk77lvPa/7bjMh9BuCk4OOoX5XTXrM7s0Z+MkPfSDfz0q7r91BhhGSs8gii/VEN/7zhCPpQ==",
+            "dev": true,
+            "requires": {
+                "object-keys": "^1.1.0"
+            }
+        },
+        "regex-not": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
+            "integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
+            "dev": true,
+            "requires": {
+                "extend-shallow": "^3.0.2",
+                "safe-regex": "^1.1.0"
+            }
+        },
+        "remove-trailing-separator": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
+            "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
+            "dev": true
+        },
+        "repeat-element": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.3.tgz",
+            "integrity": "sha512-ahGq0ZnV5m5XtZLMb+vP76kcAM5nkLqk0lpqAuojSKGgQtn4eRi4ZZGm2olo2zKFH+sMsWaqOCW1dqAnOru72g==",
+            "dev": true
+        },
+        "repeat-string": {
+            "version": "1.6.1",
+            "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+            "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
+            "dev": true
+        },
+        "request": {
+            "version": "2.88.2",
+            "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
+            "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
+            "dev": true,
+            "requires": {
+                "aws-sign2": "~0.7.0",
+                "aws4": "^1.8.0",
+                "caseless": "~0.12.0",
+                "combined-stream": "~1.0.6",
+                "extend": "~3.0.2",
+                "forever-agent": "~0.6.1",
+                "form-data": "~2.3.2",
+                "har-validator": "~5.1.3",
+                "http-signature": "~1.2.0",
+                "is-typedarray": "~1.0.0",
+                "isstream": "~0.1.2",
+                "json-stringify-safe": "~5.0.1",
+                "mime-types": "~2.1.19",
+                "oauth-sign": "~0.9.0",
+                "performance-now": "^2.1.0",
+                "qs": "~6.5.2",
+                "safe-buffer": "^5.1.2",
+                "tough-cookie": "~2.5.0",
+                "tunnel-agent": "^0.6.0",
+                "uuid": "^3.3.2"
+            },
+            "dependencies": {
+                "qs": {
+                    "version": "6.5.2",
+                    "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+                    "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
+                    "dev": true
+                }
+            }
+        },
+        "resolve": {
+            "version": "1.17.0",
+            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
+            "integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
+            "dev": true,
+            "requires": {
+                "path-parse": "^1.0.6"
+            }
+        },
+        "resolve-dir": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-1.0.1.tgz",
+            "integrity": "sha1-eaQGRMNivoLybv/nOcm7U4IEb0M=",
+            "dev": true,
+            "requires": {
+                "expand-tilde": "^2.0.0",
+                "global-modules": "^1.0.0"
+            }
+        },
+        "resolve-url": {
+            "version": "0.2.1",
+            "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
+            "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
+            "dev": true
+        },
+        "ret": {
+            "version": "0.1.15",
+            "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
+            "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
+            "dev": true
+        },
+        "rimraf": {
+            "version": "2.7.1",
+            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+            "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+            "dev": true,
+            "requires": {
+                "glob": "^7.1.3"
+            }
+        },
+        "ripemd160": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.2.tgz",
+            "integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
+            "dev": true,
+            "requires": {
+                "hash-base": "^3.0.0",
+                "inherits": "^2.0.1"
+            }
+        },
+        "rss": {
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/rss/-/rss-1.2.2.tgz",
+            "integrity": "sha1-UKFpiHYTgTOnT5oF0r3I240nqSE=",
+            "dev": true,
+            "requires": {
+                "mime-types": "2.1.13",
+                "xml": "1.0.1"
+            },
+            "dependencies": {
+                "mime-db": {
+                    "version": "1.25.0",
+                    "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.25.0.tgz",
+                    "integrity": "sha1-wY29fHOl2/b0SgJNwNFloeexw5I=",
+                    "dev": true
+                },
+                "mime-types": {
+                    "version": "2.1.13",
+                    "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.13.tgz",
+                    "integrity": "sha1-4HqqnGxrmnyjASxpADrSWjnpKog=",
+                    "dev": true,
+                    "requires": {
+                        "mime-db": "~1.25.0"
+                    }
+                }
+            }
+        },
+        "safe-buffer": {
+            "version": "5.2.1",
+            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+            "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+            "dev": true
+        },
+        "safe-json-parse": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/safe-json-parse/-/safe-json-parse-1.0.1.tgz",
+            "integrity": "sha1-PnZyPjjf3aE8mx0poeB//uSzC1c=",
+            "dev": true
+        },
+        "safe-regex": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+            "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
+            "dev": true,
+            "requires": {
+                "ret": "~0.1.10"
+            }
+        },
+        "safer-buffer": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+            "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+            "dev": true
+        },
+        "satellizer": {
+            "version": "0.15.5",
+            "resolved": "https://registry.npmjs.org/satellizer/-/satellizer-0.15.5.tgz",
+            "integrity": "sha1-Q8k9LTYcS2ts+dBtI7iIEwK1V6Q=",
+            "dev": true
+        },
+        "semver": {
+            "version": "5.7.1",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+            "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+            "dev": true
+        },
+        "send": {
+            "version": "0.17.1",
+            "resolved": "https://registry.npmjs.org/send/-/send-0.17.1.tgz",
+            "integrity": "sha512-BsVKsiGcQMFwT8UxypobUKyv7irCNRHk1T0G680vk88yf6LBByGcZJOTJCrTP2xVN6yI+XjPJcNuE3V4fT9sAg==",
+            "dev": true,
+            "requires": {
+                "debug": "2.6.9",
+                "depd": "~1.1.2",
+                "destroy": "~1.0.4",
+                "encodeurl": "~1.0.2",
+                "escape-html": "~1.0.3",
+                "etag": "~1.8.1",
+                "fresh": "0.5.2",
+                "http-errors": "~1.7.2",
+                "mime": "1.6.0",
+                "ms": "2.1.1",
+                "on-finished": "~2.3.0",
+                "range-parser": "~1.2.1",
+                "statuses": "~1.5.0"
+            },
+            "dependencies": {
+                "depd": {
+                    "version": "1.1.2",
+                    "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+                    "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
+                    "dev": true
+                },
+                "http-errors": {
+                    "version": "1.7.3",
+                    "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.3.tgz",
+                    "integrity": "sha512-ZTTX0MWrsQ2ZAhA1cejAwDLycFsd7I7nVtnkT3Ol0aqodaKW+0CTZDQ1uBv5whptCnc8e8HeRRJxRs0kmm/Qfw==",
+                    "dev": true,
+                    "requires": {
+                        "depd": "~1.1.2",
+                        "inherits": "2.0.4",
+                        "setprototypeof": "1.1.1",
+                        "statuses": ">= 1.5.0 < 2",
+                        "toidentifier": "1.0.0"
+                    }
+                },
+                "ms": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+                    "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+                    "dev": true
+                },
+                "setprototypeof": {
+                    "version": "1.1.1",
+                    "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",
+                    "integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw==",
+                    "dev": true
+                }
+            }
+        },
+        "serve-index": {
+            "version": "1.9.1",
+            "resolved": "https://registry.npmjs.org/serve-index/-/serve-index-1.9.1.tgz",
+            "integrity": "sha1-03aNabHn2C5c4FD/9bRTvqEqkjk=",
+            "dev": true,
+            "requires": {
+                "accepts": "~1.3.4",
+                "batch": "0.6.1",
+                "debug": "2.6.9",
+                "escape-html": "~1.0.3",
+                "http-errors": "~1.6.2",
+                "mime-types": "~2.1.17",
+                "parseurl": "~1.3.2"
+            }
+        },
+        "serve-static": {
+            "version": "1.14.1",
+            "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.14.1.tgz",
+            "integrity": "sha512-JMrvUwE54emCYWlTI+hGrGv5I8dEwmco/00EvkzIIsR7MqrHonbD9pO2MOfFnpFntl7ecpZs+3mW+XbQZu9QCg==",
+            "dev": true,
+            "requires": {
+                "encodeurl": "~1.0.2",
+                "escape-html": "~1.0.3",
+                "parseurl": "~1.3.3",
+                "send": "0.17.1"
+            }
+        },
+        "set-value": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.1.tgz",
+            "integrity": "sha512-JxHc1weCN68wRY0fhCoXpyK55m/XPHafOmK4UWD7m2CI14GMcFypt4w/0+NV5f/ZMby2F6S2wwA7fgynh9gWSw==",
+            "dev": true,
+            "requires": {
+                "extend-shallow": "^2.0.1",
+                "is-extendable": "^0.1.1",
+                "is-plain-object": "^2.0.3",
+                "split-string": "^3.0.1"
+            },
+            "dependencies": {
+                "extend-shallow": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                    "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                    "dev": true,
+                    "requires": {
+                        "is-extendable": "^0.1.0"
+                    }
+                }
+            }
+        },
+        "setprototypeof": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
+            "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ==",
+            "dev": true
+        },
+        "sha.js": {
+            "version": "2.4.11",
+            "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
+            "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
+            "dev": true,
+            "requires": {
+                "inherits": "^2.0.1",
+                "safe-buffer": "^5.0.1"
+            }
+        },
+        "shasum": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/shasum/-/shasum-1.0.2.tgz",
+            "integrity": "sha1-5wEjENj0F/TetXEhUOVni4euVl8=",
+            "dev": true,
+            "requires": {
+                "json-stable-stringify": "~0.0.0",
+                "sha.js": "~2.4.4"
+            }
+        },
+        "shasum-object": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/shasum-object/-/shasum-object-1.0.0.tgz",
+            "integrity": "sha512-Iqo5rp/3xVi6M4YheapzZhhGPVs0yZwHj7wvwQ1B9z8H6zk+FEnI7y3Teq7qwnekfEhu8WmG2z0z4iWZaxLWVg==",
+            "dev": true,
+            "requires": {
+                "fast-safe-stringify": "^2.0.7"
+            }
+        },
+        "shell-quote": {
+            "version": "1.7.2",
+            "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.7.2.tgz",
+            "integrity": "sha512-mRz/m/JVscCrkMyPqHc/bczi3OQHkLTqXHEFu0zDhK/qfv3UcOA4SVmRCLmos4bhjr9ekVQubj/R7waKapmiQg==",
+            "dev": true
+        },
+        "shelljs": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.3.0.tgz",
+            "integrity": "sha1-NZbmMHp4FUT1kfN9phg2DzHbV7E=",
+            "dev": true
+        },
+        "simple-concat": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+            "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+            "dev": true
+        },
+        "slugify": {
+            "version": "1.4.5",
+            "resolved": "https://registry.npmjs.org/slugify/-/slugify-1.4.5.tgz",
+            "integrity": "sha512-WpECLAgYaxHoEAJ8Q1Lo8HOs1ngn7LN7QjXgOLbmmfkcWvosyk4ZTXkTzKyhngK640USTZUlgoQJfED1kz5fnQ==",
+            "dev": true
+        },
+        "snapdragon": {
+            "version": "0.8.2",
+            "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
+            "integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
+            "dev": true,
+            "requires": {
+                "base": "^0.11.1",
+                "debug": "^2.2.0",
+                "define-property": "^0.2.5",
+                "extend-shallow": "^2.0.1",
+                "map-cache": "^0.2.2",
+                "source-map": "^0.5.6",
+                "source-map-resolve": "^0.5.0",
+                "use": "^3.1.0"
+            },
+            "dependencies": {
+                "define-property": {
+                    "version": "0.2.5",
+                    "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+                    "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+                    "dev": true,
+                    "requires": {
+                        "is-descriptor": "^0.1.0"
+                    }
+                },
+                "extend-shallow": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                    "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                    "dev": true,
+                    "requires": {
+                        "is-extendable": "^0.1.0"
+                    }
+                }
+            }
+        },
+        "snapdragon-node": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
+            "integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
+            "dev": true,
+            "requires": {
+                "define-property": "^1.0.0",
+                "isobject": "^3.0.0",
+                "snapdragon-util": "^3.0.1"
+            },
+            "dependencies": {
+                "define-property": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+                    "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+                    "dev": true,
+                    "requires": {
+                        "is-descriptor": "^1.0.0"
+                    }
+                },
+                "is-accessor-descriptor": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+                    "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+                    "dev": true,
+                    "requires": {
+                        "kind-of": "^6.0.0"
+                    }
+                },
+                "is-data-descriptor": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+                    "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+                    "dev": true,
+                    "requires": {
+                        "kind-of": "^6.0.0"
+                    }
+                },
+                "is-descriptor": {
+                    "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+                    "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+                    "dev": true,
+                    "requires": {
+                        "is-accessor-descriptor": "^1.0.0",
+                        "is-data-descriptor": "^1.0.0",
+                        "kind-of": "^6.0.2"
+                    }
+                }
+            }
+        },
+        "snapdragon-util": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
+            "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
+            "dev": true,
+            "requires": {
+                "kind-of": "^3.2.0"
+            },
+            "dependencies": {
+                "kind-of": {
+                    "version": "3.2.2",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                    "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                    "dev": true,
+                    "requires": {
+                        "is-buffer": "^1.1.5"
+                    }
+                }
+            }
+        },
+        "source-map": {
+            "version": "0.5.7",
+            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+            "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+            "dev": true
+        },
+        "source-map-resolve": {
+            "version": "0.5.3",
+            "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.3.tgz",
+            "integrity": "sha512-Htz+RnsXWk5+P2slx5Jh3Q66vhQj1Cllm0zvnaY98+NFx+Dv2CF/f5O/t8x+KaNdrdIAsruNzoh/KpialbqAnw==",
+            "dev": true,
+            "requires": {
+                "atob": "^2.1.2",
+                "decode-uri-component": "^0.2.0",
+                "resolve-url": "^0.2.1",
+                "source-map-url": "^0.4.0",
+                "urix": "^0.1.0"
+            }
+        },
+        "source-map-url": {
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
+            "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
+            "dev": true
+        },
+        "split-string": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
+            "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
+            "dev": true,
+            "requires": {
+                "extend-shallow": "^3.0.0"
+            }
+        },
+        "sprintf-js": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
+            "integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug==",
+            "dev": true
+        },
+        "sshpk": {
+            "version": "1.16.1",
+            "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
+            "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
+            "dev": true,
+            "requires": {
+                "asn1": "~0.2.3",
+                "assert-plus": "^1.0.0",
+                "bcrypt-pbkdf": "^1.0.0",
+                "dashdash": "^1.12.0",
+                "ecc-jsbn": "~0.1.1",
+                "getpass": "^0.1.1",
+                "jsbn": "~0.1.0",
+                "safer-buffer": "^2.0.2",
+                "tweetnacl": "~0.14.0"
+            }
+        },
+        "stack-utils": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-1.0.2.tgz",
+            "integrity": "sha512-MTX+MeG5U994cazkjd/9KNAapsHnibjMLnfXodlkXw76JEea0UiNzrqidzo1emMwk7w5Qhc9jd4Bn9TBb1MFwA==",
+            "dev": true
+        },
+        "static-extend": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
+            "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
+            "dev": true,
+            "requires": {
+                "define-property": "^0.2.5",
+                "object-copy": "^0.1.0"
+            },
+            "dependencies": {
+                "define-property": {
+                    "version": "0.2.5",
+                    "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+                    "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+                    "dev": true,
+                    "requires": {
+                        "is-descriptor": "^0.1.0"
+                    }
+                }
+            }
+        },
+        "statuses": {
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+            "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=",
+            "dev": true
+        },
+        "stream-browserify": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.2.tgz",
+            "integrity": "sha512-nX6hmklHs/gr2FuxYDltq8fJA1GDlxKQCz8O/IM4atRqBH8OORmBNgfvW5gG10GT/qQ9u0CzIvr2X5Pkt6ntqg==",
+            "dev": true,
+            "requires": {
+                "inherits": "~2.0.1",
+                "readable-stream": "^2.0.2"
+            }
+        },
+        "stream-combiner2": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/stream-combiner2/-/stream-combiner2-1.1.1.tgz",
+            "integrity": "sha1-+02KFCDqNidk4hrUeAOXvry0HL4=",
+            "dev": true,
+            "requires": {
+                "duplexer2": "~0.1.0",
+                "readable-stream": "^2.0.2"
+            }
+        },
+        "stream-http": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/stream-http/-/stream-http-3.1.1.tgz",
+            "integrity": "sha512-S7OqaYu0EkFpgeGFb/NPOoPLxFko7TPqtEeFg5DXPB4v/KETHG0Ln6fRFrNezoelpaDKmycEmmZ81cC9DAwgYg==",
+            "dev": true,
+            "requires": {
+                "builtin-status-codes": "^3.0.0",
+                "inherits": "^2.0.4",
+                "readable-stream": "^3.6.0",
+                "xtend": "^4.0.2"
+            },
+            "dependencies": {
+                "readable-stream": {
+                    "version": "3.6.0",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+                    "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+                    "dev": true,
+                    "requires": {
+                        "inherits": "^2.0.3",
+                        "string_decoder": "^1.1.1",
+                        "util-deprecate": "^1.0.1"
+                    }
+                }
+            }
+        },
+        "stream-splicer": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/stream-splicer/-/stream-splicer-2.0.1.tgz",
+            "integrity": "sha512-Xizh4/NPuYSyAXyT7g8IvdJ9HJpxIGL9PjyhtywCZvvP0OPIdqyrr4dMikeuvY8xahpdKEBlBTySe583totajg==",
+            "dev": true,
+            "requires": {
+                "inherits": "^2.0.1",
+                "readable-stream": "^2.0.2"
+            }
+        },
+        "string-length": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/string-length/-/string-length-1.0.1.tgz",
+            "integrity": "sha1-VpcPscOFWOnnC3KL894mmsRa36w=",
+            "dev": true,
+            "requires": {
+                "strip-ansi": "^3.0.0"
+            }
+        },
+        "string-template": {
+            "version": "0.2.1",
+            "resolved": "https://registry.npmjs.org/string-template/-/string-template-0.2.1.tgz",
+            "integrity": "sha1-QpMuWYo1LQH8IuwzZ9nYTuxsmt0=",
+            "dev": true
+        },
+        "string_decoder": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+            "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+            "dev": true,
+            "requires": {
+                "safe-buffer": "~5.2.0"
+            }
+        },
+        "strip-ansi": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+            "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+            "dev": true,
+            "requires": {
+                "ansi-regex": "^2.0.0"
+            }
+        },
+        "strip-json-comments": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz",
+            "integrity": "sha1-HhX7ysl9Pumb8tc7TGVrCCu6+5E=",
+            "dev": true
+        },
+        "subarg": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/subarg/-/subarg-1.0.0.tgz",
+            "integrity": "sha1-9izxdYHplrSPyWVpn1TAauJouNI=",
+            "dev": true,
+            "requires": {
+                "minimist": "^1.1.0"
+            }
+        },
+        "supports-color": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+            "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+            "dev": true,
+            "requires": {
+                "has-flag": "^4.0.0"
+            }
+        },
+        "sync-request": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/sync-request/-/sync-request-3.0.1.tgz",
+            "integrity": "sha1-yqEjWq+Im6UBB2oYNMQ2gwqC+3M=",
+            "dev": true,
+            "requires": {
+                "concat-stream": "^1.4.7",
+                "http-response-object": "^1.0.1",
+                "then-request": "^2.0.1"
+            }
+        },
+        "syntax-error": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/syntax-error/-/syntax-error-1.4.0.tgz",
+            "integrity": "sha512-YPPlu67mdnHGTup2A8ff7BC2Pjq0e0Yp/IyTFN03zWO0RcK07uLcbi7C2KpGR2FvWbaB0+bfE27a+sBKebSo7w==",
+            "dev": true,
+            "requires": {
+                "acorn-node": "^1.2.0"
+            }
+        },
+        "text-table": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+            "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
+            "dev": true
+        },
+        "then-request": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/then-request/-/then-request-2.2.0.tgz",
+            "integrity": "sha1-ZnizL6DKIY/laZgbvYhxtZQGDYE=",
+            "dev": true,
+            "requires": {
+                "caseless": "~0.11.0",
+                "concat-stream": "^1.4.7",
+                "http-basic": "^2.5.1",
+                "http-response-object": "^1.1.0",
+                "promise": "^7.1.1",
+                "qs": "^6.1.0"
+            },
+            "dependencies": {
+                "caseless": {
+                    "version": "0.11.0",
+                    "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
+                    "integrity": "sha1-cVuW6phBWTzDMGeSP17GDr2k99c=",
+                    "dev": true
+                }
+            }
+        },
+        "through": {
+            "version": "2.3.8",
+            "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+            "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+            "dev": true
+        },
+        "through2": {
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
+            "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
+            "dev": true,
+            "requires": {
+                "readable-stream": "~2.3.6",
+                "xtend": "~4.0.1"
+            }
+        },
+        "timers-browserify": {
+            "version": "1.4.2",
+            "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-1.4.2.tgz",
+            "integrity": "sha1-ycWLV1voQHN1y14kYtrO50NZ9B0=",
+            "dev": true,
+            "requires": {
+                "process": "~0.11.0"
+            }
+        },
+        "tiny-lr": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/tiny-lr/-/tiny-lr-1.1.1.tgz",
+            "integrity": "sha512-44yhA3tsaRoMOjQQ+5v5mVdqef+kH6Qze9jTpqtVufgYjYt08zyZAwNwwVBj3i1rJMnR52IxOW0LK0vBzgAkuA==",
+            "dev": true,
+            "requires": {
+                "body": "^5.1.0",
+                "debug": "^3.1.0",
+                "faye-websocket": "~0.10.0",
+                "livereload-js": "^2.3.0",
+                "object-assign": "^4.1.0",
+                "qs": "^6.4.0"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "3.2.6",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+                    "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "^2.1.1"
+                    }
+                },
+                "ms": {
+                    "version": "2.1.2",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+                    "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+                    "dev": true
+                }
+            }
+        },
+        "to-factory": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/to-factory/-/to-factory-1.0.0.tgz",
+            "integrity": "sha1-hzivi9lxIK0dQEeXKtpVY7+UebE=",
+            "dev": true
+        },
+        "to-object-path": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
+            "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
+            "dev": true,
+            "requires": {
+                "kind-of": "^3.0.2"
+            },
+            "dependencies": {
+                "kind-of": {
+                    "version": "3.2.2",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                    "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                    "dev": true,
+                    "requires": {
+                        "is-buffer": "^1.1.5"
+                    }
+                }
+            }
+        },
+        "to-regex": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
+            "integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
+            "dev": true,
+            "requires": {
+                "define-property": "^2.0.2",
+                "extend-shallow": "^3.0.2",
+                "regex-not": "^1.0.2",
+                "safe-regex": "^1.1.0"
+            }
+        },
+        "to-regex-range": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
+            "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+            "dev": true,
+            "requires": {
+                "is-number": "^3.0.0",
+                "repeat-string": "^1.6.1"
+            }
+        },
+        "toidentifier": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
+            "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==",
+            "dev": true
+        },
+        "tough-cookie": {
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
+            "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
+            "dev": true,
+            "requires": {
+                "psl": "^1.1.28",
+                "punycode": "^2.1.1"
+            }
+        },
+        "tslib": {
+            "version": "1.14.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+            "dev": true
+        },
+        "tty-browserify": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.1.tgz",
+            "integrity": "sha512-C3TaO7K81YvjCgQH9Q1S3R3P3BtN3RIM8n+OvX4il1K1zgE8ZhI0op7kClgkxtutIE8hQrcrHBXvIheqKUUCxw==",
+            "dev": true
+        },
+        "tunnel-agent": {
+            "version": "0.6.0",
+            "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+            "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+            "dev": true,
+            "requires": {
+                "safe-buffer": "^5.0.1"
+            }
+        },
+        "tweetnacl": {
+            "version": "0.14.5",
+            "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+            "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+            "dev": true
+        },
+        "typedarray": {
+            "version": "0.0.6",
+            "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+            "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
+            "dev": true
+        },
+        "uglify-js": {
+            "version": "3.11.1",
+            "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.11.1.tgz",
+            "integrity": "sha512-OApPSuJcxcnewwjSGGfWOjx3oix5XpmrK9Z2j0fTRlHGoZ49IU6kExfZTM0++fCArOOCet+vIfWwFHbvWqwp6g==",
+            "dev": true
+        },
+        "umd": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/umd/-/umd-3.0.3.tgz",
+            "integrity": "sha512-4IcGSufhFshvLNcMCV80UnQVlZ5pMOC8mvNPForqwA4+lzYQuetTESLDQkeLmihq8bRcnpbQa48Wb8Lh16/xow==",
+            "dev": true
+        },
+        "unc-path-regex": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/unc-path-regex/-/unc-path-regex-0.1.2.tgz",
+            "integrity": "sha1-5z3T17DXxe2G+6xrCufYxqadUPo=",
+            "dev": true
+        },
+        "undeclared-identifiers": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/undeclared-identifiers/-/undeclared-identifiers-1.1.3.tgz",
+            "integrity": "sha512-pJOW4nxjlmfwKApE4zvxLScM/njmwj/DiUBv7EabwE4O8kRUy+HIwxQtZLBPll/jx1LJyBcqNfB3/cpv9EZwOw==",
+            "dev": true,
+            "requires": {
+                "acorn-node": "^1.3.0",
+                "dash-ast": "^1.0.0",
+                "get-assigned-identifiers": "^1.2.0",
+                "simple-concat": "^1.0.0",
+                "xtend": "^4.0.1"
+            }
+        },
+        "underscore": {
+            "version": "1.11.0",
+            "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.11.0.tgz",
+            "integrity": "sha512-xY96SsN3NA461qIRKZ/+qox37YXPtSBswMGfiNptr+wrt6ds4HaMw23TP612fEyGekRE6LNRiLYr/aqbHXNedw==",
+            "dev": true
+        },
+        "underscore.string": {
+            "version": "3.3.5",
+            "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-3.3.5.tgz",
+            "integrity": "sha512-g+dpmgn+XBneLmXXo+sGlW5xQEt4ErkS3mgeN2GFbremYeMBSJKr9Wf2KJplQVaiPY/f7FN6atosWYNm9ovrYg==",
+            "dev": true,
+            "requires": {
+                "sprintf-js": "^1.0.3",
+                "util-deprecate": "^1.0.2"
+            }
+        },
+        "union-value": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.1.tgz",
+            "integrity": "sha512-tJfXmxMeWYnczCVs7XAEvIV7ieppALdyepWMkHkwciRpZraG/xwT+s2JN8+pr1+8jCRf80FFzvr+MpQeeoF4Xg==",
+            "dev": true,
+            "requires": {
+                "arr-union": "^3.1.0",
+                "get-value": "^2.0.6",
+                "is-extendable": "^0.1.1",
+                "set-value": "^2.0.1"
+            }
+        },
+        "unpipe": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+            "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
+            "dev": true
+        },
+        "unset-value": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
+            "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
+            "dev": true,
+            "requires": {
+                "has-value": "^0.3.1",
+                "isobject": "^3.0.0"
+            },
+            "dependencies": {
+                "has-value": {
+                    "version": "0.3.1",
+                    "resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
+                    "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
+                    "dev": true,
+                    "requires": {
+                        "get-value": "^2.0.3",
+                        "has-values": "^0.1.4",
+                        "isobject": "^2.0.0"
+                    },
+                    "dependencies": {
+                        "isobject": {
+                            "version": "2.1.0",
+                            "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+                            "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+                            "dev": true,
+                            "requires": {
+                                "isarray": "1.0.0"
+                            }
+                        }
+                    }
+                },
+                "has-values": {
+                    "version": "0.1.4",
+                    "resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
+                    "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E=",
+                    "dev": true
+                },
+                "isarray": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+                    "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+                    "dev": true
+                }
+            }
+        },
+        "upath": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/upath/-/upath-1.2.0.tgz",
+            "integrity": "sha512-aZwGpamFO61g3OlfT7OQCHqhGnW43ieH9WZeP7QxN/G/jS4jfqUkZxoryvJgVPEcrl5NL/ggHsSmLMHuH64Lhg==",
+            "dev": true
+        },
+        "uri-js": {
+            "version": "4.4.0",
+            "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.0.tgz",
+            "integrity": "sha512-B0yRTzYdUCCn9n+F4+Gh4yIDtMQcaJsmYBDsTSG8g/OejKBodLQ2IHfN3bM7jUsRXndopT7OIXWdYqc1fjmV6g==",
+            "dev": true,
+            "requires": {
+                "punycode": "^2.1.0"
+            }
+        },
+        "uri-path": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/uri-path/-/uri-path-1.0.0.tgz",
+            "integrity": "sha1-l0fwGDWJM8Md4PzP2C0TjmcmLjI=",
+            "dev": true
+        },
+        "urix": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
+            "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
+            "dev": true
+        },
+        "url": {
+            "version": "0.11.0",
+            "resolved": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
+            "integrity": "sha1-ODjpfPxgUh63PFJajlW/3Z4uKPE=",
+            "dev": true,
+            "requires": {
+                "punycode": "1.3.2",
+                "querystring": "0.2.0"
+            },
+            "dependencies": {
+                "punycode": {
+                    "version": "1.3.2",
+                    "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+                    "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=",
+                    "dev": true
+                }
+            }
+        },
+        "use": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
+            "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
+            "dev": true
+        },
+        "util": {
+            "version": "0.10.4",
+            "resolved": "https://registry.npmjs.org/util/-/util-0.10.4.tgz",
+            "integrity": "sha512-0Pm9hTQ3se5ll1XihRic3FDIku70C+iHUdT/W926rSgHV5QgXsYbKZN8MSC3tJtSkhuROzvsQjAaFENRXr+19A==",
+            "dev": true,
+            "requires": {
+                "inherits": "2.0.3"
+            },
+            "dependencies": {
+                "inherits": {
+                    "version": "2.0.3",
+                    "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+                    "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+                    "dev": true
+                }
+            }
+        },
+        "util-deprecate": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+            "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+            "dev": true
+        },
+        "utils-merge": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+            "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=",
+            "dev": true
+        },
+        "uuid": {
+            "version": "3.4.0",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+            "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+            "dev": true
+        },
+        "v8flags": {
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/v8flags/-/v8flags-3.1.3.tgz",
+            "integrity": "sha512-amh9CCg3ZxkzQ48Mhcb8iX7xpAfYJgePHxWMQCBWECpOSqJUXgY26ncA61UTV0BkPqfhcy6mzwCIoP4ygxpW8w==",
+            "dev": true,
+            "requires": {
+                "homedir-polyfill": "^1.0.1"
+            }
+        },
+        "verror": {
+            "version": "1.10.0",
+            "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+            "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+            "dev": true,
+            "requires": {
+                "assert-plus": "^1.0.0",
+                "core-util-is": "1.0.2",
+                "extsprintf": "^1.2.0"
+            }
+        },
+        "vm-browserify": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-1.1.2.tgz",
+            "integrity": "sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ==",
+            "dev": true
+        },
+        "watchify": {
+            "version": "3.11.1",
+            "resolved": "https://registry.npmjs.org/watchify/-/watchify-3.11.1.tgz",
+            "integrity": "sha512-WwnUClyFNRMB2NIiHgJU9RQPQNqVeFk7OmZaWf5dC5EnNa0Mgr7imBydbaJ7tGTuPM2hz1Cb4uiBvK9NVxMfog==",
+            "dev": true,
+            "requires": {
+                "anymatch": "^2.0.0",
+                "browserify": "^16.1.0",
+                "chokidar": "^2.1.1",
+                "defined": "^1.0.0",
+                "outpipe": "^1.1.0",
+                "through2": "^2.0.0",
+                "xtend": "^4.0.0"
+            }
+        },
+        "websocket-driver": {
+            "version": "0.7.4",
+            "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.4.tgz",
+            "integrity": "sha512-b17KeDIQVjvb0ssuSDF2cYXSg2iztliJ4B9WdsuB6J952qCPKmnVq4DyW5motImXHDC1cBT/1UezrJVsKw5zjg==",
+            "dev": true,
+            "requires": {
+                "http-parser-js": ">=0.5.1",
+                "safe-buffer": ">=5.1.0",
+                "websocket-extensions": ">=0.1.1"
+            }
+        },
+        "websocket-extensions": {
+            "version": "0.1.4",
+            "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.4.tgz",
+            "integrity": "sha512-OqedPIGOfsDlo31UNwYbCFMSaO9m9G/0faIHj5/dZFDMFqPTcx6UwqyOy3COEaEOg/9VsGIpdqn62W5KhoKSpg==",
+            "dev": true
+        },
+        "which": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+            "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+            "dev": true,
+            "requires": {
+                "isexe": "^2.0.0"
+            }
+        },
+        "wrappy": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+            "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+            "dev": true
+        },
+        "xml": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/xml/-/xml-1.0.1.tgz",
+            "integrity": "sha1-eLpyAgApxbyHuKgaPPzXS0ovweU=",
+            "dev": true
+        },
+        "xmlbuilder": {
+            "version": "8.2.2",
+            "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-8.2.2.tgz",
+            "integrity": "sha1-aSSGc0ELS6QuGmE2VR0pIjNap3M=",
+            "dev": true
+        },
+        "xregexp": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/xregexp/-/xregexp-3.1.0.tgz",
+            "integrity": "sha1-FNhGHgvdOCJL/uUDmgiY/EL80zY=",
+            "dev": true
+        },
+        "xtend": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+            "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+            "dev": true
+        },
+        "zepto": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/zepto/-/zepto-1.2.0.tgz",
+            "integrity": "sha1-4Se9nmb9hGvl6rSME5SIL3wOT5g=",
+            "dev": true
+        }
+    }
+}

--- a/src/tools/website/resources/assets/html/index.html.in
+++ b/src/tools/website/resources/assets/html/index.html.in
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html ng-app="elektra.rest.angular">
+<html ng-app="elektra.rest.angular" ng-strict-di>
 
     <head>
 

--- a/src/tools/website/resources/assets/js/config/auth.js
+++ b/src/tools/website/resources/assets/js/config/auth.js
@@ -7,12 +7,7 @@ module.exports = [
   "$httpProvider",
   "$provide",
   "config",
-  function(
-    $authProvider, 
-    $httpProvider,
-    $provide,
-    config
-  ) {
+  function($authProvider, $httpProvider, $provide, config) {
     $authProvider.baseUrl = config.backend.root;
     $authProvider.loginUrl = "/auth";
 

--- a/src/tools/website/resources/assets/js/config/auth.js
+++ b/src/tools/website/resources/assets/js/config/auth.js
@@ -2,34 +2,45 @@
 
 var angular = require("angular");
 
-module.exports = function($authProvider, $httpProvider, $provide, config) {
-  $authProvider.baseUrl = config.backend.root;
-  $authProvider.loginUrl = "/auth";
+module.exports = [
+  "$authProvider",
+  "$httpProvider",
+  "$provide",
+  "config",
+  function(
+    $authProvider, 
+    $httpProvider,
+    $provide,
+    config
+  ) {
+    $authProvider.baseUrl = config.backend.root;
+    $authProvider.loginUrl = "/auth";
 
-  // Setup interceptor that logs user out if being idle too long
-  $provide.factory("redirectWhenLoggedOut", [
-    "$q",
-    "$injector",
-    function($q, $injector) {
-      return {
-        responseError: function(rejection) {
-          // Need to use $injector.get to bring in $state or else we get
-          // a circular dependency error
-          var $state = $injector.get("$state");
+    // Setup interceptor that logs user out if being idle too long
+    $provide.factory("redirectWhenLoggedOut", [
+      "$q",
+      "$injector",
+      function($q, $injector) {
+        return {
+          responseError: function(rejection) {
+            // Need to use $injector.get to bring in $state or else we get
+            // a circular dependency error
+            var $state = $injector.get("$state");
 
-          var rejectionReasons = [401, 403, 405];
+            var rejectionReasons = [401, 403, 405];
 
-          angular.forEach(rejectionReasons, function(value, key) {
-            if (rejection.status === value) {
-              // Send the user to the auth state so they can login
-              $state.go("main.auth.login");
-            }
-          });
+            angular.forEach(rejectionReasons, function(value, key) {
+              if (rejection.status === value) {
+                // Send the user to the auth state so they can login
+                $state.go("main.auth.login");
+              }
+            });
 
-          return $q.reject(rejection);
-        }
-      };
-    }
-  ]);
-  $httpProvider.interceptors.push("redirectWhenLoggedOut");
-};
+            return $q.reject(rejection);
+          }
+        };
+      }
+    ]);
+    $httpProvider.interceptors.push("redirectWhenLoggedOut");
+  }
+];

--- a/src/tools/website/resources/assets/js/config/breadcrumbs.js
+++ b/src/tools/website/resources/assets/js/config/breadcrumbs.js
@@ -1,9 +1,12 @@
 "use strict";
 
-module.exports = function($breadcrumbProvider) {
-  // configure breadcrumbs
-  $breadcrumbProvider.setOptions({
-    templateUrl: "templates/breadcrumbs.html",
-    prefixStateName: "main"
-  });
-};
+module.exports = [
+  "$breadcrumbProvider",
+  function($breadcrumbProvider) {
+    // configure breadcrumbs
+    $breadcrumbProvider.setOptions({
+      templateUrl: "templates/breadcrumbs.html",
+      prefixStateName: "main"
+    });
+  }
+];

--- a/src/tools/website/resources/assets/js/config/http.js
+++ b/src/tools/website/resources/assets/js/config/http.js
@@ -1,58 +1,62 @@
 "use strict";
 
-module.exports = function($httpProvider, $provide) {
-  $provide.factory("handleServerNotReachable", [
-    "$q",
-    "$injector",
-    function($q, $injector) {
-      return {
-        responseError: function(rejection) {
-          var Notification = $injector.get("Notification");
+module.exports = [
+  "$httpProvider",
+  "$provide",
+  function($httpProvider, $provide) {
+    $provide.factory("handleServerNotReachable", [
+      "$q",
+      "$injector",
+      function($q, $injector) {
+        return {
+          responseError: function(rejection) {
+            var Notification = $injector.get("Notification");
 
-          if (rejection.status === -1) {
-            Notification.error({
-              title: "APP.GLOBAL.NOTIFICATION.HEADER.CONNECTION_ISSUE",
-              message: "APP.GLOBAL.NOTIFICATION.MESSAGE.SERVER_NOT_REACHABLE",
-              delay: 10000
-            });
+            if (rejection.status === -1) {
+              Notification.error({
+                title: "APP.GLOBAL.NOTIFICATION.HEADER.CONNECTION_ISSUE",
+                message: "APP.GLOBAL.NOTIFICATION.MESSAGE.SERVER_NOT_REACHABLE",
+                delay: 10000
+              });
+            }
+
+            return $q.reject(rejection);
           }
+        };
+      }
+    ]);
 
-          return $q.reject(rejection);
-        }
-      };
-    }
-  ]);
+    // http interceptor that deletes expired auth tokens
+    $provide.factory("handleAuthTokenExpired", [
+      "$q",
+      "$injector",
+      function($q, $injector) {
+        return {
+          responseError: function(rejection) {
+            var $auth = $injector.get("$auth");
 
-  // http interceptor that deletes expired auth tokens
-  $provide.factory("handleAuthTokenExpired", [
-    "$q",
-    "$injector",
-    function($q, $injector) {
-      return {
-        responseError: function(rejection) {
-          var $auth = $injector.get("$auth");
+            if (
+              ($auth.isAuthenticated() &&
+                rejection.status === 401 &&
+                typeof rejection.data.i18n !== "undefined" &&
+                ["NEED_AUTHENTICATION", "USER_INSUFFICIENT_PERMISSIONS"].indexOf(
+                  rejection.data.i18n
+                ) > -1) ||
+              (rejection.status === 400 &&
+                typeof rejection.data.i18n !== "undefined" &&
+                ["NO_CURRENT_USER"].indexOf(rejection.data.i18n) > -1)
+            ) {
+              // the token seems expired, let us delete it
+              $auth.logout();
+            }
 
-          if (
-            ($auth.isAuthenticated() &&
-              rejection.status === 401 &&
-              typeof rejection.data.i18n !== "undefined" &&
-              ["NEED_AUTHENTICATION", "USER_INSUFFICIENT_PERMISSIONS"].indexOf(
-                rejection.data.i18n
-              ) > -1) ||
-            (rejection.status === 400 &&
-              typeof rejection.data.i18n !== "undefined" &&
-              ["NO_CURRENT_USER"].indexOf(rejection.data.i18n) > -1)
-          ) {
-            // the token seems expired, let us delete it
-            $auth.logout();
+            return $q.reject(rejection);
           }
+        };
+      }
+    ]);
 
-          return $q.reject(rejection);
-        }
-      };
-    }
-  ]);
-
-  $httpProvider.interceptors.push("handleServerNotReachable");
-  $httpProvider.interceptors.push("handleAuthTokenExpired");
-};
+    $httpProvider.interceptors.push("handleServerNotReachable");
+    $httpProvider.interceptors.push("handleAuthTokenExpired");
+  }
+];

--- a/src/tools/website/resources/assets/js/config/http.js
+++ b/src/tools/website/resources/assets/js/config/http.js
@@ -39,9 +39,10 @@ module.exports = [
               ($auth.isAuthenticated() &&
                 rejection.status === 401 &&
                 typeof rejection.data.i18n !== "undefined" &&
-                ["NEED_AUTHENTICATION", "USER_INSUFFICIENT_PERMISSIONS"].indexOf(
-                  rejection.data.i18n
-                ) > -1) ||
+                [
+                  "NEED_AUTHENTICATION",
+                  "USER_INSUFFICIENT_PERMISSIONS"
+                ].indexOf(rejection.data.i18n) > -1) ||
               (rejection.status === 400 &&
                 typeof rejection.data.i18n !== "undefined" &&
                 ["NO_CURRENT_USER"].indexOf(rejection.data.i18n) > -1)

--- a/src/tools/website/resources/assets/js/config/marked.js
+++ b/src/tools/website/resources/assets/js/config/marked.js
@@ -6,11 +6,7 @@ module.exports = [
   "markedProvider",
   "config",
   "webStructure",
-  function(
-    markedProvider,
-    config,
-    webStructure
-  ) {
+  function(markedProvider, config, webStructure) {
     markedProvider.setOptions({
       gfm: true,
       tables: true,

--- a/src/tools/website/resources/assets/js/config/marked.js
+++ b/src/tools/website/resources/assets/js/config/marked.js
@@ -2,93 +2,112 @@
 
 var hljs = require("highlight.js");
 
-module.exports = function(markedProvider, config, webStructure) {
-  markedProvider.setOptions({
-    gfm: true,
-    tables: true,
-    highlight: function(code, lang) {
-      if (lang) {
-        return hljs.highlight(lang, code, true).value;
-      } else {
-        return hljs.highlightAuto(code).value;
+module.exports = [
+  "markedProvider",
+  "config",
+  "webStructure",
+  function(
+    markedProvider,
+    config,
+    webStructure
+  ) {
+    markedProvider.setOptions({
+      gfm: true,
+      tables: true,
+      highlight: function(code, lang) {
+        if (lang) {
+          return hljs.highlight(lang, code, true).value;
+        } else {
+          return hljs.highlightAuto(code).value;
+        }
       }
-    }
-  });
+    });
 
-  markedProvider.setRenderer({
-    table: function(head, body) {
-      return (
-        '<table class="table table-striped table-bordered">' +
-        "<thead>" +
-        head +
-        "</thead>" +
-        "<tbody>" +
-        body +
-        "</tbody>" +
-        "</table>"
-      );
-    },
-    link: function(href, title, text) {
-      // external link
-      if (href.indexOf("://") > -1) {
+    markedProvider.setRenderer({
+      table: function(head, body) {
         return (
-          '<a href="' +
-          href +
-          '"' +
-          (title ? ' title="' + title + '"' : "") +
-          ' target="_blank">' +
-          text +
-          ' <i class="fa fa-external-link"></i></a>'
+          '<table class="table table-striped table-bordered">' +
+          "<thead>" +
+          head +
+          "</thead>" +
+          "<tbody>" +
+          body +
+          "</tbody>" +
+          "</table>"
         );
-      }
-      // anchor link
-      if (href.indexOf("#") > -1) {
-        return (
-          '<a href="' +
-          href +
-          '"' +
-          (title ? ' title="' + title + '"' : "") +
-          " >" +
-          text +
-          ' <i class="fa fa-external-link"></i></a>'
-        );
-      }
-      // internal link
-      var file = findFileInWebstructure(webStructure, href);
-      // we don't have the file on the website, make external link
-      if (file === null) {
-        return (
-          '<a href="' +
-          config.github.website.root +
-          config.github.website.paths.doc_root +
-          href +
-          '"' +
-          (title ? ' title="' + title + '"' : "") +
-          ' target="_blank">' +
-          text +
-          ' <i class="fa fa-external-link"></i></a>'
-        );
-      }
-      // we have this file on the website, make internal link
-      else {
-        return (
-          '<a ui-sref="main.dyn.' +
-          file.ref +
-          "({file:'" +
-          file.slug +
-          "'})\"" +
-          (title ? ' title="' + title + '"' : "") +
-          ">" +
-          text +
-          "</a>"
-        );
-      }
-    },
-    image: function(href, title, text) {
-      // external image
-      if (href.indexOf("://") > -1) {
+      },
+      link: function(href, title, text) {
+        // external link
+        if (href.indexOf("://") > -1) {
+          return (
+            '<a href="' +
+            href +
+            '"' +
+            (title ? ' title="' + title + '"' : "") +
+            ' target="_blank">' +
+            text +
+            ' <i class="fa fa-external-link"></i></a>'
+          );
+        }
+        // anchor link
+        if (href.indexOf("#") > -1) {
+          return (
+            '<a href="' +
+            href +
+            '"' +
+            (title ? ' title="' + title + '"' : "") +
+            " >" +
+            text +
+            ' <i class="fa fa-external-link"></i></a>'
+          );
+        }
+        // internal link
+        var file = findFileInWebstructure(webStructure, href);
+        // we don't have the file on the website, make external link
+        if (file === null) {
+          return (
+            '<a href="' +
+            config.github.website.root +
+            config.github.website.paths.doc_root +
+            href +
+            '"' +
+            (title ? ' title="' + title + '"' : "") +
+            ' target="_blank">' +
+            text +
+            ' <i class="fa fa-external-link"></i></a>'
+          );
+        }
+        // we have this file on the website, make internal link
+        else {
+          return (
+            '<a ui-sref="main.dyn.' +
+            file.ref +
+            "({file:'" +
+            file.slug +
+            "'})\"" +
+            (title ? ' title="' + title + '"' : "") +
+            ">" +
+            text +
+            "</a>"
+          );
+        }
+      },
+      image: function(href, title, text) {
+        // external image
+        if (href.indexOf("://") > -1) {
+          return (
+            '<img src="' +
+            href +
+            '"' +
+            (text ? ' alt="' + text + '"' : "") +
+            (title ? ' title="' + title + '"' : "") +
+            "/>"
+          );
+        }
+        // internal link, load from github
         return (
           '<img src="' +
+          config.website.content_root +
           href +
           '"' +
           (text ? ' alt="' + text + '"' : "") +
@@ -96,34 +115,24 @@ module.exports = function(markedProvider, config, webStructure) {
           "/>"
         );
       }
-      // internal link, load from github
-      return (
-        '<img src="' +
-        config.website.content_root +
-        href +
-        '"' +
-        (text ? ' alt="' + text + '"' : "") +
-        (title ? ' title="' + title + '"' : "") +
-        "/>"
-      );
-    }
-  });
+    });
 
-  function findFileInWebstructure(list, path) {
-    var result = null;
-    for (var i = 0; i < list.length; i++) {
-      if (list[i].type === "submenu" || list[i].type === "listfiles") {
-        result = findFileInWebstructure(list[i].children, path);
-        if (result !== null && result.type === "file") {
-          if (typeof result.ref === "undefined") {
-            result.ref = list[i].ref;
+    function findFileInWebstructure(list, path) {
+      var result = null;
+      for (var i = 0; i < list.length; i++) {
+        if (list[i].type === "submenu" || list[i].type === "listfiles") {
+          result = findFileInWebstructure(list[i].children, path);
+          if (result !== null && result.type === "file") {
+            if (typeof result.ref === "undefined") {
+              result.ref = list[i].ref;
+            }
+            return result;
           }
-          return result;
+        } else if (list[i].type === "file" && list[i].options.path === path) {
+          return list[i];
         }
-      } else if (list[i].type === "file" && list[i].options.path === path) {
-        return list[i];
       }
+      return null; // did not find path
     }
-    return null; // did not find path
   }
-};
+];

--- a/src/tools/website/resources/assets/js/config/notifications.js
+++ b/src/tools/website/resources/assets/js/config/notifications.js
@@ -1,14 +1,17 @@
 "use strict";
 
-module.exports = function(NotificationProvider) {
-  NotificationProvider.setOptions({
-    delay: 5000,
-    startTop: 70,
-    startRight: 10,
-    verticalSpacing: 10,
-    horizontalSpacing: 20,
-    positionX: "right",
-    positionY: "top",
-    templateUrl: "templates/notification.html"
-  });
-};
+module.exports = [
+  "NotificationProvider",
+  function(NotificationProvider) {
+    NotificationProvider.setOptions({
+      delay: 5000,
+      startTop: 70,
+      startRight: 10,
+      verticalSpacing: 10,
+      horizontalSpacing: 20,
+      positionX: "right",
+      positionY: "top",
+      templateUrl: "templates/notification.html"
+    });
+  }
+];

--- a/src/tools/website/resources/assets/js/config/routes.js
+++ b/src/tools/website/resources/assets/js/config/routes.js
@@ -1,174 +1,166 @@
 "use strict";
 
-module.exports = function(
-  $stateProvider,
-  $urlRouterProvider,
-  $locationProvider,
-  webStructure
-) {
-  var self = this;
+module.exports = [
+  "$stateProvider",
+  "$urlRouterProvider",
+  "$locationProvider",
+  "webStructure",
+  function(
+    $stateProvider,
+    $urlRouterProvider,
+    $locationProvider,
+    webStructure
+  ) {
+    var self = this;
 
-  // configure html5mode for URLs (no #)
-  $locationProvider.html5Mode({ enabled: true });
+    // configure html5mode for URLs (no #)
+    $locationProvider.html5Mode({ enabled: true });
 
-  // configure default route
-  $urlRouterProvider.when("", "/home");
-  $urlRouterProvider.when("/", "/home");
-  $urlRouterProvider.otherwise("/error/404");
+    // configure default route
+    $urlRouterProvider.when("", "/home");
+    $urlRouterProvider.when("/", "/home");
+    $urlRouterProvider.otherwise("/error/404");
 
-  // configure application states
-  $stateProvider
-    .state("main", {
-      abstract: true,
-      templateUrl: "pages/main/template.html",
-      controller: "MainController as ctrl"
-    })
-    .state("main.error", {
-      abstract: true,
-      url: "/error",
-      templateUrl: "pages/main/error/template.html",
-      ncyBreadcrumb: {
-        label: "APP.BREADCRUMBS.MAIN.ERROR",
-        parent: "main.home"
-      }
-    })
-    .state("main.error.404", {
-      url: "/404",
-      templateUrl: "pages/main/error/404.html",
-      ncyBreadcrumb: {
-        label: "APP.BREADCRUMBS.MAIN.ERROR.404",
-        parent: "main.error"
-      }
-    })
-    .state("main.home", {
-      url: "/home",
-      templateUrl: "pages/main/website/home.html",
-      controller: "WebsiteHomeController as ctrl",
-      ncyBreadcrumb: { label: "APP.BREADCRUMBS.MAIN.HOME" }
-    })
-    .state("main.news", {
-      url: "/news/:file",
-      templateUrl: "pages/main/website/news.html",
-      controller: "WebsiteListfilesController as ctrl",
-      params: { file: null },
-      resolve: {
-        files: [
-          "news",
-          function(news) {
-            return news;
-          }
-        ],
-        currentFile: [
-          "$q",
-          "$timeout",
-          "$state",
-          "$stateParams",
-          "WebsiteService",
-          "files",
-          function($q, $timeout, $state, $stateParams, WebsiteService, files) {
-            var deferred = $q.defer();
+    // configure application states
+    $stateProvider
+      .state("main", {
+        abstract: true,
+        templateUrl: "pages/main/template.html",
+        controller: "MainController as ctrl"
+      })
+      .state("main.error", {
+        abstract: true,
+        url: "/error",
+        templateUrl: "pages/main/error/template.html",
+        ncyBreadcrumb: {
+          label: "APP.BREADCRUMBS.MAIN.ERROR",
+          parent: "main.home"
+        }
+      })
+      .state("main.error.404", {
+        url: "/404",
+        templateUrl: "pages/main/error/404.html",
+        ncyBreadcrumb: {
+          label: "APP.BREADCRUMBS.MAIN.ERROR.404",
+          parent: "main.error"
+        }
+      })
+      .state("main.home", {
+        url: "/home",
+        templateUrl: "pages/main/website/home.html",
+        controller: "WebsiteHomeController as ctrl",
+        ncyBreadcrumb: { label: "APP.BREADCRUMBS.MAIN.HOME" }
+      })
+      .state("main.news", {
+        url: "/news/:file",
+        templateUrl: "pages/main/website/news.html",
+        controller: "WebsiteListfilesController as ctrl",
+        params: { file: null },
+        resolve: {
+          files: [
+            "news",
+            function(news) {
+              return news;
+            }
+          ],
+          currentFile: [
+            "$q",
+            "$timeout",
+            "$state",
+            "$stateParams",
+            "WebsiteService",
+            "files",
+            function($q, $timeout, $state, $stateParams, WebsiteService, files) {
+              var deferred = $q.defer();
 
-            $timeout(function() {
-              if ($stateParams.file === null) {
-                $state.go("main.news", {
-                  file: files.filter(function(elem) {
-                    return elem.type === "file";
-                  })[0].slug
-                });
-                deferred.reject();
-              } else {
-                var filtered = files.filter(function(elem) {
-                  return (
-                    elem.type === "file" && elem.slug === $stateParams.file
-                  );
-                });
-                if (filtered.length === 0) {
-                  $state.go("main.news", { file: files[0].slug });
+              $timeout(function() {
+                if ($stateParams.file === null) {
+                  $state.go("main.news", {
+                    file: files.filter(function(elem) {
+                      return elem.type === "file";
+                    })[0].slug
+                  });
                   deferred.reject();
                 } else {
-                  WebsiteService.loadFile(filtered[0].file).then(function(
-                    data
-                  ) {
-                    var file = filtered[0];
-                    file.content = data;
-                    deferred.resolve(file);
+                  var filtered = files.filter(function(elem) {
+                    return (
+                      elem.type === "file" && elem.slug === $stateParams.file
+                    );
                   });
-                }
-              }
-            });
-
-            return deferred.promise;
-          }
-        ]
-      },
-      ncyBreadcrumb: { label: "APP.BREADCRUMBS.MAIN.NEWS", parent: "main.home" }
-    })
-    .state("main.dyn", {
-      abstract: true,
-      template: "<div ui-view></div>",
-      ncyBreadcrumb: { parent: "main.home" }
-    });
-
-  /* CONFIGURE DYNAMIC PAGES */
-
-  // read the structure file and handle entries
-  webStructure.forEach(function(entry) {
-    consumeEntry(entry);
-  });
-
-  // main parse function
-  function consumeEntry(entry) {
-    switch (entry.type) {
-      case "submenu":
-        entry.children.forEach(function(child) {
-          consumeEntry(child);
-        });
-        break;
-      case "listfiles":
-        $stateProvider.state("main.dyn." + entry.ref, {
-          url: "/" + entry.ref + "/:file",
-          templateUrl: "pages/main/website/listfiles.html",
-          controller: "WebsiteListfilesController as ctrl",
-          params: { file: null },
-          data: { name: entry.name, ref: entry.ref },
-          resolve: {
-            files: [
-              function() {
-                return entry.children;
-              }
-            ],
-            currentFile: [
-              "$q",
-              "$timeout",
-              "$state",
-              "$stateParams",
-              "WebsiteService",
-              "files",
-              function(
-                $q,
-                $timeout,
-                $state,
-                $stateParams,
-                WebsiteService,
-                files
-              ) {
-                var deferred = $q.defer();
-
-                $timeout(function() {
-                  if ($stateParams.file === null) {
-                    $state.go("main.dyn." + entry.ref, {
-                      file: files.filter(function(elem) {
-                        return elem.type === "file";
-                      })[0].slug
-                    });
+                  if (filtered.length === 0) {
+                    $state.go("main.news", { file: files[0].slug });
                     deferred.reject();
                   } else {
-                    var filtered = files.filter(function(elem) {
-                      return (
-                        elem.type === "file" && elem.slug === $stateParams.file
-                      );
+                    WebsiteService.loadFile(filtered[0].file).then(function(
+                      data
+                    ) {
+                      var file = filtered[0];
+                      file.content = data;
+                      deferred.resolve(file);
                     });
-                    if (filtered.length === 0) {
+                  }
+                }
+              });
+
+              return deferred.promise;
+            }
+          ]
+        },
+        ncyBreadcrumb: { label: "APP.BREADCRUMBS.MAIN.NEWS", parent: "main.home" }
+      })
+      .state("main.dyn", {
+        abstract: true,
+        template: "<div ui-view></div>",
+        ncyBreadcrumb: { parent: "main.home" }
+      });
+
+    /* CONFIGURE DYNAMIC PAGES */
+
+    // read the structure file and handle entries
+    webStructure.forEach(function(entry) {
+      consumeEntry(entry);
+    });
+
+    // main parse function
+    function consumeEntry(entry) {
+      switch (entry.type) {
+        case "submenu":
+          entry.children.forEach(function(child) {
+            consumeEntry(child);
+          });
+          break;
+        case "listfiles":
+          $stateProvider.state("main.dyn." + entry.ref, {
+            url: "/" + entry.ref + "/:file",
+            templateUrl: "pages/main/website/listfiles.html",
+            controller: "WebsiteListfilesController as ctrl",
+            params: { file: null },
+            data: { name: entry.name, ref: entry.ref },
+            resolve: {
+              files: [
+                function() {
+                  return entry.children;
+                }
+              ],
+              currentFile: [
+                "$q",
+                "$timeout",
+                "$state",
+                "$stateParams",
+                "WebsiteService",
+                "files",
+                function(
+                  $q,
+                  $timeout,
+                  $state,
+                  $stateParams,
+                  WebsiteService,
+                  files
+                ) {
+                  var deferred = $q.defer();
+
+                  $timeout(function() {
+                    if ($stateParams.file === null) {
                       $state.go("main.dyn." + entry.ref, {
                         file: files.filter(function(elem) {
                           return elem.type === "file";
@@ -176,29 +168,43 @@ module.exports = function(
                       });
                       deferred.reject();
                     } else {
-                      WebsiteService.loadFile(filtered[0].options.path).then(
-                        function(data) {
-                          var file = filtered[0];
-                          file.content = data;
-                          deferred.resolve(file);
-                        }
-                      );
+                      var filtered = files.filter(function(elem) {
+                        return (
+                          elem.type === "file" && elem.slug === $stateParams.file
+                        );
+                      });
+                      if (filtered.length === 0) {
+                        $state.go("main.dyn." + entry.ref, {
+                          file: files.filter(function(elem) {
+                            return elem.type === "file";
+                          })[0].slug
+                        });
+                        deferred.reject();
+                      } else {
+                        WebsiteService.loadFile(filtered[0].options.path).then(
+                          function(data) {
+                            var file = filtered[0];
+                            file.content = data;
+                            deferred.resolve(file);
+                          }
+                        );
+                      }
                     }
-                  }
-                });
+                  });
 
-                return deferred.promise;
-              }
-            ]
-          },
-          ncyBreadcrumb: {
-            label: "APP.BREADCRUMBS.MAIN.DYN." + entry.ref.toUpperCase(),
-            parent: "main.dyn"
-          }
-        });
-        break;
-      default:
-        break;
+                  return deferred.promise;
+                }
+              ]
+            },
+            ncyBreadcrumb: {
+              label: "APP.BREADCRUMBS.MAIN.DYN." + entry.ref.toUpperCase(),
+              parent: "main.dyn"
+            }
+          });
+          break;
+        default:
+          break;
+      }
     }
   }
-};
+];

--- a/src/tools/website/resources/assets/js/config/routes.js
+++ b/src/tools/website/resources/assets/js/config/routes.js
@@ -70,7 +70,14 @@ module.exports = [
             "$stateParams",
             "WebsiteService",
             "files",
-            function($q, $timeout, $state, $stateParams, WebsiteService, files) {
+            function(
+              $q,
+              $timeout,
+              $state,
+              $stateParams,
+              WebsiteService,
+              files
+            ) {
               var deferred = $q.defer();
 
               $timeout(function() {
@@ -106,7 +113,10 @@ module.exports = [
             }
           ]
         },
-        ncyBreadcrumb: { label: "APP.BREADCRUMBS.MAIN.NEWS", parent: "main.home" }
+        ncyBreadcrumb: {
+          label: "APP.BREADCRUMBS.MAIN.NEWS",
+          parent: "main.home"
+        }
       })
       .state("main.dyn", {
         abstract: true,
@@ -170,7 +180,8 @@ module.exports = [
                     } else {
                       var filtered = files.filter(function(elem) {
                         return (
-                          elem.type === "file" && elem.slug === $stateParams.file
+                          elem.type === "file" &&
+                          elem.slug === $stateParams.file
                         );
                       });
                       if (filtered.length === 0) {

--- a/src/tools/website/resources/assets/js/config/translations.js
+++ b/src/tools/website/resources/assets/js/config/translations.js
@@ -1,14 +1,18 @@
 "use strict";
 
-module.exports = function($translateProvider, config) {
-  // configure translations
-  $translateProvider
-    .useSanitizeValueStrategy("sanitizeParameters")
-    .useStaticFilesLoader({ prefix: "assets/translations/", suffix: ".json" })
-    .registerAvailableLanguageKeys(
-      config.translations.enabled,
-      config.translations.mappings
-    )
-    .fallbackLanguage(config.translations.default)
-    .preferredLanguage(config.translations.default);
-};
+module.exports = [
+  "$translateProvider",
+  "config",
+  function($translateProvider, config) {
+    // configure translations
+    $translateProvider
+      .useSanitizeValueStrategy("sanitizeParameters")
+      .useStaticFilesLoader({ prefix: "assets/translations/", suffix: ".json" })
+      .registerAvailableLanguageKeys(
+        config.translations.enabled,
+        config.translations.mappings
+      )
+      .fallbackLanguage(config.translations.default)
+      .preferredLanguage(config.translations.default);
+  }
+];

--- a/src/tools/website/resources/assets/js/controllers/main/MainController.js
+++ b/src/tools/website/resources/assets/js/controllers/main/MainController.js
@@ -29,7 +29,9 @@ module.exports = [
     // build date
     $scope.builddate = {
       date: new Date(
-        document.querySelector('meta[name="build-date"]').getAttribute("content")
+        document
+          .querySelector('meta[name="build-date"]')
+          .getAttribute("content")
       )
     };
     $scope.builddate.timezoneOffset =

--- a/src/tools/website/resources/assets/js/controllers/main/MainController.js
+++ b/src/tools/website/resources/assets/js/controllers/main/MainController.js
@@ -1,67 +1,77 @@
 "use strict";
 
-module.exports = function(
-  $rootScope,
-  $scope,
-  Logger,
-  $state,
-  $anchorScroll,
-  webStructure,
-  config,
-  $translate
-) {
-  $scope.$rootScope = $rootScope;
-  $scope.$state = $state;
+module.exports = [
+  "$rootScope",
+  "$scope",
+  "Logger",
+  "$state",
+  "$anchorScroll",
+  "webStructure",
+  "config",
+  "$translate",
+  function(
+    $rootScope,
+    $scope,
+    Logger,
+    $state,
+    $anchorScroll,
+    webStructure,
+    config,
+    $translate
+  ) {
+    $scope.$rootScope = $rootScope;
+    $scope.$state = $state;
 
-  // build the dynamic menu
-  $scope.menu = webStructure;
-  $rootScope.config = config;
+    // build the dynamic menu
+    $scope.menu = webStructure;
+    $rootScope.config = config;
 
-  // build date
-  $scope.builddate = {
-    date: new Date(
-      document.querySelector('meta[name="build-date"]').getAttribute("content")
-    )
-  };
-  $scope.builddate.timezoneOffset =
-    $scope.builddate.date.getTimezoneOffset() / -60;
-  $scope.builddate.pretty =
-    $scope.builddate.date.toLocaleString() +
-    " (" +
-    ($scope.builddate.timezoneOffset >= 0 ? "+" : "") +
-    $scope.builddate.timezoneOffset +
-    "h UTC)";
+    // build date
+    $scope.builddate = {
+      date: new Date(
+        document.querySelector('meta[name="build-date"]').getAttribute("content")
+      )
+    };
+    $scope.builddate.timezoneOffset =
+      $scope.builddate.date.getTimezoneOffset() / -60;
+    $scope.builddate.pretty =
+      $scope.builddate.date.toLocaleString() +
+      " (" +
+      ($scope.builddate.timezoneOffset >= 0 ? "+" : "") +
+      $scope.builddate.timezoneOffset +
+      "h UTC)";
 
-  //        var vm = this;
-  //        vm.currentLanguage = 'de';
+    //        var vm = this;
+    //        vm.currentLanguage = 'de';
 
-  //        vm.changeLanguage = changeLanguage;
-  //        vm.goSearch = goSearch;
+    //        vm.changeLanguage = changeLanguage;
+    //        vm.goSearch = goSearch;
 
-  //        $rootScope.$on('$translateChangeSuccess', function() {
-  //            vm.currentLanguage = $translate.use();
-  //        });
+    //        $rootScope.$on('$translateChangeSuccess', function() {
+    //            vm.currentLanguage = $translate.use();
+    //        });
 
-  //        function changeLanguage(newLanguage) {
-  //
-  //            $translate.use(newLanguage);
-  //            i18nService.setCurrentLang(newLanguage);
-  //
-  //        }
+    //        function changeLanguage(newLanguage) {
+    //
+    //            $translate.use(newLanguage);
+    //            i18nService.setCurrentLang(newLanguage);
+    //
+    //        }
 
-  this.scrollToTop = function() {
-    $anchorScroll();
-  };
+    this.scrollToTop = function() {
+      $anchorScroll();
+    };
 
-  Logger.info("Main template ready");
+    Logger.info("Main template ready");
 
-  // init after view has been loaded (template parsed, translation happend)
-  angular.element(document).ready(function() {
-    docsearch({
-      apiKey: "7d1e7bc1f97b53de246aaefa29484be9",
-      indexName: "elektra",
-      inputSelector: "#searchboxdocsearch",
-      debug: false // Set debug to true if you want to inspect the dropdown
+    // init after view has been loaded (template parsed, translation happend)
+    angular.element(document).ready(function() {
+      docsearch({
+        apiKey: "7d1e7bc1f97b53de246aaefa29484be9",
+        indexName: "elektra",
+        inputSelector: "#searchboxdocsearch",
+        debug: false // Set debug to true if you want to inspect the dropdown
+      });
     });
-  });
-};
+  }
+];

--- a/src/tools/website/resources/assets/js/controllers/main/auth/AuthLoginController.js
+++ b/src/tools/website/resources/assets/js/controllers/main/auth/AuthLoginController.js
@@ -6,13 +6,7 @@ module.exports = [
   "$state",
   "$auth",
   "Notification",
-  function(
-    $scope,
-    Logger,
-    $state,
-    $auth,
-    Notification
-  ) {
+  function($scope, Logger, $state, $auth, Notification) {
     var vm = this;
 
     $scope.user = {};

--- a/src/tools/website/resources/assets/js/controllers/main/auth/AuthLoginController.js
+++ b/src/tools/website/resources/assets/js/controllers/main/auth/AuthLoginController.js
@@ -1,31 +1,44 @@
 "use strict";
 
-module.exports = function($scope, Logger, $state, $auth, Notification) {
-  var vm = this;
+module.exports = [
+  "$scope",
+  "Logger",
+  "$state",
+  "$auth",
+  "Notification",
+  function(
+    $scope,
+    Logger,
+    $state,
+    $auth,
+    Notification
+  ) {
+    var vm = this;
 
-  $scope.user = {};
+    $scope.user = {};
 
-  this.doLogin = function() {
-    $auth
-      .login($scope.user, {
-        // custom options
-      })
-      .then(function(response) {
-        Logger.info("Successful login!");
-        Notification.success({
-          title: "APP.AUTH.LOGIN.NOTIFICATION.HEADER",
-          message: "APP.AUTH.LOGIN.NOTIFICATION.MESSAGE.SUCCESS"
+    this.doLogin = function() {
+      $auth
+        .login($scope.user, {
+          // custom options
+        })
+        .then(function(response) {
+          Logger.info("Successful login!");
+          Notification.success({
+            title: "APP.AUTH.LOGIN.NOTIFICATION.HEADER",
+            message: "APP.AUTH.LOGIN.NOTIFICATION.MESSAGE.SUCCESS"
+          });
+          $state.go("main.home");
+        })
+        .catch(function(response) {
+          Logger.info("Failed login!");
+          Notification.error({
+            title: "APP.AUTH.LOGIN.NOTIFICATION.HEADER",
+            message: "APP.AUTH.LOGIN.NOTIFICATION.MESSAGE." + response.data.i18n
+          });
         });
-        $state.go("main.home");
-      })
-      .catch(function(response) {
-        Logger.info("Failed login!");
-        Notification.error({
-          title: "APP.AUTH.LOGIN.NOTIFICATION.HEADER",
-          message: "APP.AUTH.LOGIN.NOTIFICATION.MESSAGE." + response.data.i18n
-        });
-      });
-  };
+    };
 
-  Logger.info("Login controller ready");
-};
+    Logger.info("Login controller ready");
+  }
+];

--- a/src/tools/website/resources/assets/js/controllers/main/auth/AuthRegistrationController.js
+++ b/src/tools/website/resources/assets/js/controllers/main/auth/AuthRegistrationController.js
@@ -1,35 +1,50 @@
 "use strict";
 
-module.exports = function($scope, Logger, $state, $http, Notification, config) {
-  var vm = this;
+module.exports = [
+  "$scope",
+  "Logger", 
+  "$state",
+  "$http",
+  "Notification",
+  "config",
+  function(
+    $scope,
+    Logger, 
+    $state,
+    $http,
+    Notification,
+    config
+  ) {
+    var vm = this;
 
-  $scope.user = {};
+    $scope.user = {};
 
-  this.doRegistration = function() {
-    $http
-      .post(config.backend.root + "user", $scope.user, {
-        // custom options
-      })
-      .then(
-        function(response) {
-          Logger.info("Successful registration!");
-          Notification.success({
-            title: "APP.AUTH.REGISTRATION.NOTIFICATION.HEADER",
-            message:
-              "APP.AUTH.REGISTRATION.NOTIFICATION.MESSAGE." + response.data.i18n
-          });
-          $state.go("main.auth.login");
-        },
-        function(response) {
-          Logger.info("Failed registration!");
-          Notification.error({
-            title: "APP.AUTH.REGISTRATION.NOTIFICATION.HEADER",
-            message:
-              "APP.AUTH.REGISTRATION.NOTIFICATION.MESSAGE." + response.data.i18n
-          });
-        }
-      );
-  };
+    this.doRegistration = function() {
+      $http
+        .post(config.backend.root + "user", $scope.user, {
+          // custom options
+        })
+        .then(
+          function(response) {
+            Logger.info("Successful registration!");
+            Notification.success({
+              title: "APP.AUTH.REGISTRATION.NOTIFICATION.HEADER",
+              message:
+                "APP.AUTH.REGISTRATION.NOTIFICATION.MESSAGE." + response.data.i18n
+            });
+            $state.go("main.auth.login");
+          },
+          function(response) {
+            Logger.info("Failed registration!");
+            Notification.error({
+              title: "APP.AUTH.REGISTRATION.NOTIFICATION.HEADER",
+              message:
+                "APP.AUTH.REGISTRATION.NOTIFICATION.MESSAGE." + response.data.i18n
+            });
+          }
+        );
+    };
 
-  Logger.info("Registration controller ready");
-};
+    Logger.info("Registration controller ready");
+  }
+];

--- a/src/tools/website/resources/assets/js/controllers/main/auth/AuthRegistrationController.js
+++ b/src/tools/website/resources/assets/js/controllers/main/auth/AuthRegistrationController.js
@@ -2,19 +2,12 @@
 
 module.exports = [
   "$scope",
-  "Logger", 
+  "Logger",
   "$state",
   "$http",
   "Notification",
   "config",
-  function(
-    $scope,
-    Logger, 
-    $state,
-    $http,
-    Notification,
-    config
-  ) {
+  function($scope, Logger, $state, $http, Notification, config) {
     var vm = this;
 
     $scope.user = {};
@@ -30,7 +23,8 @@ module.exports = [
             Notification.success({
               title: "APP.AUTH.REGISTRATION.NOTIFICATION.HEADER",
               message:
-                "APP.AUTH.REGISTRATION.NOTIFICATION.MESSAGE." + response.data.i18n
+                "APP.AUTH.REGISTRATION.NOTIFICATION.MESSAGE." +
+                response.data.i18n
             });
             $state.go("main.auth.login");
           },
@@ -39,7 +33,8 @@ module.exports = [
             Notification.error({
               title: "APP.AUTH.REGISTRATION.NOTIFICATION.HEADER",
               message:
-                "APP.AUTH.REGISTRATION.NOTIFICATION.MESSAGE." + response.data.i18n
+                "APP.AUTH.REGISTRATION.NOTIFICATION.MESSAGE." +
+                response.data.i18n
             });
           }
         );

--- a/src/tools/website/resources/assets/js/controllers/main/entries/EntryCreateController.js
+++ b/src/tools/website/resources/assets/js/controllers/main/entries/EntryCreateController.js
@@ -2,116 +2,127 @@
 
 var angular = require("angular");
 
-module.exports = function(
-  $scope,
-  Logger,
-  $state,
-  EntryService,
-  Notification,
-  Slug,
-  config,
-  formats,
-  typeaheads
-) {
-  var vm = this;
+module.exports = [
+  "$scope",
+  "Logger",
+  "$state",
+  "EntryService",
+  "Notification",
+  "Slug",
+  "config",
+  "formats",
+  "typeaheads",
+  function(
+    $scope,
+    Logger,
+    $state,
+    EntryService,
+    Notification,
+    Slug,
+    config,
+    formats,
+    typeaheads
+  ) {
+    var vm = this;
 
-  $scope.isCreate = true;
-  $scope.show = { howDoesItWork: false };
+    $scope.isCreate = true;
+    $scope.show = { howDoesItWork: false };
 
-  $scope.cb = { createScopeManually: false };
-  $scope.entry = {
-    organization: config.website.defaults.entry.form.organization,
-    scope: config.website.defaults.entry.form.scope,
-    tags: [],
-    configuration: { format: {}, formatconf: "", value: "" }
-  };
-  $scope.formats = formats.map(function(elem) {
-    var name = elem.plugin.name;
-    var space = name.indexOf(" ");
-    if (space > -1) {
-      name = name.substring(0, space);
-    }
-    elem.plugin.nameWithoutConf = name;
-    return elem;
-  });
-  $scope.entry.configuration.format = $scope.formats[0];
-  $scope.typeaheads = typeaheads;
-
-  $scope.$watch(
-    "entry.title",
-    function() {
-      if ($scope.cb.createScopeManually === true) {
-        return;
+    $scope.cb = { createScopeManually: false };
+    $scope.entry = {
+      organization: config.website.defaults.entry.form.organization,
+      scope: config.website.defaults.entry.form.scope,
+      tags: [],
+      configuration: { format: {}, formatconf: "", value: "" }
+    };
+    $scope.formats = formats.map(function(elem) {
+      var name = elem.plugin.name;
+      var space = name.indexOf(" ");
+      if (space > -1) {
+        name = name.substring(0, space);
       }
-      $scope.entry.slug = Slug.slugify($scope.entry.title).replace(
-        /[_]+/g,
-        "-"
-      );
-    },
-    true
-  );
+      elem.plugin.nameWithoutConf = name;
+      return elem;
+    });
+    $scope.entry.configuration.format = $scope.formats[0];
+    $scope.typeaheads = typeaheads;
 
-  $scope.$watch(
-    "cb.createScopeManually",
-    function() {
-      if ($scope.cb.createScopeManually === false) {
+    $scope.$watch(
+      "entry.title",
+      function() {
+        if ($scope.cb.createScopeManually === true) {
+          return;
+        }
         $scope.entry.slug = Slug.slugify($scope.entry.title).replace(
           /[_]+/g,
           "-"
         );
-      }
-    },
-    true
-  );
-
-  this.submit = function() {
-    Logger.info("Attempting to create new entry.");
-
-    var tmp = {};
-    angular.copy($scope.entry, tmp);
-    tmp.tags = $scope.entry.tags.map(function(elem) {
-      return elem.text;
-    });
-    tmp.configuration.format = $scope.entry.configuration.format.plugin.name;
-
-    if (tmp.configuration.formatconf !== "") {
-      tmp.configuration.format += " " + tmp.configuration.formatconf;
-    }
-    delete tmp.configuration.formatconf;
-
-    EntryService.create(tmp).then(
-      function(response) {
-        Logger.info("Create entry result: " + JSON.stringify(response.data));
-        Notification.success({
-          title: "APP.ENTRIES.CREATE.NOTIFICATION.HEADER",
-          message:
-            "APP.ENTRIES.CREATE.NOTIFICATION.MESSAGE." + response.data.i18n
-        });
-
-        $state.go("main.entries.details", {
-          entry:
-            tmp.organization +
-            "/" +
-            tmp.application +
-            "/" +
-            tmp.scope +
-            "/" +
-            tmp.slug
-        });
       },
-      function(response) {
-        Notification.error({
-          title: "APP.ENTRIES.CREATE.NOTIFICATION.HEADER",
-          message:
-            "APP.ENTRIES.CREATE.NOTIFICATION.MESSAGE." + response.data.i18n
-        });
-      }
+      true
     );
-  };
 
-  this.show = function(which) {
-    $scope.show[which] = true;
-  };
+    $scope.$watch(
+      "cb.createScopeManually",
+      function() {
+        if ($scope.cb.createScopeManually === false) {
+          $scope.entry.slug = Slug.slugify($scope.entry.title).replace(
+            /[_]+/g,
+            "-"
+          );
+        }
+      },
+      true
+    );
 
-  Logger.info("New entry controller ready");
-};
+    this.submit = function() {
+      Logger.info("Attempting to create new entry.");
+
+      var tmp = {};
+      angular.copy($scope.entry, tmp);
+      tmp.tags = $scope.entry.tags.map(function(elem) {
+        return elem.text;
+      });
+      tmp.configuration.format = $scope.entry.configuration.format.plugin.name;
+
+      if (tmp.configuration.formatconf !== "") {
+        tmp.configuration.format += " " + tmp.configuration.formatconf;
+      }
+      delete tmp.configuration.formatconf;
+
+      EntryService.create(tmp).then(
+        function(response) {
+          Logger.info("Create entry result: " + JSON.stringify(response.data));
+          Notification.success({
+            title: "APP.ENTRIES.CREATE.NOTIFICATION.HEADER",
+            message:
+              "APP.ENTRIES.CREATE.NOTIFICATION.MESSAGE." + response.data.i18n
+          });
+
+          $state.go("main.entries.details", {
+            entry:
+              tmp.organization +
+              "/" +
+              tmp.application +
+              "/" +
+              tmp.scope +
+              "/" +
+              tmp.slug
+          });
+        },
+        function(response) {
+          Notification.error({
+            title: "APP.ENTRIES.CREATE.NOTIFICATION.HEADER",
+            message:
+              "APP.ENTRIES.CREATE.NOTIFICATION.MESSAGE." + response.data.i18n
+          });
+        }
+      );
+    };
+
+    this.show = function(which) {
+      $scope.show[which] = true;
+    };
+
+    Logger.info("New entry controller ready");
+  }
+];

--- a/src/tools/website/resources/assets/js/controllers/main/entries/EntryDeleteConfirmationController.js
+++ b/src/tools/website/resources/assets/js/controllers/main/entries/EntryDeleteConfirmationController.js
@@ -1,17 +1,28 @@
 "use strict";
 
-module.exports = function($uibModalInstance, $scope, Logger, entry) {
-  var vm = this;
+module.exports = [
+  "$uibModalInstance",
+  "$scope",
+  "Logger",
+  "entry",
+  function(
+    $uibModalInstance,
+    $scope,
+    Logger,
+    entry
+  ) {
+    var vm = this;
 
-  $scope.entry = entry;
+    $scope.entry = entry;
 
-  this.ok = function() {
-    $uibModalInstance.close(true);
-  };
+    this.ok = function() {
+      $uibModalInstance.close(true);
+    };
 
-  this.abort = function() {
-    $uibModalInstance.dismiss(false);
-  };
+    this.abort = function() {
+      $uibModalInstance.dismiss(false);
+    };
 
-  Logger.info("Entry delete confirmation controller ready");
-};
+    Logger.info("Entry delete confirmation controller ready");
+  }
+];

--- a/src/tools/website/resources/assets/js/controllers/main/entries/EntryDeleteConfirmationController.js
+++ b/src/tools/website/resources/assets/js/controllers/main/entries/EntryDeleteConfirmationController.js
@@ -5,12 +5,7 @@ module.exports = [
   "$scope",
   "Logger",
   "entry",
-  function(
-    $uibModalInstance,
-    $scope,
-    Logger,
-    entry
-  ) {
+  function($uibModalInstance, $scope, Logger, entry) {
     var vm = this;
 
     $scope.entry = entry;

--- a/src/tools/website/resources/assets/js/controllers/main/entries/EntryDetailsController.js
+++ b/src/tools/website/resources/assets/js/controllers/main/entries/EntryDetailsController.js
@@ -1,74 +1,85 @@
 "use strict";
 
-module.exports = function(
-  $scope,
-  Logger,
-  $state,
-  FileSaver,
-  Blob,
-  entry,
-  Notification,
-  EntryService,
-  $uibModal
-) {
-  var vm = this;
+module.exports = [
+  "$scope",
+  "Logger",
+  "$state",
+  "FileSaver",
+  "Blob",
+  "entry",
+  "Notification",
+  "EntryService",
+  "$uibModal",
+  function(
+    $scope,
+    Logger,
+    $state,
+    FileSaver,
+    Blob,
+    entry,
+    Notification,
+    EntryService,
+    $uibModal
+  ) {
+    var vm = this;
 
-  $scope.entry = entry;
-  $scope.clipboardSupported = false;
+    $scope.entry = entry;
+    $scope.clipboardSupported = false;
 
-  this.saveConvertedConfiguration = function(config) {
-    Logger.info("Configuration:" + config);
-    var blob = new Blob([config.value], { type: "text/plain;charset=utf-8;" });
-    FileSaver.saveAs(blob, $scope.entry.key.slug + "." + config.format, true);
-  };
+    this.saveConvertedConfiguration = function(config) {
+      Logger.info("Configuration:" + config);
+      var blob = new Blob([config.value], { type: "text/plain;charset=utf-8;" });
+      FileSaver.saveAs(blob, $scope.entry.key.slug + "." + config.format, true);
+    };
 
-  this.copyClipboardSuccess = function() {
-    Notification.success({
-      title: "APP.ENTRIES.DETAILS.NOTIFICATION.CLIPBOARD.HEADER",
-      message: "APP.ENTRIES.DETAILS.NOTIFICATION.CLIPBOARD.MESSAGE.SUCCESS"
-    });
-  };
+    this.copyClipboardSuccess = function() {
+      Notification.success({
+        title: "APP.ENTRIES.DETAILS.NOTIFICATION.CLIPBOARD.HEADER",
+        message: "APP.ENTRIES.DETAILS.NOTIFICATION.CLIPBOARD.MESSAGE.SUCCESS"
+      });
+    };
 
-  this.copyClipboardFailed = function() {
-    Notification.error({
-      title: "APP.ENTRIES.DETAILS.NOTIFICATION.CLIPBOARD.HEADER",
-      message: "APP.ENTRIES.DETAILS.NOTIFICATION.CLIPBOARD.MESSAGE.ERROR"
-    });
-  };
+    this.copyClipboardFailed = function() {
+      Notification.error({
+        title: "APP.ENTRIES.DETAILS.NOTIFICATION.CLIPBOARD.HEADER",
+        message: "APP.ENTRIES.DETAILS.NOTIFICATION.CLIPBOARD.MESSAGE.ERROR"
+      });
+    };
 
-  this.deleteEntry = function() {
-    var confirmation = $uibModal.open({
-      templateUrl: "pages/main/entries/delete_confirmation.html",
-      controller: "EntryDeleteConfirmationController as ctrl",
-      resolve: {
-        entry: function() {
-          return entry;
-        }
-      }
-    });
-
-    confirmation.result.then(function(result) {
-      if (result === true) {
-        EntryService.delete(entry.key.full).then(
-          function(response) {
-            Notification.success({
-              title: "APP.ENTRIES.DELETE.NOTIFICATION.HEADER",
-              message:
-                "APP.ENTRIES.DELETE.NOTIFICATION.MESSAGE." + response.data.i18n
-            });
-            $state.go("main.entries.search");
-          },
-          function(response) {
-            Notification.error({
-              title: "APP.ENTRIES.DELETE.NOTIFICATION.HEADER",
-              message:
-                "APP.ENTRIES.DELETE.NOTIFICATION.MESSAGE." + response.data.i18n
-            });
+    this.deleteEntry = function() {
+      var confirmation = $uibModal.open({
+        templateUrl: "pages/main/entries/delete_confirmation.html",
+        controller: "EntryDeleteConfirmationController as ctrl",
+        resolve: {
+          entry: function() {
+            return entry;
           }
-        );
-      }
-    });
-  };
+        }
+      });
 
-  Logger.info("Entry details ready");
-};
+      confirmation.result.then(function(result) {
+        if (result === true) {
+          EntryService.delete(entry.key.full).then(
+            function(response) {
+              Notification.success({
+                title: "APP.ENTRIES.DELETE.NOTIFICATION.HEADER",
+                message:
+                  "APP.ENTRIES.DELETE.NOTIFICATION.MESSAGE." + response.data.i18n
+              });
+              $state.go("main.entries.search");
+            },
+            function(response) {
+              Notification.error({
+                title: "APP.ENTRIES.DELETE.NOTIFICATION.HEADER",
+                message:
+                  "APP.ENTRIES.DELETE.NOTIFICATION.MESSAGE." + response.data.i18n
+              });
+            }
+          );
+        }
+      });
+    };
+
+    Logger.info("Entry details ready");
+  }
+];

--- a/src/tools/website/resources/assets/js/controllers/main/entries/EntryDetailsController.js
+++ b/src/tools/website/resources/assets/js/controllers/main/entries/EntryDetailsController.js
@@ -28,7 +28,9 @@ module.exports = [
 
     this.saveConvertedConfiguration = function(config) {
       Logger.info("Configuration:" + config);
-      var blob = new Blob([config.value], { type: "text/plain;charset=utf-8;" });
+      var blob = new Blob([config.value], {
+        type: "text/plain;charset=utf-8;"
+      });
       FileSaver.saveAs(blob, $scope.entry.key.slug + "." + config.format, true);
     };
 
@@ -64,7 +66,8 @@ module.exports = [
               Notification.success({
                 title: "APP.ENTRIES.DELETE.NOTIFICATION.HEADER",
                 message:
-                  "APP.ENTRIES.DELETE.NOTIFICATION.MESSAGE." + response.data.i18n
+                  "APP.ENTRIES.DELETE.NOTIFICATION.MESSAGE." +
+                  response.data.i18n
               });
               $state.go("main.entries.search");
             },
@@ -72,7 +75,8 @@ module.exports = [
               Notification.error({
                 title: "APP.ENTRIES.DELETE.NOTIFICATION.HEADER",
                 message:
-                  "APP.ENTRIES.DELETE.NOTIFICATION.MESSAGE." + response.data.i18n
+                  "APP.ENTRIES.DELETE.NOTIFICATION.MESSAGE." +
+                  response.data.i18n
               });
             }
           );

--- a/src/tools/website/resources/assets/js/controllers/main/entries/EntryEditController.js
+++ b/src/tools/website/resources/assets/js/controllers/main/entries/EntryEditController.js
@@ -2,84 +2,93 @@
 
 var angular = require("angular");
 
-module.exports = function(
-  $scope,
-  Logger,
-  $state,
-  EntryService,
-  Notification,
-  Slug,
-  formats,
-  entry,
-  typeaheads
-) {
-  var vm = this;
+module.exports = [
+  "$scope",
+  "Logger",
+  "$state",
+  "EntryService",
+  "Notification",
+  "formats",
+  "entry",
+  "typeaheads",
+  function(
+    $scope,
+    Logger,
+    $state,
+    EntryService,
+    Notification,
+    formats,
+    entry,
+    typeaheads
+  ) {
+    var vm = this;
 
-  Logger.log(entry);
-  $scope.formats = formats.map(function(elem) {
-    var name = elem.plugin.name;
-    var space = name.indexOf(" ");
-    if (space > -1) {
-      name = name.substring(0, space);
-    }
-    elem.plugin.nameWithoutConf = name;
-    return elem;
-  });
-  $scope.entry = {
-    title: entry.meta.title,
-    description: entry.meta.description,
-    tags: !!entry.meta.tags
-      ? entry.meta.tags.map(function(elem) {
-          return { text: elem };
-        })
-      : [],
-    configuration: {
-      format: $scope.formats.filter(function(elem) {
-        return elem.plugin.name === entry.value[0].plugin;
-      })[0],
-      formatconf: "",
-      value: entry.value[0].value
-    }
-  };
-  $scope.typeaheads = typeaheads;
-
-  this.submit = function() {
-    Logger.info("Attempting to update entry.");
-
-    var tmp = {};
-    angular.copy($scope.entry, tmp);
-    tmp.tags = $scope.entry.tags.map(function(elem) {
-      return elem.text;
-    });
-    tmp.configuration.format = $scope.entry.configuration.format.plugin.name;
-
-    if (tmp.configuration.formatconf !== "") {
-      tmp.configuration.format += " " + tmp.configuration.formatconf;
-    }
-    delete tmp.configuration.formatconf;
-
-    EntryService.update(entry.key.full, tmp).then(
-      function(response) {
-        Logger.info("Update entry result: " + JSON.stringify(response.data));
-        Notification.success({
-          title: "APP.ENTRIES.EDIT.NOTIFICATION.HEADER",
-          message: "APP.ENTRIES.EDIT.NOTIFICATION.MESSAGE." + response.data.i18n
-        });
-
-        $state.go("main.entries.details", { entry: entry.key.full });
-      },
-      function(response) {
-        Notification.error({
-          title: "APP.ENTRIES.EDIT.NOTIFICATION.HEADER",
-          message: "APP.ENTRIES.EDIT.NOTIFICATION.MESSAGE." + response.data.i18n
-        });
+    Logger.log(entry);
+    $scope.formats = formats.map(function(elem) {
+      var name = elem.plugin.name;
+      var space = name.indexOf(" ");
+      if (space > -1) {
+        name = name.substring(0, space);
       }
-    );
-  };
+      elem.plugin.nameWithoutConf = name;
+      return elem;
+    });
+    $scope.entry = {
+      title: entry.meta.title,
+      description: entry.meta.description,
+      tags: !!entry.meta.tags
+        ? entry.meta.tags.map(function(elem) {
+            return { text: elem };
+          })
+        : [],
+      configuration: {
+        format: $scope.formats.filter(function(elem) {
+          return elem.plugin.name === entry.value[0].plugin;
+        })[0],
+        formatconf: "",
+        value: entry.value[0].value
+      }
+    };
+    $scope.typeaheads = typeaheads;
 
-  this.abort = function() {
-    $state.go("main.entries.details", { entry: entry.key.full });
-  };
+    this.submit = function() {
+      Logger.info("Attempting to update entry.");
 
-  Logger.info("Edit entry controller ready");
-};
+      var tmp = {};
+      angular.copy($scope.entry, tmp);
+      tmp.tags = $scope.entry.tags.map(function(elem) {
+        return elem.text;
+      });
+      tmp.configuration.format = $scope.entry.configuration.format.plugin.name;
+
+      if (tmp.configuration.formatconf !== "") {
+        tmp.configuration.format += " " + tmp.configuration.formatconf;
+      }
+      delete tmp.configuration.formatconf;
+
+      EntryService.update(entry.key.full, tmp).then(
+        function(response) {
+          Logger.info("Update entry result: " + JSON.stringify(response.data));
+          Notification.success({
+            title: "APP.ENTRIES.EDIT.NOTIFICATION.HEADER",
+            message: "APP.ENTRIES.EDIT.NOTIFICATION.MESSAGE." + response.data.i18n
+          });
+
+          $state.go("main.entries.details", { entry: entry.key.full });
+        },
+        function(response) {
+          Notification.error({
+            title: "APP.ENTRIES.EDIT.NOTIFICATION.HEADER",
+            message: "APP.ENTRIES.EDIT.NOTIFICATION.MESSAGE." + response.data.i18n
+          });
+        }
+      );
+    };
+
+    this.abort = function() {
+      $state.go("main.entries.details", { entry: entry.key.full });
+    };
+
+    Logger.info("Edit entry controller ready");
+  }
+];

--- a/src/tools/website/resources/assets/js/controllers/main/entries/EntryEditController.js
+++ b/src/tools/website/resources/assets/js/controllers/main/entries/EntryEditController.js
@@ -71,7 +71,8 @@ module.exports = [
           Logger.info("Update entry result: " + JSON.stringify(response.data));
           Notification.success({
             title: "APP.ENTRIES.EDIT.NOTIFICATION.HEADER",
-            message: "APP.ENTRIES.EDIT.NOTIFICATION.MESSAGE." + response.data.i18n
+            message:
+              "APP.ENTRIES.EDIT.NOTIFICATION.MESSAGE." + response.data.i18n
           });
 
           $state.go("main.entries.details", { entry: entry.key.full });
@@ -79,7 +80,8 @@ module.exports = [
         function(response) {
           Notification.error({
             title: "APP.ENTRIES.EDIT.NOTIFICATION.HEADER",
-            message: "APP.ENTRIES.EDIT.NOTIFICATION.MESSAGE." + response.data.i18n
+            message:
+              "APP.ENTRIES.EDIT.NOTIFICATION.MESSAGE." + response.data.i18n
           });
         }
       );

--- a/src/tools/website/resources/assets/js/controllers/main/entries/EntrySearchController.js
+++ b/src/tools/website/resources/assets/js/controllers/main/entries/EntrySearchController.js
@@ -1,158 +1,171 @@
 "use strict";
 
-module.exports = function($rootScope, $scope, Logger, $state, EntryService) {
-  var vm = this;
+module.exports = [
+  "$rootScope",
+  "$scope",
+  "Logger",
+  "$state",
+  "EntryService",
+  function(
+    $rootScope,
+    $scope,
+    Logger,
+    $state,
+    EntryService
+  ) {
+    var vm = this;
 
-  $scope.is_loaded = false;
-  $scope.options = {
-    is_advanced: false,
-    filter: $rootScope.entriesSearchString,
-    filterby: {
-      options: [
-        { id: "all", name: "APP.ENTRIES.SEARCH.ADVANCED.FILTERBY.ALL" },
-        { id: "key", name: "APP.ENTRIES.SEARCH.ADVANCED.FILTERBY.KEY" },
-        { id: "title", name: "APP.ENTRIES.SEARCH.ADVANCED.FILTERBY.TITLE" },
-        {
-          id: "description",
-          name: "APP.ENTRIES.SEARCH.ADVANCED.FILTERBY.DESCRIPTION"
-        },
-        { id: "author", name: "APP.ENTRIES.SEARCH.ADVANCED.FILTERBY.AUTHOR" },
-        { id: "tags", name: "APP.ENTRIES.SEARCH.ADVANCED.FILTERBY.TAGS" }
-      ]
-    },
-    sort: {
-      options: [
-        { id: "asc", name: "APP.ENTRIES.SEARCH.ADVANCED.SORT.ASC" },
-        { id: "desc", name: "APP.ENTRIES.SEARCH.ADVANCED.SORT.DESC" }
-      ]
-    },
-    sortby: {
-      options: [
-        { id: "key", name: "APP.ENTRIES.SEARCH.ADVANCED.SORTBY.KEY" },
-        { id: "title", name: "APP.ENTRIES.SEARCH.ADVANCED.SORTBY.TITLE" },
-        {
-          id: "created_at",
-          name: "APP.ENTRIES.SEARCH.ADVANCED.SORTBY.CREATED_AT"
-        },
-        { id: "author", name: "APP.ENTRIES.SEARCH.ADVANCED.SORTBY.AUTHOR" },
-        {
-          id: "organization",
-          name: "APP.ENTRIES.SEARCH.ADVANCED.SORTBY.ORGANIZATION"
-        },
-        {
-          id: "application",
-          name: "APP.ENTRIES.SEARCH.ADVANCED.SORTBY.APPLICATION"
-        },
-        { id: "scope", name: "APP.ENTRIES.SEARCH.ADVANCED.SORTBY.SCOPE" },
-        { id: "slug", name: "APP.ENTRIES.SEARCH.ADVANCED.SORTBY.SLUG" }
-      ]
-    },
-    rows: { options: [10, 20, 50, 100, 200], value: 10 },
-    offset: 0
-  };
-
-  $scope.options.filterby.value = $scope.options.filterby.options[0];
-  $scope.options.sort.value = $scope.options.sort.options[0];
-  $scope.options.sortby.value = $scope.options.sortby.options[0];
-
-  $scope.pagination = { currentPage: null, pageCount: null, pages: [] };
-
-  $scope.searchResult = {};
-
-  $scope.$watch(
-    "options",
-    function() {
-      vm.loadEntries();
-    },
-    true
-  ); // true for object deep-watching
-
-  this.loadEntries = function() {
-    $scope.searchResult = {};
     $scope.is_loaded = false;
-    $scope.options.filter = $rootScope.entriesSearchString;
-    var params = {
-      filter: $scope.options.filter,
-      filterby: $scope.options.filterby.value.id,
-      sort: $scope.options.sort.value.id,
-      sortby: $scope.options.sortby.value.id,
-      offset: $scope.options.offset,
-      rows: $scope.options.rows.value
+    $scope.options = {
+      is_advanced: false,
+      filter: $rootScope.entriesSearchString,
+      filterby: {
+        options: [
+          { id: "all", name: "APP.ENTRIES.SEARCH.ADVANCED.FILTERBY.ALL" },
+          { id: "key", name: "APP.ENTRIES.SEARCH.ADVANCED.FILTERBY.KEY" },
+          { id: "title", name: "APP.ENTRIES.SEARCH.ADVANCED.FILTERBY.TITLE" },
+          {
+            id: "description",
+            name: "APP.ENTRIES.SEARCH.ADVANCED.FILTERBY.DESCRIPTION"
+          },
+          { id: "author", name: "APP.ENTRIES.SEARCH.ADVANCED.FILTERBY.AUTHOR" },
+          { id: "tags", name: "APP.ENTRIES.SEARCH.ADVANCED.FILTERBY.TAGS" }
+        ]
+      },
+      sort: {
+        options: [
+          { id: "asc", name: "APP.ENTRIES.SEARCH.ADVANCED.SORT.ASC" },
+          { id: "desc", name: "APP.ENTRIES.SEARCH.ADVANCED.SORT.DESC" }
+        ]
+      },
+      sortby: {
+        options: [
+          { id: "key", name: "APP.ENTRIES.SEARCH.ADVANCED.SORTBY.KEY" },
+          { id: "title", name: "APP.ENTRIES.SEARCH.ADVANCED.SORTBY.TITLE" },
+          {
+            id: "created_at",
+            name: "APP.ENTRIES.SEARCH.ADVANCED.SORTBY.CREATED_AT"
+          },
+          { id: "author", name: "APP.ENTRIES.SEARCH.ADVANCED.SORTBY.AUTHOR" },
+          {
+            id: "organization",
+            name: "APP.ENTRIES.SEARCH.ADVANCED.SORTBY.ORGANIZATION"
+          },
+          {
+            id: "application",
+            name: "APP.ENTRIES.SEARCH.ADVANCED.SORTBY.APPLICATION"
+          },
+          { id: "scope", name: "APP.ENTRIES.SEARCH.ADVANCED.SORTBY.SCOPE" },
+          { id: "slug", name: "APP.ENTRIES.SEARCH.ADVANCED.SORTBY.SLUG" }
+        ]
+      },
+      rows: { options: [10, 20, 50, 100, 200], value: 10 },
+      offset: 0
     };
-    EntryService.search(params).then(function(data) {
-      $scope.searchResult = data;
-      vm.calculatePagination();
-      $scope.is_loaded = true;
-    });
-  };
 
-  this.calculatePagination = function() {
-    Logger.info("Current offset: " + $scope.searchResult.offset);
-    var entries = $scope.searchResult.offset;
-    entries += $scope.searchResult.elements;
-    entries += $scope.searchResult.remaining;
-    Logger.info("Current entries: " + entries);
-    var numPages = Math.ceil(entries / $scope.options.rows.value);
-    $scope.pagination.pageCount = numPages;
-    Logger.info("Current page count: " + numPages);
+    $scope.options.filterby.value = $scope.options.filterby.options[0];
+    $scope.options.sort.value = $scope.options.sort.options[0];
+    $scope.options.sortby.value = $scope.options.sortby.options[0];
 
-    var curPage =
-      Math.floor($scope.searchResult.offset / $scope.options.rows.value) + 1;
-    $scope.pagination.currentPage = curPage;
-    Logger.info("Current page: " + curPage);
+    $scope.pagination = { currentPage: null, pageCount: null, pages: [] };
 
-    var pages = [];
-    for (var i = 2; i >= 1; i--) {
-      if (curPage - i > 0) pages.push(curPage - i);
-    }
-    pages.push(curPage);
-    for (var j = 1; j <= 2; j++) {
-      if (curPage + j <= numPages) pages.push(curPage + j);
-    }
-    $scope.pagination.pages = pages;
-    Logger.info("Pages: " + pages);
-  };
+    $scope.searchResult = {};
 
-  this.goToPage = function(index) {
-    Logger.info("Go to page: " + index);
-    if (index === $scope.pagination.currentPage) return;
-    if (index <= 0) return;
-    var entries = $scope.searchResult.offset;
-    entries += $scope.searchResult.elements;
-    entries += $scope.searchResult.remaining;
-    if (index > Math.ceil(entries / $scope.options.rows.value)) return;
+    $scope.$watch(
+      "options",
+      function() {
+        vm.loadEntries();
+      },
+      true
+    ); // true for object deep-watching
 
-    $scope.options.offset = (index - 1) * $scope.options.rows.value;
-  };
+    this.loadEntries = function() {
+      $scope.searchResult = {};
+      $scope.is_loaded = false;
+      $scope.options.filter = $rootScope.entriesSearchString;
+      var params = {
+        filter: $scope.options.filter,
+        filterby: $scope.options.filterby.value.id,
+        sort: $scope.options.sort.value.id,
+        sortby: $scope.options.sortby.value.id,
+        offset: $scope.options.offset,
+        rows: $scope.options.rows.value
+      };
+      EntryService.search(params).then(function(data) {
+        $scope.searchResult = data;
+        vm.calculatePagination();
+        $scope.is_loaded = true;
+      });
+    };
 
-  this.toggleAdvancedOptions = function() {
-    $scope.options.is_advanced = !$scope.options.is_advanced;
-  };
+    this.calculatePagination = function() {
+      Logger.info("Current offset: " + $scope.searchResult.offset);
+      var entries = $scope.searchResult.offset;
+      entries += $scope.searchResult.elements;
+      entries += $scope.searchResult.remaining;
+      Logger.info("Current entries: " + entries);
+      var numPages = Math.ceil(entries / $scope.options.rows.value);
+      $scope.pagination.pageCount = numPages;
+      Logger.info("Current page count: " + numPages);
 
-  this.toggleSorting = function(sortby) {
-    var currentSortby = $scope.options.sortby.value;
-    var currentSort = $scope.options.sort.value;
-    var newSortby = $scope.options.sortby.options.filter(function(elem) {
-      return elem.id === sortby;
-    })[0];
+      var curPage =
+        Math.floor($scope.searchResult.offset / $scope.options.rows.value) + 1;
+      $scope.pagination.currentPage = curPage;
+      Logger.info("Current page: " + curPage);
 
-    if (currentSortby.id === newSortby.id) {
-      // only toggle sort direction
-      $scope.options.sort.value = $scope.options.sort.options.filter(function(
-        elem
-      ) {
-        return elem.id !== currentSort.id; // filter the same one and take the next
+      var pages = [];
+      for (var i = 2; i >= 1; i--) {
+        if (curPage - i > 0) pages.push(curPage - i);
+      }
+      pages.push(curPage);
+      for (var j = 1; j <= 2; j++) {
+        if (curPage + j <= numPages) pages.push(curPage + j);
+      }
+      $scope.pagination.pages = pages;
+      Logger.info("Pages: " + pages);
+    };
+
+    this.goToPage = function(index) {
+      Logger.info("Go to page: " + index);
+      if (index === $scope.pagination.currentPage) return;
+      if (index <= 0) return;
+      var entries = $scope.searchResult.offset;
+      entries += $scope.searchResult.elements;
+      entries += $scope.searchResult.remaining;
+      if (index > Math.ceil(entries / $scope.options.rows.value)) return;
+
+      $scope.options.offset = (index - 1) * $scope.options.rows.value;
+    };
+
+    this.toggleAdvancedOptions = function() {
+      $scope.options.is_advanced = !$scope.options.is_advanced;
+    };
+
+    this.toggleSorting = function(sortby) {
+      var currentSortby = $scope.options.sortby.value;
+      var currentSort = $scope.options.sort.value;
+      var newSortby = $scope.options.sortby.options.filter(function(elem) {
+        return elem.id === sortby;
       })[0];
-    } else {
-      $scope.options.sortby.value = newSortby;
-      $scope.options.sort.value = $scope.options.sort.options[0];
-    }
-  };
 
-  this.goToEntry = function(entry) {
-    Logger.info("Clicked entry: " + JSON.stringify(entry));
-    $state.go("main.entries.details", { entry: entry });
-  };
+      if (currentSortby.id === newSortby.id) {
+        // only toggle sort direction
+        $scope.options.sort.value = $scope.options.sort.options.filter(function(
+          elem
+        ) {
+          return elem.id !== currentSort.id; // filter the same one and take the next
+        })[0];
+      } else {
+        $scope.options.sortby.value = newSortby;
+        $scope.options.sort.value = $scope.options.sort.options[0];
+      }
+    };
 
-  Logger.info("Search ready");
-};
+    this.goToEntry = function(entry) {
+      Logger.info("Clicked entry: " + JSON.stringify(entry));
+      $state.go("main.entries.details", { entry: entry });
+    };
+
+    Logger.info("Search ready");
+  }
+];

--- a/src/tools/website/resources/assets/js/controllers/main/entries/EntrySearchController.js
+++ b/src/tools/website/resources/assets/js/controllers/main/entries/EntrySearchController.js
@@ -6,13 +6,7 @@ module.exports = [
   "Logger",
   "$state",
   "EntryService",
-  function(
-    $rootScope,
-    $scope,
-    Logger,
-    $state,
-    EntryService
-  ) {
+  function($rootScope, $scope, Logger, $state, EntryService) {
     var vm = this;
 
     $scope.is_loaded = false;

--- a/src/tools/website/resources/assets/js/controllers/main/users/UserDetailsController.js
+++ b/src/tools/website/resources/assets/js/controllers/main/users/UserDetailsController.js
@@ -1,119 +1,129 @@
 "use strict";
 
-module.exports = function(
-  $scope,
-  $rootScope,
-  Logger,
-  $state,
-  Notification,
-  UserService,
-  $stateParams,
-  user
-) {
-  var vm = this;
+module.exports = [
+  "$scope",
+  "$rootScope",
+  "Logger",
+  "$state",
+  "Notification",
+  "UserService",
+  "$stateParams",
+  "user",
+  function(
+    $scope,
+    $rootScope,
+    Logger,
+    $state,
+    Notification,
+    UserService,
+    $stateParams,
+    user
+  ) {
+    var vm = this;
 
-  $scope.user = user;
+    $scope.user = user;
 
-  $scope.ranks = [
-    { id: 10, name: "APP.USERS.DETAILS.LABEL.RANK.10" },
-    { id: 50, name: "APP.USERS.DETAILS.LABEL.RANK.50" },
-    { id: 100, name: "APP.USERS.DETAILS.LABEL.RANK.100" }
-  ];
+    $scope.ranks = [
+      { id: 10, name: "APP.USERS.DETAILS.LABEL.RANK.10" },
+      { id: 50, name: "APP.USERS.DETAILS.LABEL.RANK.50" },
+      { id: 100, name: "APP.USERS.DETAILS.LABEL.RANK.100" }
+    ];
 
-  $scope.changes = {
-    password: { input1: "", input2: "" },
-    email: "",
-    rank: $scope.ranks.filter(function(elem) {
-      return elem.id === $scope.user.rank;
-    })[0]
-  };
+    $scope.changes = {
+      password: { input1: "", input2: "" },
+      email: "",
+      rank: $scope.ranks.filter(function(elem) {
+        return elem.id === $scope.user.rank;
+      })[0]
+    };
 
-  this.changePassword = function() {
-    Logger.info("Attempting to change password");
-    vm.executeChange(
-      { password: $scope.changes.password.input1 },
-      $scope.passwordForm,
-      function() {
-        $scope.changes.password.input1 = "";
-        $scope.changes.password.input2 = "";
-      }
-    );
-  };
-
-  this.changeEmail = function() {
-    Logger.info("Attempting to change email");
-    vm.executeChange(
-      { email: $scope.changes.email },
-      $scope.emailForm,
-      function() {
-        $scope.user.email = $scope.changes.email;
-        $scope.changes.email = "";
-      }
-    );
-  };
-
-  this.changeRank = function() {
-    Logger.info("Attempting to change rank");
-    vm.executeChange(
-      { rank: $scope.changes.rank.id },
-      $scope.rankForm,
-      function() {
-        $scope.user.rank = $scope.changes.rank.id;
-      }
-    );
-  };
-
-  this.executeChange = function(data, form, callback) {
-    UserService.update(
-      $scope.user.username,
-      data,
-      $stateParams.useAuthUser
-    ).then(
-      function(response) {
-        callback();
-        Notification.success({
-          title: "APP.USERS.DETAILS.NOTIFICATION.HEADER",
-          message:
-            "APP.USERS.DETAILS.NOTIFICATION.MESSAGE." + response.data.i18n
-        });
-      },
-      function(response) {
-        Notification.error({
-          title: "APP.USERS.DETAILS.NOTIFICATION.HEADER",
-          message:
-            "APP.USERS.DETAILS.NOTIFICATION.MESSAGE." + response.data.i18n
-        });
-      }
-    );
-
-    // set form as pristine so a change has to be made for further requests
-    form.$setPristine();
-  };
-
-  this.deleteAccount = function() {
-    UserService.delete($scope.user.username).then(
-      function(response) {
-        Notification.success({
-          title: "APP.USERS.DETAILS.NOTIFICATION.HEADER",
-          message:
-            "APP.USERS.DETAILS.NOTIFICATION.MESSAGE." + response.data.i18n
-        });
-        if ($scope.user.username === $rootScope.currentUser.username) {
-          $state.go("main.auth.logout");
-        } else {
-          $state.go("main.users.search");
+    this.changePassword = function() {
+      Logger.info("Attempting to change password");
+      vm.executeChange(
+        { password: $scope.changes.password.input1 },
+        $scope.passwordForm,
+        function() {
+          $scope.changes.password.input1 = "";
+          $scope.changes.password.input2 = "";
         }
-      },
-      function(response) {
-        Notification.success({
-          title: "APP.USERS.DETAILS.NOTIFICATION.HEADER",
-          message:
-            "APP.USERS.DETAILS.NOTIFICATION.MESSAGE." + response.data.i18n
-        });
-      }
-    );
-  };
+      );
+    };
 
-  Logger.info("Showing user infos for: " + user);
-  Logger.info("User details controller ready");
-};
+    this.changeEmail = function() {
+      Logger.info("Attempting to change email");
+      vm.executeChange(
+        { email: $scope.changes.email },
+        $scope.emailForm,
+        function() {
+          $scope.user.email = $scope.changes.email;
+          $scope.changes.email = "";
+        }
+      );
+    };
+
+    this.changeRank = function() {
+      Logger.info("Attempting to change rank");
+      vm.executeChange(
+        { rank: $scope.changes.rank.id },
+        $scope.rankForm,
+        function() {
+          $scope.user.rank = $scope.changes.rank.id;
+        }
+      );
+    };
+
+    this.executeChange = function(data, form, callback) {
+      UserService.update(
+        $scope.user.username,
+        data,
+        $stateParams.useAuthUser
+      ).then(
+        function(response) {
+          callback();
+          Notification.success({
+            title: "APP.USERS.DETAILS.NOTIFICATION.HEADER",
+            message:
+              "APP.USERS.DETAILS.NOTIFICATION.MESSAGE." + response.data.i18n
+          });
+        },
+        function(response) {
+          Notification.error({
+            title: "APP.USERS.DETAILS.NOTIFICATION.HEADER",
+            message:
+              "APP.USERS.DETAILS.NOTIFICATION.MESSAGE." + response.data.i18n
+          });
+        }
+      );
+
+      // set form as pristine so a change has to be made for further requests
+      form.$setPristine();
+    };
+
+    this.deleteAccount = function() {
+      UserService.delete($scope.user.username).then(
+        function(response) {
+          Notification.success({
+            title: "APP.USERS.DETAILS.NOTIFICATION.HEADER",
+            message:
+              "APP.USERS.DETAILS.NOTIFICATION.MESSAGE." + response.data.i18n
+          });
+          if ($scope.user.username === $rootScope.currentUser.username) {
+            $state.go("main.auth.logout");
+          } else {
+            $state.go("main.users.search");
+          }
+        },
+        function(response) {
+          Notification.success({
+            title: "APP.USERS.DETAILS.NOTIFICATION.HEADER",
+            message:
+              "APP.USERS.DETAILS.NOTIFICATION.MESSAGE." + response.data.i18n
+          });
+        }
+      );
+    };
+
+    Logger.info("Showing user infos for: " + user);
+    Logger.info("User details controller ready");
+  }
+];

--- a/src/tools/website/resources/assets/js/controllers/main/users/UserSearchController.js
+++ b/src/tools/website/resources/assets/js/controllers/main/users/UserSearchController.js
@@ -1,18 +1,12 @@
 "use strict";
 
 module.exports = [
-  "$rootScope", 
-  "$scope", 
-  "Logger", 
-  "$state", 
+  "$rootScope",
+  "$scope",
+  "Logger",
+  "$state",
   "UserService",
-  function(
-    $rootScope, 
-    $scope, 
-    Logger, 
-    $state, 
-    UserService
-  ) {
+  function($rootScope, $scope, Logger, $state, UserService) {
     var vm = this;
 
     $scope.is_loaded = false;
@@ -22,7 +16,10 @@ module.exports = [
       filterby: {
         options: [
           { id: "all", name: "APP.USERS.SEARCH.ADVANCED.FILTERBY.ALL" },
-          { id: "username", name: "APP.USERS.SEARCH.ADVANCED.FILTERBY.USERNAME" },
+          {
+            id: "username",
+            name: "APP.USERS.SEARCH.ADVANCED.FILTERBY.USERNAME"
+          },
           { id: "email", name: "APP.USERS.SEARCH.ADVANCED.FILTERBY.EMAIL" }
         ]
       },

--- a/src/tools/website/resources/assets/js/controllers/main/users/UserSearchController.js
+++ b/src/tools/website/resources/assets/js/controllers/main/users/UserSearchController.js
@@ -1,143 +1,156 @@
 "use strict";
 
-module.exports = function($rootScope, $scope, Logger, $state, UserService) {
-  var vm = this;
+module.exports = [
+  "$rootScope", 
+  "$scope", 
+  "Logger", 
+  "$state", 
+  "UserService",
+  function(
+    $rootScope, 
+    $scope, 
+    Logger, 
+    $state, 
+    UserService
+  ) {
+    var vm = this;
 
-  $scope.is_loaded = false;
-  $scope.options = {
-    is_advanced: false,
-    filter: $rootScope.usersSearchString,
-    filterby: {
-      options: [
-        { id: "all", name: "APP.USERS.SEARCH.ADVANCED.FILTERBY.ALL" },
-        { id: "username", name: "APP.USERS.SEARCH.ADVANCED.FILTERBY.USERNAME" },
-        { id: "email", name: "APP.USERS.SEARCH.ADVANCED.FILTERBY.EMAIL" }
-      ]
-    },
-    sort: {
-      options: [
-        { id: "asc", name: "APP.USERS.SEARCH.ADVANCED.SORT.ASC" },
-        { id: "desc", name: "APP.USERS.SEARCH.ADVANCED.SORT.DESC" }
-      ]
-    },
-    sortby: {
-      options: [
-        { id: "username", name: "APP.USERS.SEARCH.ADVANCED.SORTBY.USERNAME" },
-        { id: "email", name: "APP.USERS.SEARCH.ADVANCED.SORTBY.EMAIL" },
-        { id: "rank", name: "APP.USERS.SEARCH.ADVANCED.SORTBY.RANK" },
-        {
-          id: "created_at",
-          name: "APP.USERS.SEARCH.ADVANCED.SORTBY.CREATED_AT"
-        }
-      ]
-    },
-    rows: { options: [10, 20, 50, 100, 200], value: 10 },
-    offset: 0
-  };
-
-  $scope.options.filterby.value = $scope.options.filterby.options[0];
-  $scope.options.sort.value = $scope.options.sort.options[0];
-  $scope.options.sortby.value = $scope.options.sortby.options[0];
-
-  $scope.pagination = { currentPage: null, pageCount: null, pages: [] };
-
-  $scope.searchResult = {};
-
-  $scope.$watch(
-    "options",
-    function() {
-      vm.loadEntries();
-    },
-    true
-  ); // true for object deep-watching
-
-  this.loadEntries = function() {
-    $scope.searchResult = {};
     $scope.is_loaded = false;
-    $scope.options.filter = $rootScope.usersSearchString;
-    var params = {
-      filter: $scope.options.filter,
-      filterby: $scope.options.filterby.value.id,
-      sort: $scope.options.sort.value.id,
-      sortby: $scope.options.sortby.value.id,
-      offset: $scope.options.offset,
-      rows: $scope.options.rows.value
+    $scope.options = {
+      is_advanced: false,
+      filter: $rootScope.usersSearchString,
+      filterby: {
+        options: [
+          { id: "all", name: "APP.USERS.SEARCH.ADVANCED.FILTERBY.ALL" },
+          { id: "username", name: "APP.USERS.SEARCH.ADVANCED.FILTERBY.USERNAME" },
+          { id: "email", name: "APP.USERS.SEARCH.ADVANCED.FILTERBY.EMAIL" }
+        ]
+      },
+      sort: {
+        options: [
+          { id: "asc", name: "APP.USERS.SEARCH.ADVANCED.SORT.ASC" },
+          { id: "desc", name: "APP.USERS.SEARCH.ADVANCED.SORT.DESC" }
+        ]
+      },
+      sortby: {
+        options: [
+          { id: "username", name: "APP.USERS.SEARCH.ADVANCED.SORTBY.USERNAME" },
+          { id: "email", name: "APP.USERS.SEARCH.ADVANCED.SORTBY.EMAIL" },
+          { id: "rank", name: "APP.USERS.SEARCH.ADVANCED.SORTBY.RANK" },
+          {
+            id: "created_at",
+            name: "APP.USERS.SEARCH.ADVANCED.SORTBY.CREATED_AT"
+          }
+        ]
+      },
+      rows: { options: [10, 20, 50, 100, 200], value: 10 },
+      offset: 0
     };
-    UserService.search(params).then(function(data) {
-      $scope.searchResult = data;
-      vm.calculatePagination();
-      $scope.is_loaded = true;
-    });
-  };
 
-  this.calculatePagination = function() {
-    Logger.info("Current offset: " + $scope.searchResult.offset);
-    var entries = $scope.searchResult.offset;
-    entries += $scope.searchResult.elements;
-    entries += $scope.searchResult.remaining;
-    Logger.info("Current entries: " + entries);
-    var numPages = Math.ceil(entries / $scope.options.rows.value);
-    $scope.pagination.pageCount = numPages;
-    Logger.info("Current page count: " + numPages);
+    $scope.options.filterby.value = $scope.options.filterby.options[0];
+    $scope.options.sort.value = $scope.options.sort.options[0];
+    $scope.options.sortby.value = $scope.options.sortby.options[0];
 
-    var curPage =
-      Math.floor($scope.searchResult.offset / $scope.options.rows.value) + 1;
-    $scope.pagination.currentPage = curPage;
-    Logger.info("Current page: " + curPage);
+    $scope.pagination = { currentPage: null, pageCount: null, pages: [] };
 
-    var pages = [];
-    for (var i = 2; i >= 1; i--) {
-      if (curPage - i > 0) pages.push(curPage - i);
-    }
-    pages.push(curPage);
-    for (var j = 1; j <= 2; j++) {
-      if (curPage + j <= numPages) pages.push(curPage + j);
-    }
-    $scope.pagination.pages = pages;
-    Logger.info("Pages: " + pages);
-  };
+    $scope.searchResult = {};
 
-  this.goToPage = function(index) {
-    Logger.info("Go to page: " + index);
-    if (index === $scope.pagination.currentPage) return;
-    if (index <= 0) return;
-    var entries = $scope.searchResult.offset;
-    entries += $scope.searchResult.elements;
-    entries += $scope.searchResult.remaining;
-    if (index > Math.ceil(entries / $scope.options.rows.value)) return;
+    $scope.$watch(
+      "options",
+      function() {
+        vm.loadEntries();
+      },
+      true
+    ); // true for object deep-watching
 
-    $scope.options.offset = (index - 1) * $scope.options.rows.value;
-  };
+    this.loadEntries = function() {
+      $scope.searchResult = {};
+      $scope.is_loaded = false;
+      $scope.options.filter = $rootScope.usersSearchString;
+      var params = {
+        filter: $scope.options.filter,
+        filterby: $scope.options.filterby.value.id,
+        sort: $scope.options.sort.value.id,
+        sortby: $scope.options.sortby.value.id,
+        offset: $scope.options.offset,
+        rows: $scope.options.rows.value
+      };
+      UserService.search(params).then(function(data) {
+        $scope.searchResult = data;
+        vm.calculatePagination();
+        $scope.is_loaded = true;
+      });
+    };
 
-  this.toggleAdvancedOptions = function() {
-    $scope.options.is_advanced = !$scope.options.is_advanced;
-  };
+    this.calculatePagination = function() {
+      Logger.info("Current offset: " + $scope.searchResult.offset);
+      var entries = $scope.searchResult.offset;
+      entries += $scope.searchResult.elements;
+      entries += $scope.searchResult.remaining;
+      Logger.info("Current entries: " + entries);
+      var numPages = Math.ceil(entries / $scope.options.rows.value);
+      $scope.pagination.pageCount = numPages;
+      Logger.info("Current page count: " + numPages);
 
-  this.toggleSorting = function(sortby) {
-    var currentSortby = $scope.options.sortby.value;
-    var currentSort = $scope.options.sort.value;
-    var newSortby = $scope.options.sortby.options.filter(function(elem) {
-      return elem.id === sortby;
-    })[0];
+      var curPage =
+        Math.floor($scope.searchResult.offset / $scope.options.rows.value) + 1;
+      $scope.pagination.currentPage = curPage;
+      Logger.info("Current page: " + curPage);
 
-    if (currentSortby.id === newSortby.id) {
-      // only toggle sort direction
-      $scope.options.sort.value = $scope.options.sort.options.filter(function(
-        elem
-      ) {
-        return elem.id !== currentSort.id; // filter the same one and take the next
+      var pages = [];
+      for (var i = 2; i >= 1; i--) {
+        if (curPage - i > 0) pages.push(curPage - i);
+      }
+      pages.push(curPage);
+      for (var j = 1; j <= 2; j++) {
+        if (curPage + j <= numPages) pages.push(curPage + j);
+      }
+      $scope.pagination.pages = pages;
+      Logger.info("Pages: " + pages);
+    };
+
+    this.goToPage = function(index) {
+      Logger.info("Go to page: " + index);
+      if (index === $scope.pagination.currentPage) return;
+      if (index <= 0) return;
+      var entries = $scope.searchResult.offset;
+      entries += $scope.searchResult.elements;
+      entries += $scope.searchResult.remaining;
+      if (index > Math.ceil(entries / $scope.options.rows.value)) return;
+
+      $scope.options.offset = (index - 1) * $scope.options.rows.value;
+    };
+
+    this.toggleAdvancedOptions = function() {
+      $scope.options.is_advanced = !$scope.options.is_advanced;
+    };
+
+    this.toggleSorting = function(sortby) {
+      var currentSortby = $scope.options.sortby.value;
+      var currentSort = $scope.options.sort.value;
+      var newSortby = $scope.options.sortby.options.filter(function(elem) {
+        return elem.id === sortby;
       })[0];
-    } else {
-      $scope.options.sortby.value = newSortby;
-      $scope.options.sort.value = $scope.options.sort.options[0];
-    }
-  };
 
-  this.goToUser = function(username) {
-    Logger.info("Clicked user: " + JSON.stringify(username));
-    $state.go("main.users.details", { username: username });
-  };
+      if (currentSortby.id === newSortby.id) {
+        // only toggle sort direction
+        $scope.options.sort.value = $scope.options.sort.options.filter(function(
+          elem
+        ) {
+          return elem.id !== currentSort.id; // filter the same one and take the next
+        })[0];
+      } else {
+        $scope.options.sortby.value = newSortby;
+        $scope.options.sort.value = $scope.options.sort.options[0];
+      }
+    };
 
-  // Do initial actions
-  Logger.info("User search ready");
-};
+    this.goToUser = function(username) {
+      Logger.info("Clicked user: " + JSON.stringify(username));
+      $state.go("main.users.details", { username: username });
+    };
+
+    // Do initial actions
+    Logger.info("User search ready");
+  }
+];

--- a/src/tools/website/resources/assets/js/controllers/main/website/WebsiteConversionController.js
+++ b/src/tools/website/resources/assets/js/controllers/main/website/WebsiteConversionController.js
@@ -67,14 +67,16 @@ module.exports = [
           $scope.parameters.output.validated = response.data.output.validated;
           Notification.success({
             title: "APP.CONVERSION.NOTIFICATION.HEADER",
-            message: "APP.CONVERSION.NOTIFICATION.MESSAGE." + response.data.i18n,
+            message:
+              "APP.CONVERSION.NOTIFICATION.MESSAGE." + response.data.i18n,
             delay: 10000
           });
         },
         function(response) {
           Notification.error({
             title: "APP.CONVERSION.NOTIFICATION.HEADER",
-            message: "APP.CONVERSION.NOTIFICATION.MESSAGE." + response.data.i18n,
+            message:
+              "APP.CONVERSION.NOTIFICATION.MESSAGE." + response.data.i18n,
             delay: 10000
           });
           $scope.lastError = response.data.i18n;

--- a/src/tools/website/resources/assets/js/controllers/main/website/WebsiteConversionController.js
+++ b/src/tools/website/resources/assets/js/controllers/main/website/WebsiteConversionController.js
@@ -2,145 +2,153 @@
 
 var angular = require("angular");
 
-module.exports = function(
-  $scope,
-  Logger,
-  formats,
-  ConversionService,
-  ReportService,
-  Notification
-) {
-  var vm = this;
+module.exports = [
+  "$scope",
+  "Logger",
+  "formats",
+  "ConversionService",
+  "ReportService",
+  "Notification",
+  function(
+    $scope,
+    Logger,
+    formats,
+    ConversionService,
+    ReportService,
+    Notification
+  ) {
+    var vm = this;
 
-  $scope.parameters = {
-    input: { format: {}, formatconf: "", snippet: "" },
-    output: { format: {}, formatconf: "", snippet: "", validated: false }
-  };
-  $scope.formats = formats.map(function(elem) {
-    var name = elem.plugin.name;
-    var space = name.indexOf(" ");
-    if (space > -1) {
-      name = name.substring(0, space);
-    }
-    elem.plugin.nameWithoutConf = name;
-    return elem;
-  });
-  $scope.formatsInput = formats.filter(function(elem) {
-    return elem.plugin.statuses.indexOf("writeonly") !== -1 ? false : true;
-  });
-  $scope.formatsOutput = formats.filter(function(elem) {
-    return elem.plugin.statuses.indexOf("readonly") !== -1 ? false : true;
-  });
-  $scope.lastError = "";
-
-  this.doConversion = function() {
-    // clear output field first
-    $scope.parameters.output.snippet = "";
-
-    var request = {};
-    angular.copy($scope.parameters, request);
-
-    request.input.format = $scope.parameters.input.format.plugin.name;
-    if ($scope.parameters.input.formatconf !== "") {
-      request.input.format += " " + $scope.parameters.input.formatconf;
-    }
-    request.output.format = $scope.parameters.output.format.plugin.name;
-    if ($scope.parameters.output.formatconf !== "") {
-      request.output.format += " " + $scope.parameters.output.formatconf;
-    }
-
-    delete request.input.formatconf;
-    delete request.output.formatconf;
-    delete request.output.snippet;
-    delete request.output.validated;
-
-    ConversionService.convert(request).then(
-      function(response) {
-        $scope.parameters.output.snippet = response.data.output.snippet;
-        $scope.parameters.output.validated = response.data.output.validated;
-        Notification.success({
-          title: "APP.CONVERSION.NOTIFICATION.HEADER",
-          message: "APP.CONVERSION.NOTIFICATION.MESSAGE." + response.data.i18n,
-          delay: 10000
-        });
-      },
-      function(response) {
-        Notification.error({
-          title: "APP.CONVERSION.NOTIFICATION.HEADER",
-          message: "APP.CONVERSION.NOTIFICATION.MESSAGE." + response.data.i18n,
-          delay: 10000
-        });
-        $scope.lastError = response.data.i18n;
+    $scope.parameters = {
+      input: { format: {}, formatconf: "", snippet: "" },
+      output: { format: {}, formatconf: "", snippet: "", validated: false }
+    };
+    $scope.formats = formats.map(function(elem) {
+      var name = elem.plugin.name;
+      var space = name.indexOf(" ");
+      if (space > -1) {
+        name = name.substring(0, space);
       }
-    );
+      elem.plugin.nameWithoutConf = name;
+      return elem;
+    });
+    $scope.formatsInput = formats.filter(function(elem) {
+      return elem.plugin.statuses.indexOf("writeonly") !== -1 ? false : true;
+    });
+    $scope.formatsOutput = formats.filter(function(elem) {
+      return elem.plugin.statuses.indexOf("readonly") !== -1 ? false : true;
+    });
+    $scope.lastError = "";
 
-    // set form as pristine so a change has to be made for further requests
-    $scope.convertForm.$setPristine();
-  };
+    this.doConversion = function() {
+      // clear output field first
+      $scope.parameters.output.snippet = "";
 
-  this.clearFields = function(pristine) {
-    pristine = typeof pristine === "undefined" ? false : pristine;
+      var request = {};
+      angular.copy($scope.parameters, request);
 
-    $scope.parameters.input.format = $scope.formatsInput[0];
-    $scope.parameters.output.format = $scope.formatsOutput[0];
-    $scope.parameters.input.snippet = "";
-    $scope.parameters.output.snippet = "";
-    $scope.parameters.output.validated = false;
+      request.input.format = $scope.parameters.input.format.plugin.name;
+      if ($scope.parameters.input.formatconf !== "") {
+        request.input.format += " " + $scope.parameters.input.formatconf;
+      }
+      request.output.format = $scope.parameters.output.format.plugin.name;
+      if ($scope.parameters.output.formatconf !== "") {
+        request.output.format += " " + $scope.parameters.output.formatconf;
+      }
 
-    if (pristine === true) {
+      delete request.input.formatconf;
+      delete request.output.formatconf;
+      delete request.output.snippet;
+      delete request.output.validated;
+
+      ConversionService.convert(request).then(
+        function(response) {
+          $scope.parameters.output.snippet = response.data.output.snippet;
+          $scope.parameters.output.validated = response.data.output.validated;
+          Notification.success({
+            title: "APP.CONVERSION.NOTIFICATION.HEADER",
+            message: "APP.CONVERSION.NOTIFICATION.MESSAGE." + response.data.i18n,
+            delay: 10000
+          });
+        },
+        function(response) {
+          Notification.error({
+            title: "APP.CONVERSION.NOTIFICATION.HEADER",
+            message: "APP.CONVERSION.NOTIFICATION.MESSAGE." + response.data.i18n,
+            delay: 10000
+          });
+          $scope.lastError = response.data.i18n;
+        }
+      );
+
+      // set form as pristine so a change has to be made for further requests
       $scope.convertForm.$setPristine();
-    }
-  };
+    };
 
-  this.createGithubIssue = function() {
-    var title =
-      "Convert with plugin " +
-      $scope.parameters.input.format.plugin.name +
-      " to " +
-      $scope.parameters.output.format.plugin.name;
-    var message =
-      "I tried to convert a snippet on the website, but got the error: " +
-      $scope.lastError +
-      "\n\n" +
-      "## Used plugins\n" +
-      "```\n" +
-      "Input:\n" +
-      "- Plugin: " +
-      $scope.parameters.input.format.plugin.name +
-      "\n" +
-      "- Format: " +
-      $scope.parameters.input.format.format +
-      "\n" +
-      "- Additional config: " +
-      $scope.parameters.input.formatconf +
-      "\n" +
-      "Output:\n" +
-      "- Plugin: " +
-      $scope.parameters.output.format.plugin.name +
-      "\n" +
-      "- Format: " +
-      $scope.parameters.output.format.format +
-      "\n" +
-      "- Additional config: " +
-      $scope.parameters.output.formatconf +
-      "\n" +
-      "```\n\n" +
-      "## Input configuration\n" +
-      "```\n" +
-      $scope.parameters.input.snippet +
-      "\n" +
-      "```\n\n" +
-      "## Last output configuration\n" +
-      "```\n" +
-      $scope.parameters.output.snippet +
-      "\n" +
-      "```\n\n" +
-      "## Additional information\n";
-    var labels = ["website"];
+    this.clearFields = function(pristine) {
+      pristine = typeof pristine === "undefined" ? false : pristine;
 
-    ReportService.reportIssue(title, message, labels);
-  };
+      $scope.parameters.input.format = $scope.formatsInput[0];
+      $scope.parameters.output.format = $scope.formatsOutput[0];
+      $scope.parameters.input.snippet = "";
+      $scope.parameters.output.snippet = "";
+      $scope.parameters.output.validated = false;
 
-  this.clearFields();
-  Logger.info("Conversion controller ready");
-};
+      if (pristine === true) {
+        $scope.convertForm.$setPristine();
+      }
+    };
+
+    this.createGithubIssue = function() {
+      var title =
+        "Convert with plugin " +
+        $scope.parameters.input.format.plugin.name +
+        " to " +
+        $scope.parameters.output.format.plugin.name;
+      var message =
+        "I tried to convert a snippet on the website, but got the error: " +
+        $scope.lastError +
+        "\n\n" +
+        "## Used plugins\n" +
+        "```\n" +
+        "Input:\n" +
+        "- Plugin: " +
+        $scope.parameters.input.format.plugin.name +
+        "\n" +
+        "- Format: " +
+        $scope.parameters.input.format.format +
+        "\n" +
+        "- Additional config: " +
+        $scope.parameters.input.formatconf +
+        "\n" +
+        "Output:\n" +
+        "- Plugin: " +
+        $scope.parameters.output.format.plugin.name +
+        "\n" +
+        "- Format: " +
+        $scope.parameters.output.format.format +
+        "\n" +
+        "- Additional config: " +
+        $scope.parameters.output.formatconf +
+        "\n" +
+        "```\n\n" +
+        "## Input configuration\n" +
+        "```\n" +
+        $scope.parameters.input.snippet +
+        "\n" +
+        "```\n\n" +
+        "## Last output configuration\n" +
+        "```\n" +
+        $scope.parameters.output.snippet +
+        "\n" +
+        "```\n\n" +
+        "## Additional information\n";
+      var labels = ["website"];
+
+      ReportService.reportIssue(title, message, labels);
+    };
+
+    this.clearFields();
+    Logger.info("Conversion controller ready");
+  }
+];

--- a/src/tools/website/resources/assets/js/controllers/main/website/WebsiteHomeController.js
+++ b/src/tools/website/resources/assets/js/controllers/main/website/WebsiteHomeController.js
@@ -4,11 +4,7 @@ module.exports = [
   "$scope",
   "Logger",
   "news",
-  function(
-    $scope, 
-    Logger, 
-    news
-  ) {
+  function($scope, Logger, news) {
     var vm = this;
 
     news = news.filter(function(elem) {

--- a/src/tools/website/resources/assets/js/controllers/main/website/WebsiteHomeController.js
+++ b/src/tools/website/resources/assets/js/controllers/main/website/WebsiteHomeController.js
@@ -1,31 +1,40 @@
 "use strict";
 
-module.exports = function($scope, Logger, $interval, config, news) {
-  var vm = this;
+module.exports = [
+  "$scope",
+  "Logger",
+  "news",
+  function(
+    $scope, 
+    Logger, 
+    news
+  ) {
+    var vm = this;
 
-  news = news.filter(function(elem) {
-    return elem.type === "file";
-  });
-  if (news.length > 5) {
-    $scope.news = news.slice(0, 5);
-  } else {
-    $scope.news = news;
+    news = news.filter(function(elem) {
+      return elem.type === "file";
+    });
+    if (news.length > 5) {
+      $scope.news = news.slice(0, 5);
+    } else {
+      $scope.news = news;
+    }
+
+    $scope.slogan = {
+      adjectives: [
+        "fast",
+        "specified",
+        "globally",
+        "shareable",
+        "now",
+        "validated",
+        "simply",
+        "correctly",
+        "easily",
+        "finally"
+      ]
+    };
+
+    Logger.info("Home controller ready");
   }
-
-  $scope.slogan = {
-    adjectives: [
-      "fast",
-      "specified",
-      "globally",
-      "shareable",
-      "now",
-      "validated",
-      "simply",
-      "correctly",
-      "easily",
-      "finally"
-    ]
-  };
-
-  Logger.info("Home controller ready");
-};
+];

--- a/src/tools/website/resources/assets/js/controllers/main/website/WebsiteListfilesController.js
+++ b/src/tools/website/resources/assets/js/controllers/main/website/WebsiteListfilesController.js
@@ -2,28 +2,38 @@
 
 var angular = require("angular");
 
-module.exports = function(
-  $scope,
-  Logger,
-  $state,
-  $compile,
-  config,
-  marked,
-  files,
-  currentFile
-) {
-  var vm = this;
+module.exports = [
+  "$scope",
+  "Logger",
+  "$state",
+  "$compile",
+  "config",
+  "marked",
+  "files",
+  "currentFile",
+  function(
+    $scope,
+    Logger,
+    $state,
+    $compile,
+    config,
+    marked,
+    files,
+    currentFile
+  ) {
+    var vm = this;
 
-  $scope.$state = $state;
-  $scope.githubRoot =
-    config.github.website.root + config.github.website.paths.doc_root;
+    $scope.$state = $state;
+    $scope.githubRoot =
+      config.github.website.root + config.github.website.paths.doc_root;
 
-  $scope.files = files;
-  $scope.currentFile = currentFile;
+    $scope.files = files;
+    $scope.currentFile = currentFile;
 
-  var doc = marked($scope.currentFile.content);
-  doc = $compile(doc)($scope);
-  angular.element(document.getElementById("markdown-document")).html(doc);
+    var doc = marked($scope.currentFile.content);
+    doc = $compile(doc)($scope);
+    angular.element(document.getElementById("markdown-document")).html(doc);
 
-  Logger.info("Website listfiles controller ready");
-};
+    Logger.info("Website listfiles controller ready");
+  }
+];

--- a/src/tools/website/resources/assets/js/directives/html/EqualInputDirective.js
+++ b/src/tools/website/resources/assets/js/directives/html/EqualInputDirective.js
@@ -1,30 +1,33 @@
 "use strict";
 
-module.exports = function($parse) {
-  return {
-    restrict: "A",
-    require: "?ngModel",
-    link: function($scope, elem, attrs, ngModel) {
-      if (!ngModel) return; // do nothing if no ng-model
+module.exports = [
+  "$parse",
+  function($parse) {
+    return {
+      restrict: "A",
+      require: "?ngModel",
+      link: function($scope, elem, attrs, ngModel) {
+        if (!ngModel) return; // do nothing if no ng-model
 
-      // watch own value and re-validate on change
-      $scope.$watch(attrs.ngModel, function() {
-        validate();
-      });
+        // watch own value and re-validate on change
+        $scope.$watch(attrs.ngModel, function() {
+          validate();
+        });
 
-      // observe the other value and re-validate on change
-      $scope.$watch(attrs.equalInput, function() {
-        validate();
-      });
+        // observe the other value and re-validate on change
+        $scope.$watch(attrs.equalInput, function() {
+          validate();
+        });
 
-      var validate = function() {
-        // values
-        var val1 = ngModel.$viewValue;
-        var val2 = $parse(attrs.equalInput)($scope);
+        var validate = function() {
+          // values
+          var val1 = ngModel.$viewValue;
+          var val2 = $parse(attrs.equalInput)($scope);
 
-        // set validity
-        ngModel.$setValidity("equalInput", val1 === val2);
-      };
-    }
-  };
-};
+          // set validity
+          ngModel.$setValidity("equalInput", val1 === val2);
+        };
+      }
+    };
+  }
+];

--- a/src/tools/website/resources/assets/js/directives/html/OnKeyEnterDirective.js
+++ b/src/tools/website/resources/assets/js/directives/html/OnKeyEnterDirective.js
@@ -1,15 +1,17 @@
 "use strict";
 
-module.exports = function() {
-  return function($scope, element, attrs) {
-    element.bind("keydown keypress", function(event) {
-      if (event.which === 13) {
-        $scope.$apply(function() {
-          $scope.$eval(attrs.onKeyEnter);
-        });
+module.exports = [
+  function() {
+    return function($scope, element, attrs) {
+      element.bind("keydown keypress", function(event) {
+        if (event.which === 13) {
+          $scope.$apply(function() {
+            $scope.$eval(attrs.onKeyEnter);
+          });
 
-        event.preventDefault();
-      }
-    });
-  };
-};
+          event.preventDefault();
+        }
+      });
+    };
+  }
+];

--- a/src/tools/website/resources/assets/js/directives/permission/HasRankDirective.js
+++ b/src/tools/website/resources/assets/js/directives/permission/HasRankDirective.js
@@ -1,21 +1,25 @@
 "use strict";
 
-module.exports = function(Logger, $rootScope) {
-  return {
-    restrict: "A",
-    scope: { hasRank: "=" },
-    link: function($scope, elem, attrs) {
-      $rootScope.$watch("currentUser", function() {
-        Logger.info("Checking for rank: " + $scope.hasRank);
-        if (
-          $rootScope.currentUser &&
-          $rootScope.currentUser.rank >= $scope.hasRank
-        ) {
-          elem.show();
-        } else {
-          elem.hide();
-        }
-      });
-    }
-  };
-};
+module.exports = [
+  "Logger",
+  "$rootScope",
+  function(Logger, $rootScope) {
+    return {
+      restrict: "A",
+      scope: { hasRank: "=" },
+      link: function($scope, elem, attrs) {
+        $rootScope.$watch("currentUser", function() {
+          Logger.info("Checking for rank: " + $scope.hasRank);
+          if (
+            $rootScope.currentUser &&
+            $rootScope.currentUser.rank >= $scope.hasRank
+          ) {
+            elem.show();
+          } else {
+            elem.hide();
+          }
+        });
+      }
+    };
+  }
+];

--- a/src/tools/website/resources/assets/js/directives/permission/HasRankOrIsOwnerDirective.js
+++ b/src/tools/website/resources/assets/js/directives/permission/HasRankOrIsOwnerDirective.js
@@ -1,51 +1,55 @@
 "use strict";
 
-module.exports = function(Logger, $rootScope) {
-  return {
-    restrict: "A",
-    scope: { hasRankOrIsOwner: "=" },
-    link: function($scope, elem, attrs) {
-      if (typeof $scope.hasRankOrIsOwner !== "object") {
-        Logger.error(
-          "hasRankOrIsOwner directive requires object with rank and owner property"
-        );
-      }
-
-      $rootScope.$watch("currentUser", function() {
-        check();
-      });
-
-      $scope.$watch(
-        attrs.hasRankOrIsOwner,
-        function() {
-          check();
-        },
-        true
-      ); // deep watcher
-
-      var check = function() {
-        Logger.info(
-          "Checking for rank: " +
-            $scope.hasRankOrIsOwner.rank +
-            " or owner: " +
-            $scope.hasRankOrIsOwner.owner
-        );
-        if (
-          $rootScope.currentUser &&
-          $rootScope.currentUser.rank >= $scope.hasRankOrIsOwner.rank
-        ) {
-          Logger.info("Rank sufficient: " + $rootScope.currentUser.rank);
-          elem.show();
-        } else if (
-          $rootScope.currentUser &&
-          $rootScope.currentUser.username === $scope.hasRankOrIsOwner.owner
-        ) {
-          Logger.info("Owner found: " + $rootScope.currentUser.username);
-          elem.show();
-        } else {
-          elem.hide();
+module.exports = [
+  "Logger",
+  "$rootScope",
+  function(Logger, $rootScope) {
+    return {
+      restrict: "A",
+      scope: { hasRankOrIsOwner: "=" },
+      link: function($scope, elem, attrs) {
+        if (typeof $scope.hasRankOrIsOwner !== "object") {
+          Logger.error(
+            "hasRankOrIsOwner directive requires object with rank and owner property"
+          );
         }
-      };
-    }
-  };
-};
+
+        $rootScope.$watch("currentUser", function() {
+          check();
+        });
+
+        $scope.$watch(
+          attrs.hasRankOrIsOwner,
+          function() {
+            check();
+          },
+          true
+        ); // deep watcher
+
+        var check = function() {
+          Logger.info(
+            "Checking for rank: " +
+              $scope.hasRankOrIsOwner.rank +
+              " or owner: " +
+              $scope.hasRankOrIsOwner.owner
+          );
+          if (
+            $rootScope.currentUser &&
+            $rootScope.currentUser.rank >= $scope.hasRankOrIsOwner.rank
+          ) {
+            Logger.info("Rank sufficient: " + $rootScope.currentUser.rank);
+            elem.show();
+          } else if (
+            $rootScope.currentUser &&
+            $rootScope.currentUser.username === $scope.hasRankOrIsOwner.owner
+          ) {
+            Logger.info("Owner found: " + $rootScope.currentUser.username);
+            elem.show();
+          } else {
+            elem.hide();
+          }
+        };
+      }
+    };
+  }
+];

--- a/src/tools/website/resources/assets/js/directives/text/DateNowDirective.js
+++ b/src/tools/website/resources/assets/js/directives/text/DateNowDirective.js
@@ -1,7 +1,10 @@
 "use strict";
 
-module.exports = function($filter) {
-  return function($scope, element, attrs) {
-    element.text($filter("date")(new Date(), attrs.dateNow));
-  };
-};
+module.exports = [
+  "$filter",
+  function($filter) {
+    return function($scope, element, attrs) {
+      element.text($filter("date")(new Date(), attrs.dateNow));
+    };
+  }
+];

--- a/src/tools/website/resources/assets/js/directives/text/InputToLowerCaseDirective.js
+++ b/src/tools/website/resources/assets/js/directives/text/InputToLowerCaseDirective.js
@@ -1,21 +1,23 @@
 "use strict";
 
-module.exports = function() {
-  return {
-    restrict: "A",
-    require: "ngModel",
-    link: function(scope, element, attrs, modelCtrl) {
-      var lower = function(inputValue) {
-        if (inputValue === undefined) inputValue = "";
-        var lowered = inputValue.toLowerCase();
-        if (lowered !== inputValue) {
-          modelCtrl.$setViewValue(lowered);
-          modelCtrl.$render();
-        }
-        return lowered;
-      };
-      modelCtrl.$parsers.push(lower);
-      lower(scope[attrs.ngModel]);
-    }
-  };
-};
+module.exports = [
+  function() {
+    return {
+      restrict: "A",
+      require: "ngModel",
+      link: function(scope, element, attrs, modelCtrl) {
+        var lower = function(inputValue) {
+          if (inputValue === undefined) inputValue = "";
+          var lowered = inputValue.toLowerCase();
+          if (lowered !== inputValue) {
+            modelCtrl.$setViewValue(lowered);
+            modelCtrl.$render();
+          }
+          return lowered;
+        };
+        modelCtrl.$parsers.push(lower);
+        lower(scope[attrs.ngModel]);
+      }
+    };
+  }
+];

--- a/src/tools/website/resources/assets/js/filter/FirstCapitalizeFilter.js
+++ b/src/tools/website/resources/assets/js/filter/FirstCapitalizeFilter.js
@@ -1,19 +1,21 @@
 "use strict";
 
-module.exports = function() {
-  return function(input, eachWord) {
-    eachWord = typeof eachWord !== "undefined" ? eachWord : false;
-    if (eachWord === true) {
-      return input
-        .split(" ")
-        .map(function(elem) {
-          return elem.charAt(0).toUpperCase() + elem.substr(1).toLowerCase();
-        })
-        .join(" ");
-    } else {
-      return !!input
-        ? input.charAt(0).toUpperCase() + input.substr(1).toLowerCase()
-        : "";
-    }
-  };
-};
+module.exports = [
+  function() {
+    return function(input, eachWord) {
+      eachWord = typeof eachWord !== "undefined" ? eachWord : false;
+      if (eachWord === true) {
+        return input
+          .split(" ")
+          .map(function(elem) {
+            return elem.charAt(0).toUpperCase() + elem.substr(1).toLowerCase();
+          })
+          .join(" ");
+      } else {
+        return !!input
+          ? input.charAt(0).toUpperCase() + input.substr(1).toLowerCase()
+          : "";
+      }
+    };
+  }
+];

--- a/src/tools/website/resources/assets/js/run/logger.js
+++ b/src/tools/website/resources/assets/js/run/logger.js
@@ -1,6 +1,10 @@
 "use strict";
 
-module.exports = function(Logger, config) {
-  // configure logger
-  Logger.debug = config.logger.enabled;
-};
+module.exports = [
+  "Logger",
+  "config",
+  function(Logger, config) {
+    // configure logger
+    Logger.debug = config.logger.enabled;
+  }
+];

--- a/src/tools/website/resources/assets/js/run/states.js
+++ b/src/tools/website/resources/assets/js/run/states.js
@@ -7,14 +7,7 @@ module.exports = [
   "$auth",
   "$anchorScroll",
   "UserService",
-  function(
-    Logger,
-    $rootScope,
-    $state,
-    $auth,
-    $anchorScroll,
-    UserService
-  ) {
+  function(Logger, $rootScope, $state, $auth, $anchorScroll, UserService) {
     $rootScope.$on("$stateChangeError", console.log.bind(console));
 
     $rootScope.$on("$stateChangeStart", function(

--- a/src/tools/website/resources/assets/js/run/states.js
+++ b/src/tools/website/resources/assets/js/run/states.js
@@ -1,102 +1,110 @@
 "use strict";
 
-module.exports = function(
-  Logger,
-  $rootScope,
-  $state,
-  $auth,
-  $anchorScroll,
-  UserService
-) {
-  $rootScope.$on("$stateChangeError", console.log.bind(console));
-
-  $rootScope.$on("$stateChangeStart", function(
-    event,
-    toState,
-    toParams,
-    fromState,
-    fromParams
+module.exports = [
+  "Logger",
+  "$rootScope",
+  "$state",
+  "$auth",
+  "$anchorScroll",
+  "UserService",
+  function(
+    Logger,
+    $rootScope,
+    $state,
+    $auth,
+    $anchorScroll,
+    UserService
   ) {
-    Logger.info(
-      "Change state from '" +
-        fromState.name +
-        "' (" +
-        fromParams +
-        ") to '" +
-        toState.name +
-        "' (" +
-        toParams +
-        ")"
-    );
-    Logger.info("From state: " + JSON.stringify(fromState));
-    Logger.info("To state: " + JSON.stringify(toState));
+    $rootScope.$on("$stateChangeError", console.log.bind(console));
 
-    if ($auth.isAuthenticated()) {
-      Logger.log("User is authenticated");
+    $rootScope.$on("$stateChangeStart", function(
+      event,
+      toState,
+      toParams,
+      fromState,
+      fromParams
+    ) {
+      Logger.info(
+        "Change state from '" +
+          fromState.name +
+          "' (" +
+          fromParams +
+          ") to '" +
+          toState.name +
+          "' (" +
+          toParams +
+          ")"
+      );
+      Logger.info("From state: " + JSON.stringify(fromState));
+      Logger.info("To state: " + JSON.stringify(toState));
 
-      // if user is already logged in, go to dashboard
-      if (toState.name === "main.auth.login") {
-        // Preventing the default behavior allows us to use $state.go
-        // to change states
-        event.preventDefault();
+      if ($auth.isAuthenticated()) {
+        Logger.log("User is authenticated");
 
-        Logger.info("Redirect to home");
-        $state.go("main.home");
-      }
-
-      // get user data of currently authenticated user
-      UserService.get("", true).then(
-        function(data) {
-          $rootScope.authenticated = true;
-          $rootScope.currentUser = data;
-          Logger.info(
-            "Current user: " + JSON.stringify($rootScope.currentUser)
-          );
-
-          // check if user has permissions for required route
-          if (toState.data && toState.data.rank) {
-            Logger.log("Check route permissions");
-
-            if (
-              !$auth.isAuthenticated() ||
-              !$rootScope.currentUser ||
-              $rootScope.currentUser.rank < toState.data.rank
-            ) {
-              Logger.log("Insufficient permissions");
-
-              event.preventDefault();
-              if (fromState.abstract === true) {
-                $state.go("main.home");
-              }
-            }
-          }
-        },
-        function(data) {
-          Logger.info("Could not load details for current user, go home");
+        // if user is already logged in, go to dashboard
+        if (toState.name === "main.auth.login") {
+          // Preventing the default behavior allows us to use $state.go
+          // to change states
           event.preventDefault();
+
+          Logger.info("Redirect to home");
           $state.go("main.home");
         }
-      );
-    } else {
-      Logger.log("Not authenticated");
 
-      $rootScope.authenticated = false;
-      $rootScope.currentUser = null;
-    }
-  });
+        // get user data of currently authenticated user
+        UserService.get("", true).then(
+          function(data) {
+            $rootScope.authenticated = true;
+            $rootScope.currentUser = data;
+            Logger.info(
+              "Current user: " + JSON.stringify($rootScope.currentUser)
+            );
 
-  // (re-)load user data on state changes
-  $rootScope.$on("$stateChangeSuccess", function(
-    event,
-    toState,
-    toParams,
-    fromState,
-    fromParams
-  ) {
-    Logger.info("State change success!");
+            // check if user has permissions for required route
+            if (toState.data && toState.data.rank) {
+              Logger.log("Check route permissions");
 
-    $rootScope.currentState = toState.name;
+              if (
+                !$auth.isAuthenticated() ||
+                !$rootScope.currentUser ||
+                $rootScope.currentUser.rank < toState.data.rank
+              ) {
+                Logger.log("Insufficient permissions");
 
-    $anchorScroll();
-  });
-};
+                event.preventDefault();
+                if (fromState.abstract === true) {
+                  $state.go("main.home");
+                }
+              }
+            }
+          },
+          function(data) {
+            Logger.info("Could not load details for current user, go home");
+            event.preventDefault();
+            $state.go("main.home");
+          }
+        );
+      } else {
+        Logger.log("Not authenticated");
+
+        $rootScope.authenticated = false;
+        $rootScope.currentUser = null;
+      }
+    });
+
+    // (re-)load user data on state changes
+    $rootScope.$on("$stateChangeSuccess", function(
+      event,
+      toState,
+      toParams,
+      fromState,
+      fromParams
+    ) {
+      Logger.info("State change success!");
+
+      $rootScope.currentState = toState.name;
+
+      $anchorScroll();
+    });
+  }
+];

--- a/src/tools/website/resources/assets/js/services/ConversionService.js
+++ b/src/tools/website/resources/assets/js/services/ConversionService.js
@@ -5,12 +5,7 @@ module.exports = [
   "$http",
   "$q",
   "config",
-  function(
-    Logger,
-    $http,
-    $q,
-    config
-  ) {
+  function(Logger, $http, $q, config) {
     var service = this;
 
     this.convert = function(parameters) {

--- a/src/tools/website/resources/assets/js/services/ConversionService.js
+++ b/src/tools/website/resources/assets/js/services/ConversionService.js
@@ -1,13 +1,24 @@
 "use strict";
 
-module.exports = function(Logger, $http, $q, config) {
-  var service = this;
+module.exports = [
+  "Logger",
+  "$http",
+  "$q",
+  "config",
+  function(
+    Logger,
+    $http,
+    $q,
+    config
+  ) {
+    var service = this;
 
-  this.convert = function(parameters) {
-    return $http.post(config.backend.root + "conversion", parameters, {
-      // custom options
-    });
-  };
+    this.convert = function(parameters) {
+      return $http.post(config.backend.root + "conversion", parameters, {
+        // custom options
+      });
+    };
 
-  Logger.info("Conversion service ready!");
-};
+    Logger.info("Conversion service ready!");
+  }
+];

--- a/src/tools/website/resources/assets/js/services/EntryService.js
+++ b/src/tools/website/resources/assets/js/services/EntryService.js
@@ -7,12 +7,7 @@ module.exports = [
   "$http",
   "$q",
   "config",
-  function(
-    Logger,
-    $http,
-    $q,
-    config
-  ) {
+  function(Logger, $http, $q, config) {
     var service = this;
 
     this.cache = {

--- a/src/tools/website/resources/assets/js/services/EntryService.js
+++ b/src/tools/website/resources/assets/js/services/EntryService.js
@@ -2,219 +2,230 @@
 
 var angular = require("angular");
 
-module.exports = function(Logger, $http, $q, config) {
-  var service = this;
+module.exports = [
+  "Logger",
+  "$http",
+  "$q",
+  "config",
+  function(
+    Logger,
+    $http,
+    $q,
+    config
+  ) {
+    var service = this;
 
-  this.cache = {
-    formats: [],
-    typeaheads: {
-      cached: false,
-      data: { organizations: [], applications: [], scopes: [], tags: [] }
-    },
-    search: {
-      cached: false,
-      entries: {},
-      params: {
-        filter: "",
-        filterby: "",
-        sort: "",
-        sortby: "",
-        rows: 0,
-        offset: 0
+    this.cache = {
+      formats: [],
+      typeaheads: {
+        cached: false,
+        data: { organizations: [], applications: [], scopes: [], tags: [] }
+      },
+      search: {
+        cached: false,
+        entries: {},
+        params: {
+          filter: "",
+          filterby: "",
+          sort: "",
+          sortby: "",
+          rows: 0,
+          offset: 0
+        }
       }
-    }
-  };
+    };
 
-  this.create = function(entry) {
-    Logger.info("Attempting to create entry.");
+    this.create = function(entry) {
+      Logger.info("Attempting to create entry.");
 
-    return $http.post(config.backend.root + "database", entry, {
-      // custom options
-    });
-  };
+      return $http.post(config.backend.root + "database", entry, {
+        // custom options
+      });
+    };
 
-  this.update = function(key, entry) {
-    Logger.info("Attempting to update entry.");
+    this.update = function(key, entry) {
+      Logger.info("Attempting to update entry.");
 
-    return $http.put(config.backend.root + "database/" + key, entry, {
-      // custom options
-    });
-  };
+      return $http.put(config.backend.root + "database/" + key, entry, {
+        // custom options
+      });
+    };
 
-  this.delete = function(key) {
-    Logger.info("Attempting to delete entry.");
+    this.delete = function(key) {
+      Logger.info("Attempting to delete entry.");
 
-    return $http.delete(config.backend.root + "database/" + key, {
-      // custom options
-    });
-  };
+      return $http.delete(config.backend.root + "database/" + key, {
+        // custom options
+      });
+    };
 
-  this.get = function(key) {
-    Logger.info("Attempting to download entry: " + key);
+    this.get = function(key) {
+      Logger.info("Attempting to download entry: " + key);
 
-    var deferred = $q.defer();
+      var deferred = $q.defer();
 
-    if (key.length <= 1) {
-      deferred.reject("Invalid key");
-    } else {
-      var url = config.backend.root + "database/" + key;
-      $http.get(url).then(
-        function(response) {
-          deferred.resolve(response.data);
-        },
-        function(response) {
-          deferred.reject("Error loading data");
-        }
-      );
-    }
-
-    return deferred.promise;
-  };
-
-  this.search = function(params, force) {
-    Logger.info("Load entries");
-
-    var deferred = $q.defer();
-
-    if (
-      !service.cache.search.cached ||
-      !angular.equals(service.cache.search.params, params) ||
-      force
-    ) {
-      Logger.info("Loading entries");
-      $http.get(config.backend.root + "database", { params: params }).then(
-        function(response) {
-          service.cache.search.entries = response.data;
-          service.cache.search.params = params;
-          deferred.resolve(service.cache.search.entries);
-        },
-        function(response) {
-          deferred.reject("Error loading data");
-        }
-      );
-    } else {
-      deferred.resolve(service.cache.search.entries);
-    }
-
-    return deferred.promise;
-  };
-
-  this.hasSearchCache = function() {
-    return this.cache.search.cached;
-  };
-
-  this.getSearchCache = function() {
-    return this.cache.search.entries;
-  };
-
-  this.getSearchFilter = function() {
-    return this.cache.search.params.filter;
-  };
-
-  this.loadAvailableFormats = function() {
-    Logger.info("Attempting to load available formats.");
-
-    var deferred = $q.defer();
-
-    if (service.cache.formats.length > 0) {
-      deferred.resolve(service.cache.formats);
-    } else {
-      $http
-        .get(config.backend.root + "conversion/formats", {
-          // custom options
-        })
-        .then(
+      if (key.length <= 1) {
+        deferred.reject("Invalid key");
+      } else {
+        var url = config.backend.root + "database/" + key;
+        $http.get(url).then(
           function(response) {
-            var plugins = [];
-            var foundPlugin;
-            config.website.formats.preferred.forEach(function(plugin) {
-              foundPlugin = response.data.find(function(elem) {
-                return elem.plugin.name === plugin;
-              });
-              if (typeof foundPlugin !== "undefined") {
-                plugins.push(foundPlugin);
-              }
-            });
-            response.data = response.data.filter(function(elem) {
-              return plugins.indexOf(elem) < 0;
-            });
-            plugins.push.apply(plugins, response.data);
-            service.cache.formats = plugins;
-            deferred.resolve(service.cache.formats);
+            deferred.resolve(response.data);
           },
           function(response) {
-            deferred.reject(response.data);
+            deferred.reject("Error loading data");
           }
         );
-    }
+      }
 
-    return deferred.promise;
-  };
+      return deferred.promise;
+    };
 
-  this.loadAvailableTypeaheads = function() {
-    Logger.info("Attempting to load available typeaheads.");
+    this.search = function(params, force) {
+      Logger.info("Load entries");
 
-    var deferred = $q.defer();
+      var deferred = $q.defer();
 
-    if (service.cache.typeaheads.cache === true) {
-      deferred.resolve(service.cache.typeaheads.data);
-    } else {
-      $http
-        .get(config.backend.root + "database", {
-          // custom options
-        })
-        .then(
+      if (
+        !service.cache.search.cached ||
+        !angular.equals(service.cache.search.params, params) ||
+        force
+      ) {
+        Logger.info("Loading entries");
+        $http.get(config.backend.root + "database", { params: params }).then(
           function(response) {
-            if (
-              response.data.elements > 0 &&
-              typeof response.data.entries !== "undefined"
-            ) {
-              response.data.entries.forEach(function(entry) {
-                if (
-                  service.cache.typeaheads.data.organizations.indexOf(
-                    entry.key.organization
-                  ) === -1
-                ) {
-                  service.cache.typeaheads.data.organizations.push(
-                    entry.key.organization
-                  );
-                }
-                if (
-                  service.cache.typeaheads.data.applications.indexOf(
-                    entry.key.application
-                  ) === -1
-                ) {
-                  service.cache.typeaheads.data.applications.push(
-                    entry.key.application
-                  );
-                }
-                if (
-                  service.cache.typeaheads.data.scopes.indexOf(
-                    entry.key.scope
-                  ) === -1
-                ) {
-                  service.cache.typeaheads.data.scopes.push(entry.key.scope);
-                }
-                if (entry.tags && Array.isArray(entry.tags)) {
-                  entry.tags.forEach(function(tag) {
-                    if (
-                      service.cache.typeaheads.data.tags.indexOf(tag) === -1
-                    ) {
-                      service.cache.typeaheads.data.tags.push(tag);
-                    }
-                  });
+            service.cache.search.entries = response.data;
+            service.cache.search.params = params;
+            deferred.resolve(service.cache.search.entries);
+          },
+          function(response) {
+            deferred.reject("Error loading data");
+          }
+        );
+      } else {
+        deferred.resolve(service.cache.search.entries);
+      }
+
+      return deferred.promise;
+    };
+
+    this.hasSearchCache = function() {
+      return this.cache.search.cached;
+    };
+
+    this.getSearchCache = function() {
+      return this.cache.search.entries;
+    };
+
+    this.getSearchFilter = function() {
+      return this.cache.search.params.filter;
+    };
+
+    this.loadAvailableFormats = function() {
+      Logger.info("Attempting to load available formats.");
+
+      var deferred = $q.defer();
+
+      if (service.cache.formats.length > 0) {
+        deferred.resolve(service.cache.formats);
+      } else {
+        $http
+          .get(config.backend.root + "conversion/formats", {
+            // custom options
+          })
+          .then(
+            function(response) {
+              var plugins = [];
+              var foundPlugin;
+              config.website.formats.preferred.forEach(function(plugin) {
+                foundPlugin = response.data.find(function(elem) {
+                  return elem.plugin.name === plugin;
+                });
+                if (typeof foundPlugin !== "undefined") {
+                  plugins.push(foundPlugin);
                 }
               });
+              response.data = response.data.filter(function(elem) {
+                return plugins.indexOf(elem) < 0;
+              });
+              plugins.push.apply(plugins, response.data);
+              service.cache.formats = plugins;
+              deferred.resolve(service.cache.formats);
+            },
+            function(response) {
+              deferred.reject(response.data);
             }
-            service.cache.typeaheads.cache = true;
-            deferred.resolve(service.cache.typeaheads.data);
-          },
-          function(response) {
-            deferred.reject(response.data);
-          }
-        );
-    }
+          );
+      }
 
-    return deferred.promise;
-  };
-};
+      return deferred.promise;
+    };
+
+    this.loadAvailableTypeaheads = function() {
+      Logger.info("Attempting to load available typeaheads.");
+
+      var deferred = $q.defer();
+
+      if (service.cache.typeaheads.cache === true) {
+        deferred.resolve(service.cache.typeaheads.data);
+      } else {
+        $http
+          .get(config.backend.root + "database", {
+            // custom options
+          })
+          .then(
+            function(response) {
+              if (
+                response.data.elements > 0 &&
+                typeof response.data.entries !== "undefined"
+              ) {
+                response.data.entries.forEach(function(entry) {
+                  if (
+                    service.cache.typeaheads.data.organizations.indexOf(
+                      entry.key.organization
+                    ) === -1
+                  ) {
+                    service.cache.typeaheads.data.organizations.push(
+                      entry.key.organization
+                    );
+                  }
+                  if (
+                    service.cache.typeaheads.data.applications.indexOf(
+                      entry.key.application
+                    ) === -1
+                  ) {
+                    service.cache.typeaheads.data.applications.push(
+                      entry.key.application
+                    );
+                  }
+                  if (
+                    service.cache.typeaheads.data.scopes.indexOf(
+                      entry.key.scope
+                    ) === -1
+                  ) {
+                    service.cache.typeaheads.data.scopes.push(entry.key.scope);
+                  }
+                  if (entry.tags && Array.isArray(entry.tags)) {
+                    entry.tags.forEach(function(tag) {
+                      if (
+                        service.cache.typeaheads.data.tags.indexOf(tag) === -1
+                      ) {
+                        service.cache.typeaheads.data.tags.push(tag);
+                      }
+                    });
+                  }
+                });
+              }
+              service.cache.typeaheads.cache = true;
+              deferred.resolve(service.cache.typeaheads.data);
+            },
+            function(response) {
+              deferred.reject(response.data);
+            }
+          );
+      }
+
+      return deferred.promise;
+    };
+  }
+];

--- a/src/tools/website/resources/assets/js/services/ReportService.js
+++ b/src/tools/website/resources/assets/js/services/ReportService.js
@@ -1,22 +1,31 @@
 "use strict";
 
-module.exports = function(Logger, $window, config) {
-  var service = this;
+module.exports = [
+  "Logger",
+  "$window",
+  "config",
+  function(
+    Logger,
+    $window,
+    config
+  ) {
+    var service = this;
 
-  this.reportIssue = function(title, message, labels) {
-    var url =
-      config.github.website.root +
-      config.github.website.paths.issues +
-      "?title=" +
-      encodeURIComponent(title) +
-      "&body=" +
-      encodeURIComponent(message);
-    labels.forEach(function(elem) {
-      url += "&labels[]=" + encodeURIComponent(elem);
-    });
+    this.reportIssue = function(title, message, labels) {
+      var url =
+        config.github.website.root +
+        config.github.website.paths.issues +
+        "?title=" +
+        encodeURIComponent(title) +
+        "&body=" +
+        encodeURIComponent(message);
+      labels.forEach(function(elem) {
+        url += "&labels[]=" + encodeURIComponent(elem);
+      });
 
-    $window.open(url, "_blank");
-  };
+      $window.open(url, "_blank");
+    };
 
-  Logger.info("Report service ready!");
-};
+    Logger.info("Report service ready!");
+  }
+];

--- a/src/tools/website/resources/assets/js/services/ReportService.js
+++ b/src/tools/website/resources/assets/js/services/ReportService.js
@@ -4,11 +4,7 @@ module.exports = [
   "Logger",
   "$window",
   "config",
-  function(
-    Logger,
-    $window,
-    config
-  ) {
+  function(Logger, $window, config) {
     var service = this;
 
     this.reportIssue = function(title, message, labels) {

--- a/src/tools/website/resources/assets/js/services/UserService.js
+++ b/src/tools/website/resources/assets/js/services/UserService.js
@@ -7,12 +7,7 @@ module.exports = [
   "$http",
   "$q",
   "config",
-  function(
-    Logger,
-    $http,
-    $q,
-    config
-  ) {
+  function(Logger, $http, $q, config) {
     var service = this;
 
     this.cache = {

--- a/src/tools/website/resources/assets/js/services/UserService.js
+++ b/src/tools/website/resources/assets/js/services/UserService.js
@@ -2,148 +2,159 @@
 
 var angular = require("angular");
 
-module.exports = function(Logger, $http, $q, config) {
-  var service = this;
+module.exports = [
+  "Logger",
+  "$http",
+  "$q",
+  "config",
+  function(
+    Logger,
+    $http,
+    $q,
+    config
+  ) {
+    var service = this;
 
-  this.cache = {
-    search: {
-      cached: false,
-      users: {},
-      params: {
-        filter: "",
-        filterby: "",
-        sort: "",
-        sortby: "",
-        rows: 0,
-        offset: 0
+    this.cache = {
+      search: {
+        cached: false,
+        users: {},
+        params: {
+          filter: "",
+          filterby: "",
+          sort: "",
+          sortby: "",
+          rows: 0,
+          offset: 0
+        }
+      },
+      currentUser: { hasUser: false, lastFetch: 0, user: {} }
+    };
+
+    this.clear = function() {
+      service.cache.currentUser.hasCache = false;
+      service.cache.currentUser.lastFetch = 0;
+      service.cache.currentUser.user = {};
+    };
+
+    this.get = function(username, currentUser, force) {
+      Logger.info("Attempting to load user details");
+
+      currentUser = typeof currentUser === "undefined" ? false : currentUser;
+      force = typeof force === "undefined" ? false : force;
+      if (
+        service.cache.currentUser.lastFetch + config.jwt.validity <
+        Math.floor(Date.now() / 1000)
+      ) {
+        force = true;
       }
-    },
-    currentUser: { hasUser: false, lastFetch: 0, user: {} }
-  };
 
-  this.clear = function() {
-    service.cache.currentUser.hasCache = false;
-    service.cache.currentUser.lastFetch = 0;
-    service.cache.currentUser.user = {};
-  };
+      var deferred = $q.defer();
 
-  this.get = function(username, currentUser, force) {
-    Logger.info("Attempting to load user details");
-
-    currentUser = typeof currentUser === "undefined" ? false : currentUser;
-    force = typeof force === "undefined" ? false : force;
-    if (
-      service.cache.currentUser.lastFetch + config.jwt.validity <
-      Math.floor(Date.now() / 1000)
-    ) {
-      force = true;
-    }
-
-    var deferred = $q.defer();
-
-    if (currentUser === true) {
-      if (!service.cache.currentUser.hasUser || force) {
+      if (currentUser === true) {
+        if (!service.cache.currentUser.hasUser || force) {
+          $http
+            .get(config.backend.root + "user?current=true", {
+              // custom options
+            })
+            .then(
+              function(response) {
+                service.cache.currentUser.user = response.data;
+                service.cache.currentUser.lastFetch = Math.floor(
+                  Date.now() / 1000
+                );
+                service.cache.currentUser.hasUser = true;
+                deferred.resolve(service.cache.currentUser.user);
+              },
+              function(response) {
+                deferred.reject(response.data);
+              }
+            );
+        } else {
+          deferred.resolve(service.cache.currentUser.user);
+        }
+      } else {
         $http
-          .get(config.backend.root + "user?current=true", {
+          .get(config.backend.root + "user/" + username, {
             // custom options
           })
           .then(
             function(response) {
-              service.cache.currentUser.user = response.data;
-              service.cache.currentUser.lastFetch = Math.floor(
-                Date.now() / 1000
-              );
-              service.cache.currentUser.hasUser = true;
-              deferred.resolve(service.cache.currentUser.user);
+              deferred.resolve(response.data);
             },
             function(response) {
               deferred.reject(response.data);
             }
           );
-      } else {
-        deferred.resolve(service.cache.currentUser.user);
       }
-    } else {
-      $http
-        .get(config.backend.root + "user/" + username, {
+
+      return deferred.promise;
+    };
+
+    this.update = function(username, data, currentUser) {
+      Logger.info("Attempting to update user");
+
+      currentUser = typeof currentUser === "undefined" ? false : currentUser;
+
+      if (currentUser === true) {
+        return $http.put(config.backend.root + "user?current=true", data, {
           // custom options
-        })
-        .then(
+        });
+      } else {
+        return $http.put(config.backend.root + "user/" + username, data, {
+          // custom options
+        });
+      }
+    };
+
+    this.delete = function(username) {
+      Logger.info("Attempting to delete user.");
+
+      return $http.delete(config.backend.root + "user/" + username, {
+        // custom options
+      });
+    };
+
+    this.search = function(params, force) {
+      Logger.info("Load users");
+
+      var deferred = $q.defer();
+
+      if (
+        !service.cache.search.cached ||
+        !angular.equals(service.cache.search.params, params) ||
+        force
+      ) {
+        Logger.info("Loading users");
+        $http.get(config.backend.root + "user", { params: params }).then(
           function(response) {
-            deferred.resolve(response.data);
+            service.cache.search.users = response.data;
+            service.cache.search.params = params;
+            deferred.resolve(service.cache.search.users);
           },
           function(response) {
-            deferred.reject(response.data);
+            deferred.reject("Error loading data");
           }
         );
-    }
+      } else {
+        deferred.resolve(service.cache.search.users);
+      }
 
-    return deferred.promise;
-  };
+      return deferred.promise;
+    };
 
-  this.update = function(username, data, currentUser) {
-    Logger.info("Attempting to update user");
+    this.hasSearchCache = function() {
+      return this.cache.search.cached;
+    };
 
-    currentUser = typeof currentUser === "undefined" ? false : currentUser;
+    this.getSearchCache = function() {
+      return this.cache.search.users;
+    };
 
-    if (currentUser === true) {
-      return $http.put(config.backend.root + "user?current=true", data, {
-        // custom options
-      });
-    } else {
-      return $http.put(config.backend.root + "user/" + username, data, {
-        // custom options
-      });
-    }
-  };
+    this.getSearchFilter = function() {
+      return this.cache.search.params.filter;
+    };
 
-  this.delete = function(username) {
-    Logger.info("Attempting to delete user.");
-
-    return $http.delete(config.backend.root + "user/" + username, {
-      // custom options
-    });
-  };
-
-  this.search = function(params, force) {
-    Logger.info("Load users");
-
-    var deferred = $q.defer();
-
-    if (
-      !service.cache.search.cached ||
-      !angular.equals(service.cache.search.params, params) ||
-      force
-    ) {
-      Logger.info("Loading users");
-      $http.get(config.backend.root + "user", { params: params }).then(
-        function(response) {
-          service.cache.search.users = response.data;
-          service.cache.search.params = params;
-          deferred.resolve(service.cache.search.users);
-        },
-        function(response) {
-          deferred.reject("Error loading data");
-        }
-      );
-    } else {
-      deferred.resolve(service.cache.search.users);
-    }
-
-    return deferred.promise;
-  };
-
-  this.hasSearchCache = function() {
-    return this.cache.search.cached;
-  };
-
-  this.getSearchCache = function() {
-    return this.cache.search.users;
-  };
-
-  this.getSearchFilter = function() {
-    return this.cache.search.params.filter;
-  };
-
-  Logger.info("User service ready!");
-};
+    Logger.info("User service ready!");
+  }
+];

--- a/src/tools/website/resources/assets/js/services/WebsiteService.js
+++ b/src/tools/website/resources/assets/js/services/WebsiteService.js
@@ -1,24 +1,35 @@
 "use strict";
 
-module.exports = function(Logger, $http, $q, config) {
-  var service = this;
+module.exports = [
+  "Logger",
+  "$http",
+  "$q",
+  "config",
+  function(
+    Logger,
+    $http,
+    $q,
+    config
+  ) {
+    var service = this;
 
-  this.loadFile = function(url) {
-    var deferred = $q.defer();
+    this.loadFile = function(url) {
+      var deferred = $q.defer();
 
-    $http
-      .get(config.website.content_root + url, { skipAuthorization: true })
-      .then(
-        function(response) {
-          deferred.resolve(response.data);
-        },
-        function(response) {
-          deferred.reject(response.data);
-        }
-      );
+      $http
+        .get(config.website.content_root + url, { skipAuthorization: true })
+        .then(
+          function(response) {
+            deferred.resolve(response.data);
+          },
+          function(response) {
+            deferred.reject(response.data);
+          }
+        );
 
-    return deferred.promise;
-  };
+      return deferred.promise;
+    };
 
-  Logger.info("Website service ready!");
-};
+    Logger.info("Website service ready!");
+  }
+];

--- a/src/tools/website/resources/assets/js/services/WebsiteService.js
+++ b/src/tools/website/resources/assets/js/services/WebsiteService.js
@@ -5,12 +5,7 @@ module.exports = [
   "$http",
   "$q",
   "config",
-  function(
-    Logger,
-    $http,
-    $q,
-    config
-  ) {
+  function(Logger, $http, $q, config) {
     var service = this;
 
     this.loadFile = function(url) {


### PR DESCRIPTION
This PR fixes #3508. Most likely the issue has been minification of the JavaScript sources, which can lead to changed variable names and therefore broken dependency injection. Compare
```js
module.exports = function ($http) { ... }
```
where `$http` can be renamed by the minifier (e.g. to a shorter name like `a`) with
```js
module.exports = ["$http", function ($http) { ... }];
```
where this may also happen, but only to the function argument and not the string.

The code now basically uses a special syntax which lets angular know that all items in the array except the last one should be resolved from the dependency container and injected as arguments to the last entry, which is the module function. The `ng-strict-di` directive on the root element in `index.html` additionally forces that only this type of dependency injection is allowed and will shout immediately when the old (and dangerous) syntax is used.

---

Additionally, I generated a `package-lock.json` with a set of package versions which produced a successful build. Providing such a lock file ensures that builds (for individual commits) are repeatable. If no lock file is provided, npm will resolve the most recent matching package versions, which can lead to broken builds if package maintainers do not respect semver. The versions in the lock file should be updated once in a while though, to pick up latest security patches. Currently only one security issue is reported, although it shouldn't affect us the way we use the library.