### PR TITLE
build: use Debian Bullseye to build the documentation (closes #4455)

### DIFF
--- a/doc/news/2021-02-01_0.9.4.md
+++ b/doc/news/2021-02-01_0.9.4.md
@@ -280,7 +280,7 @@ you up to date with the multi-language support provided by Elektra.
 
 ### Docker
 
-- We added a Docker image for [building the documentation on Debian Sid](https://github.com/atmaxinger/libelektra/blob/799fecd94dcb482ea9338facaf63d39f8e5ab5bd/scripts/docker/debian/sid/doc.Dockerfile). _(René Schwaiger)_
+- We added a Docker image for [building the documentation on Debian Sid](https://github.com/ElektraInitiative/libelektra/blob/799fecd94dcb482ea9338facaf63d39f8e5ab5bd/scripts/docker/debian/sid/doc.Dockerfile). _(René Schwaiger)_
 - We removed the Docker image for building the documentation on Debian Stretch. _(René Schwaiger)_
 - Add Fedora 33 Dockerfile for Cirrus and Jenkins CI. _(Mihael Pranjić)_
 - Debian Sid: update to clang 11. _(Mihael Pranjić)_

--- a/doc/news/2021-02-01_0.9.4.md
+++ b/doc/news/2021-02-01_0.9.4.md
@@ -280,7 +280,7 @@ you up to date with the multi-language support provided by Elektra.
 
 ### Docker
 
-- We added a Docker image for [building the documentation on Debian Sid](../../scripts/docker/debian/sid/doc.Dockerfile). _(René Schwaiger)_
+- We added a Docker image for [building the documentation on Debian Sid](https://github.com/atmaxinger/libelektra/blob/799fecd94dcb482ea9338facaf63d39f8e5ab5bd/scripts/docker/debian/sid/doc.Dockerfile). _(René Schwaiger)_
 - We removed the Docker image for building the documentation on Debian Stretch. _(René Schwaiger)_
 - Add Fedora 33 Dockerfile for Cirrus and Jenkins CI. _(Mihael Pranjić)_
 - Debian Sid: update to clang 11. _(Mihael Pranjić)_

--- a/doc/news/_preparation_next_release.md
+++ b/doc/news/_preparation_next_release.md
@@ -334,7 +334,7 @@ you up-to-date with the multi-language support provided by Elektra.
 ### Docker
 
 - Bump Alpine Linux to 3.16.0. _(Mihael Pranjić @mpranj)_
-- <<TODO>>
+- The Docker image for building the documentation is now [based on Debian Bullseye](../../scripts/docker/debian/bullseye/doc.Dockerfile). _(Maximilian Irlinger @atmaxinger)_
 - <<TODO>>
 - <<TODO>>
 - <<TODO>>

--- a/scripts/docker/debian/bullseye/doc.Dockerfile
+++ b/scripts/docker/debian/bullseye/doc.Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:sid
+FROM debian:bullseye
 
 ENV LANG C.UTF-8
 ENV LANGUAGE C.UTF-8
@@ -52,5 +52,5 @@ RUN useradd \
 USER ${JENKINS_USERID}
 
 # Ronn-NG
-ENV PATH="$PATH:/home/jenkins/.local/share/gem/ruby/3.0.0/bin"
+ENV PATH="$PATH:/home/jenkins/.local/share/gem/ruby/2.7.0/bin"
 RUN gem install --user-install ronn-ng -v 0.10.1.pre1 && ronn --version

--- a/scripts/jenkins/Jenkinsfile
+++ b/scripts/jenkins/Jenkinsfile
@@ -229,15 +229,6 @@ def dockerInit() {
       "./scripts/docker/debian/sid/Dockerfile"
     )
 
-    /* Build Elektra's documentation with this image.
-     * Also contains latex for pdf creation.
-     */
-    DOCKER_IMAGES.sid_doc = dockerUtils.createDockerImageDesc(
-      "debian-sid-doc", dockerUtils.&idTesting,
-      "./scripts/docker/debian/sid",
-      "./scripts/docker/debian/sid/doc.Dockerfile"
-    )
-
     /*
      * Debian Bullseye. Used for testing and packaging.
      */
@@ -264,6 +255,15 @@ def dockerInit() {
       "./scripts/docker/debian/bullseye",
       "./scripts/docker/debian/bullseye/i386.Dockerfile"
     )
+
+	/* Build Elektra's documentation with this image.
+	 * Also contains latex for pdf creation.
+	 */
+	DOCKER_IMAGES.bullseye_doc = dockerUtils.createDockerImageDesc(
+	  "debian-bullseye-doc", dockerUtils.&idTesting,
+	  "./scripts/docker/debian/bullseye",
+	  "./scripts/docker/debian/bullseye/doc.Dockerfile"
+	)
 
     /* Our main target for compatibility is Debian stable
      * (currently buster).
@@ -820,7 +820,7 @@ def buildTodo() {
 '''
   return [(stageName): {
     stage(stageName) {
-      withDockerEnv(DOCKER_IMAGES.sid_doc) {
+      withDockerEnv(DOCKER_IMAGES.bullseye_doc) {
         sh "sloccount --duplicates --wide --details ${WORKSPACE} > sloccount.sc"
         step([$class: 'SloccountPublisher', ignoreBuildFailure: true])
         recordIssues(tools: [taskScanner(ignoreCase: true, includePattern: openTaskPatterns, lowTags: 'TODO,FIXME')])
@@ -910,7 +910,7 @@ def buildDoc() {
   ]
   return [(stageName): {
     stage(stageName) {
-      withDockerEnv(DOCKER_IMAGES.sid_doc) {
+      withDockerEnv(DOCKER_IMAGES.bullseye_doc) {
         dir('build') {
           deleteDir()
           utils.cmake(env.WORKSPACE, cmakeFlags)


### PR DESCRIPTION
Build the documentation with Debian Bullseye instead of Sid. This fixes #4455.

<!--
Check relevant points but **please do not remove entries**.
-->

## Basics

<!--
These points need to be fulfilled for every PR.
-->

- [x] Short descriptions of your changes are in the release notes
      (added as entry in `doc/news/_preparation_next_release.md` which
      contains `_(my name)_`)
      **Please always add something to the release notes.**
- [x] Details of what you changed are in commit messages
      (first line should have `module: short statement` syntax)
- [x] References to issues, e.g. `close #X`, are in the commit messages.
- [x] The buildservers are happy. If not, fix **in this order**:
  - [x] add a line in `doc/news/_preparation_next_release.md`
  - [x] reformat the code with `scripts/dev/reformat-all`
  - [x] make all unit tests pass
  - [x] fix all memleaks
- [x] The PR is rebased with current master.

<!--
If you have any troubles fulfilling these criteria, please write
about the trouble as comment in the PR. We will help you,
but we cannot accept PRs that do not fulfill the basics.
-->

## Checklist

<!--
For docu fixes, spell checking, and similar none of these points below
need to be checked.
-->

- [x] I added unit tests for my code
- [x] I fully described what my PR does in the documentation
      (not in the PR description)
- [x] I fixed all affected documentation
- [x] I added code comments, logging, and assertions as appropriate (see [Coding Guidelines](https://master.libelektra.org/doc/CODING.md))
- [x] I updated all meta data (e.g. README.md of plugins and [METADATA.ini](https://master.libelektra.org/doc/METADATA.ini))
- [x] I mentioned [every code](/.reuse/dep5) not directly written by me in [reuse syntax](https://reuse.software/)

## Review

<!--
Reviewers should check the following.
-->

- [x] Documentation is introductory, concise, good to read and describes everything what the PR does
- [x] Examples are well chosen and understandable
- [x] Code is conforming to [our Coding Guidelines](https://master.libelektra.org/doc/CODING.md)
- [x] APIs are conforming to [our Design Guidelines](https://master.libelektra.org/doc/DESIGN.md)
- [x] Code is consistent to [our Design Decisions](https://master.libelektra.org/doc/decisions)

## Labels

<!--
If you are already Elektra developer, please adjust the labels.
Otherwise, write a comment and it will be done for you.
-->

- [x] Add the "work in progress" label if you do not want the PR to be reviewed yet.
- [x] Add the "ready to merge" label **if the basics are fulfilled** and no further pushes are planned by you.
