### PR TITLE
elektrad: attempt to fix for keyname overhaul

### DIFF
--- a/doc/news/_preparation_next_release.md
+++ b/doc/news/_preparation_next_release.md
@@ -135,7 +135,7 @@ you up to date with the multi-language support provided by Elektra.
 
 ## Tools
 
-- <<TODO>>
+- There have been a few bugfixes for elektrad. _(Klemens Böswirth)_
 - <<TODO>>
 - <<TODO>>
 

--- a/src/tools/elektrad/find_handler_test.go
+++ b/src/tools/elektrad/find_handler_test.go
@@ -15,7 +15,7 @@ func TestGetFind(t *testing.T) {
 		setupKey(t, keyName)
 	}
 
-	w := testGet(t, "/kdbFind/user/tests/elektrad/kdbfind/get")
+	w := testGet(t, "/kdbFind/user:/tests/elektrad/kdbfind/get")
 
 	code := w.Result().StatusCode
 	Assertf(t, code == http.StatusOK, "wrong status code: %v", code)
@@ -24,4 +24,8 @@ func TestGetFind(t *testing.T) {
 	parseBody(t, w, &result)
 	Assertf(t, len(result) == 2, "result of kdbFind should haven len() 2 but has %d", len(result))
 	Assertf(t, keyNames[0] == result[0] && keyNames[1] == result[1], "the result of kdbFind is unexpected")
+
+	for _, keyName := range keyNames {
+		removeKey(t, keyName)
+	}
 }

--- a/src/tools/elektrad/go.mod
+++ b/src/tools/elektrad/go.mod
@@ -2,6 +2,8 @@ module github.com/ElektraInitiative/libelektra/elektrad
 
 go 1.13
 
