### PR TITLE
[FLOSS T1] plugin: date: Fix rfc822 validation issue

### DIFF
--- a/doc/news/_preparation_next_release.md
+++ b/doc/news/_preparation_next_release.md
@@ -172,6 +172,12 @@ The following text lists news about the [plugins](https://www.libelektra.org/plu
 - <<TODO>>
 - <<TODO>>
 
+### date
+
+- Fix an Issue with validationg RFC 822 date-times _(Juri Schreib @Bujuhu)_ _(Nikola Prvulovic @Dynamichost96)_
+- Improve Code Coverage _(Juri Schreib @Bujuhu)_ _(Nikola Prvulovic @Dynamichost96)_
+- <<TODO>>
+
 ## Libraries
 
 The text below summarizes updates to the [C (and C++)-based libraries](https://www.libelektra.org/libraries/readme) of Elektra.

--- a/src/plugins/date/date.c
+++ b/src/plugins/date/date.c
@@ -387,7 +387,7 @@ static int rfc822StringValidation (const char * date)
 {
 	struct tm tm;
 	memset (&tm, 0, sizeof (struct tm));
-	for (int i = 0; rfc2822strings[i] != NULL; ++i)
+	for (int i = 0; rfc822strings[i] != NULL; ++i)
 	{
 		char * ptr = strptime (date, rfc822strings[i], &tm);
 		if (ptr)

--- a/src/plugins/date/date.h
+++ b/src/plugins/date/date.h
@@ -25,19 +25,7 @@ Plugin * ELEKTRA_PLUGIN_EXPORT;
  *
  */
 
-const char * rfc822strings[] = { "%a, %d %b %y %T",
-				 "%d %b %y %T",
-				 "%a, %d %b %y %H:%M",
-				 "%d %b %y %H:%M",
-				 "%a, %d %b %y %T %z",
-				 "%d %b %y %T %z",
-				 "%a, %d %b %y %H:%M %z",
-				 "%d %b %y %H:%M %z",
-				 "%a, %d %b %y %T %Z",
-				 "%d %b %y %T %Z",
-				 "%a, %d %b %y %H:%M %Z",
-				 "%d %b %y %H:%M %Z",
-				 NULL };
+const char * rfc822strings[] = { "%a, %d %b %y %T %z", "%d %b %y %T %z", "%a, %d %b %y %H:%M %z", "%d %b %y %H:%M %z", NULL };
 
 
 /*

--- a/src/plugins/date/testmod_date.c
+++ b/src/plugins/date/testmod_date.c
@@ -35,7 +35,7 @@ static void testFmt (const char * date, const char * fmt, const short res)
 	PLUGIN_CLOSE ();
 }
 
-static void testIso (const char * date, const char * isoString, const short res)
+static void testIso (const char * date, const char * isoString, const short expectedResult)
 {
 	Key * parentKey = keyNew ("user:/tests/date", KEY_VALUE, "", KEY_END);
 	KeySet * ks = ksNew (5,
@@ -44,14 +44,16 @@ static void testIso (const char * date, const char * isoString, const short res)
 			     KS_END);
 	KeySet * conf = ksNew (0, KS_END);
 	PLUGIN_OPEN ("date");
-	succeed_if (plugin->kdbGet (plugin, ks, parentKey) == res, "validation failed");
+	short actualResult = plugin->kdbGet (plugin, ks, parentKey);
+	succeed_if_fmt (expectedResult == actualResult, "validation for %s, %s failed. Expected result: %hi, actual result %hi", date,
+			isoString, expectedResult, actualResult);
 	ksDel (ks);
 	keyDel (parentKey);
 	PLUGIN_CLOSE ();
 }
 
 #ifdef __GNU_LIBRARY__
-static void testRfc2822 (const char * date, const short res)
+static void testRfc2822 (const char * date, const short expectedResult)
 {
 	Key * parentKey = keyNew ("user:/tests/date", KEY_VALUE, "", KEY_END);
 	KeySet * ks = ksNew (5,
@@ -60,7 +62,25 @@ static void testRfc2822 (const char * date, const short res)
 			     KS_END);
 	KeySet * conf = ksNew (0, KS_END);
 	PLUGIN_OPEN ("date");
-	succeed_if (plugin->kdbGet (plugin, ks, parentKey) == res, "validation failed");
+	short actualResult = plugin->kdbGet (plugin, ks, parentKey);
+	succeed_if_fmt (expectedResult == actualResult, "validation for %s failed. Expected result: %hi, actual result %hi", date,
+			expectedResult, actualResult);
+	ksDel (ks);
+	keyDel (parentKey);
+	PLUGIN_CLOSE ();
+}
+static void testRfc822 (const char * date, const short expectedResult)
+{
+	Key * parentKey = keyNew ("user:/tests/date", KEY_VALUE, "", KEY_END);
+	KeySet * ks = ksNew (5,
+			     keyNew ("user:/tests/date/test", KEY_VALUE, date, KEY_META, "check/date", "RFC822", KEY_META,
+				     "check/date/format", "", KEY_END),
+			     KS_END);
+	KeySet * conf = ksNew (0, KS_END);
+	PLUGIN_OPEN ("date");
+	short actualResult = plugin->kdbGet (plugin, ks, parentKey);
+	succeed_if_fmt (expectedResult == actualResult, "validation for %s failed. Expected result: %hi, actual result %hi", date,
+			expectedResult, actualResult);
 	ksDel (ks);
 	keyDel (parentKey);
 	PLUGIN_CLOSE ();
@@ -97,6 +117,11 @@ int main (int argc, char ** argv)
 	testIso ("22:30+04", "utc extended", 1);
 	testIso ("22:30-04", "utc extended", 1);
 	testIso ("2016-W23", "weekdate", 1);
+	testIso ("2022-11-23", "calendardate", 1);
+	testIso ("2022-327", "ordinaldate", 1);
+	testIso ("2022-11-23", "date", 1);
+	testIso ("2022-327", "date", 1);
+	testIso ("2022-W47", "date", 1);
 
 	setlocale (LC_ALL, "C");
 	testRfc2822 ("Sat, 01 Mar 2016 23:59:01 +0400", 1);
@@ -104,6 +129,16 @@ int main (int argc, char ** argv)
 	testRfc2822 ("Sat, Mar 01 2016 23:59:01 +0400", -1);
 	testRfc2822 ("01 Mar 2016 23:59 +0400", 1);
 	testRfc2822 ("01 Mar 2016 01:00:59", -1);
+
+	testRfc822 ("Sat, 01 Mar 16 23:59:01 +0400", 1);
+	testRfc822 ("Sat, 01 Mar 2016 23:59:01 +0400", -1);
+	testRfc822 ("01 Mar 16 23:59:01 -0400", 1);
+	testRfc822 ("01 Mar 2016 23:59:01 -0400", -1);
+	testRfc822 ("Sat, Mar 01 16 23:59:01 +0400", -1);
+	testRfc822 ("01 Mar 16 23:59 +0400", 1);
+	testRfc822 ("01 Mar 16 01:00", -1);
+	testRfc822 ("Sat, 01 Mar 16 01:00", -1);
+
 	setlocale (LC_ALL, old_locale);
 #else
 	testIso ("2016-12-12T23:59:01", "datetime truncated", -1);
@@ -111,6 +146,11 @@ int main (int argc, char ** argv)
 #endif
 	testIso ("2230", "timeofday extended", -1);
 	testIso ("2230", "timeofday basic", 1);
+	testIso ("2230", "timeofday extended", -1);
+	testIso ("2230", "time", 1);
+
+	testIso ("2022-11-23", "bogus", -1);
+
 
 	print_result ("testmod_date");
 


### PR DESCRIPTION
- add tests
- fix an issue where rfc822 dates are not correctly validated

There are also two date types for rfc822 dates which are accepted by the validaton, but invalid according to the specification. I did not change them for now, as I did not want to break backwards compatibility. I commented this on the affected test cases. 

- We found the bug by wanting to improve the code coverage to the date plugin
- tests run on jenkins and cirrus-ci
- we split the test cases we wrote and identified and fixed the issue together

## Basics

<!--
These points need to be fulfilled for every PR.
-->

- [ ] Short descriptions of your changes are in the release notes
      (added as entry in `doc/news/_preparation_next_release.md` which
      contains `_(my name)_`)
      **Please always add something to the release notes.**
- [ ] Details of what you changed are in commit messages
      (first line should have `module: short statement` syntax)
- [ ] References to issues, e.g. `close #X`, are in the commit messages.
- [ ] The buildservers are happy. If not, fix **in this order**:
  - [ ] add a line in `doc/news/_preparation_next_release.md`
  - [ ] reformat the code with `scripts/dev/reformat-all`
  - [ ] make all unit tests pass
  - [ ] fix all memleaks
- [ ] The PR is rebased with current master.

<!--
If you have any troubles fulfilling these criteria, please write
about the trouble as comment in the PR. We will help you,
but we cannot accept PRs that do not fulfill the basics.
-->

## Checklist

<!--
For docu fixes, spell checking, and similar none of these points below
need to be checked.
-->

- [ ] I added unit tests for my code
- [ ] I fully described what my PR does in the documentation
      (not in the PR description)
- [ ] I fixed all affected documentation (see [Documentation Guidelines](https://www.libelektra.org/devgettingstarted/documentation))
- [ ] I fixed all affected decisions (see [Decision Process](https://www.libelektra.org/decisions/decision-process))
- [ ] I added code comments, logging, and assertions as appropriate (see [Coding Guidelines](https://www.libelektra.org/devgettingstarted/coding))
- [ ] I updated all meta data (e.g. README.md of plugins and [METADATA.ini](https://master.libelektra.org/doc/METADATA.ini))
- [ ] I mentioned [every code](/.reuse/dep5) not directly written by me in [reuse syntax](https://reuse.software/)

## Review

<!--
Reviewers should check the following.
-->

- [ ] Documentation is introductory, concise, good to read and describes everything what the PR does
- [ ] Examples are well chosen and understandable
- [ ] Code is conforming to [our Coding Guidelines](https://master.libelektra.org/doc/CODING.md)
- [ ] APIs are conforming to [our Design Guidelines](https://master.libelektra.org/doc/DESIGN.md)
- [ ] Code is consistent to [our Design Decisions](https://master.libelektra.org/doc/decisions)

## Labels

<!--
If you are already Elektra developer, please adjust the labels.
Otherwise, write a comment and it will be done for you.
-->

- [ ] Add the "work in progress" label if you do not want the PR to be reviewed yet.
- [ ] Add the "ready to merge" label **if the basics are fulfilled** and no further pushes are planned by you.
