### PR TITLE
[New Backend] Discussion: Mount tooling

### DIFF
--- a/doc/dev/kdb-mount.md
+++ b/doc/dev/kdb-mount.md
@@ -1,0 +1,204 @@
+<!-- TODO: not an appropriate place for this type of docs -->
+
+# `kdb mount` Command
+
+## Basics: Direct Mode
+
+The `kdb mount` command is used to mount a new backend at some mountpoint.
+The basic usage of the command is:
+
+```
+kdb mount [OPTIONS...] <MOUNTPOINT> <BACKEND_PLUGIN> [...]
+```
+
+The arguments are as follows:
+
+- `<MOUNTPOINT>`: the mountpoint (i.e. a key name) at which the new backend shall be mounted
+- `<BACKEND_PLUGIN>`: the backend plugin used for the backend.
+  This is the main plugin responsible for the mountpoint.
+- `[...]`: any arguments after `<BACKEND_PLUGIN>` are passed as is to the backend plugin for further processing.
+  How these options are interpreted is entirely up to the backend plugin and may differ drastically between backend plugins.
+- `[OPTIONS...]`: general options processed by `kdb mount`
+
+This mode of operation is called Direct Mode, because the command-line arguments are processed directly by the backend plugin.
+The `kdb mount` command also supports different modes called Mountpoint Info and Import Mode.
+These are described further below.
+
+### Supported Options
+
+The options supported by `kdb mount` are:
+
+- `-I --import=<IMPORT_PLUGIN>:<IMPORT_FILE>`:
+  Use Import Mode for mounting (see below).
+- `-v --verbose`:
+  Print more information about what is happening.
+- `-d --debug`:
+  Print even more information than `--verbose`.
+  This option automatically implies `--verbose`.
+- `-W --with-recommends`:
+  Instruct the backend plugin to use recommended plugins in addition to required ones.
+  This option will simply be ignored, if the backend plugin doesn't support it.
+  This option is not supported in Import Mode.
+- `-q --quiet`:
+  Print nothing, if the operation was successful.
+  Error information will still be printed.
+- `-C --confirm`:
+  Print what will be changed in the KDB and ask the user for confirmation, before applying the change.
+- `-m --merge`:
+  This option is only supported in Import Mode.
+  Instead of failing when `<MOUNTPOINT>` is already in use, a merge will be attempted.
+- `-s --strategy=<STRATEGY>`:
+  This option is only supported in Import Mode when using `--merge`.
+  Specifies the merge strategy to use to resolve conflicts.
+- `-f --force`:
+  **This option is dangerous.**
+  If `<MOUNTPOINT>` is already in use, the existing backend will be removed and replaced by the newly created one.
+  The operation will still fail, if the backend plugin reports an error, or if the validation in Import Mode fails.
+  It is not possible to create an invalid backend configuration with this option, but replacing existing backends may break applications that relied on it.
+- `-c --config=<KEY>=<VALUE>`:
+  A repeatable option to define config keys that are stored in the `/config` part of the backend configuration.
+  `<KEY>` must be a cascading key and cannot contain the `=` character.
+  This option is not supported in Import Mode.
+- `--config-file=<CONFIG_PLUGIN>:<CONFIG_FILE>`:
+  Defines file `<CONFIG_FILE>` that will be read with the (storage) plugin `<CONFIG_PLUGIN>`.
+  The resulting `KeySet` will be stored in the `/config` part of the backend configuration.
+  This is an alternative to `--config`, which can be used if binary values or keys with `=` characters are needed.
+  This option is not supported in Import Mode.
+
+## Mountpoint Info
+
+The `kdb mount` command can also be used to display information about existing backends.
+For this mode invoke the command without at most one argument:
+
+```
+kdb mount [MOUNTPOINT]
+```
+
+Here `[MOUNTPOINT]` is an optional argument.
+If it is present information about the backend mounted at `[MOUNTPOINT]` will be printed.
+Without the any arguments `kdb mount` prints basic information about all existing backends.
+
+## Import Mode
+
+Some backend plugins may require complex configuration.
+It is not always (easily) possible to express the full scope of such configurations in a series of command-line arguments.
+To solve this problem, `kdb mount` also has an import mode:
+
+```
+kdb mount -I <IMPORT_PLUGIN>:<IMPORT_FILE> [IMPORT_OPTIONS...] <MOUNTPOINT> <BACKEND_PLUGIN>
+```
+
+or
+
+```
+kdb mount --import=<IMPORT_PLUGIN>:<IMPORT_FILE> [IMPORT_OPTIONS...] <MOUNTPOINT> <BACKEND_PLUGIN>
+```
+
+> **Note:** Any arguments after `<BACKEND_PLUGIN>` will be ignored in this mode.
+> Additionally, not all options for `kdb mount` may be compatible with import mode.
+
+In this mode `kdb mount` will use the (storage) plugin `<IMPORT_PLUGIN>` to load the file `<IMPORT_FILE>`.
+The resulting `KeySet` will be passed to `<BACKEND_PLUGIN>` for validation and then used directly as the configuration for the new backend mounted at `<MOUNTPOINT>`.
+Essentially, this is like a `kdb import` directly into `system:/elektra/mountpoints` with some additional validation.
+The corresponding `kdb import` command would be (`<EM>` is the escaped form of `<MOUNTPOINT>`):
+
+```
+cat <IMPORT_FILE> | kdb import system:/elektra/mountpoints/<EM> <IMPORT_PLUGIN>`
+```
+
+> **Note:** The command above is only theoretical, since `kdb import` doesn't allow writing to keys below `system:/elektra/mountpoints` to avoid creating invalid backend configurations.
+
+## Example Usage: `backend`
+
+To create a standard file-based backend the default backend plugin `backend` can be used.
+
+As a reminder, the plugin `backend` will receive all the remaining arguments `[...]` from the command:
+
+```
+kdb mount [OPTIONS...] <MOUNTPOINT> <BACKEND_PLUGIN> [...]
+```
+
+These arguments are interpreted one by one as follows:
+
+- The first argument will be used as the relative path of the backing configuration file.
+- If an argument starts with a `/`, it is a config key for the preceding plugin.
+- Otherwise, it specifies a plugin.
+
+Arguments `<plugin>` that specify a plugin result in a new section `plugins/<plugin>` with at least the key `plugins/<plugin>/name = <plugin>` in the backend configuration.
+
+The arguments that start with a `/` must be of the form `<key>=<value>`, where `<key>` must be a cascading key name (`<value>` can be empty).
+The config key `<key>` with the value `<value>` will be assigned to the preceding plugin.
+In other words, this results in the key `plugins/<plugin>/config/<key> = <value>` being added to the backend configuration, where `<plugin>` is the last `<plugin>` that was specified.
+
+An example `kdb mount` invocation could look like this:
+
+```
+kdb mount \
+  -c general/config/a=1 \
+  --config=general/config/b=2 \
+  --config=general/config/c=3 \
+  /hosts \
+  backend \
+  myhosts \
+  glob \
+  /set/#0= \
+  /set/#1= \
+  /set/#2= \
+  /set/#3= \
+  /set/#4/flags= \
+  hosts \
+  error
+```
+
+This will result in the following configuration:
+
+```
+system:/elektra/mountpoints/\/hosts/plugins/resolver/name (="resolver")
+system:/elektra/mountpoints/\/hosts/plugins/glob/name (="glob")
+system:/elektra/mountpoints/\/hosts/plugins/glob/config/set/#0
+system:/elektra/mountpoints/\/hosts/plugins/glob/config/set/#1
+system:/elektra/mountpoints/\/hosts/plugins/glob/config/set/#2
+system:/elektra/mountpoints/\/hosts/plugins/glob/config/set/#3
+system:/elektra/mountpoints/\/hosts/plugins/glob/config/set/#4/flags
+system:/elektra/mountpoints/\/hosts/plugins/hosts/name (="hosts")
+system:/elektra/mountpoints/\/hosts/plugins/sync/name (="sync")
+system:/elektra/mountpoints/\/hosts/plugins/error/name (="error")
+system:/elektra/mountpoints/\/hosts/plugins/network/name (="network")
+
+system:/elektra/mountpoints/\/hosts/plugins/backend/name (="backend")
+
+system:/elektra/mountpoints/\/hosts/config/general/config/a (="1")
+system:/elektra/mountpoints/\/hosts/config/general/config/b (="2")
+system:/elektra/mountpoints/\/hosts/config/general/config/c (="3")
+
+system:/elektra/mountpoints/\/hosts/definition/path (="myhosts")
+
+system:/elektra/mountpoints/\/hosts/definition/positions/get/resolver (="resolver")
+system:/elektra/mountpoints/\/hosts/definition/positions/get/storage (="hosts")
+system:/elektra/mountpoints/\/hosts/definition/positions/get/poststorage/#0 (="glob")
+
+system:/elektra/mountpoints/\/hosts/definition/positions/set/resolver (="resolver")
+system:/elektra/mountpoints/\/hosts/definition/positions/set/prestorage/#0 (="glob")
+system:/elektra/mountpoints/\/hosts/definition/positions/set/prestorage/#1 (="error")
+system:/elektra/mountpoints/\/hosts/definition/positions/set/prestorage/#2 (="network")
+system:/elektra/mountpoints/\/hosts/definition/positions/set/storage (="hosts")
+system:/elektra/mountpoints/\/hosts/definition/positions/set/precommit/#0 (="sync")
+system:/elektra/mountpoints/\/hosts/definition/positions/set/commit (="resolver")
+system:/elektra/mountpoints/\/hosts/definition/positions/set/rollback (="resolver")
+```
+
+The positions for the plugins are determined automatically via their plugin contract.
+If you need a more advanced configuration, you must use the Import Mode for `kdb mount`.
+
+Specifying the same plugin multiple times is valid, but will generate a warning.
+It will not result in multiple instances of a single plugin.
+For that you must use Import Mode.
+
+It is still possible that two names refer to the same plugin because of e.g. symlinks.
+This will not be detected here.
+It will, however, result in a warning when the backend is initialized at runtime.
+This is because symlinks could change at any time.
+
+> **Note:** This example also shows, that if none is specified, the default resolver plugin `resolver` will be added automatically.
+> This is not the case for the storage plugin.
+> You must define exactly one storage plugin, or an error will be reported.

--- a/doc/dev/mountpoints.md
+++ b/doc/dev/mountpoints.md
@@ -134,10 +134,9 @@ system:/elektra/mountpoints/\/hosts/plugins/#1/config/set/#4/flags
 system:/elektra/mountpoints/\/hosts/plugins/#2/name (="hosts")
 system:/elektra/mountpoints/\/hosts/plugins/#3/name (="sync")
 system:/elektra/mountpoints/\/hosts/plugins/#4/name (="network")
-system:/elektra/mountpoints/\/hosts/plugins/#5/name (="other_backend")
 
 # Define backend plugin
-system:/elektra/mountpoints/\/hosts/backend (="#5")
+system:/elektra/mountpoints/\/hosts/plugins/backend/name (="other_backend")
 
 # Configuration for backend plugin
 system:/elektra/mountpoints/\/hosts/path (="myhosts")
@@ -161,10 +160,9 @@ The plugin `other_backend` may also impose its own restrictions on plugins confi
 For example, it may define that such plugins must not generate, remove or modify keys and provide a different position for such plugins.
 
 ```
