### PR TITLE
[new-backend] resolver: add strategy for sudo user:/ namespace

### DIFF
--- a/doc/COMPILE.md
+++ b/doc/COMPILE.md
@@ -324,8 +324,8 @@ The following base flags are available:
 
 The user flags are (the order matters!):
 
-- `p` use passwd/ldap to lookup home directory using `getpwnam_r` with the username from the POSIX environment variable LOGNAME
-- `s` same as `p` but with the environment variable SUDO_USER, which enables access to the `user:/` namespace of the executing user when using `sudo`
+- `p` use passwd/ldap to lookup home directory using `getpwuid_r`
+- `s` same as `p` but with the username specified in the environment variable `SUDO_USER` or `DOAS_USER`, which enables access to the `user:/` namespace of the executing user when using `sudo` or `doas`.
 - `h` use the environment variable HOME
 - `u` use the environment variable USER
 - `b` use the built-in default cmake variable `KDB_DB_HOME`

--- a/doc/COMPILE.md
+++ b/doc/COMPILE.md
@@ -325,7 +325,7 @@ The following base flags are available:
 The user flags are (the order matters!):
 
 - `p` use passwd/ldap to lookup home directory using `getpwuid_r`
-- `s` same as `p` but with the username specified in the environment variable `SUDO_USER` or `DOAS_USER`, which enables access to the `user:/` namespace of the executing user when using `sudo` or `doas`.
+- `s` same as `p` but with `sudo` compatibility - see [the README of the resolver plugin](../src/plugins/resolver/README.md).
 - `h` use the environment variable HOME
 - `u` use the environment variable USER
 - `b` use the built-in default cmake variable `KDB_DB_HOME`

--- a/doc/COMPILE.md
+++ b/doc/COMPILE.md
@@ -324,7 +324,8 @@ The following base flags are available:
 
 The user flags are (the order matters!):
 
-- `p` use passwd/ldap to lookup home directory using `getpwuid_r`
+- `p` use passwd/ldap to lookup home directory using `getpwnam_r` with the username from the POSIX environment variable LOGNAME
+- `s` same as `p` but with the environment variable SUDO_USER, which enables access to the `user:/` namespace of the executing user when using `sudo`
 - `h` use the environment variable HOME
 - `u` use the environment variable USER
 - `b` use the built-in default cmake variable `KDB_DB_HOME`

--- a/doc/news/_preparation_next_release.md
+++ b/doc/news/_preparation_next_release.md
@@ -47,6 +47,9 @@ docker run -it elektra/elektra
 
 The following section lists news about the [plugins](https://www.libelektra.org/plugins/readme) we updated in this release.
 
+### resolver
+- New strategy `s` for user namespaces: allows for resolving the `user:/` namespace for the user executing via `sudo` or `doas` _(Maximilian Irlinger @atmaxinger)_
+
 ### filecheck
 
 - Removed unused variable that threw an error in filecheck.c. _(Vaibhav Ganesh @flackojr)_

--- a/src/plugins/resolver/CMakeLists.txt
+++ b/src/plugins/resolver/CMakeLists.txt
@@ -25,6 +25,7 @@ foreach (plugin ${PLUGINS})
 			resolver_fm_xp_x
 			resolver_fm_xhp_x
 			resolver_fm_uhb_xb
+			resolver_fm_sp_b # for RecordElektra
 			resolver_fm_hpu_b # default
 		)
 	endif ()

--- a/src/plugins/resolver/README.md
+++ b/src/plugins/resolver/README.md
@@ -103,6 +103,12 @@ way:
 - if no file was found, the least important element will be used for
   potential write attempts.
 
+### SUDO/DOAS Compatibility
+
+The `s` variant of the resolver adds `sudo` and `doas` compatibility for the `user:/` namespace.
+In this variant, the environment variables `SUDO_USER` and `DOAS_USER` are checked (in this order).
+This allows the `user:/` namespace to be resolved for the user executing the `sudo` or `doas` command instead of resolving it for root.
+
 ## Reading Configuration
 
 1. If no update needed (unchanged modification time): quit successfully


### PR DESCRIPTION
I have added a resolver strategy called `s` for the `user:/` namespace.
If the environment variable `SUDO_USER` is set, it will use passwd to resolve the path for this user.
Unforunately, the tests do not work (yet), but this seems to be the case of the `new-backend` branch - not quite sure how to fix them yet.

<!--
Check relevant points but **please do not remove entries**.
-->

## Basics

<!--
These points need to be fulfilled for every PR.
-->

- [ ] Short descriptions of your changes are in the release notes
      (added as entry in `doc/news/_preparation_next_release.md` which
      contains `_(my name)_`)
      **Please always add something to the release notes.**
- [ ] Details of what you changed are in commit messages
      (first line should have `module: short statement` syntax)
- [ ] References to issues, e.g. `close #X`, are in the commit messages.
- [ ] The buildservers are happy. If not, fix **in this order**:
  - [ ] add a line in `doc/news/_preparation_next_release.md`
  - [ ] reformat the code with `scripts/dev/reformat-all`
  - [ ] make all unit tests pass
  - [ ] fix all memleaks
- [ ] The PR is rebased with current master.

<!--
If you have any troubles fulfilling these criteria, please write
about the trouble as comment in the PR. We will help you,
but we cannot accept PRs that do not fulfill the basics.
-->

## Checklist

<!--
For docu fixes, spell checking, and similar none of these points below
need to be checked.
-->

- [ ] I added unit tests for my code
- [ ] I fully described what my PR does in the documentation
      (not in the PR description)
- [ ] I fixed all affected documentation
- [ ] I added code comments, logging, and assertions as appropriate (see [Coding Guidelines](https://master.libelektra.org/doc/CODING.md))
- [ ] I updated all meta data (e.g. README.md of plugins and [METADATA.ini](https://master.libelektra.org/doc/METADATA.ini))
- [ ] I mentioned [every code](/.reuse/dep5) not directly written by me in [reuse syntax](https://reuse.software/)

## Review

<!--
Reviewers should check the following.
-->

- [ ] Documentation is introductory, concise, good to read and describes everything what the PR does
- [ ] Examples are well chosen and understandable
- [ ] Code is conforming to [our Coding Guidelines](https://master.libelektra.org/doc/CODING.md)
- [ ] APIs are conforming to [our Design Guidelines](https://master.libelektra.org/doc/DESIGN.md)
- [ ] Code is consistent to [our Design Decisions](https://master.libelektra.org/doc/decisions)

## Labels

<!--
If you are already Elektra developer, please adjust the labels.
Otherwise, write a comment and it will be done for you.
-->

- [ ] Add the "work in progress" label if you do not want the PR to be reviewed yet.
- [ ] Add the "ready to merge" label **if the basics are fulfilled** and no further pushes are planned by you.
