### PR TITLE
Use `type` metakey as fallback in range plugin

### DIFF
--- a/doc/METADATA.ini
+++ b/doc/METADATA.ini
@@ -260,7 +260,8 @@ type= "enum
 status= implemented
 usedby/plugin= range type
 description="Defines the type of the value, as specified in CORBA
-	Unlike check/type, type is also used for code generation and within the APIs"
+	Unlike check/type, type is also used for code generation and within the APIs.
+	The range plugin uses type as fallback, if check/type is not specified."
 example= any
 
 [binary]
@@ -812,7 +813,9 @@ description= "defines the type of the value, as specified in CORBA
 	Unlike type, check/type is *only* used for validation.
 
 	Tools with support for `check/type`, should also always check for `type`.
-	The type plugin prefers `check/type` if it is present."
+	The type plugin prefers `check/type` if it is present.
+			 
+	 The range plugin uses type as fallback, if check/type is not specified."
 example = any
 
 [check/range]

--- a/doc/news/_preparation_next_release.md
+++ b/doc/news/_preparation_next_release.md
@@ -53,6 +53,10 @@ The following section lists news about the [plugins](https://www.libelektra.org/
 - The `gopts` plugin now includes deeply nested options and arguments in the generated help message. _(Tobias Schubert @qwepoizt)_
 - Errors from `gopts` are now correctly reported. _(Klemens Böswirth)_
 
+### range
+
+- The `range` plugin now uses metaky `type` as fallback, if `check/type` is not specified. _(Tobias Schubert @qwepoizt)_
+
 ### spec
 
 - The `spec` plugin now runs before other `postgetstorage` plugins, so that validation can happen during `kdbGet` as well.

--- a/src/plugins/range/README.md
+++ b/src/plugins/range/README.md
@@ -6,7 +6,7 @@
 - infos/recommends =
 - infos/placements = presetstorage postgetstorage
 - infos/status = maintained conformant compatible coverage specific unittest tested libc preview unfinished
-- infos/metadata = check/range check/type
+- infos/metadata = check/range check/type type
 - infos/description = tests if a value is within a given range
 
 ## Introduction

--- a/src/plugins/range/README.md
+++ b/src/plugins/range/README.md
@@ -20,9 +20,12 @@ The package is called `libelektra5-experimental`.
 
 ## Usage
 
-The plugin checks every `Key` in the `KeySet` for the metakey `check/range` which contains either a single range with the syntax `[-]min-[-]max`, or a list of ranges or values separated by `,` and tests if the `Key`'s value is within the range(s).
-
-`check/type` can be used to specify the data type. If not specified otherwise the default value is `long long`
+- The plugin checks every `Key` in the `KeySet` having a metakey `check/range`.
+- For these keys, it checks whether the key value is within the specified range.
+- `check/range` can contain either:
+  1. a single range with the syntax `[-]min-[-]max`
+  2. or a list of ranges or values separated by `,`
+- Metakey `check/type` can be used to specify the data type. If not specified, metakey `type` will be used as fallback. If both are unspecified or unsupported, the type is assumed to be `long long`.
 
 Possible values:
 

--- a/src/plugins/range/range.c
+++ b/src/plugins/range/range.c
@@ -405,7 +405,7 @@ static RangeType getType (const Key * key)
 {
 	const Key * typeMeta = keyGetMeta (key, "check/type");
 
-	// If "check/type" is not specified, fall back to "type.
+	// If "check/type" is not specified, fall back to "type".
 	// As decided in https://github.com/ElektraInitiative/libelektra/issues/3984#issuecomment-909144492
 	if (typeMeta == NULL)
 	{

--- a/src/plugins/range/range.c
+++ b/src/plugins/range/range.c
@@ -404,6 +404,14 @@ static RangeType stringToType (const Key * typeMeta)
 static RangeType getType (const Key * key)
 {
 	const Key * typeMeta = keyGetMeta (key, "check/type");
+
+	// If "check/type" is not specified, fall back to "type.
+	// As decided in https://github.com/ElektraInitiative/libelektra/issues/3984#issuecomment-909144492
+	if (typeMeta == NULL)
+	{
+		typeMeta = keyGetMeta (key, "type");
+	}
+
 	RangeType type = stringToType (typeMeta);
 
 	if (type == NA)


### PR DESCRIPTION
Fixes #3984.

Changes the range plugin to use `type` metakey as fallback if `check/type` is not given.

## Basics

These points need to be fulfilled for every PR:

- [x] Short descriptions of your changes are in the release notes
      (added as entry in `doc/news/_preparation_next_release.md` which
      contains `_(my name)_`)
      **Please always add something to the release notes.**
- [x] Details of what you changed are in commit messages
      (first line should have `module: short statement` syntax)
- [x] References to issues, e.g. `close #X`, are in the commit messages.
- [x] The buildservers are happy. If not, fix **in this order**:
  - [x] add a line in `doc/news/_preparation_next_release.md`
  - [x] reformat the code with `scripts/dev/reformat-all`
  - [x] make all unit tests pass
  - [x] fix all memleaks
- [x] The PR is rebased with current master.

If you have any troubles fulfilling these criteria, please write
about the trouble as comment in the PR. We will help you.
But we cannot accept PRs that do not fulfill the basics.

## Checklist

Check relevant points but **please do not remove entries**.
For docu fixes, spell checking, and similar none of these points below
need to be checked.

- [ ] I added unit tests for my code
- [x] I fully described what my PR does in the documentation
      (not in the PR description)
- [x] I fixed all affected documentation
- [x] I added code comments, logging, and assertions as appropriate (see [Coding Guidelines](https://master.libelektra.org/doc/CODING.md))
- [x] I updated all meta data (e.g. README.md of plugins and [METADATA.ini](https://master.libelektra.org/doc/METADATA.ini))
- [ ] I mentioned every code not directly written by me in [THIRD-PARTY-LICENSES](doc/THIRD-PARTY-LICENSES)

## Review

Reviewers will usually check the following:

- [ ] Documentation is introductory, concise, good to read and describes everything what the PR does
- [ ] Examples are well chosen and understandable
- [ ] Code is conforming to [our Coding Guidelines](https://master.libelektra.org/doc/CODING.md)
- [ ] APIs are conforming to [our Design Guidelines](https://master.libelektra.org/doc/DESIGN.md)
- [ ] Code is consistent to [our Design Decisions](https://master.libelektra.org/doc/decisions)

## Labels

If you are already Elektra developer:

- Add the "work in progress" label if you do not want the PR to be reviewed yet.
- Add the "ready to merge" label **if the basics are fulfilled** and you also
  say that everything is ready to be merged.
