### PR TITLE
cmerge: add methods to get all conflicting keys

### DIFF
--- a/doc/man/man7/elektra-libs.7
+++ b/doc/man/man7/elektra-libs.7
@@ -1,6 +1,6 @@
 .\" generated with Ronn-NG/v0.10.1
 .\" http://github.com/apjanke/ronn-ng/tree/0.10.1.pre1
-.TH "ELEKTRA\-LIBS" "7" "July 2022" ""
+.TH "ELEKTRA\-LIBS" "7" "October 2022" ""
 .SH "NAME"
 \fBelektra\-libs\fR \- libs overview
 .IP "" 4
@@ -65,6 +65,12 @@ libelektra\-meta\.so
 .fi
 .P
 \fBlibmeta \fImeta/meta\.c\fR\fR contains metadata operations as described in \fBMETADATA\.ini \fI/doc/METADATA\.ini\fR\fR\. Currently mainly contains legacy code and some generic metadata operations\.
+.SS "Libmerge"
+.nf
+libelektra\-merge\.so
+.fi
+.P
+\fBlibmerge \fImerge/\fR\fR provides functionality for 3\-way merges of keysets\.
 .SS "Libelektra"
 Is a legacy library that provides the same functionality as \fBlibelektra\-kdb\fR and \fBlibelektra\-core\fR\. The sources can be found in \fBlibelektra \fIelektra/\fR\fR\.
 .SH "Other Libraries"

