### PR TITLE
quickdump: don't close stdout

### DIFF
--- a/doc/news/_preparation_next_release.md
+++ b/doc/news/_preparation_next_release.md
@@ -67,11 +67,9 @@ The following section lists news about the [plugins](https://www.libelektra.org/
 - <<TODO>>
 - <<TODO>>
 
-### <<Plugin>>
+### specload
 
-- <<TODO>>
-- <<TODO>>
-- <<TODO>>
+- fail if either the spec or parentKey parameter of elektraSpecloadSendSpec is NULL _(@hannes99)_
 
 ### <<Plugin>>
 

--- a/doc/news/_preparation_next_release.md
+++ b/doc/news/_preparation_next_release.md
@@ -71,11 +71,9 @@ The following section lists news about the [plugins](https://www.libelektra.org/
 
 - fail if either the spec or parentKey parameter of elektraSpecloadSendSpec is NULL _(@hannes99)_
 
-### <<Plugin>>
+### quickdump
 
-- <<TODO>>
-- <<TODO>>
-- <<TODO>>
+- elektraQuickdumpSet: don't fclose if stdout _(@hannes99)_
 
 ### <<Plugin>>
 

--- a/src/plugins/specload/specload.c
+++ b/src/plugins/specload/specload.c
@@ -157,6 +157,10 @@ int elektraSpecloadClose (Plugin * handle, Key * errorKey)
  */
 int elektraSpecloadSendSpec (Plugin * handle ELEKTRA_UNUSED, KeySet * spec, Key * parentKey)
 {
+	if (spec == NULL || parentKey == NULL)
+	{
+		return ELEKTRA_PLUGIN_STATUS_ERROR;
+	}
 	Key * errorKey = keyNew ("/", KEY_END);
 
 	KeySet * quickDumpConf = ksNew (0, KS_END);

--- a/src/plugins/specload/testmod_specload.c
+++ b/src/plugins/specload/testmod_specload.c
@@ -303,8 +303,6 @@ static void test_sendspec (void)
 
 	PLUGIN_OPEN ("specload");
 
-	// TODO: if elektraSpecloadSendSpec should not fail as expected stdout will be closed with the current quickdump implementation
-
 	int tmp = elektraSpecloadSendSpec (plugin, NULL, parentKey);
 	succeed_if (tmp == ELEKTRA_PLUGIN_STATUS_ERROR, "sendspec should return an error if spec is NULL");
 

--- a/src/plugins/specload/testmod_specload.c
+++ b/src/plugins/specload/testmod_specload.c
@@ -292,6 +292,32 @@ static void test_remove (bool directFile)
 	PLUGIN_CLOSE ();
 }
 
+static void test_sendspec (void)
+{
+	printf ("test sendspec\n");
+
+	KeySet * ks = ksNew (0, KS_END);
+	ksAppendKey (ks, keyNew (PARENT_KEY "/key", KEY_META, "description", "abc", KEY_META, "opt/help", "def", KEY_END));
+	KeySet * conf = ksNew (2, keyNew ("/file", KEY_VALUE, srcdir_file ("specload/spec.quickdump"), KEY_END), KS_END);
+	Key * parentKey = keyNew (PARENT_KEY, KEY_END);
+
+	PLUGIN_OPEN ("specload");
+
+	// TODO: if elektraSpecloadSendSpec should not fail as expected stdout will be closed with the current quickdump implementation
+
+	int tmp = elektraSpecloadSendSpec (plugin, NULL, parentKey);
+	succeed_if (tmp == ELEKTRA_PLUGIN_STATUS_ERROR, "sendspec should return an error if spec is NULL");
+
+	tmp = elektraSpecloadSendSpec (plugin, ks, NULL);
+	succeed_if (tmp == ELEKTRA_PLUGIN_STATUS_ERROR, "sendspec should return an error if parentKey is NULL");
+
+	tmp = elektraSpecloadSendSpec (plugin, NULL, NULL);
+	succeed_if (tmp == ELEKTRA_PLUGIN_STATUS_ERROR, "sendspec should return an error if spec and parentKey are NULL");
+
+	keyDel (parentKey);
+	ksDel (ks);
+	PLUGIN_CLOSE ();
+}
 
 int main (int argc, char ** argv)
 {
@@ -314,6 +340,8 @@ int main (int argc, char ** argv)
 
 	test_newfile (true);
 	test_newfile (false);
+
+	test_sendspec ();
 
 	print_result ("testmod_specload");
 


### PR DESCRIPTION
elektraQuickdumpSet always(at the end or on failure) closed `file`, which makes sense, but `file` can be `stdout` in which case it should not be closed.

Should be merge after #4469 since a `TODO` added in acecca9e8f0e56d4aad7cfab76c16f92bc735569 is removed.

## Basics

<!--
These points need to be fulfilled for every PR.
-->

- [x] Short descriptions of your changes are in the release notes
      (added as entry in `doc/news/_preparation_next_release.md` which
      contains `_(my name)_`)
      **Please always add something to the release notes.**
- [x] Details of what you changed are in commit messages
      (first line should have `module: short statement` syntax)
- [ ] References to issues, e.g. `close #X`, are in the commit messages.
- [ ] The buildservers are happy. If not, fix **in this order**:
  - [ ] add a line in `doc/news/_preparation_next_release.md`
  - [ ] reformat the code with `scripts/dev/reformat-all`
  - [ ] make all unit tests pass
  - [ ] fix all memleaks
- [x] The PR is rebased with current master(+1).

<!--
If you have any troubles fulfilling these criteria, please write
about the trouble as comment in the PR. We will help you,
but we cannot accept PRs that do not fulfill the basics.
-->

## Checklist

<!--
For docu fixes, spell checking, and similar none of these points below
need to be checked.
-->

- [ ] I added unit tests for my code
- [ ] I fully described what my PR does in the documentation
      (not in the PR description)
- [ ] I fixed all affected documentation
- [ ] I added code comments, logging, and assertions as appropriate (see [Coding Guidelines](https://master.libelektra.org/doc/CODING.md))
- [ ] I updated all meta data (e.g. README.md of plugins and [METADATA.ini](https://master.libelektra.org/doc/METADATA.ini))
- [ ] I mentioned [every code](/.reuse/dep5) not directly written by me in [reuse syntax](https://reuse.software/)

## Review

<!--
Reviewers should check the following.
-->

- [ ] Documentation is introductory, concise, good to read and describes everything what the PR does
- [ ] Examples are well chosen and understandable
- [ ] Code is conforming to [our Coding Guidelines](https://master.libelektra.org/doc/CODING.md)
- [ ] APIs are conforming to [our Design Guidelines](https://master.libelektra.org/doc/DESIGN.md)
- [ ] Code is consistent to [our Design Decisions](https://master.libelektra.org/doc/decisions)

## Labels

<!--
If you are already Elektra developer, please adjust the labels.
Otherwise, write a comment and it will be done for you.
-->

- [ ] Add the "work in progress" label if you do not want the PR to be reviewed yet.
- [x] Add the "ready to merge" label **if the basics are fulfilled** and no further pushes are planned by you.