+replace go.libelektra.org => /home/klemens/coding/bsc/go-elektra
+
 require (
 	github.com/google/uuid v1.1.1
 	github.com/gorilla/mux v1.7.3

--- a/src/tools/elektrad/go.mod
+++ b/src/tools/elektrad/go.mod
@@ -2,8 +2,6 @@ module github.com/ElektraInitiative/libelektra/elektrad
 
 go 1.13
 
-replace go.libelektra.org => /home/klemens/coding/bsc/go-elektra
-
 require (
 	github.com/google/uuid v1.1.1
 	github.com/gorilla/mux v1.7.3

--- a/src/tools/elektrad/handlepool.go
+++ b/src/tools/elektrad/handlepool.go
@@ -75,7 +75,7 @@ func (p *handlePool) refillLoop() {
 			h, err := newHandle()
 
 			if err != nil {
-				panic("could not create new handle")
+				panic("could not create new handle: " + err.Error())
 			}
 
 			p.handles <- h

--- a/src/tools/elektrad/helper_test.go
+++ b/src/tools/elektrad/helper_test.go
@@ -78,6 +78,9 @@ func setupKey(t *testing.T, keyNames ...string) {
 func removeKey(t *testing.T, keyName string) {
 	t.Helper()
 
+	errKey, err := elektra.NewKey(keyName)
+	Checkf(t, err, "could not create key: %v", err)
+
 	parentKey, err := elektra.NewKey(keyName)
 	Checkf(t, err, "could not create key: %v", err)
 
@@ -86,7 +89,7 @@ func removeKey(t *testing.T, keyName string) {
 	Checkf(t, err, "could not open kdb: %v", err)
 
 	ks := elektra.NewKeySet()
-	_, err = kdb.Get(ks, parentKey)
+	_, err = kdb.Get(ks, errKey)
 	Checkf(t, err, "could not create key: %v", err)
 
 	k := ks.Lookup(parentKey)
@@ -99,12 +102,15 @@ func removeKey(t *testing.T, keyName string) {
 	ks.Remove(k)
 	Checkf(t, err, "could not remove key %s: %v", keyName, err)
 
-	_, err = kdb.Set(ks, parentKey)
+	_, err = kdb.Set(ks, errKey)
 	Checkf(t, err, "could not save removal of key %s: %v", keyName, err)
 }
 
 func setupKeyWithMeta(t *testing.T, keyName string, meta ...keyValueBody) {
 	t.Helper()
+
+	errKey, err := elektra.NewKey(keyName)
+	Checkf(t, err, "could not create key: %v", err)
 
 	parentKey, err := elektra.NewKey(keyName)
 	Checkf(t, err, "could not create key: %v", err)
@@ -114,7 +120,7 @@ func setupKeyWithMeta(t *testing.T, keyName string, meta ...keyValueBody) {
 	Checkf(t, err, "could not open kdb: %v", err)
 
 	ks := elektra.NewKeySet()
-	_, err = kdb.Get(ks, parentKey)
+	_, err = kdb.Get(ks, errKey)
 	Checkf(t, err, "could not get KeySet: %v", err)
 
 	k := ks.Lookup(parentKey)
@@ -131,7 +137,7 @@ func setupKeyWithMeta(t *testing.T, keyName string, meta ...keyValueBody) {
 		Checkf(t, err, "could not set meta %s = %s: %v", m.Key, *m.Value, err)
 	}
 
-	_, err = kdb.Set(ks, parentKey)
+	_, err = kdb.Set(ks, errKey)
 	Checkf(t, err, "could not save key %s: %v", keyName, err)
 }
 

--- a/src/tools/elektrad/kdb.go
+++ b/src/tools/elektrad/kdb.go
@@ -9,17 +9,15 @@ import (
 func set(handle elektra.KDB, ks elektra.KeySet, key elektra.Key) error {
 	_, err := handle.Set(ks, key)
 
-	if !errors.Is(err, elektra.ErrConflictingState) {
-		return err
+	for errors.Is(err, elektra.ErrConflictingState) {
+		_, err = handle.Get(ks, key)
+
+		if err != nil {
+			return err
+		}
+
+		_, err = handle.Set(ks, key)
 	}
-
-	_, err = handle.Get(ks, key)
-
-	if err != nil {
-		return err
-	}
-
-	_, err = handle.Set(ks, key)
 
 	return err
 }

--- a/src/tools/elektrad/kdb_handler.go
+++ b/src/tools/elektrad/kdb_handler.go
@@ -47,7 +47,16 @@ func (s *server) getKdbHandler(w http.ResponseWriter, r *http.Request) {
 
 	handle, ks := getHandle(r)
 
-	_, err = handle.Get(ks, key)
+	errKey, err := elektra.NewKey(keyName)
+
+	if err != nil {
+		internalServerError(w)
+		return
+	}
+
+	defer errKey.Close()
+
+	_, err = handle.Get(ks, errKey)
 
 	if err != nil {
 		writeError(w, err)
@@ -98,9 +107,18 @@ func (s *server) putKdbHandler(w http.ResponseWriter, r *http.Request) {
 
 	defer key.Close()
 
+	errKey, err := elektra.NewKey(keyName)
+
+	if err != nil {
+		internalServerError(w)
+		return
+	}
+
+	defer errKey.Close()
+
 	handle, ks := getHandle(r)
 
-	_, err = handle.Get(ks, key)
+	_, err = handle.Get(ks, errKey)
 
 	if err != nil {
 		writeError(w, err)
@@ -127,7 +145,7 @@ func (s *server) putKdbHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	err = set(handle, ks, key)
+	err = set(handle, ks, errKey)
 
 	if err != nil {
 		writeError(w, err)
@@ -162,9 +180,18 @@ func (s *server) deleteKdbHandler(w http.ResponseWriter, r *http.Request) {
 
 	defer key.Close()
 
+	errKey, err := elektra.NewKey(keyName)
+
+	if err != nil {
+		internalServerError(w)
+		return
+	}
+
+	defer errKey.Close()
+
 	handle, ks := getHandle(r)
 
-	_, err = handle.Get(ks, key)
+	_, err = handle.Get(ks, errKey)
 
 	if err != nil {
 		writeError(w, err)
@@ -178,7 +205,7 @@ func (s *server) deleteKdbHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	err = set(handle, ks, key)
+	err = set(handle, ks, errKey)
 
 	if err != nil {
 		writeError(w, err)

--- a/src/tools/elektrad/kdb_handler_test.go
+++ b/src/tools/elektrad/kdb_handler_test.go
@@ -23,6 +23,9 @@ func TestGetKdb(t *testing.T) {
 	Assert(t, response.Exists, "key not found")
 	Assert(t, response.Path == keyName, "key path is wrong")
 	CompareStrings(t, []string{keyName, keyNameChild}, response.Ls, "Children are not the same")
+
+	removeKey(t, keyName)
+	removeKey(t, keyNameChild)
 }
 
 func TestPutKdb(t *testing.T) {
@@ -35,8 +38,9 @@ func TestPutKdb(t *testing.T) {
 	Assertf(t, code == http.StatusCreated, "wrong status code: %v", code)
 
 	key := getKey(t, keyName)
-	retrievedValue := key.String()
+	removeKey(t, keyName)
 	Assert(t, key != nil, "key was not created")
+	retrievedValue := key.String()
 	Assertf(t, retrievedValue == value, "wrong key value %s, expected %s", retrievedValue, value)
 }
 
@@ -51,5 +55,6 @@ func TestDeleteKdb(t *testing.T) {
 	Assertf(t, code == http.StatusNoContent, "wrong status code: %v", code)
 
 	key := getKey(t, keyName)
+	removeKey(t, keyName)
 	Assert(t, key == nil, "key was not deleted")
 }

--- a/src/tools/elektrad/meta_handler.go
+++ b/src/tools/elektrad/meta_handler.go
@@ -41,6 +41,15 @@ func (s *server) postMetaHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	errKey, err := elektra.NewKey(keyName)
+
+	if err != nil {
+		internalServerError(w)
+		return
+	}
+
+	defer errKey.Close()
+
 	parentKey, err := elektra.NewKey(keyName)
 
 	if err != nil {
@@ -51,6 +60,13 @@ func (s *server) postMetaHandler(w http.ResponseWriter, r *http.Request) {
 	defer parentKey.Close()
 
 	handle, ks := getHandle(r)
+
+	_, err = handle.Get(ks, errKey)
+
+	if err != nil {
+		writeError(w, err)
+		return
+	}
 
 	k := ks.LookupByName(keyName)
 
@@ -70,7 +86,7 @@ func (s *server) postMetaHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	err = set(handle, ks, parentKey)
+	err = set(handle, ks, errKey)
 
 	if err != nil {
 		writeError(w, err)
@@ -112,9 +128,18 @@ func (s *server) deleteMetaHandler(w http.ResponseWriter, r *http.Request) {
 
 	defer key.Close()
 
+	errKey, err := elektra.NewKey(keyName)
+
+	if err != nil {
+		internalServerError(w)
+		return
+	}
+
+	defer errKey.Close()
+
 	handle, ks := getHandle(r)
 
-	_, err = handle.Get(ks, key)
+	_, err = handle.Get(ks, errKey)
 
 	if err != nil {
 		writeError(w, err)
@@ -135,7 +160,7 @@ func (s *server) deleteMetaHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	err = set(handle, ks, key)
+	err = set(handle, ks, errKey)
 
 	if err != nil {
 		writeError(w, err)

--- a/src/tools/elektrad/meta_handler_test.go
+++ b/src/tools/elektrad/meta_handler_test.go
@@ -24,6 +24,7 @@ func TestPostMeta(t *testing.T) {
 	Assertf(t, code == http.StatusNoContent, "wrong status code: %v", code)
 
 	key := getKey(t, keyName)
+	removeKey(t, keyName)
 	Assert(t, key.Meta("postmeta") == value, "key has wrong meta value")
 }
 
@@ -31,7 +32,7 @@ func TestDeleteMetaHandler(t *testing.T) {
 	keyName := "user:/tests/elektrad/kdbmeta/delete/test"
 	value := "value"
 	meta := keyValueBody{
-		Key:   "postmeta",
+		Key:   "delmeta",
 		Value: &value,
 	}
 
@@ -42,6 +43,10 @@ func TestDeleteMetaHandler(t *testing.T) {
 	code := w.Result().StatusCode
 	Assertf(t, code == http.StatusNoContent, "wrong status code: %v", code)
 
-	metaValue := getKey(t, keyName).Meta("postmeta")
+	key := getKey(t, keyName)
+	removeKey(t, keyName)
+	Assert(t, key != nil, "key not found")
+
+	metaValue := key.Meta(meta.Key)
 	Assertf(t, metaValue == "", "key meta value is not empty: %q", metaValue)
 }

--- a/src/tools/elektrad/move_handler_test.go
+++ b/src/tools/elektrad/move_handler_test.go
@@ -18,5 +18,6 @@ func TestPostMove(t *testing.T) {
 	Assertf(t, code == http.StatusNoContent, "wrong status code: %v", code)
 
 	key := getKey(t, keyNameTo)
+	removeKey(t, keyNameTo)
 	Assert(t, key != nil, "key has not been moved")
 }

--- a/src/tools/elektrad/router.go
+++ b/src/tools/elektrad/router.go
@@ -72,6 +72,10 @@ func created(w http.ResponseWriter) {
 	w.WriteHeader(http.StatusCreated)
 }
 
+func internalServerError(w http.ResponseWriter) {
+	w.WriteHeader(http.StatusInternalServerError)
+}
+
 func writeError(w http.ResponseWriter, err error) {
 	badRequest(w)
 


### PR DESCRIPTION
## Basics

These points need to be fulfilled for every PR:

- [x] Short descriptions of your changes are in the release notes
      (added as entry in `doc/news/_preparation_next_release.md` which
      contains `_(my name)_`)
- [ ] Details of what you changed are in commit messages
      (first line should have `module: short statement` syntax)
- [ ] References to issues, e.g. `close #X`, are in the commit messages.
- [ ] The buildservers are happy. If not, fix **in this order**:
  - [ ] add a line in `doc/news/_preparation_next_release.md`
  - [ ] reformat the code with `scripts/dev/reformat-all`
  - [ ] make all unit tests pass
  - [ ] fix all memleaks
- [ ] The PR is rebased with current master.

If you have any troubles fulfilling these criteria, please write
about the trouble as comment in the PR. We will help you.
But we cannot accept PRs that do not fulfill the basics.

## Checklist

Check relevant points but **please do not remove entries**.
For docu fixes, spell checking, and similar none of these points below
need to be checked.

- [ ] I added unit tests for my code
- [ ] I fully described what my PR does in the documentation
      (not in the PR description)
- [ ] I fixed all affected documentation
- [ ] I added code comments, logging, and assertions as appropriate (see [Coding Guidelines](https://master.libelektra.org/doc/CODING.md))
- [ ] I updated all meta data (e.g. README.md of plugins and [METADATA.ini](https://master.libelektra.org/doc/METADATA.ini))
- [ ] I mentioned every code not directly written by me in [THIRD-PARTY-LICENSES](doc/THIRD-PARTY-LICENSES)

## Review

Reviewers will usually check the following:

- [ ] Documentation is introductory, concise, good to read and describes everything what the PR does
- [ ] Examples are well chosen and understandable
- [ ] Code is conforming to [our Coding Guidelines](https://master.libelektra.org/doc/CODING.md)
- [ ] APIs are conforming to [our Design Guidelines](https://master.libelektra.org/doc/DESIGN.md)
- [ ] Code is consistent to [our Design Decisions](https://master.libelektra.org/doc/decisions)