--- a/doc/news/_preparation_next_release.md
+++ b/doc/news/_preparation_next_release.md
@@ -244,7 +244,7 @@ The text below summarizes updates to the [C (and C++)-based libraries](https://w
 - Check file flags for `elektraIoFdSetFlags`: file flags must be exactly one of: read only, write only or read write _(Richard Stöckl @Eiskasten)_
 ### Merge
 
-- Add methods to check which keys were causing a merge conflict _(Maximilian Irlinger @atmaxinger)_.
+- Add methods `elektraMergeGetConflictingKeys` and `elektraMergeIsKeyConflicting` to check which keys were causing a merge conflict _(Maximilian Irlinger @atmaxinger)_.
 - <<TODO>>
 - <<TODO>>
 

--- a/doc/news/_preparation_next_release.md
+++ b/doc/news/_preparation_next_release.md
@@ -242,6 +242,9 @@ The text below summarizes updates to the [C (and C++)-based libraries](https://w
 ### io
 
 - Check file flags for `elektraIoFdSetFlags`: file flags must be exactly one of: read only, write only or read write _(Richard Stöckl @Eiskasten)_
+### Merge
+
+- Add methods to check which keys were causing a merge conflict _(Maximilian Irlinger @atmaxinger)_.
 - <<TODO>>
 - <<TODO>>
 

--- a/doc/news/_preparation_next_release.md
+++ b/doc/news/_preparation_next_release.md
@@ -242,6 +242,7 @@ The text below summarizes updates to the [C (and C++)-based libraries](https://w
 ### io
 
 - Check file flags for `elektraIoFdSetFlags`: file flags must be exactly one of: read only, write only or read write _(Richard Stöckl @Eiskasten)_
+
 ### Merge
 
 - Add methods `elektraMergeGetConflictingKeys` and `elektraMergeIsKeyConflicting` to check which keys were causing a merge conflict _(Maximilian Irlinger @atmaxinger)_.

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -23,6 +23,7 @@ foreach (file ${TESTS})
 endforeach (file ${TESTS})
 
 target_link_elektra (cascading elektra-kdb)
+target_link_elektra (cmerge elektra-merge)
 target_link_elektra (ksCut elektra-kdb)
 target_link_elektra (kdbget elektra-kdb)
 target_link_elektra (kdbget_error elektra-kdb)

--- a/examples/cmerge.c
+++ b/examples/cmerge.c
@@ -1,0 +1,97 @@
+/**
+* @file
+*
+* @brief
+*
+* @copyright BSD License (see LICENSE.md or https://www.libelektra.org)
+*/
+
+#include <kdb.h>
+#include <kdbmerge.h>
+#include <stdio.h>
+
+static void print_results(KeySet * result, Key * resultRoot, Key * informationKey)
+{
+	KeySet * conflictingKeys = elektraMergeGetConflictingKeys (informationKey, resultRoot);
+
+	for (elektraCursor i = 0; i < ksGetSize (conflictingKeys); i++)
+	{
+		printf("Conflict in key %s\n", keyName (ksAtCursor (conflictingKeys, i)));
+	}
+
+	printf ("Result:\n");
+
+	for (elektraCursor i = 0; i < ksGetSize (result); i++)
+	{
+		Key * k = ksAtCursor (result, i);
+		printf("%s = %s\n", keyName (k), keyString (k));
+	}
+
+	if (result == NULL)
+	{
+		printf ("Aborted.\n");
+	}
+
+	ksDel (conflictingKeys);
+}
+
+int main (void)
+{
+	Key * baseRoot = keyNew ("user:/screen", KEY_END);
+	KeySet * base = ksNew (1,
+			       keyNew ("user:/screen/background", KEY_VALUE, "blue", KEY_END),
+			       KS_END);
+
+	Key * theirRoot = keyDup (baseRoot, KEY_CP_ALL);
+	KeySet * their = ksNew (2,
+				keyNew ("user:/screen/background", KEY_VALUE, "red", KEY_END),
+				keyNew ("user:/screen/brightness", KEY_VALUE, "100", KEY_END),
+				KS_END
+				);
+
+	Key * ourRoot = keyDup (baseRoot, KEY_CP_ALL);
+	KeySet * our = ksNew (2,
+				keyNew ("user:/screen/background", KEY_VALUE, "purple", KEY_END),
+				keyNew ("user:/screen/standby", KEY_VALUE, "on", KEY_END),
+				KS_END
+	);
+
+	Key * resultRoot = keyDup (baseRoot, KEY_CP_ALL);
+	Key * informationKey = keyDup (baseRoot, KEY_CP_ALL);
+
+	// Strategy: Abort
+	// Will abort due to user:/screen/background changes in both their and our
+	printf ("Trying merge strategy ABORT\n");
+	KeySet * result = elektraMerge (our, ourRoot, their, theirRoot, base, baseRoot, resultRoot, MERGE_STRATEGY_ABORT, informationKey);
+	print_results (result, resultRoot, informationKey);
+
+	ksDel (result);
+
+	// Strategy: Our
+	// Will take value of our for user:/screen/background
+	printf ("\nTrying merge strategy OUR\n");
+	result = elektraMerge (our, ourRoot, their, theirRoot, base, baseRoot, resultRoot, MERGE_STRATEGY_OUR, informationKey);
+	print_results (result, resultRoot, informationKey);
+
+	ksDel (result);
+
+	// Strategy: Their
+	// Will take value of their for user:/screen/background
+	printf ("\nTrying merge strategy THEIR\n");
+	result = elektraMerge (our, ourRoot, their, theirRoot, base, baseRoot, resultRoot, MERGE_STRATEGY_THEIR, informationKey);
+	print_results (result, resultRoot, informationKey);
+
+	ksDel (result);
+
+	ksDel (base);
+	ksDel (their);
+	ksDel (our);
+
+	keyDel (baseRoot);
+	keyDel (theirRoot);
+	keyDel (ourRoot);
+	keyDel (informationKey);
+	keyDel (resultRoot);
+
+	return 0;
+}

--- a/examples/cmerge.c
+++ b/examples/cmerge.c
@@ -1,22 +1,22 @@
 /**
-* @file
-*
-* @brief
-*
-* @copyright BSD License (see LICENSE.md or https://www.libelektra.org)
-*/
+ * @file
+ *
+ * @brief
+ *
+ * @copyright BSD License (see LICENSE.md or https://www.libelektra.org)
+ */
 
 #include <kdb.h>
 #include <kdbmerge.h>
 #include <stdio.h>
 
-static void print_results(KeySet * result, Key * resultRoot, Key * informationKey)
+static void print_results (KeySet * result, Key * resultRoot, Key * informationKey)
 {
 	KeySet * conflictingKeys = elektraMergeGetConflictingKeys (informationKey, resultRoot);
 
 	for (elektraCursor i = 0; i < ksGetSize (conflictingKeys); i++)
 	{
-		printf("Conflict in key %s\n", keyName (ksAtCursor (conflictingKeys, i)));
+		printf ("Conflict in key %s\n", keyName (ksAtCursor (conflictingKeys, i)));
 	}
 
 	printf ("Result:\n");
@@ -24,7 +24,7 @@ static void print_results(KeySet * result, Key * resultRoot, Key * informationKe
 	for (elektraCursor i = 0; i < ksGetSize (result); i++)
 	{
 		Key * k = ksAtCursor (result, i);
-		printf("%s = %s\n", keyName (k), keyString (k));
+		printf ("%s = %s\n", keyName (k), keyString (k));
 	}
 
 	if (result == NULL)
@@ -38,23 +38,15 @@ static void print_results(KeySet * result, Key * resultRoot, Key * informationKe
 int main (void)
 {
 	Key * baseRoot = keyNew ("user:/screen", KEY_END);
-	KeySet * base = ksNew (1,
-			       keyNew ("user:/screen/background", KEY_VALUE, "blue", KEY_END),
-			       KS_END);
+	KeySet * base = ksNew (1, keyNew ("user:/screen/background", KEY_VALUE, "blue", KEY_END), KS_END);
 
 	Key * theirRoot = keyDup (baseRoot, KEY_CP_ALL);
-	KeySet * their = ksNew (2,
-				keyNew ("user:/screen/background", KEY_VALUE, "red", KEY_END),
-				keyNew ("user:/screen/brightness", KEY_VALUE, "100", KEY_END),
-				KS_END
-				);
+	KeySet * their = ksNew (2, keyNew ("user:/screen/background", KEY_VALUE, "red", KEY_END),
+				keyNew ("user:/screen/brightness", KEY_VALUE, "100", KEY_END), KS_END);
 
 	Key * ourRoot = keyDup (baseRoot, KEY_CP_ALL);
-	KeySet * our = ksNew (2,
-				keyNew ("user:/screen/background", KEY_VALUE, "purple", KEY_END),
-				keyNew ("user:/screen/standby", KEY_VALUE, "on", KEY_END),
-				KS_END
-	);
+	KeySet * our = ksNew (2, keyNew ("user:/screen/background", KEY_VALUE, "purple", KEY_END),
+			      keyNew ("user:/screen/standby", KEY_VALUE, "on", KEY_END), KS_END);
 
 	Key * resultRoot = keyDup (baseRoot, KEY_CP_ALL);
 	Key * informationKey = keyDup (baseRoot, KEY_CP_ALL);

--- a/src/bindings/swig/python/merge.i
+++ b/src/bindings/swig/python/merge.i
@@ -12,17 +12,23 @@
 #include "kdbmerge.h"
 %}
 
-
 ckdb::KeySet * elektraMerge (ckdb::KeySet * our, ckdb::Key * ourRoot, ckdb::KeySet * their, ckdb::Key * theirRoot, ckdb::KeySet * base, ckdb::Key * baseRoot, ckdb::Key * resultKey,
 		      ckdb::MergeStrategy strategy, ckdb::Key * informationKey);
 int elektraMergeGetConflicts (ckdb::Key * informationKey);
+
+%inline %{
+ 	// we wrap the elektraMerge function, because I haven't found a way to correctly wrap the enum ...
+	ckdb::KeySet * elektraMergeWrap (ckdb::KeySet * our, ckdb::Key * ourRoot, ckdb::KeySet * their, ckdb::Key * theirRoot, ckdb::KeySet * base, ckdb::Key * baseRoot, ckdb::Key * resultKey,
+		     int strategy, ckdb::Key * informationKey) {
+	       return elektraMerge (our, ourRoot, their, theirRoot, base, baseRoot, resultKey, (ckdb::MergeStrategy) strategy, informationKey);
+       }
+%}
 
 %pythoncode {
 from enum import Enum
 
 class ConflictStrategy(Enum):
   ABORT = 1
-  INTERACTIVE = 2
   OUR = 3
   THEIR = 4
 
@@ -46,6 +52,6 @@ class MergeResult:
 class Merger:
   def merge(self, base, ours, theirs, root, conflictStrategy):
     informationKey = kdb.Key()
-    res = elektraMerge(ours.keys.getKeySet(), ours.root.getKey(), theirs.keys.getKeySet(), theirs.root.getKey(), base.keys.getKeySet(), base.root.getKey(), root.getKey(), conflictStrategy.value, informationKey.getKey())
+    res = elektraMergeWrap(ours.keys.getKeySet(), ours.root.getKey(), theirs.keys.getKeySet(), theirs.root.getKey(), base.keys.getKeySet(), base.root.getKey(), root.getKey(), conflictStrategy.value, informationKey.getKey())
     return MergeResult(res, informationKey)
 };

--- a/src/bindings/swig/python/merge.i
+++ b/src/bindings/swig/python/merge.i
@@ -14,7 +14,7 @@
 
 
 ckdb::KeySet * elektraMerge (ckdb::KeySet * our, ckdb::Key * ourRoot, ckdb::KeySet * their, ckdb::Key * theirRoot, ckdb::KeySet * base, ckdb::Key * baseRoot, ckdb::Key * resultKey,
-		       int strategy, ckdb::Key * informationKey);
+		      ckdb::MergeStrategy strategy, ckdb::Key * informationKey);
 int elektraMergeGetConflicts (ckdb::Key * informationKey);
 
 %pythoncode {

--- a/src/include/kdbmerge.h
+++ b/src/include/kdbmerge.h
@@ -10,6 +10,7 @@
 #define KDBMERGE_H_
 
 #include "kdb.h"
+#include "kdbtypes.h"
 
 #ifdef __cplusplus
 namespace ckdb
@@ -28,6 +29,9 @@ enum
 KeySet * elektraMerge (KeySet * our, Key * ourRoot, KeySet * their, Key * theirRoot, KeySet * base, Key * baseRoot, Key * resultKey,
 		       int strategy, Key * informationKey);
 int elektraMergeGetConflicts (Key * informationKey);
+
+KeySet * elektraMergeGetConflictingKeys (Key * informationKey, Key * root);
+bool elektraMergeIsKeyConflicting (Key * informationKey, Key * root, Key * key);
 
 #ifdef __cplusplus
 }

--- a/src/include/kdbmerge.h
+++ b/src/include/kdbmerge.h
@@ -25,7 +25,7 @@ enum MergeStrategy
 {
 	MERGE_STRATEGY_ABORT = 1, /*!< Abort merging if a conflict occurs */
 	// MERGE_STRATEGY_INTERACTIVE = 2, /*!< Perform an interactive conflict resolution. Currently not implemented */
-	MERGE_STRATEGY_OUR = 3, /*!< Prefer our keys in case of conflict */
+	MERGE_STRATEGY_OUR = 3,	  /*!< Prefer our keys in case of conflict */
 	MERGE_STRATEGY_THEIR = 4, /*!< Prefer their keys in case of conflict */
 };
 

--- a/src/include/kdbmerge.h
+++ b/src/include/kdbmerge.h
@@ -18,16 +18,19 @@ namespace ckdb
 extern "C" {
 #endif
 
-enum
+/**
+ * The strategy to use when a merge conflict occurs
+ */
+enum MergeStrategy
 {
-	MERGE_STRATEGY_ABORT = 1,
-	MERGE_STRATEGY_INTERACTIVE = 2,
-	MERGE_STRATEGY_OUR = 3,
-	MERGE_STRATEGY_THEIR = 4,
+	MERGE_STRATEGY_ABORT = 1, /*!< Abort merging if a conflict occurs */
+	// MERGE_STRATEGY_INTERACTIVE = 2, /*!< Perform an interactive conflict resolution. Currently not implemented */
+	MERGE_STRATEGY_OUR = 3, /*!< Prefer our keys in case of conflict */
+	MERGE_STRATEGY_THEIR = 4, /*!< Prefer their keys in case of conflict */
 };
 
 KeySet * elektraMerge (KeySet * our, Key * ourRoot, KeySet * their, Key * theirRoot, KeySet * base, Key * baseRoot, Key * resultKey,
-		       int strategy, Key * informationKey);
+		       enum MergeStrategy strategy, Key * informationKey);
 int elektraMergeGetConflicts (Key * informationKey);
 
 KeySet * elektraMergeGetConflictingKeys (Key * informationKey, Key * root);

--- a/src/libs/README.md
+++ b/src/libs/README.md
@@ -87,6 +87,14 @@ libelektra-meta.so
 **[libmeta](meta/meta.c)** contains metadata operations as described in **[METADATA.ini](/doc/METADATA.ini)**.
 Currently mainly contains legacy code and some generic metadata operations.
 
+### Libmerge
+
+```
+libelektra-merge.so
+```
+
+**[libmerge](merge/)** provides functionality for 3-way merges of keysets.
+
 ### Libelektra
 
 Is a legacy library that provides the same functionality as `libelektra-kdb` and `libelektra-core`.

--- a/src/libs/merge/kdbmerge.c
+++ b/src/libs/merge/kdbmerge.c
@@ -1160,11 +1160,10 @@ KeySet * elektraMerge (KeySet * our, Key * ourRoot, KeySet * their, Key * theirR
 		return NULL;
 	}
 
-	KeySet * informationMeta = keyMeta (informationKey);
-	ksAppendKey (informationMeta, keyNew (META_ELEKTRA_MERGE_ROOT_OUR, KEY_VALUE, keyName (ourRoot), KEY_END));
-	ksAppendKey (informationMeta, keyNew (META_ELEKTRA_MERGE_ROOT_THEIR, KEY_VALUE, keyName (theirRoot), KEY_END));
-	ksAppendKey (informationMeta, keyNew (META_ELEKTRA_MERGE_ROOT_BASE, KEY_VALUE, keyName (baseRoot), KEY_END));
-	ksAppendKey (informationMeta, keyNew (META_ELEKTRA_MERGE_ROOT_RESULT, KEY_VALUE, keyName (resultRoot), KEY_END));
+	keySetMeta (informationKey, META_ELEKTRA_MERGE_ROOT_OUR, keyName (ourRoot));
+	keySetMeta (informationKey, META_ELEKTRA_MERGE_ROOT_THEIR, keyName (theirRoot));
+	keySetMeta (informationKey, META_ELEKTRA_MERGE_ROOT_BASE, keyName (baseRoot));
+	keySetMeta (informationKey, META_ELEKTRA_MERGE_ROOT_RESULT, keyName (resultRoot));
 
 	KeySet * result = ksNew (0, KS_END);
 	bool ourDominant = false;

--- a/src/libs/merge/kdbmerge.c
+++ b/src/libs/merge/kdbmerge.c
@@ -3,8 +3,9 @@
 #include "kdbassert.h"
 #include "kdberrors.h"
 #include "kdblogger.h"
-#include "kdbprivate.h"
-#include <ctype.h>
+#include "kdbease.h"
+#include "kdbprivate.h" // for ksFindHierarchy
+
 #include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/src/libs/merge/kdbmerge.c
+++ b/src/libs/merge/kdbmerge.c
@@ -278,8 +278,8 @@ static bool isSpecifiedRootPartOfMerge (Key * informationKey, const char * root)
  *
  * NOTE: Even if the conflict was resolved via the provided conflict strategy, the key will still be marked as being part of a conflict.
  *
- * @param informationKey The information key of the merge session
- * @param root The root key (either for base, theirs, ours or result) that was used in the merge session
+ * @param informationKey stores errors as well as statistics
+ * @param root The root key (either for base, theirs, ours or result) that was used in the merge
  * @param key That key that should be checked. Must be located under the specified root key
  * @retval 1 if the key was part of a conflict
  * @retval 0 if the key was not part of a conflict or the given root was not part of the merge
@@ -307,10 +307,10 @@ bool elektraMergeIsKeyConflicting (Key * informationKey, Key * root, Key * key)
 
 /**
  * Returns a keyset with all conflicting keys under the specified root
- * @param informationKey The information key of the merge session
- * @param root The root key (either for base, theirs, ours or result) that was used in the merge session
+ * @param informationKey stores errors as well as statistics
+ * @param root The root key (either for base, theirs, ours or result) that was used in the merge
  * @return KeySet containing all keys that are part of a merge conflict.
- *         Will be empty im the specified root key was not part of the merge session.
+ *         Will be empty if the specified root key was not part of the merge.
  */
 KeySet * elektraMergeGetConflictingKeys (Key * informationKey, Key * root)
 {

--- a/src/libs/merge/kdbmerge.c
+++ b/src/libs/merge/kdbmerge.c
@@ -279,7 +279,8 @@ static bool isSpecifiedRootPartOfMerge (Key * informationKey, const char * root)
  * @param informationKey The information key of the merge session
  * @param root The root key (either for base, theirs, ours or result) that was used in the merge session
  * @param key That key that should be checked. Must be located under the specified root key
- * @return true if the key was part of a conflict, false if the key was not part of a conflict or the given root was not part of the merge
+ * @retval 1 if the key was part of a conflict
+ * @retval 0 if the key was not part of a conflict or the given root was not part of the merge
  */
 bool elektraMergeIsKeyConflicting (Key * informationKey, Key * root, Key * key)
 {

--- a/src/libs/merge/kdbmerge.c
+++ b/src/libs/merge/kdbmerge.c
@@ -198,15 +198,15 @@ static void addConflictingKeys (Key * informationKey, KeySet * conflictingKeys, 
 	Key * conflictsRoot = keyNew (META_ELEKTRA_MERGE_CONFLICT, KEY_END);
 	for (elektraCursor end, it = ksFindHierarchy (meta, conflictsRoot, &end); it < end; ++it)
 	{
-		Key * metaKey = ksAtCursor(meta, it);
+		Key * metaKey = ksAtCursor (meta, it);
 
-		if(!keyIsDirectlyBelow (conflictsRoot, metaKey))
+		if (!keyIsDirectlyBelow (conflictsRoot, metaKey))
 		{
 			continue;
 		}
 
 		// remove from conflicting keys
-		ksLookupByName(conflictingKeys, keyString (metaKey), KDB_O_POP);
+		ksLookupByName (conflictingKeys, keyString (metaKey), KDB_O_POP);
 	}
 
 	for (elektraCursor it = 0; it < ksGetSize (conflictingKeys); it++)
@@ -221,38 +221,38 @@ static void addConflictingKeys (Key * informationKey, KeySet * conflictingKeys, 
 	keyDel (conflictsRoot);
 }
 
-static bool isSpecifiedRootPartOfMerge(Key * informationKey, const char * root)
+static bool isSpecifiedRootPartOfMerge (Key * informationKey, const char * root)
 {
 	KeySet * meta = keyMeta (informationKey);
 	Key * tmp;
 
-	if((tmp = ksLookupByName (meta, META_ELEKTRA_MERGE_ROOT_OUR, 0)) != NULL)
+	if ((tmp = ksLookupByName (meta, META_ELEKTRA_MERGE_ROOT_OUR, 0)) != NULL)
 	{
-		if(strcmp (root, keyString (tmp)) == 0)
+		if (strcmp (root, keyString (tmp)) == 0)
 		{
 			return true;
 		}
 	}
 
-	if((tmp = ksLookupByName (meta, META_ELEKTRA_MERGE_ROOT_THEIR, 0)) != NULL)
+	if ((tmp = ksLookupByName (meta, META_ELEKTRA_MERGE_ROOT_THEIR, 0)) != NULL)
 	{
-		if(strcmp (root, keyString (tmp)) == 0)
+		if (strcmp (root, keyString (tmp)) == 0)
 		{
 			return true;
 		}
 	}
 
-	if((tmp = ksLookupByName (meta, META_ELEKTRA_MERGE_ROOT_BASE, 0)) != NULL)
+	if ((tmp = ksLookupByName (meta, META_ELEKTRA_MERGE_ROOT_BASE, 0)) != NULL)
 	{
-		if(strcmp (root, keyString (tmp)) == 0)
+		if (strcmp (root, keyString (tmp)) == 0)
 		{
 			return true;
 		}
 	}
 
-	if((tmp = ksLookupByName (meta, META_ELEKTRA_MERGE_ROOT_RESULT, 0)) != NULL)
+	if ((tmp = ksLookupByName (meta, META_ELEKTRA_MERGE_ROOT_RESULT, 0)) != NULL)
 	{
-		if(strcmp (root, keyString (tmp)) == 0)
+		if (strcmp (root, keyString (tmp)) == 0)
 		{
 			return true;
 		}
@@ -272,7 +272,7 @@ static bool isSpecifiedRootPartOfMerge(Key * informationKey, const char * root)
  */
 bool elektraMergeIsKeyConflicting (Key * informationKey, Key * root, Key * key)
 {
-	if (!isSpecifiedRootPartOfMerge(informationKey, keyName (root)))
+	if (!isSpecifiedRootPartOfMerge (informationKey, keyName (root)))
 	{
 		return false;
 	}
@@ -303,7 +303,7 @@ KeySet * elektraMergeGetConflictingKeys (Key * informationKey, Key * root)
 	KeySet * conflictingKeys = ksNew (0, KS_END);
 	const char * rootKeyName = keyName (root);
 
-	if (!isSpecifiedRootPartOfMerge(informationKey, rootKeyName))
+	if (!isSpecifiedRootPartOfMerge (informationKey, rootKeyName))
 	{
 		return conflictingKeys;
 	}
@@ -312,14 +312,14 @@ KeySet * elektraMergeGetConflictingKeys (Key * informationKey, Key * root)
 	Key * conflictsRoot = keyNew (META_ELEKTRA_MERGE_CONFLICT, KEY_END);
 	for (elektraCursor end, it = ksFindHierarchy (meta, conflictsRoot, &end); it < end; ++it)
 	{
-		Key * metaKey = ksAtCursor(meta, it);
+		Key * metaKey = ksAtCursor (meta, it);
 
-		if(!keyIsDirectlyBelow (conflictsRoot, metaKey))
+		if (!keyIsDirectlyBelow (conflictsRoot, metaKey))
 		{
 			continue;
 		}
 
-		Key * tmp = keyNew (keyString(metaKey), KEY_END);
+		Key * tmp = keyNew (keyString (metaKey), KEY_END);
 
 		ksAppendKey (conflictingKeys, prependStringToKeyName (tmp, rootKeyName, informationKey));
 
@@ -495,8 +495,8 @@ static KeySet * removeRoot (KeySet * original, Key * root, Key * informationKey)
 
 		if (keyIsBelow (root, currentKey) || keyCmp (currentKey, root) == 0)
 		{
-			Key * duplicateKey = removeRootFromKey(currentKey, root, informationKey);
-			if(duplicateKey == NULL)
+			Key * duplicateKey = removeRootFromKey (currentKey, root, informationKey);
+			if (duplicateKey == NULL)
 			{
 				ksDel (result);
 				keyDel (duplicateKey);
@@ -569,13 +569,13 @@ static int twoOfThreeExistHelper (Key * checkedKey, Key * keyInFirst, Key * keyI
 	}
 	if (thisConflict)
 	{
-		addConflictingKeys (informationKey, ksNew(3, checkedKey, keyInFirst, keyInSecond, KS_END), "nonOverlapBaseEmptyCounter");
+		addConflictingKeys (informationKey, ksNew (3, checkedKey, keyInFirst, keyInSecond, KS_END), "nonOverlapBaseEmptyCounter");
 	}
 	if (!keysAreEqual (checkedKey, existingKey))
 	{
 		// overlap  with single empty
 		// This spot is hit twice for a single overlap conflict. Thus calculate half later on.
-		addConflictingKeys (informationKey, ksNew(3, checkedKey, existingKey, KS_END), "overlap1empty");
+		addConflictingKeys (informationKey, ksNew (3, checkedKey, existingKey, KS_END), "overlap1empty");
 		if (checkedIsDominant)
 		{
 			if (ksAppendKey (result, checkedKey) < 0)
@@ -600,7 +600,8 @@ static int twoOfThreeExistHelper (Key * checkedKey, Key * keyInFirst, Key * keyI
 		{
 			// base is empty and other and their have the same (non-empty) value
 			// this is a conflict
-			addConflictingKeys (informationKey, ksNew(3, checkedKey, keyInFirst, keyInSecond, KS_END), "nonOverlapBaseEmptyCounter");
+			addConflictingKeys (informationKey, ksNew (3, checkedKey, keyInFirst, keyInSecond, KS_END),
+					    "nonOverlapBaseEmptyCounter");
 			if (checkedIsDominant)
 			{
 				if (ksAppendKey (result, checkedKey) < 0)
@@ -645,7 +646,8 @@ static bool twoOfThoseKeysAreEqual (Key * checkedKey, Key * keyInFirst, Key * ke
 			/** This is a non-overlap conflict
 			 *  Base is currently checked and has value A, their and our have a different value B
 			 */
-			addConflictingKeys (informationKey, ksNew (3, checkedKey, keyInFirst, keyInSecond, KS_END), "nonOverlapAllExistCounter");
+			addConflictingKeys (informationKey, ksNew (3, checkedKey, keyInFirst, keyInSecond, KS_END),
+					    "nonOverlapAllExistCounter");
 			if (checkedIsDominant)
 			{
 				// If base is also dominant then append it's key
@@ -705,7 +707,8 @@ static bool twoOfThoseKeysAreEqual (Key * checkedKey, Key * keyInFirst, Key * ke
 				 *  Base is currently firstCompare and has value A, their and our have a different
 				 *  value B
 				 */
-				addConflictingKeys (informationKey, ksNew (2, checkedKey, keyInSecond, KS_END), "nonOverlapAllExistCounter");
+				addConflictingKeys (informationKey, ksNew (2, checkedKey, keyInSecond, KS_END),
+						    "nonOverlapAllExistCounter");
 				if (checkedIsDominant)
 				{
 					// If base is also dominant then append it's key

--- a/src/libs/merge/kdbmerge.c
+++ b/src/libs/merge/kdbmerge.c
@@ -275,6 +275,7 @@ static bool isSpecifiedRootPartOfMerge (Key * informationKey, const char * root)
 
 /**
  * Check whether the given key was part of a conflict.
+ *
  * NOTE: Even if the conflict was resolved via the provided conflict strategy, the key will still be marked as being part of a conflict.
  *
  * @param informationKey The information key of the merge session

--- a/src/libs/merge/kdbmerge.c
+++ b/src/libs/merge/kdbmerge.c
@@ -345,13 +345,6 @@ KeySet * elektraMergeGetConflictingKeys (Key * informationKey, Key * root)
 	return conflictingKeys;
 }
 
-int ELEKTRA_SYMVER (getConflicts, v1) (Key * informationKey)
-{
-	return elektraMergeGetConflicts (informationKey);
-}
-
-ELEKTRA_SYMVER_DECLARE ("libelektra_0.8", getConflicts, v1)
-
 /**
  * This function returns the number of conflicts that is store in the key
  *

--- a/src/libs/merge/kdbmerge.c
+++ b/src/libs/merge/kdbmerge.c
@@ -1101,6 +1101,8 @@ static int handleArrays (KeySet * ourSet, KeySet * theirSet, KeySet * baseSet, K
 			case MERGE_STRATEGY_THEIR:
 				options.favor = GIT_MERGE_FILE_FAVOR_THEIRS;
 				break;
+			case MERGE_STRATEGY_ABORT:
+				break;
 			}
 			int ret = git_merge_file (&out, &libgit_base, &libgit_our, &libgit_their, &options);
 			if (ret == 0)

--- a/src/libs/merge/kdbmerge.c
+++ b/src/libs/merge/kdbmerge.c
@@ -1,9 +1,9 @@
 #include "kdbmerge.h"
 #include "kdb.h"
 #include "kdbassert.h"
+#include "kdbease.h"
 #include "kdberrors.h"
 #include "kdblogger.h"
-#include "kdbease.h"
 #include "kdbprivate.h" // for ksFindHierarchy
 
 #include <stdbool.h>
@@ -32,7 +32,7 @@ static Key * removeRootFromKey (const Key * currentKey, const Key * root, Key * 
  */
 enum BaseIndicator
 {
-	BASE_CHECKED_SET = 0,     /*!< base Key(Set) is the checked Key(Set) */
+	BASE_CHECKED_SET = 0,	  /*!< base Key(Set) is the checked Key(Set) */
 	BASE_FIRST_COMPARED = 1,  /*!< base Key(Set) is the first compared Key(Set) */
 	BASE_SECOND_COMPARED = 2, /*!< base Key(Set) is the second compared Key(Set) */
 };
@@ -1040,7 +1040,8 @@ static int numberOfConflictMarkers (const char * text)
  * @retval 0 on success
  * @retval -1 on error
  */
-static int handleArrays (KeySet * ourSet, KeySet * theirSet, KeySet * baseSet, KeySet * resultSet, Key * informationKey, enum MergeStrategy strategy)
+static int handleArrays (KeySet * ourSet, KeySet * theirSet, KeySet * baseSet, KeySet * resultSet, Key * informationKey,
+			 enum MergeStrategy strategy)
 {
 	ELEKTRA_LOG ("cmerge now handles arrays");
 	KeySet * toAppend = NULL;

--- a/src/libs/merge/kdbmerge.c
+++ b/src/libs/merge/kdbmerge.c
@@ -307,6 +307,9 @@ bool elektraMergeIsKeyConflicting (Key * informationKey, Key * root, Key * key)
 
 /**
  * Returns a keyset with all conflicting keys under the specified root
+ *
+ * @include cmerge.c
+ *
  * @param informationKey stores errors as well as statistics
  * @param root The root key (either for base, theirs, ours or result) that was used in the merge
  * @return KeySet containing all keys that are part of a merge conflict.
@@ -1156,6 +1159,8 @@ static int handleArrays (KeySet * ourSet, KeySet * theirSet, KeySet * baseSet, K
  *
  * This function can incorporate changes from two modified versions (our and their) into a common preceding version (base) of a key set.
  * This lets you merge the sets of changes represented by the two newer key sets. This is called a three-way merge between key sets.
+ *
+ * @include cmerge.c
  *
  * @brief Join three key sets together
  * @param our our key set

--- a/src/libs/merge/symbols.map
+++ b/src/libs/merge/symbols.map
@@ -7,5 +7,7 @@ libelektra_0.8 {
 libelektra_0.9 {
         # kdbmerge.h
 	elektraMergeGetConflicts;
+	elektraMergeIsKeyConflicting;
+	elektraMergeGetConflictingKeys;
 };
 

--- a/src/libs/merge/symbols.map
+++ b/src/libs/merge/symbols.map
@@ -1,7 +1,6 @@
 libelektra_0.8 {
         # kdbmerge.h
 	elektraMerge;
-	getConflicts;
 };
 
 libelektra_0.9 {

--- a/src/tools/kdb/cmerge.cpp
+++ b/src/tools/kdb/cmerge.cpp
@@ -35,7 +35,7 @@ int CMergeCommand::execute (Cmdline const & cl ELEKTRA_UNUSED)
 	kdb::Key theirsRoot = cl.createKey (1);
 	kdb::Key baseRoot = cl.createKey (2);
 	kdb::Key resultRoot = cl.createKey (3);
-	int strategy = ckdb::MERGE_STRATEGY_ABORT;
+	ckdb::MergeStrategy strategy = ckdb::MERGE_STRATEGY_ABORT;
 	if (cl.strategy == "preserve")
 	{
 		/** This is here for compatibility. The old merge has preserve as default as defined in cmdline.cpp.

--- a/tests/ctest/test_merge.c
+++ b/tests/ctest/test_merge.c
@@ -9,6 +9,12 @@
 #include <kdbmerge.h>
 #include <tests_internal.h>
 
+static Key * addKeyToKeySet (Key * key, KeySet * ks)
+{
+	ksAppendKey (ks, key);
+	return key;
+}
+
 static void test_new_keys_in_both (void)
 {
 	printf ("test new keys in both merge scenario\n");
@@ -34,6 +40,8 @@ static void test_new_keys_in_both (void)
 
 	KeySet * result = elektraMerge (ksOurs, oursRoot, ksTheirs, theirsRoot, ksBase, baseRoot, root, MERGE_STRATEGY_ABORT, information);
 
+	KeySet * trashcan = ksNew (0, KS_END);
+
 	succeed_if (result != NULL, "result must not be NULL");
 	succeed_if (ksGetSize (result) == 3, "result must contain 3 keys");
 	succeed_if (ksLookupByName (result, "system:/test/k1", KDB_O_NONE) != NULL, "system:/test/k1 must be included in result");
@@ -41,11 +49,11 @@ static void test_new_keys_in_both (void)
 	succeed_if (ksLookupByName (result, "system:/test/k3", KDB_O_NONE) != NULL, "system:/test/k3 must be included in result");
 	succeed_if (elektraMergeGetConflicts (information) == 0, "must not have any conflicts");
 
-	succeed_if (elektraMergeIsKeyConflicting (information, root, keyNew ("system:/test/k1", KEY_END)) == false,
+	succeed_if (elektraMergeIsKeyConflicting (information, root, addKeyToKeySet (keyNew ("system:/test/k1", KEY_END), trashcan)) == false,
 		    "system:/test/k1 must not conflict");
-	succeed_if (elektraMergeIsKeyConflicting (information, root, keyNew ("system:/test/k2", KEY_END)) == false,
+	succeed_if (elektraMergeIsKeyConflicting (information, root, addKeyToKeySet (keyNew ("system:/test/k2", KEY_END), trashcan)) == false,
 		    "system:/test/k2 must not conflict");
-	succeed_if (elektraMergeIsKeyConflicting (information, root, keyNew ("system:/test/k3", KEY_END)) == false,
+	succeed_if (elektraMergeIsKeyConflicting (information, root, addKeyToKeySet (keyNew ("system:/test/k3", KEY_END), trashcan)) == false,
 		    "system:/test/k3 must not conflict");
 
 	KeySet * conflicts = elektraMergeGetConflictingKeys (information, root);
@@ -62,6 +70,7 @@ static void test_new_keys_in_both (void)
 	ksDel (ksTheirs);
 	ksDel (result);
 	ksDel (conflicts);
+	ksDel (trashcan);
 }
 
 static void test_removed_keys_in_both (void)
@@ -93,16 +102,18 @@ static void test_removed_keys_in_both (void)
 
 	KeySet * result = elektraMerge (ksOurs, oursRoot, ksTheirs, theirsRoot, ksBase, baseRoot, root, MERGE_STRATEGY_ABORT, information);
 
+	KeySet * trashcan = ksNew (0, KS_END);
+
 	succeed_if (result != NULL, "result must not be NULL");
 	succeed_if (ksGetSize (result) == 1, "result must contain 1 keys");
 	succeed_if (ksLookupByName (result, "system:/test/k1", KDB_O_NONE) != NULL, "system:/test/k1 must be included in result");
 	succeed_if (elektraMergeGetConflicts (information) == 0, "must not have any conflicts");
 
-	succeed_if (elektraMergeIsKeyConflicting (information, root, keyNew ("system:/test/k1", KEY_END)) == false,
+	succeed_if (elektraMergeIsKeyConflicting (information, root, addKeyToKeySet (keyNew ("system:/test/k1", KEY_END), trashcan)) == false,
 		    "system:/test/k1 must not conflict");
-	succeed_if (elektraMergeIsKeyConflicting (information, root, keyNew ("system:/test/k2", KEY_END)) == false,
+	succeed_if (elektraMergeIsKeyConflicting (information, root, addKeyToKeySet (keyNew ("system:/test/k2", KEY_END), trashcan)) == false,
 		    "system:/test/k2 must not conflict");
-	succeed_if (elektraMergeIsKeyConflicting (information, root, keyNew ("system:/test/k3", KEY_END)) == false,
+	succeed_if (elektraMergeIsKeyConflicting (information, root, addKeyToKeySet (keyNew ("system:/test/k3", KEY_END), trashcan)) == false,
 		    "system:/test/k3 must not conflict");
 
 	KeySet * conflicts = elektraMergeGetConflictingKeys (information, root);
@@ -119,6 +130,7 @@ static void test_removed_keys_in_both (void)
 	ksDel (ksTheirs);
 	ksDel (result);
 	ksDel (conflicts);
+	ksDel (trashcan);
 }
 
 static void test_changed_different_keys_in_both (void)
@@ -152,6 +164,8 @@ static void test_changed_different_keys_in_both (void)
 
 	KeySet * result = elektraMerge (ksOurs, oursRoot, ksTheirs, theirsRoot, ksBase, baseRoot, root, MERGE_STRATEGY_ABORT, information);
 
+	KeySet * trashcan = ksNew (0, KS_END);
+
 	succeed_if (result != NULL, "result must not be NULL");
 
 	succeed_if (ksGetSize (result) == 3, "result must contain 3 keys");
@@ -169,11 +183,11 @@ static void test_changed_different_keys_in_both (void)
 
 	succeed_if (elektraMergeGetConflicts (information) == 0, "must not have any conflicts");
 
-	succeed_if (elektraMergeIsKeyConflicting (information, root, keyNew ("system:/test/k1", KEY_END)) == false,
+	succeed_if (elektraMergeIsKeyConflicting (information, root, addKeyToKeySet (keyNew ("system:/test/k1", KEY_END), trashcan)) == false,
 		    "system:/test/k1 must not conflict");
-	succeed_if (elektraMergeIsKeyConflicting (information, root, keyNew ("system:/test/k2", KEY_END)) == false,
+	succeed_if (elektraMergeIsKeyConflicting (information, root, addKeyToKeySet (keyNew ("system:/test/k2", KEY_END), trashcan)) == false,
 		    "system:/test/k2 must not conflict");
-	succeed_if (elektraMergeIsKeyConflicting (information, root, keyNew ("system:/test/k3", KEY_END)) == false,
+	succeed_if (elektraMergeIsKeyConflicting (information, root, addKeyToKeySet (keyNew ("system:/test/k3", KEY_END), trashcan)) == false,
 		    "system:/test/k3 must not conflict");
 
 	KeySet * conflicts = elektraMergeGetConflictingKeys (information, root);
@@ -190,6 +204,7 @@ static void test_changed_different_keys_in_both (void)
 	ksDel (ksTheirs);
 	ksDel (result);
 	ksDel (conflicts);
+	ksDel (trashcan);
 }
 
 static void test_changed_same_key_abort (void)
@@ -220,12 +235,14 @@ static void test_changed_same_key_abort (void)
 
 	KeySet * result = elektraMerge (ksOurs, oursRoot, ksTheirs, theirsRoot, ksBase, baseRoot, root, MERGE_STRATEGY_ABORT, information);
 
+	KeySet * trashcan = ksNew (0, KS_END);
+
 	succeed_if (result == NULL, "result must be NULL");
 	succeed_if (elektraMergeGetConflicts (information) == 1, "must have 1 conflicts");
 
-	succeed_if (elektraMergeIsKeyConflicting (information, root, keyNew ("system:/test/k1", KEY_END)) == false,
+	succeed_if (elektraMergeIsKeyConflicting (information, root, addKeyToKeySet (keyNew ("system:/test/k1", KEY_END), trashcan)) == false,
 		    "system:/test/k1 must not conflict");
-	succeed_if (elektraMergeIsKeyConflicting (information, root, keyNew ("system:/test/k2", KEY_END)) == true,
+	succeed_if (elektraMergeIsKeyConflicting (information, root, addKeyToKeySet (keyNew ("system:/test/k2", KEY_END), trashcan)) == true,
 		    "system:/test/k2 must conflict");
 
 	KeySet * conflicts = elektraMergeGetConflictingKeys (information, root);
@@ -242,6 +259,8 @@ static void test_changed_same_key_abort (void)
 	ksDel (ksOurs);
 	ksDel (ksTheirs);
 	ksDel (result);
+	ksDel (conflicts);
+	ksDel (trashcan);
 }
 
 static void test_changed_same_key_their (void)
@@ -272,6 +291,8 @@ static void test_changed_same_key_their (void)
 
 	KeySet * result = elektraMerge (ksOurs, oursRoot, ksTheirs, theirsRoot, ksBase, baseRoot, root, MERGE_STRATEGY_THEIR, information);
 
+	KeySet * trashcan = ksNew (0, KS_END);
+
 	succeed_if (result != NULL, "result must not be NULL");
 
 	succeed_if (ksGetSize (result) == 2, "result must contain 2 keys");
@@ -285,9 +306,9 @@ static void test_changed_same_key_their (void)
 
 	succeed_if (elektraMergeGetConflicts (information) == 1, "must have 1 conflicts");
 
-	succeed_if (elektraMergeIsKeyConflicting (information, root, keyNew ("system:/test/k1", KEY_END)) == false,
+	succeed_if (elektraMergeIsKeyConflicting (information, root, addKeyToKeySet (keyNew ("system:/test/k1", KEY_END), trashcan)) == false,
 		    "system:/test/k1 must not conflict");
-	succeed_if (elektraMergeIsKeyConflicting (information, root, keyNew ("system:/test/k2", KEY_END)) == true,
+	succeed_if (elektraMergeIsKeyConflicting (information, root, addKeyToKeySet (keyNew ("system:/test/k2", KEY_END), trashcan)) == true,
 		    "system:/test/k2 must conflict");
 
 	KeySet * conflicts = elektraMergeGetConflictingKeys (information, root);
@@ -305,6 +326,7 @@ static void test_changed_same_key_their (void)
 	ksDel (ksTheirs);
 	ksDel (result);
 	ksDel (conflicts);
+	ksDel (trashcan);
 }
 
 static void test_changed_same_key_our (void)
@@ -335,6 +357,8 @@ static void test_changed_same_key_our (void)
 
 	KeySet * result = elektraMerge (ksOurs, oursRoot, ksTheirs, theirsRoot, ksBase, baseRoot, root, MERGE_STRATEGY_OUR, information);
 
+	KeySet * trashcan = ksNew (0, KS_END);
+
 	succeed_if (result != NULL, "result must not be NULL");
 
 	succeed_if (ksGetSize (result) == 2, "result must contain 2 keys");
@@ -348,9 +372,9 @@ static void test_changed_same_key_our (void)
 
 	succeed_if (elektraMergeGetConflicts (information) == 1, "must have 1 conflicts");
 
-	succeed_if (elektraMergeIsKeyConflicting (information, root, keyNew ("system:/test/result/k1", KEY_END)) == false,
+	succeed_if (elektraMergeIsKeyConflicting (information, root, addKeyToKeySet (keyNew ("system:/test/result/k1", KEY_END), trashcan)) == false,
 		    "system:/test/result/k1 must not conflict");
-	succeed_if (elektraMergeIsKeyConflicting (information, root, keyNew ("system:/test/result/k2", KEY_END)) == true,
+	succeed_if (elektraMergeIsKeyConflicting (information, root, addKeyToKeySet (keyNew ("system:/test/result/k2", KEY_END), trashcan)) == true,
 		    "system:/test/result/k2 must conflict");
 
 	KeySet * conflicts = elektraMergeGetConflictingKeys (information, oursRoot);
@@ -368,6 +392,7 @@ static void test_changed_same_key_our (void)
 	ksDel (ksTheirs);
 	ksDel (result);
 	ksDel (conflicts);
+	ksDel (trashcan);
 }
 
 int main (int argc, char ** argv)

--- a/tests/ctest/test_merge.c
+++ b/tests/ctest/test_merge.c
@@ -41,6 +41,13 @@ static void test_new_keys_in_both (void)
 	succeed_if (ksLookupByName (result, "system:/test/k3", KDB_O_NONE) != NULL, "system:/test/k3 must be included in result");
 	succeed_if (elektraMergeGetConflicts (information) == 0, "must not have any conflicts");
 
+	succeed_if (elektraMergeIsKeyConflicting (information, root, keyNew("system:/test/k1", KEY_END)) == false, "system:/test/k1 must not conflict");
+	succeed_if (elektraMergeIsKeyConflicting (information, root, keyNew("system:/test/k2", KEY_END)) == false, "system:/test/k2 must not conflict");
+	succeed_if (elektraMergeIsKeyConflicting (information, root, keyNew("system:/test/k3", KEY_END)) == false, "system:/test/k3 must not conflict");
+
+	KeySet * conflicts = elektraMergeGetConflictingKeys(information, root);
+	succeed_if (ksGetSize (conflicts) == 0, "conflicts must be empty")
+
 	keyDel (baseRoot);
 	keyDel (oursRoot);
 	keyDel (theirsRoot);
@@ -51,6 +58,7 @@ static void test_new_keys_in_both (void)
 	ksDel (ksOurs);
 	ksDel (ksTheirs);
 	ksDel (result);
+	ksDel (conflicts);
 }
 
 static void test_removed_keys_in_both (void)
@@ -87,6 +95,13 @@ static void test_removed_keys_in_both (void)
 	succeed_if (ksLookupByName (result, "system:/test/k1", KDB_O_NONE) != NULL, "system:/test/k1 must be included in result");
 	succeed_if (elektraMergeGetConflicts (information) == 0, "must not have any conflicts");
 
+	succeed_if (elektraMergeIsKeyConflicting (information, root, keyNew("system:/test/k1", KEY_END)) == false, "system:/test/k1 must not conflict");
+	succeed_if (elektraMergeIsKeyConflicting (information, root, keyNew("system:/test/k2", KEY_END)) == false, "system:/test/k2 must not conflict");
+	succeed_if (elektraMergeIsKeyConflicting (information, root, keyNew("system:/test/k3", KEY_END)) == false, "system:/test/k3 must not conflict");
+
+	KeySet * conflicts = elektraMergeGetConflictingKeys(information, root);
+	succeed_if (ksGetSize (conflicts) == 0, "conflicts must be empty")
+
 	keyDel (baseRoot);
 	keyDel (oursRoot);
 	keyDel (theirsRoot);
@@ -97,6 +112,7 @@ static void test_removed_keys_in_both (void)
 	ksDel (ksOurs);
 	ksDel (ksTheirs);
 	ksDel (result);
+	ksDel (conflicts);
 }
 
 static void test_changed_different_keys_in_both (void)
@@ -147,6 +163,13 @@ static void test_changed_different_keys_in_both (void)
 
 	succeed_if (elektraMergeGetConflicts (information) == 0, "must not have any conflicts");
 
+	succeed_if (elektraMergeIsKeyConflicting (information, root, keyNew("system:/test/k1", KEY_END)) == false, "system:/test/k1 must not conflict");
+	succeed_if (elektraMergeIsKeyConflicting (information, root, keyNew("system:/test/k2", KEY_END)) == false, "system:/test/k2 must not conflict");
+	succeed_if (elektraMergeIsKeyConflicting (information, root, keyNew("system:/test/k3", KEY_END)) == false, "system:/test/k3 must not conflict");
+
+	KeySet * conflicts = elektraMergeGetConflictingKeys(information, root);
+	succeed_if (ksGetSize (conflicts) == 0, "conflicts must be empty")
+
 	keyDel (baseRoot);
 	keyDel (oursRoot);
 	keyDel (theirsRoot);
@@ -157,6 +180,7 @@ static void test_changed_different_keys_in_both (void)
 	ksDel (ksOurs);
 	ksDel (ksTheirs);
 	ksDel (result);
+	ksDel (conflicts);
 }
 
 static void test_changed_same_key_abort (void)
@@ -189,6 +213,13 @@ static void test_changed_same_key_abort (void)
 
 	succeed_if (result == NULL, "result must be NULL");
 	succeed_if (elektraMergeGetConflicts (information) == 1, "must have 1 conflicts");
+
+	succeed_if (elektraMergeIsKeyConflicting (information, root, keyNew("system:/test/k1", KEY_END)) == false, "system:/test/k1 must not conflict");
+	succeed_if (elektraMergeIsKeyConflicting (information, root, keyNew("system:/test/k2", KEY_END)) == true, "system:/test/k2 must conflict");
+
+	KeySet * conflicts = elektraMergeGetConflictingKeys(information, root);
+	succeed_if (ksGetSize (conflicts) == 1, "conflicts must contain single key");
+	succeed_if (ksLookupByName (conflicts, "system:/test/k2", 0) != NULL, "conflicts must contain entry for system:/test/k2");
 
 	keyDel (baseRoot);
 	keyDel (oursRoot);
@@ -243,6 +274,13 @@ static void test_changed_same_key_their (void)
 
 	succeed_if (elektraMergeGetConflicts (information) == 1, "must have 1 conflicts");
 
+	succeed_if (elektraMergeIsKeyConflicting (information, root, keyNew("system:/test/k1", KEY_END)) == false, "system:/test/k1 must not conflict");
+	succeed_if (elektraMergeIsKeyConflicting (information, root, keyNew("system:/test/k2", KEY_END)) == true, "system:/test/k2 must conflict");
+
+	KeySet * conflicts = elektraMergeGetConflictingKeys(information, root);
+	succeed_if (ksGetSize (conflicts) == 1, "conflicts must contain single key");
+	succeed_if (ksLookupByName (conflicts, "system:/test/k2", 0) != NULL, "conflicts must contain entry for system:/test/k2");
+
 	keyDel (baseRoot);
 	keyDel (oursRoot);
 	keyDel (theirsRoot);
@@ -253,6 +291,7 @@ static void test_changed_same_key_their (void)
 	ksDel (ksOurs);
 	ksDel (ksTheirs);
 	ksDel (result);
+	ksDel (conflicts);
 }
 
 static void test_changed_same_key_our (void)
@@ -263,21 +302,21 @@ static void test_changed_same_key_our (void)
 	KeySet * ksOurs = ksNew (0, KS_END);
 	KeySet * ksTheirs = ksNew (0, KS_END);
 
-	Key * baseRoot = keyNew ("system:/test", KEY_END);
-	Key * oursRoot = keyNew ("system:/test", KEY_END);
-	Key * theirsRoot = keyNew ("system:/test", KEY_END);
-	Key * root = keyNew ("system:/test", KEY_END);
+	Key * baseRoot = keyNew ("system:/test/base", KEY_END);
+	Key * oursRoot = keyNew ("system:/test/our", KEY_END);
+	Key * theirsRoot = keyNew ("system:/test/their", KEY_END);
+	Key * root = keyNew ("system:/test/result", KEY_END);
 
-	ksAppendKey (ksBase, keyNew ("system:/test/k1", KEY_VALUE, "k1", KEY_END));
-	ksAppendKey (ksBase, keyNew ("system:/test/k2", KEY_VALUE, "k2", KEY_END));
+	ksAppendKey (ksBase, keyNew ("system:/test/base/k1", KEY_VALUE, "k1", KEY_END));
+	ksAppendKey (ksBase, keyNew ("system:/test/base/k2", KEY_VALUE, "k2", KEY_END));
 
 	// we changed k2
-	ksAppendKey (ksOurs, keyNew ("system:/test/k1", KEY_VALUE, "k1", KEY_END));
-	ksAppendKey (ksOurs, keyNew ("system:/test/k2", KEY_VALUE, "k2-our", KEY_END));
+	ksAppendKey (ksOurs, keyNew ("system:/test/our/k1", KEY_VALUE, "k1", KEY_END));
+	ksAppendKey (ksOurs, keyNew ("system:/test/our/k2", KEY_VALUE, "k2-our", KEY_END));
 
 	// they changed k2
-	ksAppendKey (ksTheirs, keyNew ("system:/test/k1", KEY_VALUE, "k1", KEY_END));
-	ksAppendKey (ksTheirs, keyNew ("system:/test/k2", KEY_VALUE, "k2-their", KEY_END));
+	ksAppendKey (ksTheirs, keyNew ("system:/test/their/k1", KEY_VALUE, "k1", KEY_END));
+	ksAppendKey (ksTheirs, keyNew ("system:/test/their/k2", KEY_VALUE, "k2-their", KEY_END));
 
 	Key * information = keyNew ("system:/", KEY_END);
 
@@ -286,15 +325,22 @@ static void test_changed_same_key_our (void)
 	succeed_if (result != NULL, "result must not be NULL");
 
 	succeed_if (ksGetSize (result) == 2, "result must contain 2 keys");
-	Key * k1 = ksLookupByName (result, "system:/test/k1", KDB_O_NONE);
-	succeed_if (k1 != NULL, "system:/test/k1 must be included in result");
+	Key * k1 = ksLookupByName (result, "system:/test/result/k1", KDB_O_NONE);
+	succeed_if (k1 != NULL, "system:/test/result/k1 must be included in result");
 	succeed_if (strcmp ("k1", keyString (k1)) == 0, "value of k1 must be 'k1'");
 
-	Key * k2 = ksLookupByName (result, "system:/test/k2", KDB_O_NONE);
-	succeed_if (k2 != NULL, "system:/test/k2 must be included in result");
+	Key * k2 = ksLookupByName (result, "system:/test/result/k2", KDB_O_NONE);
+	succeed_if (k2 != NULL, "system:/test/result/k2 must be included in result");
 	succeed_if (strcmp ("k2-our", keyString (k2)) == 0, "value of k2 must be 'k2-our'");
 
 	succeed_if (elektraMergeGetConflicts (information) == 1, "must have 1 conflicts");
+
+	succeed_if (elektraMergeIsKeyConflicting (information, root, keyNew("system:/test/result/k1", KEY_END)) == false, "system:/test/result/k1 must not conflict");
+	succeed_if (elektraMergeIsKeyConflicting (information, root, keyNew("system:/test/result/k2", KEY_END)) == true, "system:/test/result/k2 must conflict");
+
+	KeySet * conflicts = elektraMergeGetConflictingKeys(information, oursRoot);
+	succeed_if (ksGetSize (conflicts) == 1, "conflicts must contain single key");
+	succeed_if (ksLookupByName (conflicts, "system:/test/our/k2", 0) != NULL, "conflicts must contain entry for system:/test/our/k2");
 
 	keyDel (baseRoot);
 	keyDel (oursRoot);
@@ -306,6 +352,7 @@ static void test_changed_same_key_our (void)
 	ksDel (ksOurs);
 	ksDel (ksTheirs);
 	ksDel (result);
+	ksDel (conflicts);
 }
 
 int main (int argc, char ** argv)

--- a/tests/ctest/test_merge.c
+++ b/tests/ctest/test_merge.c
@@ -41,14 +41,17 @@ static void test_new_keys_in_both (void)
 	succeed_if (ksLookupByName (result, "system:/test/k3", KDB_O_NONE) != NULL, "system:/test/k3 must be included in result");
 	succeed_if (elektraMergeGetConflicts (information) == 0, "must not have any conflicts");
 
-	succeed_if (elektraMergeIsKeyConflicting (information, root, keyNew("system:/test/k1", KEY_END)) == false, "system:/test/k1 must not conflict");
-	succeed_if (elektraMergeIsKeyConflicting (information, root, keyNew("system:/test/k2", KEY_END)) == false, "system:/test/k2 must not conflict");
-	succeed_if (elektraMergeIsKeyConflicting (information, root, keyNew("system:/test/k3", KEY_END)) == false, "system:/test/k3 must not conflict");
+	succeed_if (elektraMergeIsKeyConflicting (information, root, keyNew ("system:/test/k1", KEY_END)) == false,
+		    "system:/test/k1 must not conflict");
+	succeed_if (elektraMergeIsKeyConflicting (information, root, keyNew ("system:/test/k2", KEY_END)) == false,
+		    "system:/test/k2 must not conflict");
+	succeed_if (elektraMergeIsKeyConflicting (information, root, keyNew ("system:/test/k3", KEY_END)) == false,
+		    "system:/test/k3 must not conflict");
 
-	KeySet * conflicts = elektraMergeGetConflictingKeys(information, root);
+	KeySet * conflicts = elektraMergeGetConflictingKeys (information, root);
 	succeed_if (ksGetSize (conflicts) == 0, "conflicts must be empty")
 
-	keyDel (baseRoot);
+		keyDel (baseRoot);
 	keyDel (oursRoot);
 	keyDel (theirsRoot);
 	keyDel (root);
@@ -95,14 +98,17 @@ static void test_removed_keys_in_both (void)
 	succeed_if (ksLookupByName (result, "system:/test/k1", KDB_O_NONE) != NULL, "system:/test/k1 must be included in result");
 	succeed_if (elektraMergeGetConflicts (information) == 0, "must not have any conflicts");
 
-	succeed_if (elektraMergeIsKeyConflicting (information, root, keyNew("system:/test/k1", KEY_END)) == false, "system:/test/k1 must not conflict");
-	succeed_if (elektraMergeIsKeyConflicting (information, root, keyNew("system:/test/k2", KEY_END)) == false, "system:/test/k2 must not conflict");
-	succeed_if (elektraMergeIsKeyConflicting (information, root, keyNew("system:/test/k3", KEY_END)) == false, "system:/test/k3 must not conflict");
+	succeed_if (elektraMergeIsKeyConflicting (information, root, keyNew ("system:/test/k1", KEY_END)) == false,
+		    "system:/test/k1 must not conflict");
+	succeed_if (elektraMergeIsKeyConflicting (information, root, keyNew ("system:/test/k2", KEY_END)) == false,
+		    "system:/test/k2 must not conflict");
+	succeed_if (elektraMergeIsKeyConflicting (information, root, keyNew ("system:/test/k3", KEY_END)) == false,
+		    "system:/test/k3 must not conflict");
 
-	KeySet * conflicts = elektraMergeGetConflictingKeys(information, root);
+	KeySet * conflicts = elektraMergeGetConflictingKeys (information, root);
 	succeed_if (ksGetSize (conflicts) == 0, "conflicts must be empty")
 
-	keyDel (baseRoot);
+		keyDel (baseRoot);
 	keyDel (oursRoot);
 	keyDel (theirsRoot);
 	keyDel (root);
@@ -163,14 +169,17 @@ static void test_changed_different_keys_in_both (void)
 
 	succeed_if (elektraMergeGetConflicts (information) == 0, "must not have any conflicts");
 
-	succeed_if (elektraMergeIsKeyConflicting (information, root, keyNew("system:/test/k1", KEY_END)) == false, "system:/test/k1 must not conflict");
-	succeed_if (elektraMergeIsKeyConflicting (information, root, keyNew("system:/test/k2", KEY_END)) == false, "system:/test/k2 must not conflict");
-	succeed_if (elektraMergeIsKeyConflicting (information, root, keyNew("system:/test/k3", KEY_END)) == false, "system:/test/k3 must not conflict");
+	succeed_if (elektraMergeIsKeyConflicting (information, root, keyNew ("system:/test/k1", KEY_END)) == false,
+		    "system:/test/k1 must not conflict");
+	succeed_if (elektraMergeIsKeyConflicting (information, root, keyNew ("system:/test/k2", KEY_END)) == false,
+		    "system:/test/k2 must not conflict");
+	succeed_if (elektraMergeIsKeyConflicting (information, root, keyNew ("system:/test/k3", KEY_END)) == false,
+		    "system:/test/k3 must not conflict");
 
-	KeySet * conflicts = elektraMergeGetConflictingKeys(information, root);
+	KeySet * conflicts = elektraMergeGetConflictingKeys (information, root);
 	succeed_if (ksGetSize (conflicts) == 0, "conflicts must be empty")
 
-	keyDel (baseRoot);
+		keyDel (baseRoot);
 	keyDel (oursRoot);
 	keyDel (theirsRoot);
 	keyDel (root);
@@ -214,10 +223,12 @@ static void test_changed_same_key_abort (void)
 	succeed_if (result == NULL, "result must be NULL");
 	succeed_if (elektraMergeGetConflicts (information) == 1, "must have 1 conflicts");
 
-	succeed_if (elektraMergeIsKeyConflicting (information, root, keyNew("system:/test/k1", KEY_END)) == false, "system:/test/k1 must not conflict");
-	succeed_if (elektraMergeIsKeyConflicting (information, root, keyNew("system:/test/k2", KEY_END)) == true, "system:/test/k2 must conflict");
+	succeed_if (elektraMergeIsKeyConflicting (information, root, keyNew ("system:/test/k1", KEY_END)) == false,
+		    "system:/test/k1 must not conflict");
+	succeed_if (elektraMergeIsKeyConflicting (information, root, keyNew ("system:/test/k2", KEY_END)) == true,
+		    "system:/test/k2 must conflict");
 
-	KeySet * conflicts = elektraMergeGetConflictingKeys(information, root);
+	KeySet * conflicts = elektraMergeGetConflictingKeys (information, root);
 	succeed_if (ksGetSize (conflicts) == 1, "conflicts must contain single key");
 	succeed_if (ksLookupByName (conflicts, "system:/test/k2", 0) != NULL, "conflicts must contain entry for system:/test/k2");
 
@@ -274,10 +285,12 @@ static void test_changed_same_key_their (void)
 
 	succeed_if (elektraMergeGetConflicts (information) == 1, "must have 1 conflicts");
 
-	succeed_if (elektraMergeIsKeyConflicting (information, root, keyNew("system:/test/k1", KEY_END)) == false, "system:/test/k1 must not conflict");
-	succeed_if (elektraMergeIsKeyConflicting (information, root, keyNew("system:/test/k2", KEY_END)) == true, "system:/test/k2 must conflict");
+	succeed_if (elektraMergeIsKeyConflicting (information, root, keyNew ("system:/test/k1", KEY_END)) == false,
+		    "system:/test/k1 must not conflict");
+	succeed_if (elektraMergeIsKeyConflicting (information, root, keyNew ("system:/test/k2", KEY_END)) == true,
+		    "system:/test/k2 must conflict");
 
-	KeySet * conflicts = elektraMergeGetConflictingKeys(information, root);
+	KeySet * conflicts = elektraMergeGetConflictingKeys (information, root);
 	succeed_if (ksGetSize (conflicts) == 1, "conflicts must contain single key");
 	succeed_if (ksLookupByName (conflicts, "system:/test/k2", 0) != NULL, "conflicts must contain entry for system:/test/k2");
 
@@ -335,10 +348,12 @@ static void test_changed_same_key_our (void)
 
 	succeed_if (elektraMergeGetConflicts (information) == 1, "must have 1 conflicts");
 
-	succeed_if (elektraMergeIsKeyConflicting (information, root, keyNew("system:/test/result/k1", KEY_END)) == false, "system:/test/result/k1 must not conflict");
-	succeed_if (elektraMergeIsKeyConflicting (information, root, keyNew("system:/test/result/k2", KEY_END)) == true, "system:/test/result/k2 must conflict");
+	succeed_if (elektraMergeIsKeyConflicting (information, root, keyNew ("system:/test/result/k1", KEY_END)) == false,
+		    "system:/test/result/k1 must not conflict");
+	succeed_if (elektraMergeIsKeyConflicting (information, root, keyNew ("system:/test/result/k2", KEY_END)) == true,
+		    "system:/test/result/k2 must conflict");
 
-	KeySet * conflicts = elektraMergeGetConflictingKeys(information, oursRoot);
+	KeySet * conflicts = elektraMergeGetConflictingKeys (information, oursRoot);
 	succeed_if (ksGetSize (conflicts) == 1, "conflicts must contain single key");
 	succeed_if (ksLookupByName (conflicts, "system:/test/our/k2", 0) != NULL, "conflicts must contain entry for system:/test/our/k2");
 

--- a/tests/ctest/test_merge.c
+++ b/tests/ctest/test_merge.c
@@ -49,11 +49,14 @@ static void test_new_keys_in_both (void)
 	succeed_if (ksLookupByName (result, "system:/test/k3", KDB_O_NONE) != NULL, "system:/test/k3 must be included in result");
 	succeed_if (elektraMergeGetConflicts (information) == 0, "must not have any conflicts");
 
-	succeed_if (elektraMergeIsKeyConflicting (information, root, addKeyToKeySet (keyNew ("system:/test/k1", KEY_END), trashcan)) == false,
+	succeed_if (elektraMergeIsKeyConflicting (information, root, addKeyToKeySet (keyNew ("system:/test/k1", KEY_END), trashcan)) ==
+			    false,
 		    "system:/test/k1 must not conflict");
-	succeed_if (elektraMergeIsKeyConflicting (information, root, addKeyToKeySet (keyNew ("system:/test/k2", KEY_END), trashcan)) == false,
+	succeed_if (elektraMergeIsKeyConflicting (information, root, addKeyToKeySet (keyNew ("system:/test/k2", KEY_END), trashcan)) ==
+			    false,
 		    "system:/test/k2 must not conflict");
-	succeed_if (elektraMergeIsKeyConflicting (information, root, addKeyToKeySet (keyNew ("system:/test/k3", KEY_END), trashcan)) == false,
+	succeed_if (elektraMergeIsKeyConflicting (information, root, addKeyToKeySet (keyNew ("system:/test/k3", KEY_END), trashcan)) ==
+			    false,
 		    "system:/test/k3 must not conflict");
 
 	KeySet * conflicts = elektraMergeGetConflictingKeys (information, root);
@@ -109,11 +112,14 @@ static void test_removed_keys_in_both (void)
 	succeed_if (ksLookupByName (result, "system:/test/k1", KDB_O_NONE) != NULL, "system:/test/k1 must be included in result");
 	succeed_if (elektraMergeGetConflicts (information) == 0, "must not have any conflicts");
 
-	succeed_if (elektraMergeIsKeyConflicting (information, root, addKeyToKeySet (keyNew ("system:/test/k1", KEY_END), trashcan)) == false,
+	succeed_if (elektraMergeIsKeyConflicting (information, root, addKeyToKeySet (keyNew ("system:/test/k1", KEY_END), trashcan)) ==
+			    false,
 		    "system:/test/k1 must not conflict");
-	succeed_if (elektraMergeIsKeyConflicting (information, root, addKeyToKeySet (keyNew ("system:/test/k2", KEY_END), trashcan)) == false,
+	succeed_if (elektraMergeIsKeyConflicting (information, root, addKeyToKeySet (keyNew ("system:/test/k2", KEY_END), trashcan)) ==
+			    false,
 		    "system:/test/k2 must not conflict");
-	succeed_if (elektraMergeIsKeyConflicting (information, root, addKeyToKeySet (keyNew ("system:/test/k3", KEY_END), trashcan)) == false,
+	succeed_if (elektraMergeIsKeyConflicting (information, root, addKeyToKeySet (keyNew ("system:/test/k3", KEY_END), trashcan)) ==
+			    false,
 		    "system:/test/k3 must not conflict");
 
 	KeySet * conflicts = elektraMergeGetConflictingKeys (information, root);
@@ -183,11 +189,14 @@ static void test_changed_different_keys_in_both (void)
 
 	succeed_if (elektraMergeGetConflicts (information) == 0, "must not have any conflicts");
 
-	succeed_if (elektraMergeIsKeyConflicting (information, root, addKeyToKeySet (keyNew ("system:/test/k1", KEY_END), trashcan)) == false,
+	succeed_if (elektraMergeIsKeyConflicting (information, root, addKeyToKeySet (keyNew ("system:/test/k1", KEY_END), trashcan)) ==
+			    false,
 		    "system:/test/k1 must not conflict");
-	succeed_if (elektraMergeIsKeyConflicting (information, root, addKeyToKeySet (keyNew ("system:/test/k2", KEY_END), trashcan)) == false,
+	succeed_if (elektraMergeIsKeyConflicting (information, root, addKeyToKeySet (keyNew ("system:/test/k2", KEY_END), trashcan)) ==
+			    false,
 		    "system:/test/k2 must not conflict");
-	succeed_if (elektraMergeIsKeyConflicting (information, root, addKeyToKeySet (keyNew ("system:/test/k3", KEY_END), trashcan)) == false,
+	succeed_if (elektraMergeIsKeyConflicting (information, root, addKeyToKeySet (keyNew ("system:/test/k3", KEY_END), trashcan)) ==
+			    false,
 		    "system:/test/k3 must not conflict");
 
 	KeySet * conflicts = elektraMergeGetConflictingKeys (information, root);
@@ -240,9 +249,11 @@ static void test_changed_same_key_abort (void)
 	succeed_if (result == NULL, "result must be NULL");
 	succeed_if (elektraMergeGetConflicts (information) == 1, "must have 1 conflicts");
 
-	succeed_if (elektraMergeIsKeyConflicting (information, root, addKeyToKeySet (keyNew ("system:/test/k1", KEY_END), trashcan)) == false,
+	succeed_if (elektraMergeIsKeyConflicting (information, root, addKeyToKeySet (keyNew ("system:/test/k1", KEY_END), trashcan)) ==
+			    false,
 		    "system:/test/k1 must not conflict");
-	succeed_if (elektraMergeIsKeyConflicting (information, root, addKeyToKeySet (keyNew ("system:/test/k2", KEY_END), trashcan)) == true,
+	succeed_if (elektraMergeIsKeyConflicting (information, root, addKeyToKeySet (keyNew ("system:/test/k2", KEY_END), trashcan)) ==
+			    true,
 		    "system:/test/k2 must conflict");
 
 	KeySet * conflicts = elektraMergeGetConflictingKeys (information, root);
@@ -306,9 +317,11 @@ static void test_changed_same_key_their (void)
 
 	succeed_if (elektraMergeGetConflicts (information) == 1, "must have 1 conflicts");
 
-	succeed_if (elektraMergeIsKeyConflicting (information, root, addKeyToKeySet (keyNew ("system:/test/k1", KEY_END), trashcan)) == false,
+	succeed_if (elektraMergeIsKeyConflicting (information, root, addKeyToKeySet (keyNew ("system:/test/k1", KEY_END), trashcan)) ==
+			    false,
 		    "system:/test/k1 must not conflict");
-	succeed_if (elektraMergeIsKeyConflicting (information, root, addKeyToKeySet (keyNew ("system:/test/k2", KEY_END), trashcan)) == true,
+	succeed_if (elektraMergeIsKeyConflicting (information, root, addKeyToKeySet (keyNew ("system:/test/k2", KEY_END), trashcan)) ==
+			    true,
 		    "system:/test/k2 must conflict");
 
 	KeySet * conflicts = elektraMergeGetConflictingKeys (information, root);
@@ -372,9 +385,11 @@ static void test_changed_same_key_our (void)
 
 	succeed_if (elektraMergeGetConflicts (information) == 1, "must have 1 conflicts");
 
-	succeed_if (elektraMergeIsKeyConflicting (information, root, addKeyToKeySet (keyNew ("system:/test/result/k1", KEY_END), trashcan)) == false,
+	succeed_if (elektraMergeIsKeyConflicting (information, root,
+						  addKeyToKeySet (keyNew ("system:/test/result/k1", KEY_END), trashcan)) == false,
 		    "system:/test/result/k1 must not conflict");
-	succeed_if (elektraMergeIsKeyConflicting (information, root, addKeyToKeySet (keyNew ("system:/test/result/k2", KEY_END), trashcan)) == true,
+	succeed_if (elektraMergeIsKeyConflicting (information, root,
+						  addKeyToKeySet (keyNew ("system:/test/result/k2", KEY_END), trashcan)) == true,
 		    "system:/test/result/k2 must conflict");
 
 	KeySet * conflicts = elektraMergeGetConflictingKeys (information, oursRoot);


### PR DESCRIPTION
Fixes #4489
 

## Basics

<!--
These points need to be fulfilled for every PR.
-->

- [x] Short descriptions of your changes are in the release notes
      (added as entry in `doc/news/_preparation_next_release.md` which
      contains `_(my name)_`)
      **Please always add something to the release notes.**
- [x] Details of what you changed are in commit messages
      (first line should have `module: short statement` syntax)
- [ ] References to issues, e.g. `close #X`, are in the commit messages.
- [x] The buildservers are happy. If not, fix **in this order**:
  - [x] add a line in `doc/news/_preparation_next_release.md`
  - [x] reformat the code with `scripts/dev/reformat-all`
  - [x] make all unit tests pass
  - [x] fix all memleaks
- [x] The PR is rebased with current master.

<!--
If you have any troubles fulfilling these criteria, please write
about the trouble as comment in the PR. We will help you,
but we cannot accept PRs that do not fulfill the basics.
-->

## Checklist

<!--
For docu fixes, spell checking, and similar none of these points below
need to be checked.
-->

- [x] I added unit tests for my code
- [x] I fully described what my PR does in the documentation
      (not in the PR description)
- [x] I fixed all affected documentation (see [Documentation Guidelines](https://master.libelektra.org/doc/contrib/documentation.md))
- [x] I added code comments, logging, and assertions as appropriate (see [Coding Guidelines](https://master.libelektra.org/doc/CODING.md))
- [x] I updated all meta data (e.g. README.md of plugins and [METADATA.ini](https://master.libelektra.org/doc/METADATA.ini))
- [x] I mentioned [every code](/.reuse/dep5) not directly written by me in [reuse syntax](https://reuse.software/)

## Review

<!--
Reviewers should check the following.
-->

- [ ] Documentation is introductory, concise, good to read and describes everything what the PR does
- [ ] Examples are well chosen and understandable
- [ ] Code is conforming to [our Coding Guidelines](https://master.libelektra.org/doc/CODING.md)
- [ ] APIs are conforming to [our Design Guidelines](https://master.libelektra.org/doc/DESIGN.md)
- [ ] Code is consistent to [our Design Decisions](https://master.libelektra.org/doc/decisions)

## Labels

<!--
If you are already Elektra developer, please adjust the labels.
Otherwise, write a comment and it will be done for you.
-->

- [ ] Add the "work in progress" label if you do not want the PR to be reviewed yet.
- [ ] Add the "ready to merge" label **if the basics are fulfilled** and no further pushes are planned by you.
