### PR TITLE
bindings/rust: update bindgen version

### DIFF
--- a/doc/news/_preparation_next_release.md
+++ b/doc/news/_preparation_next_release.md
@@ -163,9 +163,9 @@ The text below summarizes updates to the [C (and C++)-based libraries](https://w
 Bindings allow you to utilize Elektra using [various programming languages](https://www.libelektra.org/bindings/readme).
 This section keeps you up-to-date with the multi-language support provided by Elektra.
 
-### <<Binding>>
+## Rust
 
-- <<TODO>>
+- Update bindgen version (0.55 => 0.66) _(Jannis Adamek @horenso)_
 - <<TODO>>
 - <<TODO>>
 

--- a/src/bindings/rust/elektra-sys/Cargo.toml.in
+++ b/src/bindings/rust/elektra-sys/Cargo.toml.in
@@ -16,5 +16,5 @@ resolver = "2"
 [dependencies]
 
 [build-dependencies]
-bindgen = "= 0.55.1"
+bindgen = "= 0.66.1"
 object = "< 0.30.0"

--- a/src/bindings/rust/elektra-sys/build.rs.in
+++ b/src/bindings/rust/elektra-sys/build.rs.in
@@ -20,8 +20,8 @@ fn main() {
         // bindings for.
         .header("wrapper.h")
         // Include only the necessary functions and enums
-        .whitelist_function("(key|ks|kdb).*")
-        .whitelist_var("(KEY|KDB).*")
+        .allowlist_function("(key|ks|kdb).*")
+        .allowlist_var("(KEY|KDB).*")
         // bindgen uses clang for anything C-related.
         // Here we set the necessary include directories
         // such that any includes in the wrapper can be found.

--- a/src/bindings/rust/elektra-sys/published_Cargo.toml
+++ b/src/bindings/rust/elektra-sys/published_Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "elektra-sys"
-version = "0.11.0"
+version = "0.11.1"
 authors = ["PhilippGackstatter <philipp.gackstatter@student.tuwien.ac.at>"]
 edition = "2018"
 build = "build.rs"
@@ -16,5 +16,5 @@ default = []
 [dependencies]
 
 [build-dependencies]
-bindgen = "0.55.1"
+bindgen = "0.66.1"
 pkg-config = { version = "0.3.16", optional = true }

--- a/src/bindings/rust/elektra-sys/published_build.rs
+++ b/src/bindings/rust/elektra-sys/published_build.rs
@@ -22,8 +22,8 @@ fn main() {
         // bindings for.
         .header("wrapper.h")
         // Include only the necessary functions and enums
-        .whitelist_function("(key|ks|kdb).*")
-        .whitelist_var("(KEY|KDB).*")
+        .allowlist_function("(key|ks|kdb).*")
+        .allowlist_var("(KEY|KDB).*")
         // bindgen uses clang for anything C-related.
         // Here we set the necessary include directories
         // such that any includes in the wrapper can be found.

--- a/src/bindings/rust/elektra/published_Cargo.toml
+++ b/src/bindings/rust/elektra/published_Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "elektra"
-version = "0.11.0"
+version = "0.11.1"
 authors = ["PhilippGackstatter <philipp.gackstatter@student.tuwien.ac.at>"]
 edition = "2018"
 description = "Elektra serves as a universal and secure framework to access configuration parameters in a global, hierarchical key database."
@@ -16,5 +16,5 @@ default = []
 pkg-config = ["elektra-sys/pkg-config"]
 
 [dependencies]
-elektra-sys = { version = "0.11.0" }
+elektra-sys = { version = "0.11.1" }
 bitflags = "1.1.0"


### PR DESCRIPTION
Update `bindgen` for rust bindings to 0.66.1 #4989.

`bindgen` changed some defaults regarding the equality of `usize` and `size_t`. They added the option `.size_t_is_usize(true)` but made it default `true` in a later version. When bumping the `bindgen` version
the error goes away. Read more about this in [this issue](https://github.com/rust-lang/rust-bindgen/issues/1901) and [also here](https://github.com/rust-lang/rust-bindgen/issues/1671).

<!--
Check relevant points but **please do not remove entries**.
-->

## Basics

<!--
These points need to be fulfilled for every PR.
-->

- [x] Short descriptions of your changes are in the release notes
      (added as entry in `doc/news/_preparation_next_release.md` which contains `_(my name)_`)
      **Please always add them to the release notes.**
- [x] Details of what you changed are in commit messages
      (first line should have `module: short statement` syntax)
- [x] References to issues, e.g. `close #X`, are in the commit messages.
- [ ] The buildservers are happy. If not, fix **in this order**:
  - add a line in `doc/news/_preparation_next_release.md`
  - reformat the code with `scripts/dev/reformat-all`
  - make all unit tests pass
  - fix all memleaks
  - fix the CI itself (or rebase if already fixed)
- [x] The PR is rebased with current master.

<!--
If you have any troubles fulfilling these criteria, please write about the trouble as comment in the PR.
We will help you, but we cannot accept PRs that do not fulfill the basics.
-->

## Checklist

<!--
For documentation fixes, spell checking, and similar none of these points below need to be checked.
-->

- [ ] I added unit tests for my code
- [ ] I fully described what my PR does in the documentation
      (not in the PR description)
- [ ] I fixed all affected documentation (see [Documentation Guidelines](https://www.libelektra.org/devgettingstarted/documentation))
- [ ] I fixed all affected decisions (see [Decision Process](https://www.libelektra.org/decisions/decision-process))
- [ ] I added code comments, logging, and assertions as appropriate (see [Coding Guidelines](https://www.libelektra.org/devgettingstarted/coding))
- [ ] I updated all meta data (e.g. README.md of plugins and [METADATA.ini](https://master.libelektra.org/doc/METADATA.ini))
- [ ] I mentioned [every code](/.reuse/dep5) not directly written by me in [reuse syntax](https://reuse.software/)

## Review

<!--
Reviewers should check the following.
-->

- [ ] Documentation is introductory, concise, good to read and describes everything what the PR does
- [ ] Examples are well chosen and understandable
- [ ] Code is conforming to [our Coding Guidelines](https://master.libelektra.org/doc/CODING.md)
- [ ] APIs are conforming to [our Design Guidelines](https://master.libelektra.org/doc/DESIGN.md)
- [ ] Code is consistent to [our Design Decisions](https://master.libelektra.org/doc/decisions)

## Labels

<!--
If you are already Elektra developer, please adjust the labels.
Otherwise, write a comment and it will be done for you.
-->

- [x] Add the "work in progress" label if you do not want the PR to be reviewed yet.
- [ ] Add the "ready to merge" label **if everything is done** and no further pushes are planned by you.
