### PR TITLE
[FLOSS T1] Fix segfault from circular links (overrides)

### DIFF
--- a/doc/news/_preparation_next_release.md
+++ b/doc/news/_preparation_next_release.md
@@ -143,7 +143,7 @@ The text below summarizes updates to the [C (and C++)-based libraries](https://w
 - <<TODO>>
 - <<TODO>>
 - <<TODO>>
-- <<TODO>>
+- Check for circular links (overrides) _(@0x6178656c)_
 - <<TODO>>
 - <<TODO>>
 - <<TODO>>

--- a/src/libs/elektra/keyset.c
+++ b/src/libs/elektra/keyset.c
@@ -1970,6 +1970,12 @@ static Key * elektraLookupBySpecLinks (KeySet * ks, Key * specKey, char * buffer
 		}
 		else
 			keySetName (k, keyString (m));
+		// circular reference: abort
+		if (!strcmp (keyName (specKey), keyName (k)))
+		{
+			ret = NULL;
+			break;
+		}
 		ret = ksLookup (ks, k, KDB_O_NODEFAULT);
 		if (ret) break;
 		++i;

--- a/tests/ctest/test_ks.c
+++ b/tests/ctest/test_ks.c
@@ -66,6 +66,17 @@ static void test_cascadingLookup (void)
 	ksDel (ks);
 }
 
+static void test_circularLinkLookup (void)
+{
+	printf ("Test circular link lookup\n");
+	KeySet * ks = ksNew (10, keyNew ("spec:/circular", KEY_META, "override/#0", "/circular", KEY_END), KS_END);
+	Key * search = keyNew ("/circular", KEY_END);
+	Key * found = ksLookup (ks, search, 0);
+	succeed_if (found == NULL, "found nonexistent key");
+	keyDel (search);
+	ksDel (ks);
+}
+
 static void test_creatingLookup (void)
 {
 	printf ("Test creating lookup\n");
@@ -564,6 +575,7 @@ int main (int argc, char ** argv)
 	test_ksToArray ();
 	test_ksRenameKeys ();
 	test_cascadingLookup ();
+	test_circularLinkLookup ();
 	test_creatingLookup ();
 	test_ksNoAlloc ();
 	test_ksRename ();


### PR DESCRIPTION
Fixes the segfault from doing a circular lookup:

```sh
$ kdb meta-set "spec:/circular" "override/#0" "/circular"
$ kdb get "/circular"
# SEGFAULT
```

Note that this only handles the trivial self-reference. Circular lookups with multiple hops still cause havoc:

```sh
$ kdb meta-set "spec:/circular1" "override/#0" "/circular2"
$ kdb meta-set "spec:/circular2" "override/#0" "/circular1"
$ kdb get "/circular1"
# SEGFAULT
```

Nevertheless, I think this is an improvement since the self-reference is certainly more likely than the situation with multiple hops.

<!--
Check relevant points but **please do not remove entries**.
-->

## Basics

<!--
These points need to be fulfilled for every PR.
-->

- [x] Short descriptions of your changes are in the release notes
      (added as entry in `doc/news/_preparation_next_release.md` which
      contains `_(my name)_`)
      **Please always add something to the release notes.**
- [x] Details of what you changed are in commit messages
      (first line should have `module: short statement` syntax)
- [ ] References to issues, e.g. `close #X`, are in the commit messages.
- [ ] The buildservers are happy. If not, fix **in this order**:
  - [ ] add a line in `doc/news/_preparation_next_release.md`
  - [ ] reformat the code with `scripts/dev/reformat-all`
  - [ ] make all unit tests pass
  - [ ] fix all memleaks
- [x] The PR is rebased with current master.

<!--
If you have any troubles fulfilling these criteria, please write
about the trouble as comment in the PR. We will help you,
but we cannot accept PRs that do not fulfill the basics.
-->

## Checklist

<!--
For docu fixes, spell checking, and similar none of these points below
need to be checked.
-->

- [ ] I added unit tests for my code
- [ ] I fully described what my PR does in the documentation
      (not in the PR description)
- [ ] I fixed all affected documentation (see [Documentation Guidelines](https://www.libelektra.org/devgettingstarted/documentation))
- [ ] I fixed all affected decisions (see [Decision Process](https://www.libelektra.org/decisions/decision-process))
- [ ] I added code comments, logging, and assertions as appropriate (see [Coding Guidelines](https://www.libelektra.org/devgettingstarted/coding))
- [ ] I updated all meta data (e.g. README.md of plugins and [METADATA.ini](https://master.libelektra.org/doc/METADATA.ini))
- [ ] I mentioned [every code](/.reuse/dep5) not directly written by me in [reuse syntax](https://reuse.software/)

## Review

<!--
Reviewers should check the following.
-->

- [ ] Documentation is introductory, concise, good to read and describes everything what the PR does
- [ ] Examples are well chosen and understandable
- [ ] Code is conforming to [our Coding Guidelines](https://master.libelektra.org/doc/CODING.md)
- [ ] APIs are conforming to [our Design Guidelines](https://master.libelektra.org/doc/DESIGN.md)
- [ ] Code is consistent to [our Design Decisions](https://master.libelektra.org/doc/decisions)

## Labels

<!--
If you are already Elektra developer, please adjust the labels.
Otherwise, write a comment and it will be done for you.
-->

- [ ] Add the "work in progress" label if you do not want the PR to be reviewed yet.
- [ ] Add the "ready to merge" label **if the basics are fulfilled** and no further pushes are planned by you.
