### PR TITLE
[CM T3] kdb: Fixed a bug where the mv-command deletes subkeys of the moved key.

### DIFF
--- a/doc/news/_preparation_next_release.md
+++ b/doc/news/_preparation_next_release.md
@@ -202,9 +202,9 @@ you up-to-date with the multi-language support provided by Elektra.
 - <<TODO>>
 - <<TODO>>
 
-### <<Tool>>
+### KDB
 
-- <<TODO>>
+- Fixed a bug where the mv-command deletes subkeys of the moved key _(@Gratla)_
 - <<TODO>>
 - <<TODO>>
 

--- a/src/tools/kdb/mv.cpp
+++ b/src/tools/kdb/mv.cpp
@@ -75,6 +75,12 @@ int MvCommand::execute (Cmdline const & cl)
 			return 11;
 		}
 		newConf.append (rename_key (k, sourceName, newDirName, cl.verbose));
+
+		// move the remaining keys back to the original position
+		while ((k = oldConf.next ()))
+		{
+			newConf.append (k);
+		}
 	}
 	newConf.append (tmpConf); // these are unrelated keys
 	// drop the original configuration


### PR DESCRIPTION
Fixes #3648 

<!--
Check relevant points but **please do not remove entries**.
-->

## Basics

<!--
These points need to be fulfilled for every PR.
-->

- [x] Short descriptions of your changes are in the release notes
      (added as entry in `doc/news/_preparation_next_release.md` which
      contains `_(my name)_`)
      **Please always add something to the release notes.**
- [x] Details of what you changed are in commit messages
      (first line should have `module: short statement` syntax)
- [ ] References to issues, e.g. `close #X`, are in the commit messages.
- [ ] The buildservers are happy. If not, fix **in this order**:
  - [ ] add a line in `doc/news/_preparation_next_release.md`
  - [ ] reformat the code with `scripts/dev/reformat-all`
  - [ ] make all unit tests pass
  - [ ] fix all memleaks
- [ ] The PR is rebased with current master.

<!--
If you have any troubles fulfilling these criteria, please write
about the trouble as comment in the PR. We will help you,
but we cannot accept PRs that do not fulfill the basics.
-->

## Checklist

<!--
For docu fixes, spell checking, and similar none of these points below
need to be checked.
-->

- [ ] I added unit tests for my code
- [ ] I fully described what my PR does in the documentation
      (not in the PR description)
- [ ] I fixed all affected documentation
- [ ] I added code comments, logging, and assertions as appropriate (see [Coding Guidelines](https://master.libelektra.org/doc/CODING.md))
- [ ] I updated all meta data (e.g. README.md of plugins and [METADATA.ini](https://master.libelektra.org/doc/METADATA.ini))
- [ ] I mentioned [every code](/.reuse/dep5) not directly written by me in [reuse syntax](https://reuse.software/)

## Review

<!--
Reviewers should check the following.
-->

- [ ] Documentation is introductory, concise, good to read and describes everything what the PR does
- [ ] Examples are well chosen and understandable
- [ ] Code is conforming to [our Coding Guidelines](https://master.libelektra.org/doc/CODING.md)
- [ ] APIs are conforming to [our Design Guidelines](https://master.libelektra.org/doc/DESIGN.md)
- [ ] Code is consistent to [our Design Decisions](https://master.libelektra.org/doc/decisions)

## Labels

<!--
If you are already Elektra developer, please adjust the labels.
Otherwise, write a comment and it will be done for you.
-->

- [ ] Add the "work in progress" label if you do not want the PR to be reviewed yet.
- [ ] Add the "ready to merge" label **if the basics are fulfilled** and no further pushes are planned by you.