-system:/elektra/mountpoints/\/hosts/plugins/#0/name (="db_backend")
-system:/elektra/mountpoints/\/hosts/plugins/#1/name (="network")
+system:/elektra/mountpoints/\/hosts/plugins/network/name (="network")
 
-system:/elektra/mountpoints/\/hosts/backend (="#0")
+system:/elektra/mountpoints/\/hosts/plugins/backend/name (="db_backend")
 
 system:/elektra/mountpoints/\/hosts/db/driver (="postgres")
 system:/elektra/mountpoints/\/hosts/db/server (="127.0.0.1")
@@ -172,7 +170,7 @@ system:/elektra/mountpoints/\/hosts/db/port (="5432")
 system:/elektra/mountpoints/\/hosts/db/user (="admin")
 system:/elektra/mountpoints/\/hosts/db/password (="supersecret")
 
-system:/elektra/mountpoints/\/hosts/phases/set/prestorage/#0 (="#1")
+system:/elektra/mountpoints/\/hosts/phases/set/prestorage/#0 (="network")
 ```
 
 This example shows an entirely different type of backend.
@@ -185,10 +183,9 @@ Which phases can be used and how the must be configured of course depends on `db
 One might also imagine there could be a (probably quite complicated) part of the mountpoint definition that defines how the relational tables of the database are mapped into the KDB.
 
 ```
-system:/elektra/mountpoints/\/hosts/plugins/#0/name (="http_backend")
-system:/elektra/mountpoints/\/hosts/plugins/#1/name (="yajl")
+system:/elektra/mountpoints/\/hosts/plugins/yajl/name (="yajl")
 
-system:/elektra/mountpoints/\/hosts/backend (="#0")
+system:/elektra/mountpoints/\/hosts/plugins/backend/name (="http_backend")
 
 system:/elektra/mountpoints/\/hosts/url (="https://api.ipify.org/?format=JSON")
 

--- a/scripts/cmake/Modules/LibAddPlugin.cmake
+++ b/scripts/cmake/Modules/LibAddPlugin.cmake
@@ -408,7 +408,7 @@ endfunction ()
 #   like LINK_ELEKTRA but only applies to plugin tests
 # ~~~
 function (add_plugin PLUGIN_SHORT_NAME)
-	# TODO (kodebach): validate that plugin name doesn't contain / or start with #, possibly more
+	# TODO (kodebach): validate that plugin name doesn't contain '/', ' ' or start with '#', possibly more
 	set (
 		MULTI_VALUE_KEYWORDS
 		SOURCES

--- a/scripts/cmake/Modules/LibAddPlugin.cmake
+++ b/scripts/cmake/Modules/LibAddPlugin.cmake
@@ -408,6 +408,7 @@ endfunction ()
 #   like LINK_ELEKTRA but only applies to plugin tests
 # ~~~
 function (add_plugin PLUGIN_SHORT_NAME)
+	# TODO (kodebach): validate that plugin name doesn't contain / or start with #, possibly more
 	set (
 		MULTI_VALUE_KEYWORDS
 		SOURCES

--- a/src/include/CMakeLists.txt
+++ b/src/include/CMakeLists.txt
@@ -191,6 +191,8 @@ install (
 	      kdbmacros.h
 	      kdbmerge.h
 	      kdbgopts.h
+	      kdbmount.h
+	      kdbplacement.h
 	DESTINATION include/${TARGET_INCLUDE_FOLDER}
 	COMPONENT libelektra-dev)
 

--- a/src/include/kdbmount.h
+++ b/src/include/kdbmount.h
@@ -1,0 +1,103 @@
+/**
+ * @file
+ *
+ * @brief INTERNAL header for libelektra-opts
+ *
+ * @copyright BSD License (see LICENSE.md or https://www.libelektra.org)
+ */
+
+
+#ifndef ELEKTRA_KDBMOUNT_H
+#define ELEKTRA_KDBMOUNT_H
+
+#include "kdb.h"
+#include <stdbool.h>
+
+#ifdef __cplusplus
+namespace ckdb
+{
+extern "C" {
+#endif
+
+// private struct
+struct _ElektraPluginList
+{
+	char ** plugins;
+	size_t size;
+	size_t alloc;
+};
+
+typedef struct _ElektraPluginList ElektraPluginList;
+typedef struct _ElektraPluginList ElektraPluginAliasList;
+
+ElektraPluginList * elektraPluginListCreate (size_t alloc);
+size_t elektraPluginListSize (const ElektraPluginList * list);
+const char * elektraPluginListGet (const ElektraPluginList * list, size_t index);
+const char * elektraPluginListSet (const ElektraPluginList * list, size_t index, const char * plugin);
+const char * elektraPluginListEnsureAlloc (const ElektraPluginList * list, size_t alloc);
+void elektraPluginListDelete (ElektraPluginList * list);
+
+// finds all plugins for an alias; contract/provides, contract/name (= plugin->name), file name
+ElektraPluginList * elektraMountFindPluginsByAlias (const char * alias);
+
+// (for spec-mount) finds all plugins that support metakey; contract/metadata
+ElektraPluginList * elektraMountFindPluginsByMeta (const char * metaName);
+
+// selects the best plugin from a set of candidates; based on contract/status
+const char * elektraMountSelectBestPlugin (const ElektraPluginList * candidates);
+
+// gets the list of other plugins recommneded by a concrete(!) plugin; contract/recommends
+ElektraPluginAliasList * elektraMountGetRecommendedPlugins (const char * plugin);
+
+// resolves all plugins in aliases (NULL terminated) with elektraMountFindPluginsByAlias
+// finds plugins for all meta:/ keys in metaKeys
+// if withRecommends==true also resolves recommended plugins with elektraMountGetRecommendedPlugins and elektraMountFindPluginsByAlias
+// returns the list of all resolved plugins
+ElektraPluginList * elektraMountResolveAllPlugins (const char ** aliases, KeySet * metaKeys, bool withRecommends);
+
+/*
+ replace infos/needs, config/needs with contract/needs
+
+ all of this is processed at runtime by libelektra-kdb
+
+ # general config (was config/needs)
+ contract/needs/config/... = ...
+
+ # plugin (was infos/needs) + config (not possible before)
+ contract/needs/<plugin>/name = <some_plugin>
+ contract/needs/<plugin>/config/... = ...
+*/
+
+/* Usage example:
+
+ElektraPluginList * tomlCandidates = elektraMountFindPluginsByAlias ("storage/toml");
+const char * toml = elektraMountSelectBestPlugin (tomlCandidates);
+
+ElektraPluginAliasList * tomlRecommendsAliases = elektraMountGetRecommendedPlugins (toml);
+size_t aliasCount = elektraPluginListSize (tomlRecommendsAliases);
+ElektraPluginList * tomlRecommended = elektraPluginListCreate (aliasCount);
+for (size_t i = 0; i < aliasCount; ++i)
+{
+	const char * alias = elektraPluginListGet (tomlRecommendsAliases, i);
+	ElektraPluginList * candidates = elektraMountFindPluginsByAlias (alias);
+	const char * recommended = elektraMountSelectBestPlugin (candidates);
+	elektraPluginListSet (tomlRecommended, i, recommended);
+}
+
+ElektraPluginList * typeCandidates = elektraMountFindPluginsByMeta ("meta:/type");
+const char * type = elektraMountSelectBestPlugin (typeCandidates);
+
+// create mountpoint configuration with plugins
+
+elektraPluginListDelete (tomlCandidates);
+elektraPluginListDelete (tomlRecommendsAliases);
+elektraPluginListDelete (tomlRecommended);
+elektraPluginListDelete (typeCandidates);
+*/
+
+#ifdef __cplusplus
+}
+}
+#endif
+
+#endif // ELEKTRA_KDBMOUNT_H

--- a/src/include/kdbplacement.h
+++ b/src/include/kdbplacement.h
@@ -1,0 +1,125 @@
+/**
+ * @file
+ *
+ * @brief INTERNAL header for libelektra-opts
+ *
+ * @copyright BSD License (see LICENSE.md or https://www.libelektra.org)
+ */
+
+
+#ifndef ELEKTRA_KDBPLACEMENT_H
+#define ELEKTRA_KDBPLACEMENT_H
+
+#include "kdbmount.h"
+
+#ifdef __cplusplus
+namespace ckdb
+{
+extern "C" {
+#endif
+
+/*
+infos/ordering - barely used, should be supported via placements
+infos/stacking - only used by glob, should be supported via separate placements for get/set
+infos/placements - needs changes
+
+--> use this
+
+# <pvariant> is the variant of placement, different backends may use different variants
+contract/placements/<pvariant>... = ...
+
+# infos/placements corresponds to contract/placements/basic
+contract/placements/basic = ...
+# but we can also split get and set
+contract/placements/basic/get = ...
+contract/placements/basic/set = ...
+
+# odering constraints in contract/placements/basic
+# <op> is get or set
+contract/placements/basic/<op>/before = ... # during <op> run this plugin before the listed ones
+contract/placements/basic/<op>/after = ... # during <op> run this plugin after the listed ones
+
+# every backend plugins should support the 'basic' variant of placement
+# sometimes it may make sense to ignore some parts e.g. the resolver or storage placements are useless in an SQL backend
+# backend plugins that don't use other plugins (e.g. version) are obviously an exception
+# if possible the 'basic' variant should be mapped to whatever placement variant the backend plugin uses natively
+
+# other placement variants could enhance backend functionality e.g. there could be a variant that groups plugins
+# by functionality (e.g. generation, transformation, validation) and calls them when appropriate. For example the
+# backend plugin could do generation -> transformation -> validation in a loop until nothing changes. Obviously something
+# like this couldn't be supported by every plugin, so requiring the declaration of a separate placement makes sense.
+
+# parsing of the 'basic' variant (and in future possibly others) is implemented by libelektra-placement
+
+*/
+
+// TODO (kodebach) [Q]: should this be a public struct?
+// the struct should be stable, unless there is some new drastic change to libelektra-kdb
+// if we make the struct opaque we need creation, deletion and accessor functions
+typedef struct
+{
+	char * resolver; // used for get/resolver, set/resolver, commit and rollback
+	char * storage;	 // used for get/storage and set/storage
+
+	struct
+	{
+		ElektraPluginList * prestorage;
+		ElektraPluginList * poststorage;
+	} get;
+
+	struct
+	{
+		ElektraPluginList * prestorage;
+		ElektraPluginList * poststorage;
+		ElektraPluginList * precommit;
+		ElektraPluginList * postcommit;
+		ElektraPluginList * prerollback;
+		ElektraPluginList * postrollback;
+	} set;
+} ElektraBasicPlacedPlugins;
+
+/*
+// if the struct above is opaque we also need these
+ElektraBasicPlacedPlugins * elektraPlacementBasicCreate (void);
+const char * elektraPlacementBasicResolver (ElektraBasicPlacedPlugins * placedPlugins);
+const char * elektraPlacementBasicStorage (ElektraBasicPlacedPlugins * placedPlugins);
+
+typedef enum
+{
+	ELEKTRA_BASIC_PLACED_GET_PRESTORAGE,
+	ELEKTRA_BASIC_PLACED_GET_POSTSTORAGE,
+	ELEKTRA_BASIC_PLACED_SET_PRESTORAGE,
+	ELEKTRA_BASIC_PLACED_SET_POSTSTORAGE,
+	ELEKTRA_BASIC_PLACED_SET_PRECOMMIT,
+	ELEKTRA_BASIC_PLACED_SET_POSTCOMMIT,
+	ELEKTRA_BASIC_PLACED_SET_PREROLLBACK,
+	ELEKTRA_BASIC_PLACED_SET_POSTROLLBACK,
+} ElektraBasicPlacedPluginsList;
+
+ElektraPluginList * elektraPlacementBasicGetList (ElektraBasicPlacedPlugins * placedPlugins, ElektraBasicPlacedPluginsList listType);
+
+void elektraPlacementBasicDelete (ElektraBasicPlacedPlugins * placedPlugins);
+*/
+
+int elektraPlacementBasicPlacePlugin (ElektraBasicPlacedPlugins * placedPlugins, const char * plugin);
+
+/* Usage example:
+
+ElektraPluginList * plugins = elektraMountResolveAllPlugins (aliases, metaKeys, withRecommends);
+
+ElektraBasicPlacedPlugins * placedPlugins;
+// init placedPlugins on stack, or via elektraPlacementBasicCreate depending on API
+for (size_t i = 0; i < elektraPluginListSize (plugins); ++i)
+{
+	elektraPlacementBasicPlacePlugin (placedPlugins, plugin);
+}
+
+// process placedPlugins into plugin configuration
+*/
+
+#ifdef __cplusplus
+}
+}
+#endif
+
+#endif // ELEKTRA_KDBPLACEMENT_H

--- a/src/libs/CMakeLists.txt
+++ b/src/libs/CMakeLists.txt
@@ -14,7 +14,9 @@ set (
 	notification
 	highlevel
 	merge
-	opts)
+	opts
+	mount
+	placement)
 
 # The subdirectory for LibElektra must be the last entry!
 list (APPEND SUBDIRS elektra)

--- a/src/libs/mount/CMakeLists.txt
+++ b/src/libs/mount/CMakeLists.txt
@@ -1,0 +1,2 @@
+set (SOURCES mount.c)
+add_lib (mount SOURCES ${SOURCES} COMPONENT libelektra${SO_VERSION})

--- a/src/libs/mount/mount.c
+++ b/src/libs/mount/mount.c
@@ -1,0 +1,12 @@
+/**
+ * @file
+ *
+ * @brief Access plugin handle.
+ *
+ * @copyright BSD License (see LICENSE.md or https://www.libelektra.org)
+ */
+
+#include "kdbmacros.h"
+#include "kdbmount.h"
+
+static const int dummy ELEKTRA_UNUSED = 0;

--- a/src/libs/mount/symbols.map
+++ b/src/libs/mount/symbols.map
@@ -1,0 +1,2 @@
+libelektra_1.0 {
+};

--- a/src/libs/placement/CMakeLists.txt
+++ b/src/libs/placement/CMakeLists.txt
@@ -1,0 +1,2 @@
+set (SOURCES placement.c)
+add_lib (placement SOURCES ${SOURCES} COMPONENT libelektra${SO_VERSION})

--- a/src/libs/placement/placement.c
+++ b/src/libs/placement/placement.c
@@ -1,0 +1,12 @@
+/**
+ * @file
+ *
+ * @brief Access plugin handle.
+ *
+ * @copyright BSD License (see LICENSE.md or https://www.libelektra.org)
+ */
+
+#include "kdbmacros.h"
+#include "kdbmount.h"
+
+static const int dummy ELEKTRA_UNUSED = 0;

--- a/src/libs/placement/symbols.map
+++ b/src/libs/placement/symbols.map
@@ -1,0 +1,2 @@
+libelektra_1.0 {
+};


### PR DESCRIPTION
**DO NOT MERGE**

This PR contains my suggestions for the new `kdb mount` tooling. (ignore the changes to `doc/dev/mountpoints.md`; just fixes for stuff I missed).

The user-side interface of `kdb mount` is described in the Markdown file `doc/dev/kdb-mount.md`. Apart from maybe the set of `[OPTIONS...]` I'm pretty sure this is the best solution here.

The files `kdbmount.h` and `kdbplacement.h` contain my suggestion for the tooling API that would be used by backend plugins to support `kdb mount`.

The functions in `kdbmount.h` will be needed by every backend plugin that calls other plugins (*). A basic backend like `version` of course doesn't need them.  In most cases `elektraMountResolveAllPlugins` should do the job, but sometimes more granular access could be required, so I would just expose all functions.

(*) In general they could be used by any plugins that calls another plugin. However, I think we should cover this use-case differently, so that `elektraPluginOpen` only happens 

`kdbplacement.h` is the implementation for the `placements` contract of plugins. The idea is that there are different variants for placements, but there is a standardized `basic` variant (what we have now in `infos/placements`). This standarized variant is implemented in `kdbplacement.h`. In future we could add other standard placements to `kdbplacement.h`, however, a backend plugin could also use it's own contract if needed.

Regarding embedded systems: The validation function mentioned in the "Import Mode" docs, is essentially just what already happens in `kdbOpen`, so that shouldn't really impact the binary size. The code needed within `backend` for "Direct Mode" should be too much, but we will need to link against `libelektra-mount` and `libelektra-placement` for it to work. There is probably a way to strip out all this when building for embedded systems, or we could supply dummy libs that have the symbols but only return `NULL` or something like that. However, I will look into putting the mount-logic into a separate `.so` file (e.g. `libelektra-backend-meta.so` for the plugin `libelektra-backend.so`).

@markus2330 Please take a look and let me know, what you think. We can also discuss this on Monday.